### PR TITLE
Add List Channel API Integration

### DIFF
--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -196,7 +196,7 @@ fn spawn_transport_task(
             //     tracing::warn!("Authenticated session missing tcp_port; TCP APIs unavailable");
             //     continue;
             // };
-            let port = 7349;
+            let port = 4433;
 
             if transport.is_open().await
                 && let Err(e) = transport.close().await

--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -169,7 +169,7 @@ fn spawn_transport_task(
             exec.timer(std::time::Duration::from_millis(500)).await;
 
             let session = match cx.update(|cx| auth_state.read(cx).clone()) {
-                AuthState::Authenticated(session) => Some(session),
+                AuthState::Connecting(session) | AuthState::Authenticated(session) => Some(session),
                 _ => None,
             };
 
@@ -190,6 +190,14 @@ fn spawn_transport_task(
 
             let Some(host) = session.tcp_host.clone() else {
                 tracing::warn!("Authenticated session missing tcp_host; TCP APIs unavailable");
+                cx.update(|cx| {
+                    auth_state.update(cx, |state, cx| {
+                        if matches!(state, AuthState::Connecting(_)) {
+                            *state = AuthState::NotAuthenticated;
+                            cx.notify();
+                        }
+                    });
+                });
                 continue;
             };
             // let Some(port) = session.tcp_port else {
@@ -206,6 +214,7 @@ fn spawn_transport_task(
 
             tracing::info!("Connecting shared TCP transport to {host}:{port}");
             let token = session.token.clone();
+            let session_for_update = session.clone();
             match transport
                 .connect(
                     &host,
@@ -230,21 +239,31 @@ fn spawn_transport_task(
                 .await
             {
                 Ok(()) => {
-                    connected_token = Some(token);
                     tracing::info!("Shared TCP transport connected");
 
-                    cx.background_executor()
-                        .timer(std::time::Duration::from_millis(250))
-                        .await;
+                    exec.timer(std::time::Duration::from_millis(250)).await;
                     match api.get_account().await {
                         Ok(account) => {
+                            connected_token = Some(token);
                             tracing::info!("get_account over shared TCP succeeded");
                             tracing::info!("  User ID: {}", account.user_id);
                             tracing::info!("  Username: {}", account.username);
                             tracing::info!("  Email: {:?}", account.email);
                             tracing::info!("  Display name: {:?}", account.display_name);
+
+                            cx.update(|cx| {
+                                auth_state.update(cx, |state, cx| {
+                                    if matches!(state, AuthState::Connecting(_)) {
+                                        *state = AuthState::Authenticated(session_for_update);
+                                        cx.notify();
+                                    }
+                                });
+                            });
                         }
-                        Err(e) => tracing::error!("get_account over shared TCP failed: {e}"),
+                        Err(e) => {
+                            tracing::error!("get_account over shared TCP failed: {e}");
+                            let _ = transport.close().await;
+                        }
                     }
                 }
                 Err(e) => {
@@ -260,8 +279,8 @@ fn spawn_transport_task(
 
 /// Attempt to restore a valid session from the OS keychain.
 ///
-/// - Valid + not expired → `Authenticated`
-/// - Valid + expired     → try silent refresh → `Authenticated` on success, else `NotAuthenticated`
+/// - Valid + not expired → `Connecting` (TCP transport not yet established)
+/// - Valid + expired     → try silent refresh → `Connecting` on success, else `NotAuthenticated`
 /// - Nothing stored      → `NotAuthenticated`
 fn resolve_initial_auth_state(rt: &tokio::runtime::Runtime, client: &MezonClient) -> AuthState {
     match keychain::load_session() {
@@ -271,7 +290,7 @@ fn resolve_initial_auth_state(rt: &tokio::runtime::Runtime, client: &MezonClient
         }
         Some(session) if !mezon_client::Session::is_expired(&session) => {
             tracing::info!("Restored valid session for user_id={}", session.user_id);
-            AuthState::Authenticated(session)
+            AuthState::Connecting(session)
         }
         Some(session) => {
             tracing::info!("Stored session expired — attempting silent refresh");
@@ -284,7 +303,7 @@ fn resolve_initial_auth_state(rt: &tokio::runtime::Runtime, client: &MezonClient
                     if let Err(e) = keychain::save_session(&new_session) {
                         tracing::warn!("Failed to update keychain after refresh: {e}");
                     }
-                    AuthState::Authenticated(new_session)
+                    AuthState::Connecting(new_session)
                 }
                 Err(e) => {
                     tracing::warn!("Silent refresh failed: {e} — showing login");

--- a/crates/mezon-client/src/abridged_tcp_adapter.rs
+++ b/crates/mezon-client/src/abridged_tcp_adapter.rs
@@ -117,8 +117,7 @@ impl AbridgedTcpAdapter {
                     if buf.len() < RAW_HEADER_LENGTH {
                         return Ok(());
                     }
-                    let code =
-                        u32::from_be_bytes([buf[3], buf[4], buf[5], buf[6]]);
+                    let code = u32::from_be_bytes([buf[3], buf[4], buf[5], buf[6]]);
                     let fin_flag = (code & 0xffff) as u16;
                     if fin_flag == CODE_FIN {
                         if buf.len() == RAW_HEADER_LENGTH {
@@ -153,8 +152,7 @@ impl AbridgedTcpAdapter {
                     if buf.len() < 4 {
                         return Ok(());
                     }
-                    let payload_len =
-                        u32::from_le_bytes([buf[1], buf[2], buf[3], 0]) as usize * 4;
+                    let payload_len = u32::from_le_bytes([buf[1], buf[2], buf[3], 0]) as usize * 4;
                     let total = 4 + payload_len;
                     if buf.len() < total {
                         return Ok(());
@@ -163,10 +161,7 @@ impl AbridgedTcpAdapter {
                     buf.drain(..total);
                     Some((msg, false))
                 } else {
-                    tracing::warn!(
-                        "📥 Unexpected first byte: {:#x}, skipping",
-                        first_byte
-                    );
+                    tracing::warn!("📥 Unexpected first byte: {:#x}, skipping", first_byte);
                     buf.drain(..1);
                     Some((vec![], true))
                 }
@@ -197,10 +192,16 @@ impl AbridgedTcpAdapter {
                 let fin_flag = (code & 0xffff) as u16;
 
                 let (payload, payload_len) = if fin_flag == CODE_FIN {
-                    (data[RAW_HEADER_LENGTH..].to_vec(), data.len() - RAW_HEADER_LENGTH)
+                    (
+                        data[RAW_HEADER_LENGTH..].to_vec(),
+                        data.len() - RAW_HEADER_LENGTH,
+                    )
                 } else {
                     let len = u32::from_be_bytes([data[7], data[8], data[9], data[10]]) as usize;
-                    (data[RAW_CHUNK_HEADER_LENGTH..RAW_CHUNK_HEADER_LENGTH + len].to_vec(), len)
+                    (
+                        data[RAW_CHUNK_HEADER_LENGTH..RAW_CHUNK_HEADER_LENGTH + len].to_vec(),
+                        len,
+                    )
                 };
 
                 tracing::info!(
@@ -230,11 +231,7 @@ impl AbridgedTcpAdapter {
                 } else {
                     let chunks = streams.entry(cid).or_insert_with(Vec::new);
                     chunks.push(payload);
-                    tracing::info!(
-                        "📥 Buffered chunk for cid={} ({} total)",
-                        cid,
-                        chunks.len()
-                    );
+                    tracing::info!("📥 Buffered chunk for cid={} ({} total)", cid, chunks.len());
                 }
                 continue;
             }
@@ -247,8 +244,7 @@ impl AbridgedTcpAdapter {
                 );
                 (1, data[0] as usize * 4)
             } else {
-                let len =
-                    u32::from_le_bytes([data[1], data[2], data[3], 0]) as usize * 4;
+                let len = u32::from_le_bytes([data[1], data[2], data[3], 0]) as usize * 4;
                 tracing::info!("📥 Extended msg: len={}", len);
                 (4, len)
             };

--- a/crates/mezon-client/src/abridged_tcp_adapter.rs
+++ b/crates/mezon-client/src/abridged_tcp_adapter.rs
@@ -66,7 +66,7 @@ const CODE_FIN: u16 = 0xff;
 const PREFIX_RAW: u8 = 0xff;
 const PREFIX_EXTENDED: u8 = 0x7f;
 const RAW_HEADER_LENGTH: usize = 7;
-const PAYLOAD_HEADER_LENGTH: usize = 11;
+const RAW_CHUNK_HEADER_LENGTH: usize = 11;
 
 type TlsStream = tokio_rustls::client::TlsStream<TcpStream>;
 
@@ -75,6 +75,7 @@ pub struct AbridgedTcpAdapter {
     handlers: Arc<Mutex<AdapterHandlers>>,
     streams: Arc<Mutex<HashMap<u16, Vec<Vec<u8>>>>>,
     is_connected: Arc<Mutex<bool>>,
+    read_buffer: Arc<Mutex<Vec<u8>>>,
 }
 
 impl AbridgedTcpAdapter {
@@ -84,128 +85,190 @@ impl AbridgedTcpAdapter {
             handlers: Arc::new(Mutex::new(AdapterHandlers::default())),
             streams: Arc::new(Mutex::new(HashMap::new())),
             is_connected: Arc::new(Mutex::new(false)),
+            read_buffer: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
-    async fn handle_data(&self, data: Vec<u8>) -> Result<()> {
-        tracing::info!("📥 handle_data called: {} bytes", data.len());
-        if data.is_empty() {
+    async fn handle_data(&self, incoming: Vec<u8>) -> Result<()> {
+        if incoming.is_empty() {
             return Ok(());
         }
 
-        tracing::info!("📥 First byte: {:#04x}", data[0]);
+        self.read_buffer.lock().await.extend(incoming);
+
         let handlers = self.handlers.lock().await.clone();
 
-        if data[0] == 0x00 {
-            if data.len() >= 3 {
+        loop {
+            let msg_bytes = {
+                let mut buf = self.read_buffer.lock().await;
+                if buf.is_empty() {
+                    return Ok(());
+                }
+
+                let first_byte = buf[0];
+                if first_byte == 0x00 {
+                    if buf.len() < 3 {
+                        return Ok(());
+                    }
+                    let msg = buf[..3].to_vec();
+                    buf.drain(..3);
+                    Some((msg, false))
+                } else if first_byte == PREFIX_RAW {
+                    if buf.len() < RAW_HEADER_LENGTH {
+                        return Ok(());
+                    }
+                    let code =
+                        u32::from_be_bytes([buf[3], buf[4], buf[5], buf[6]]);
+                    let fin_flag = (code & 0xffff) as u16;
+                    if fin_flag == CODE_FIN {
+                        if buf.len() == RAW_HEADER_LENGTH {
+                            return Ok(());
+                        }
+                        let msg = buf.clone();
+                        buf.clear();
+                        Some((msg, false))
+                    } else if buf.len() < RAW_CHUNK_HEADER_LENGTH {
+                        return Ok(());
+                    } else {
+                        let payload_len =
+                            u32::from_be_bytes([buf[7], buf[8], buf[9], buf[10]]) as usize;
+                        let total = RAW_CHUNK_HEADER_LENGTH + payload_len;
+                        if buf.len() < total {
+                            return Ok(());
+                        }
+                        let msg = buf[..total].to_vec();
+                        buf.drain(..total);
+                        Some((msg, false))
+                    }
+                } else if first_byte < 127 {
+                    let payload_len = first_byte as usize * 4;
+                    let total = 1 + payload_len;
+                    if buf.len() < total {
+                        return Ok(());
+                    }
+                    let msg = buf[..total].to_vec();
+                    buf.drain(..total);
+                    Some((msg, false))
+                } else if first_byte == PREFIX_EXTENDED {
+                    if buf.len() < 4 {
+                        return Ok(());
+                    }
+                    let payload_len =
+                        u32::from_le_bytes([buf[1], buf[2], buf[3], 0]) as usize * 4;
+                    let total = 4 + payload_len;
+                    if buf.len() < total {
+                        return Ok(());
+                    }
+                    let msg = buf[..total].to_vec();
+                    buf.drain(..total);
+                    Some((msg, false))
+                } else {
+                    tracing::warn!(
+                        "📥 Unexpected first byte: {:#x}, skipping",
+                        first_byte
+                    );
+                    buf.drain(..1);
+                    Some((vec![], true))
+                }
+            };
+
+            let (data, skipped) = match msg_bytes {
+                Some(v) => v,
+                None => continue,
+            };
+
+            if skipped {
+                continue;
+            }
+
+            tracing::info!("📥 process_message: {} bytes", data.len());
+
+            if data[0] == 0x00 {
                 let cid = u16::from_be_bytes([data[1], data[2]]);
                 tracing::info!("📨 PONG: cid={}", cid);
                 handlers.trigger_message(cid, 0, vec![]);
+                continue;
             }
-            return Ok(());
-        }
 
-        if data[0] == PREFIX_RAW {
-            tracing::info!("📥 RAW API response detected");
-            if data.len() < RAW_HEADER_LENGTH {
-                return Ok(());
-            }
-            let cid = u16::from_be_bytes([data[1], data[2]]);
-            let code = u32::from_be_bytes([data[3], data[4], data[5], data[6]]);
-            tracing::info!("📥 RAW: cid={} code={:#x}", cid, code);
+            if data[0] == PREFIX_RAW {
+                let cid = u16::from_be_bytes([data[1], data[2]]);
+                let code = u32::from_be_bytes([data[3], data[4], data[5], data[6]]);
+                let response_code = (code >> 16) & 0xffff;
+                let fin_flag = (code & 0xffff) as u16;
 
-            if data.len() < PAYLOAD_HEADER_LENGTH {
-                handlers.trigger_message(cid, code, vec![]);
-                return Ok(());
+                let (payload, payload_len) = if fin_flag == CODE_FIN {
+                    (data[RAW_HEADER_LENGTH..].to_vec(), data.len() - RAW_HEADER_LENGTH)
+                } else {
+                    let len = u32::from_be_bytes([data[7], data[8], data[9], data[10]]) as usize;
+                    (data[RAW_CHUNK_HEADER_LENGTH..RAW_CHUNK_HEADER_LENGTH + len].to_vec(), len)
+                };
+
+                tracing::info!(
+                    "📥 RAW: cid={} code={:#x} response_code={} fin_flag={:#x} payload_len={}",
+                    cid,
+                    code,
+                    response_code,
+                    fin_flag,
+                    payload_len
+                );
+
+                let mut streams = self.streams.lock().await;
+                if fin_flag == CODE_FIN {
+                    let chunks = streams.entry(cid).or_insert_with(Vec::new);
+                    if payload_len > 0 {
+                        chunks.push(payload);
+                    }
+                    let complete_buffer: Vec<u8> = chunks.concat();
+                    tracing::info!(
+                        "📨 Complete API response: cid={} code={} len={} bytes",
+                        cid,
+                        response_code,
+                        complete_buffer.len()
+                    );
+                    handlers.trigger_message(cid, response_code, complete_buffer);
+                    streams.remove(&cid);
+                } else {
+                    let chunks = streams.entry(cid).or_insert_with(Vec::new);
+                    chunks.push(payload);
+                    tracing::info!(
+                        "📥 Buffered chunk for cid={} ({} total)",
+                        cid,
+                        chunks.len()
+                    );
+                }
+                continue;
             }
-            let payload_len = u32::from_be_bytes([data[7], data[8], data[9], data[10]]) as usize;
-            let payload = if data.len() >= PAYLOAD_HEADER_LENGTH + payload_len {
-                data[PAYLOAD_HEADER_LENGTH..PAYLOAD_HEADER_LENGTH + payload_len].to_vec()
+
+            let (header_size, payload_length) = if data[0] < 127 {
+                tracing::info!(
+                    "📥 Standard msg: 1-byte header ({}*4={}bytes)",
+                    data[0],
+                    data[0] as usize * 4
+                );
+                (1, data[0] as usize * 4)
             } else {
-                vec![]
+                let len =
+                    u32::from_le_bytes([data[1], data[2], data[3], 0]) as usize * 4;
+                tracing::info!("📥 Extended msg: len={}", len);
+                (4, len)
             };
 
-            let response_code = (code >> 16) & 0xffff;
-            let fin_flag = (code & 0xffff) as u16;
+            let payload = &data[header_size..header_size + payload_length];
             tracing::info!(
-                "📥 RAW: response_code={} fin_flag={:#x} payload_len={}",
-                response_code,
-                fin_flag,
-                payload_len
+                "📨 Std msg payload: {} bytes {:02x?}",
+                payload.len(),
+                &payload[..payload.len().min(32)]
             );
 
-            let mut streams = self.streams.lock().await;
-            if fin_flag == CODE_FIN {
-                let chunks = streams.entry(cid).or_insert_with(Vec::new);
-                if payload_len > 0 {
-                    chunks.push(payload);
-                }
-                let complete_buffer: Vec<u8> = chunks.concat();
-                tracing::info!(
-                    "📨 Complete API response: cid={} code={} len={} bytes",
-                    cid,
-                    response_code,
-                    complete_buffer.len()
-                );
-                handlers.trigger_message(cid, response_code, complete_buffer);
-                streams.remove(&cid);
+            if let Ok(envelope) = mezon_proto::realtime::Envelope::decode(payload) {
+                tracing::info!("📨 Envelope decoded: cid={}", envelope.cid);
+                handlers.trigger_message(envelope.cid as u16, 0, payload.to_vec());
             } else {
-                let chunks = streams.entry(cid).or_insert_with(Vec::new);
-                chunks.push(payload);
-                tracing::info!("📥 Buffered chunk for cid={} ({} total)", cid, chunks.len());
+                let cid = decode_cid_field(payload).unwrap_or(0);
+                tracing::warn!("📨 Failed to decode Envelope, passing raw cid={cid}");
+                handlers.trigger_message(cid, 0, payload.to_vec());
             }
-            return Ok(());
         }
-
-        let (header_size, payload_length) = if data[0] < 127 {
-            tracing::info!(
-                "📥 Standard msg: 1-byte header ({}*4={}bytes)",
-                data[0],
-                data[0] as usize * 4
-            );
-            (1, data[0] as usize * 4)
-        } else if data[0] == PREFIX_EXTENDED {
-            if data.len() < 4 {
-                return Ok(());
-            }
-            let len = u32::from_le_bytes([data[1], data[2], data[3], 0]) as usize * 4;
-            tracing::info!("📥 Extended msg: len={}", len);
-            (4, len)
-        } else {
-            tracing::warn!(
-                "📥 Unexpected first byte: {:#x}, raw={:02x?}",
-                data[0],
-                &data[..data.len().min(32)]
-            );
-            return Ok(());
-        };
-
-        if data.len() < header_size + payload_length {
-            tracing::warn!(
-                "📥 Incomplete packet: have {} need {}",
-                data.len(),
-                header_size + payload_length
-            );
-            return Ok(());
-        }
-
-        let payload = &data[header_size..header_size + payload_length];
-        tracing::info!(
-            "📨 Std msg payload: {} bytes {:02x?}",
-            payload.len(),
-            &payload[..payload.len().min(32)]
-        );
-
-        if let Ok(envelope) = mezon_proto::realtime::Envelope::decode(payload) {
-            tracing::info!("📨 Envelope decoded: cid={}", envelope.cid);
-            handlers.trigger_message(envelope.cid as u16, 0, payload.to_vec());
-        } else {
-            let cid = decode_cid_field(payload).unwrap_or(0);
-            tracing::warn!("📨 Failed to decode Envelope, passing raw cid={cid}");
-            handlers.trigger_message(cid, 0, payload.to_vec());
-        }
-
-        Ok(())
     }
 
     async fn io_loop(
@@ -215,6 +278,7 @@ impl AbridgedTcpAdapter {
         handlers: Arc<Mutex<AdapterHandlers>>,
         streams: Arc<Mutex<HashMap<u16, Vec<Vec<u8>>>>>,
         is_connected: Arc<Mutex<bool>>,
+        read_buffer: Arc<Mutex<Vec<u8>>>,
     ) {
         let mut read_buf = vec![0u8; 8192];
         let mut read_count = 0u64;
@@ -247,6 +311,7 @@ impl AbridgedTcpAdapter {
                                 handlers: handlers.clone(),
                                 streams: streams.clone(),
                                 is_connected: is_connected.clone(),
+                                read_buffer: read_buffer.clone(),
                             };
                             if let Err(e) = adapter.handle_data(data).await {
                                 tracing::error!("✗ handle_data error: {}", e);
@@ -372,10 +437,11 @@ impl TransportAdapter for AbridgedTcpAdapter {
         let h = self.handlers.clone();
         let st = self.streams.clone();
         let ic = self.is_connected.clone();
+        let rb = self.read_buffer.clone();
 
         tracing::info!("🔌 Spawning I/O loop...");
         tokio::spawn(async move {
-            Self::io_loop(tls, write_rx, ready_tx, h, st, ic).await;
+            Self::io_loop(tls, write_rx, ready_tx, h, st, ic, rb).await;
         });
 
         // Wait for I/O loop to signal readiness

--- a/crates/mezon-client/src/app_api.rs
+++ b/crates/mezon-client/src/app_api.rs
@@ -25,6 +25,10 @@ impl AppApi {
         self.transport.list_channel_descs(clan_id).await
     }
 
+    pub async fn list_channel_by_user_id(&self) -> Result<Vec<ApiChannelDesc>> {
+        self.transport.list_channel_by_user_id().await
+    }
+
     pub async fn list_clan_descs(&self) -> Result<Vec<ApiClanDesc>> {
         self.transport.list_clan_descs().await
     }

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -239,6 +239,11 @@ pub struct ApiChannelDesc {
     pub channel_id: String,
     pub channel_label: String,
     pub channel_type: u32,
+    pub clan_id: String,
+    pub category_name: String,
+    pub category_id: String,
+    pub channel_private: i32,
+    pub count_mess_unread: i32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -298,6 +303,11 @@ impl MezonTransport {
             channel_id: channel.channel_id.to_string(),
             channel_label: channel.channel_label,
             channel_type: channel.r#type as u32,
+            clan_id: channel.clan_id.to_string(),
+            category_name: channel.category_name,
+            category_id: channel.category_id.to_string(),
+            channel_private: channel.channel_private,
+            count_mess_unread: channel.count_mess_unread,
         }
     }
 
@@ -913,7 +923,7 @@ impl MezonTransport {
     }
 
     /// List channels by user ID.
-    pub async fn list_channel_by_user_id(&self) -> Result<api::ChannelDescList> {
+    pub async fn list_channel_by_user_id(&self) -> Result<Vec<ApiChannelDesc>> {
         let cid = self.generate_cid();
         let (code, response) = self
             .send_api_request(cid, "ListChannelByUserId", Vec::new())
@@ -921,7 +931,12 @@ impl MezonTransport {
         if code != 0 {
             return Err(anyhow::anyhow!("API error: code={}", code));
         }
-        Ok(api::ChannelDescList::decode(response.as_slice())?)
+        let channel_list = api::ChannelDescList::decode(response.as_slice())?;
+        Ok(channel_list
+            .channeldesc
+            .into_iter()
+            .map(Self::channel_desc_from_proto)
+            .collect())
     }
 
     /// Get notification settings for a clan.

--- a/crates/mezon-client/src/transport_runtime.rs
+++ b/crates/mezon-client/src/transport_runtime.rs
@@ -123,6 +123,18 @@ impl TransportClient {
             .expect("Transport task panicked")
     }
 
+    /// List channels for the current user over the shared transport.
+    pub async fn list_channel_by_user_id(&self) -> Result<Vec<crate::transport::ApiChannelDesc>> {
+        tracing::info!("📞 TransportClient::list_channel_by_user_id() called");
+
+        let transport = self.inner.clone();
+
+        runtime()
+            .spawn(async move { transport.list_channel_by_user_id().await })
+            .await
+            .expect("Transport task panicked")
+    }
+
     /// List clan descriptions over the shared transport.
     pub async fn list_clan_descs(&self) -> Result<Vec<crate::transport::ApiClanDesc>> {
         tracing::info!("📞 TransportClient::list_clan_descs() called");

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -1,3 +1,5 @@
+use mezon_client::transport::ApiChannelDesc;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChannelType {
     Text,
@@ -11,6 +13,9 @@ pub struct Channel {
     pub channel_type: ChannelType,
     pub unread: bool,
     pub private: bool,
+    pub clan_id: String,
+    pub category_name: String,
+    pub category_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -65,5 +70,20 @@ impl ChannelList {
             .iter()
             .flat_map(|category| &category.channels)
             .find(|channel| channel.id == channel_id)
+    }
+}
+
+impl From<ApiChannelDesc> for Channel {
+    fn from(c: ApiChannelDesc) -> Self {
+        Self {
+            id: c.channel_id,
+            name: c.channel_label,
+            channel_type: ChannelType::Text,
+            unread: c.count_mess_unread > 0,
+            private: c.channel_private != 0,
+            clan_id: c.clan_id,
+            category_name: c.category_name,
+            category_id: Some(c.category_id).filter(|s| !s.is_empty() && s != "0"),
+        }
     }
 }

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -141,6 +141,8 @@ pub enum AuthState {
     /// OAuth2 browser was opened; waiting for the `mezonapp://callback` deep link.
     /// Kept for future OAuth integration.
     AwaitingCallback,
-    /// Token received and session is valid.
+    /// TCP transport handshake in progress — loading screen visible.
+    Connecting(Session),
+    /// Token received, transport connected, and session is valid.
     Authenticated(Session),
 }

--- a/crates/mezon-ui/src/channel_sidebar.rs
+++ b/crates/mezon-ui/src/channel_sidebar.rs
@@ -26,6 +26,22 @@ fn on_channel_click(
     }
 }
 
+fn on_category_click(
+    sidebar: Entity<ChannelSidebar>,
+    category_name: String,
+) -> impl Fn(&ClickEvent, &mut Window, &mut App) {
+    move |_: &ClickEvent, _: &mut Window, cx: &mut App| {
+        sidebar.update(cx, |this, cx| {
+            if this.collapsed.contains(&category_name) {
+                this.collapsed.remove(&category_name);
+            } else {
+                this.collapsed.insert(category_name.clone());
+            }
+            cx.notify();
+        });
+    }
+}
+
 pub struct ChannelSidebar {
     clan_list: Entity<ClanList>,
     channel_list: Entity<ChannelList>,
@@ -113,13 +129,13 @@ impl Render for ChannelSidebar {
                     .flex_col()
                     .flex_1()
                     .children(categories.into_iter().map(
-                        move |(cat_name, is_collapsed, cat_channels)| {
-                            let cat_name2 = cat_name.clone();
+                        move |(category_name, is_collapsed, category_channels)| {
+                            let category_name = category_name.clone();
                             let nav = on_navigate.clone();
                             let clan_id_for_nav = active_clan_id_for_nav.clone();
 
                             let mut header = div()
-                                .id(SharedString::from(format!("cat-{}", cat_name)))
+                                .id(SharedString::from(format!("cat-{}", category_name)))
                                 .flex()
                                 .flex_row()
                                 .items_center()
@@ -139,21 +155,11 @@ impl Render for ChannelSidebar {
                                     .size(px(12.0))
                                     .text_color(theme_clone.text_muted),
                                 )
-                                .child(div().ml_1().child(cat_name.clone()));
+                                .child(div().ml_1().child(category_name.clone()));
 
-                            let sidebar_for_cat = sidebar_entity.clone();
-                            header.interactivity().on_click(
-                                move |_: &ClickEvent, _: &mut Window, cx: &mut App| {
-                                    sidebar_for_cat.update(cx, |this, cx| {
-                                        if this.collapsed.contains(&cat_name2) {
-                                            this.collapsed.remove(&cat_name2);
-                                        } else {
-                                            this.collapsed.insert(cat_name2.clone());
-                                        }
-                                        cx.notify();
-                                    });
-                                },
-                            );
+                            header
+                                .interactivity()
+                                .on_click(on_category_click(sidebar_entity.clone(), category_name));
 
                             div()
                                 .flex()
@@ -162,7 +168,7 @@ impl Render for ChannelSidebar {
                                 .children(if is_collapsed {
                                     vec![]
                                 } else {
-                                    cat_channels
+                                    category_channels
                                         .iter()
                                         .map(|ch| {
                                             let ch_id = ch.id.clone();

--- a/crates/mezon-ui/src/chat_layout.rs
+++ b/crates/mezon-ui/src/chat_layout.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use gpui::{App, AsyncApp, Context, Entity, FontWeight, Window, div, prelude::*, px};
+use gpui::{App, Context, Entity, FontWeight, Window, div, prelude::*, px};
 use mezon_client::AppApi;
 use mezon_store::{AuthState, Category, Channel, ChannelList, Clan, ClanList};
 
@@ -39,20 +39,8 @@ fn group_channels_by_category(channels: Vec<Channel>) -> Vec<Category> {
     categories
 }
 
-async fn wait_for_api_ready(api: &AppApi, cx: &AsyncApp) {
-    loop {
-        if api.is_open().await && api.ping_roundtrip().await.is_ok() {
-            break;
-        }
-        cx.background_executor()
-            .timer(std::time::Duration::from_millis(1000))
-            .await;
-    }
-}
-
 fn spawn_clan_list_fetcher(api: Arc<AppApi>, clan_list: Entity<ClanList>, cx: &mut App) {
     cx.spawn(async move |cx| {
-        wait_for_api_ready(&api, cx).await;
         tracing::info!("Fetching clan list...");
         match api.list_clan_descs().await {
             Ok(clans) => {
@@ -81,8 +69,6 @@ fn spawn_channel_list_fetcher(
     cx: &mut App,
 ) {
     cx.spawn(async move |cx| {
-        wait_for_api_ready(&api, cx).await;
-
         let mut last_clan_id: Option<String> = None;
         let mut error_count: u32 = 0;
         const MAX_CONSECUTIVE_ERRORS: u32 = 5;
@@ -133,6 +119,10 @@ pub struct ChatLayout {
     clan_sidebar: Entity<ClanSidebar>,
     channel_sidebar: Entity<ChannelSidebar>,
     user_info_bar: UserInfoBar,
+    /// Guard: spawn data fetchers only on the first render call.
+    fetchers_spawned: bool,
+    api: Arc<AppApi>,
+    clan_list: Entity<ClanList>,
 }
 
 impl ChatLayout {
@@ -167,21 +157,31 @@ impl ChatLayout {
         let _ = cx.observe(&channel_list, |_, _, cx| cx.notify());
         let _ = cx.observe(&clan_list, |_, _, cx| cx.notify());
 
-        spawn_clan_list_fetcher(api.clone(), clan_list.clone(), cx);
-
-        spawn_channel_list_fetcher(api.clone(), clan_list.clone(), channel_list.clone(), cx);
         Self {
             router,
             channel_list,
             clan_sidebar,
             channel_sidebar,
             user_info_bar,
+            fetchers_spawned: false,
+            api,
+            clan_list,
         }
     }
 }
 
 impl Render for ChatLayout {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if !self.fetchers_spawned {
+            self.fetchers_spawned = true;
+            spawn_clan_list_fetcher(self.api.clone(), self.clan_list.clone(), cx);
+            spawn_channel_list_fetcher(
+                self.api.clone(),
+                self.clan_list.clone(),
+                self.channel_list.clone(),
+                cx,
+            );
+        }
         let theme = Theme::dark();
         let channels = self.channel_list.read(cx);
 

--- a/crates/mezon-ui/src/chat_layout.rs
+++ b/crates/mezon-ui/src/chat_layout.rs
@@ -1,13 +1,131 @@
 use std::sync::Arc;
 
-use gpui::{Context, Entity, FontWeight, Window, div, prelude::*, px};
+use gpui::{App, AsyncApp, Context, Entity, FontWeight, Window, div, prelude::*, px};
 use mezon_client::AppApi;
-use mezon_store::{AuthState, ChannelList, Clan, ClanList};
+use mezon_store::{AuthState, Category, Channel, ChannelList, Clan, ClanList};
 
 use crate::components::compositions::user_info_bar::UserInfoBar;
 use crate::router::{Route, Router};
 use crate::theme::Theme;
 use crate::{ChannelSidebar, ClanSidebar};
+
+/// Group flat channels into categories by `category_name`.
+/// Channels with an empty `category_name` are placed into a "General" category.
+fn group_channels_by_category(channels: Vec<Channel>) -> Vec<Category> {
+    let mut map: std::collections::HashMap<String, Vec<Channel>> = std::collections::HashMap::new();
+
+    for ch in channels {
+        let cat_name = if ch.category_name.is_empty() {
+            "General".to_string()
+        } else {
+            ch.category_name.clone()
+        };
+        map.entry(cat_name).or_default().push(ch);
+    }
+
+    let mut categories: Vec<Category> = map
+        .into_iter()
+        .map(|(name, chs)| {
+            let clan_id = chs.first().map(|ch| ch.clan_id.clone()).unwrap_or_default();
+            Category {
+                clan_id,
+                name,
+                channels: chs,
+            }
+        })
+        .collect();
+
+    categories.sort_by(|a, b| a.name.cmp(&b.name));
+    categories
+}
+
+async fn wait_for_api_ready(api: &AppApi, cx: &AsyncApp) {
+    loop {
+        if api.is_open().await && api.ping_roundtrip().await.is_ok() {
+            break;
+        }
+        cx.background_executor()
+            .timer(std::time::Duration::from_millis(1000))
+            .await;
+    }
+}
+
+fn spawn_clan_list_fetcher(api: Arc<AppApi>, clan_list: Entity<ClanList>, cx: &mut App) {
+    cx.spawn(async move |cx| {
+        wait_for_api_ready(&api, cx).await;
+        tracing::info!("Fetching clan list...");
+        match api.list_clan_descs().await {
+            Ok(clans) => {
+                tracing::info!("Fetched {} clans", clans.len());
+                if !clans.is_empty() {
+                    let store_clans: Vec<Clan> = clans.into_iter().map(Clan::from).collect();
+                    clan_list.update(cx, |model, cx| {
+                        model.update_clans(store_clans);
+                        cx.notify();
+                    });
+                    tracing::info!("Updated ClanList with real data");
+                }
+            }
+            Err(e) => {
+                tracing::error!("Failed to fetch clan list: {}", e);
+            }
+        }
+    })
+    .detach();
+}
+
+fn spawn_channel_list_fetcher(
+    api: Arc<AppApi>,
+    clan_list: Entity<ClanList>,
+    channel_list: Entity<ChannelList>,
+    cx: &mut App,
+) {
+    cx.spawn(async move |cx| {
+        wait_for_api_ready(&api, cx).await;
+
+        let mut last_clan_id: Option<String> = None;
+        let mut error_count: u32 = 0;
+        const MAX_CONSECUTIVE_ERRORS: u32 = 5;
+        loop {
+            let current_clan_id: Option<String> =
+                cx.update(|app| clan_list.read(app).active_clan_id.clone());
+            if current_clan_id.is_some() && current_clan_id != last_clan_id {
+                if let Some(ref clan_id) = current_clan_id {
+                    match api.list_channel_by_user_id().await {
+                        Ok(api_channels) => {
+                            error_count = 0;
+                            let clan_channels: Vec<Channel> = api_channels
+                                .into_iter()
+                                .filter(|c| c.clan_id == *clan_id)
+                                .map(Channel::from)
+                                .collect();
+                            let categories = group_channels_by_category(clan_channels);
+                            channel_list.update(cx, |list, cx| {
+                                list.categories = categories;
+                                cx.notify();
+                            });
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to fetch channels: {}", e);
+                            error_count += 1;
+                            if error_count >= MAX_CONSECUTIVE_ERRORS {
+                                tracing::error!(
+                                    "Too many consecutive channel fetch failures, stopping watcher"
+                                );
+                                break;
+                            }
+                        }
+                    }
+                }
+                last_clan_id = current_clan_id;
+            }
+            cx.background_executor()
+                .timer(std::time::Duration::from_millis(500))
+                .await;
+        }
+    })
+    .detach();
+}
 
 pub struct ChatLayout {
     router: Router,
@@ -49,40 +167,9 @@ impl ChatLayout {
         let _ = cx.observe(&channel_list, |_, _, cx| cx.notify());
         let _ = cx.observe(&clan_list, |_, _, cx| cx.notify());
 
-        let api_clone = api.clone();
-        let clan_list_clone = clan_list.clone();
-        cx.spawn(async move |_, cx| {
-            // Wait for connection to be fully ready (TCP open + handshake)
-            loop {
-                if api_clone.is_open().await && api_clone.ping_roundtrip().await.is_ok() {
-                    break;
-                }
-                cx.background_executor()
-                    .timer(std::time::Duration::from_millis(1000))
-                    .await;
-            }
+        spawn_clan_list_fetcher(api.clone(), clan_list.clone(), cx);
 
-            tracing::info!("🔍 Investigation: Fetching real clan list...");
-            match api_clone.list_clan_descs().await {
-                Ok(clans) => {
-                    tracing::info!("✅ Investigation: Fetched {} clans", clans.len());
-                    if !clans.is_empty() {
-                        let store_clans: Vec<Clan> = clans.into_iter().map(Clan::from).collect();
-
-                        clan_list_clone.update(cx, |model, cx| {
-                            model.update_clans(store_clans);
-                            cx.notify();
-                        });
-                        tracing::info!("✅ Updated ClanList with real data");
-                    }
-                }
-                Err(e) => {
-                    tracing::error!("❌ Investigation: Failed to fetch clan list: {}", e);
-                }
-            }
-        })
-        .detach();
-
+        spawn_channel_list_fetcher(api.clone(), clan_list.clone(), channel_list.clone(), cx);
         Self {
             router,
             channel_list,

--- a/crates/mezon-ui/src/clan_sidebar.rs
+++ b/crates/mezon-ui/src/clan_sidebar.rs
@@ -4,19 +4,18 @@ use mezon_store::ClanList;
 use gpui_component::Sizable;
 
 use crate::components::primitives::{Avatar, Badge, Icon, IconName, Size};
+use crate::text_utils::compute_initials;
 use crate::theme::Theme;
 
-fn compute_initials(name: &str) -> String {
-    let initials: String = name
-        .split_whitespace()
-        .take(2)
-        .filter_map(|s| s.chars().next())
-        .collect::<String>()
-        .to_uppercase();
-    if initials.is_empty() {
-        "?".to_string()
-    } else {
-        initials
+fn on_clan_click(
+    clan_list: Entity<ClanList>,
+    clan_id: String,
+) -> impl Fn(&ClickEvent, &mut Window, &mut App) {
+    move |_: &ClickEvent, _: &mut Window, cx: &mut App| {
+        clan_list.update(cx, |m, cx| {
+            m.select_clan(&clan_id);
+            cx.notify();
+        });
     }
 }
 
@@ -81,14 +80,9 @@ impl Render for ClanSidebar {
                             )
                         });
 
-                    clan_div.interactivity().on_click(
-                        move |_event: &ClickEvent, _window: &mut Window, cx: &mut App| {
-                            clan_list_handle.update(cx, |m, cx| {
-                                m.select_clan(&clan_id);
-                                cx.notify();
-                            });
-                        },
-                    );
+                    clan_div
+                        .interactivity()
+                        .on_click(on_clan_click(clan_list_handle, clan_id));
 
                     let clan_initials = compute_initials(&clan.name);
 

--- a/crates/mezon-ui/src/components/compositions/user_info_bar.rs
+++ b/crates/mezon-ui/src/components/compositions/user_info_bar.rs
@@ -3,23 +3,19 @@ use gpui::{App, ClickEvent, Entity, SharedString, Window, div, prelude::*, px};
 use gpui_component::Sizable;
 
 use crate::components::primitives::{Avatar, Icon, IconName, Size};
+use crate::text_utils::compute_initials;
 use crate::theme::Theme;
 use mezon_store::AuthState;
 
-fn compute_initials(name: &str) -> String {
-    let initials: String = name
-        .split_whitespace()
-        .take(2)
-        .filter_map(|s| s.chars().next())
-        .collect::<String>()
-        .to_uppercase();
-    if initials.is_empty() {
-        "?".to_string()
-    } else {
-        initials
+fn on_settings_click(
+    on_settings: Option<crate::components::NavigateFn>,
+) -> impl Fn(&ClickEvent, &mut Window, &mut App) {
+    move |_: &ClickEvent, _: &mut Window, cx: &mut App| {
+        if let Some(ref cb) = on_settings {
+            cb("/settings", cx);
+        }
     }
 }
-
 pub struct UserInfoBar {
     auth_state: Entity<AuthState>,
     presence: String,
@@ -57,7 +53,6 @@ impl UserInfoBar {
             _ => theme.status_offline,
         };
 
-        let on_settings = self.on_settings.clone();
         let mut settings_btn = div()
             .id(SharedString::from("settings-btn"))
             .cursor_pointer()
@@ -66,13 +61,9 @@ impl UserInfoBar {
                     .size(px(16.0))
                     .text_color(theme.text_muted),
             );
-        settings_btn.interactivity().on_click(
-            move |_: &ClickEvent, _: &mut Window, cx: &mut App| {
-                if let Some(ref cb) = on_settings {
-                    cb("/settings", cx);
-                }
-            },
-        );
+        settings_btn
+            .interactivity()
+            .on_click(on_settings_click(self.on_settings.clone()));
 
         div()
             .flex()

--- a/crates/mezon-ui/src/lib.rs
+++ b/crates/mezon-ui/src/lib.rs
@@ -9,6 +9,7 @@ pub mod main_layout;
 pub mod root;
 pub mod router;
 pub mod settings_screen;
+pub mod text_utils;
 pub mod theme;
 pub mod title_bar;
 

--- a/crates/mezon-ui/src/login_view.rs
+++ b/crates/mezon-ui/src/login_view.rs
@@ -279,8 +279,8 @@ impl LoginView {
         tracing::info!("  TCP URL: {:?}", session.tcp_url);
 
         auth_state.update(cx, |state, cx| {
-            *state = AuthState::Authenticated(session);
-            tracing::debug!("User authenticated, transitioning to main app view.");
+            *state = AuthState::Connecting(session);
+            tracing::debug!("User authenticated, connecting transport.");
             cx.notify();
         });
     }

--- a/crates/mezon-ui/src/root.rs
+++ b/crates/mezon-ui/src/root.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
 use gpui::{App, ClickEvent, Context, Entity, FontWeight, Window, div, prelude::*};
+use gpui_component::Sizable;
 use mezon_client::{AppApi, MezonClient};
 use mezon_store::AuthState;
 
 use crate::chat_layout::ChatLayout;
-use crate::components::primitives::{Button, Icon, IconName};
+use crate::components::primitives::{Button, Icon, IconName, Size, Spinner};
 use crate::login_view::LoginView;
 use crate::router::{Route, Router};
 use crate::settings_screen::SettingsScreen;
@@ -83,6 +84,7 @@ impl Render for RootView {
                 self.login_view.clone().into_any_element()
             }
             AuthState::AwaitingCallback => render_awaiting_callback(&theme),
+            AuthState::Connecting(_) => render_connecting(&theme),
             AuthState::Authenticated(_) => {
                 let route = self.router.route();
                 match route {
@@ -125,6 +127,29 @@ fn render_awaiting_callback(theme: &Theme) -> gpui::AnyElement {
                 .text_sm()
                 .text_color(theme.text_secondary)
                 .child("Connecting - complete sign-in in your browser..."),
+        )
+        .into_any_element()
+}
+
+fn render_connecting(theme: &Theme) -> gpui::AnyElement {
+    div()
+        .flex()
+        .flex_1()
+        .items_center()
+        .justify_center()
+        .flex_col()
+        .gap_4()
+        .child(
+            Spinner::new()
+                .with_size(Size::Large)
+                .color(theme.brand.into()),
+        )
+        .child(
+            div()
+                .text_xl()
+                .font_weight(FontWeight::BOLD)
+                .text_color(theme.text_primary)
+                .child("Loading..."),
         )
         .into_any_element()
 }

--- a/crates/mezon-ui/src/text_utils.rs
+++ b/crates/mezon-ui/src/text_utils.rs
@@ -1,0 +1,13 @@
+pub fn compute_initials(name: &str) -> String {
+    let initials: String = name
+        .split_whitespace()
+        .take(2)
+        .filter_map(|s| s.chars().next())
+        .collect::<String>()
+        .to_uppercase();
+    if initials.is_empty() {
+        "?".to_string()
+    } else {
+        initials
+    }
+}


### PR DESCRIPTION
## Description
Previously ApiChannelDesc only carried channel_id and channel_label,
and the channel listing endpoints returned raw protobuf types without
converting to the app-level ApiChannelDesc.

## Changes:
- Extend ApiChannelDesc with clan_id, category_name, category_id,
  channel_private, and count_mess_unread to match the actual API
  response shape
- Expose list_channel_by_user_id through AppApi and TransportClient,
  returning Vec<ApiChannelDesc> with proper proto-to-model conversion
  via channel_desc_from_proto
- Add channel_desc_from_proto helper to map new fields from protobuf

## Image
<img width="1285" height="724" alt="image" src="https://github.com/user-attachments/assets/6b318417-2078-4896-8901-c5b353009030" />
