### PR TITLE
Fix RAW API response parsing for TCP-fragmented packets

### DIFF
--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -196,7 +196,7 @@ fn spawn_transport_task(
             //     tracing::warn!("Authenticated session missing tcp_port; TCP APIs unavailable");
             //     continue;
             // };
-            let port = 7349;
+            let port = 4433;
 
             if transport.is_open().await
                 && let Err(e) = transport.close().await

--- a/crates/mezon-client/src/abridged_tcp_adapter.rs
+++ b/crates/mezon-client/src/abridged_tcp_adapter.rs
@@ -117,8 +117,7 @@ impl AbridgedTcpAdapter {
                     if buf.len() < RAW_HEADER_LENGTH {
                         return Ok(());
                     }
-                    let code =
-                        u32::from_be_bytes([buf[3], buf[4], buf[5], buf[6]]);
+                    let code = u32::from_be_bytes([buf[3], buf[4], buf[5], buf[6]]);
                     let fin_flag = (code & 0xffff) as u16;
                     if fin_flag == CODE_FIN {
                         if buf.len() == RAW_HEADER_LENGTH {
@@ -153,8 +152,7 @@ impl AbridgedTcpAdapter {
                     if buf.len() < 4 {
                         return Ok(());
                     }
-                    let payload_len =
-                        u32::from_le_bytes([buf[1], buf[2], buf[3], 0]) as usize * 4;
+                    let payload_len = u32::from_le_bytes([buf[1], buf[2], buf[3], 0]) as usize * 4;
                     let total = 4 + payload_len;
                     if buf.len() < total {
                         return Ok(());
@@ -163,10 +161,7 @@ impl AbridgedTcpAdapter {
                     buf.drain(..total);
                     Some((msg, false))
                 } else {
-                    tracing::warn!(
-                        "📥 Unexpected first byte: {:#x}, skipping",
-                        first_byte
-                    );
+                    tracing::warn!("📥 Unexpected first byte: {:#x}, skipping", first_byte);
                     buf.drain(..1);
                     Some((vec![], true))
                 }
@@ -197,10 +192,16 @@ impl AbridgedTcpAdapter {
                 let fin_flag = (code & 0xffff) as u16;
 
                 let (payload, payload_len) = if fin_flag == CODE_FIN {
-                    (data[RAW_HEADER_LENGTH..].to_vec(), data.len() - RAW_HEADER_LENGTH)
+                    (
+                        data[RAW_HEADER_LENGTH..].to_vec(),
+                        data.len() - RAW_HEADER_LENGTH,
+                    )
                 } else {
                     let len = u32::from_be_bytes([data[7], data[8], data[9], data[10]]) as usize;
-                    (data[RAW_CHUNK_HEADER_LENGTH..RAW_CHUNK_HEADER_LENGTH + len].to_vec(), len)
+                    (
+                        data[RAW_CHUNK_HEADER_LENGTH..RAW_CHUNK_HEADER_LENGTH + len].to_vec(),
+                        len,
+                    )
                 };
 
                 tracing::info!(
@@ -230,11 +231,7 @@ impl AbridgedTcpAdapter {
                 } else {
                     let chunks = streams.entry(cid).or_insert_with(Vec::new);
                     chunks.push(payload);
-                    tracing::info!(
-                        "📥 Buffered chunk for cid={} ({} total)",
-                        cid,
-                        chunks.len()
-                    );
+                    tracing::info!("📥 Buffered chunk for cid={} ({} total)", cid, chunks.len());
                 }
                 continue;
             }
@@ -247,8 +244,7 @@ impl AbridgedTcpAdapter {
                 );
                 (1, data[0] as usize * 4)
             } else {
-                let len =
-                    u32::from_le_bytes([data[1], data[2], data[3], 0]) as usize * 4;
+                let len = u32::from_le_bytes([data[1], data[2], data[3], 0]) as usize * 4;
                 tracing::info!("📥 Extended msg: len={}", len);
                 (4, len)
             };

--- a/crates/mezon-client/src/abridged_tcp_adapter.rs
+++ b/crates/mezon-client/src/abridged_tcp_adapter.rs
@@ -66,7 +66,7 @@ const CODE_FIN: u16 = 0xff;
 const PREFIX_RAW: u8 = 0xff;
 const PREFIX_EXTENDED: u8 = 0x7f;
 const RAW_HEADER_LENGTH: usize = 7;
-const PAYLOAD_HEADER_LENGTH: usize = 11;
+const RAW_CHUNK_HEADER_LENGTH: usize = 11;
 
 type TlsStream = tokio_rustls::client::TlsStream<TcpStream>;
 
@@ -75,6 +75,7 @@ pub struct AbridgedTcpAdapter {
     handlers: Arc<Mutex<AdapterHandlers>>,
     streams: Arc<Mutex<HashMap<u16, Vec<Vec<u8>>>>>,
     is_connected: Arc<Mutex<bool>>,
+    read_buffer: Arc<Mutex<Vec<u8>>>,
 }
 
 impl AbridgedTcpAdapter {
@@ -84,128 +85,190 @@ impl AbridgedTcpAdapter {
             handlers: Arc::new(Mutex::new(AdapterHandlers::default())),
             streams: Arc::new(Mutex::new(HashMap::new())),
             is_connected: Arc::new(Mutex::new(false)),
+            read_buffer: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
-    async fn handle_data(&self, data: Vec<u8>) -> Result<()> {
-        tracing::info!("📥 handle_data called: {} bytes", data.len());
-        if data.is_empty() {
+    async fn handle_data(&self, incoming: Vec<u8>) -> Result<()> {
+        if incoming.is_empty() {
             return Ok(());
         }
 
-        tracing::info!("📥 First byte: {:#04x}", data[0]);
+        self.read_buffer.lock().await.extend(incoming);
+
         let handlers = self.handlers.lock().await.clone();
 
-        if data[0] == 0x00 {
-            if data.len() >= 3 {
+        loop {
+            let msg_bytes = {
+                let mut buf = self.read_buffer.lock().await;
+                if buf.is_empty() {
+                    return Ok(());
+                }
+
+                let first_byte = buf[0];
+                if first_byte == 0x00 {
+                    if buf.len() < 3 {
+                        return Ok(());
+                    }
+                    let msg = buf[..3].to_vec();
+                    buf.drain(..3);
+                    Some((msg, false))
+                } else if first_byte == PREFIX_RAW {
+                    if buf.len() < RAW_HEADER_LENGTH {
+                        return Ok(());
+                    }
+                    let code =
+                        u32::from_be_bytes([buf[3], buf[4], buf[5], buf[6]]);
+                    let fin_flag = (code & 0xffff) as u16;
+                    if fin_flag == CODE_FIN {
+                        if buf.len() == RAW_HEADER_LENGTH {
+                            return Ok(());
+                        }
+                        let msg = buf.clone();
+                        buf.clear();
+                        Some((msg, false))
+                    } else if buf.len() < RAW_CHUNK_HEADER_LENGTH {
+                        return Ok(());
+                    } else {
+                        let payload_len =
+                            u32::from_be_bytes([buf[7], buf[8], buf[9], buf[10]]) as usize;
+                        let total = RAW_CHUNK_HEADER_LENGTH + payload_len;
+                        if buf.len() < total {
+                            return Ok(());
+                        }
+                        let msg = buf[..total].to_vec();
+                        buf.drain(..total);
+                        Some((msg, false))
+                    }
+                } else if first_byte < 127 {
+                    let payload_len = first_byte as usize * 4;
+                    let total = 1 + payload_len;
+                    if buf.len() < total {
+                        return Ok(());
+                    }
+                    let msg = buf[..total].to_vec();
+                    buf.drain(..total);
+                    Some((msg, false))
+                } else if first_byte == PREFIX_EXTENDED {
+                    if buf.len() < 4 {
+                        return Ok(());
+                    }
+                    let payload_len =
+                        u32::from_le_bytes([buf[1], buf[2], buf[3], 0]) as usize * 4;
+                    let total = 4 + payload_len;
+                    if buf.len() < total {
+                        return Ok(());
+                    }
+                    let msg = buf[..total].to_vec();
+                    buf.drain(..total);
+                    Some((msg, false))
+                } else {
+                    tracing::warn!(
+                        "📥 Unexpected first byte: {:#x}, skipping",
+                        first_byte
+                    );
+                    buf.drain(..1);
+                    Some((vec![], true))
+                }
+            };
+
+            let (data, skipped) = match msg_bytes {
+                Some(v) => v,
+                None => continue,
+            };
+
+            if skipped {
+                continue;
+            }
+
+            tracing::info!("📥 process_message: {} bytes", data.len());
+
+            if data[0] == 0x00 {
                 let cid = u16::from_be_bytes([data[1], data[2]]);
                 tracing::info!("📨 PONG: cid={}", cid);
                 handlers.trigger_message(cid, 0, vec![]);
+                continue;
             }
-            return Ok(());
-        }
 
-        if data[0] == PREFIX_RAW {
-            tracing::info!("📥 RAW API response detected");
-            if data.len() < RAW_HEADER_LENGTH {
-                return Ok(());
-            }
-            let cid = u16::from_be_bytes([data[1], data[2]]);
-            let code = u32::from_be_bytes([data[3], data[4], data[5], data[6]]);
-            tracing::info!("📥 RAW: cid={} code={:#x}", cid, code);
+            if data[0] == PREFIX_RAW {
+                let cid = u16::from_be_bytes([data[1], data[2]]);
+                let code = u32::from_be_bytes([data[3], data[4], data[5], data[6]]);
+                let response_code = (code >> 16) & 0xffff;
+                let fin_flag = (code & 0xffff) as u16;
 
-            if data.len() < PAYLOAD_HEADER_LENGTH {
-                handlers.trigger_message(cid, code, vec![]);
-                return Ok(());
+                let (payload, payload_len) = if fin_flag == CODE_FIN {
+                    (data[RAW_HEADER_LENGTH..].to_vec(), data.len() - RAW_HEADER_LENGTH)
+                } else {
+                    let len = u32::from_be_bytes([data[7], data[8], data[9], data[10]]) as usize;
+                    (data[RAW_CHUNK_HEADER_LENGTH..RAW_CHUNK_HEADER_LENGTH + len].to_vec(), len)
+                };
+
+                tracing::info!(
+                    "📥 RAW: cid={} code={:#x} response_code={} fin_flag={:#x} payload_len={}",
+                    cid,
+                    code,
+                    response_code,
+                    fin_flag,
+                    payload_len
+                );
+
+                let mut streams = self.streams.lock().await;
+                if fin_flag == CODE_FIN {
+                    let chunks = streams.entry(cid).or_insert_with(Vec::new);
+                    if payload_len > 0 {
+                        chunks.push(payload);
+                    }
+                    let complete_buffer: Vec<u8> = chunks.concat();
+                    tracing::info!(
+                        "📨 Complete API response: cid={} code={} len={} bytes",
+                        cid,
+                        response_code,
+                        complete_buffer.len()
+                    );
+                    handlers.trigger_message(cid, response_code, complete_buffer);
+                    streams.remove(&cid);
+                } else {
+                    let chunks = streams.entry(cid).or_insert_with(Vec::new);
+                    chunks.push(payload);
+                    tracing::info!(
+                        "📥 Buffered chunk for cid={} ({} total)",
+                        cid,
+                        chunks.len()
+                    );
+                }
+                continue;
             }
-            let payload_len = u32::from_be_bytes([data[7], data[8], data[9], data[10]]) as usize;
-            let payload = if data.len() >= PAYLOAD_HEADER_LENGTH + payload_len {
-                data[PAYLOAD_HEADER_LENGTH..PAYLOAD_HEADER_LENGTH + payload_len].to_vec()
+
+            let (header_size, payload_length) = if data[0] < 127 {
+                tracing::info!(
+                    "📥 Standard msg: 1-byte header ({}*4={}bytes)",
+                    data[0],
+                    data[0] as usize * 4
+                );
+                (1, data[0] as usize * 4)
             } else {
-                vec![]
+                let len =
+                    u32::from_le_bytes([data[1], data[2], data[3], 0]) as usize * 4;
+                tracing::info!("📥 Extended msg: len={}", len);
+                (4, len)
             };
 
-            let response_code = (code >> 16) & 0xffff;
-            let fin_flag = (code & 0xffff) as u16;
+            let payload = &data[header_size..header_size + payload_length];
             tracing::info!(
-                "📥 RAW: response_code={} fin_flag={:#x} payload_len={}",
-                response_code,
-                fin_flag,
-                payload_len
+                "📨 Std msg payload: {} bytes {:02x?}",
+                payload.len(),
+                &payload[..payload.len().min(32)]
             );
 
-            let mut streams = self.streams.lock().await;
-            if fin_flag == CODE_FIN {
-                let chunks = streams.entry(cid).or_insert_with(Vec::new);
-                if payload_len > 0 {
-                    chunks.push(payload);
-                }
-                let complete_buffer: Vec<u8> = chunks.concat();
-                tracing::info!(
-                    "📨 Complete API response: cid={} code={} len={} bytes",
-                    cid,
-                    response_code,
-                    complete_buffer.len()
-                );
-                handlers.trigger_message(cid, response_code, complete_buffer);
-                streams.remove(&cid);
+            if let Ok(envelope) = mezon_proto::realtime::Envelope::decode(payload) {
+                tracing::info!("📨 Envelope decoded: cid={}", envelope.cid);
+                handlers.trigger_message(envelope.cid as u16, 0, payload.to_vec());
             } else {
-                let chunks = streams.entry(cid).or_insert_with(Vec::new);
-                chunks.push(payload);
-                tracing::info!("📥 Buffered chunk for cid={} ({} total)", cid, chunks.len());
+                let cid = decode_cid_field(payload).unwrap_or(0);
+                tracing::warn!("📨 Failed to decode Envelope, passing raw cid={cid}");
+                handlers.trigger_message(cid, 0, payload.to_vec());
             }
-            return Ok(());
         }
-
-        let (header_size, payload_length) = if data[0] < 127 {
-            tracing::info!(
-                "📥 Standard msg: 1-byte header ({}*4={}bytes)",
-                data[0],
-                data[0] as usize * 4
-            );
-            (1, data[0] as usize * 4)
-        } else if data[0] == PREFIX_EXTENDED {
-            if data.len() < 4 {
-                return Ok(());
-            }
-            let len = u32::from_le_bytes([data[1], data[2], data[3], 0]) as usize * 4;
-            tracing::info!("📥 Extended msg: len={}", len);
-            (4, len)
-        } else {
-            tracing::warn!(
-                "📥 Unexpected first byte: {:#x}, raw={:02x?}",
-                data[0],
-                &data[..data.len().min(32)]
-            );
-            return Ok(());
-        };
-
-        if data.len() < header_size + payload_length {
-            tracing::warn!(
-                "📥 Incomplete packet: have {} need {}",
-                data.len(),
-                header_size + payload_length
-            );
-            return Ok(());
-        }
-
-        let payload = &data[header_size..header_size + payload_length];
-        tracing::info!(
-            "📨 Std msg payload: {} bytes {:02x?}",
-            payload.len(),
-            &payload[..payload.len().min(32)]
-        );
-
-        if let Ok(envelope) = mezon_proto::realtime::Envelope::decode(payload) {
-            tracing::info!("📨 Envelope decoded: cid={}", envelope.cid);
-            handlers.trigger_message(envelope.cid as u16, 0, payload.to_vec());
-        } else {
-            let cid = decode_cid_field(payload).unwrap_or(0);
-            tracing::warn!("📨 Failed to decode Envelope, passing raw cid={cid}");
-            handlers.trigger_message(cid, 0, payload.to_vec());
-        }
-
-        Ok(())
     }
 
     async fn io_loop(
@@ -215,6 +278,7 @@ impl AbridgedTcpAdapter {
         handlers: Arc<Mutex<AdapterHandlers>>,
         streams: Arc<Mutex<HashMap<u16, Vec<Vec<u8>>>>>,
         is_connected: Arc<Mutex<bool>>,
+        read_buffer: Arc<Mutex<Vec<u8>>>,
     ) {
         let mut read_buf = vec![0u8; 8192];
         let mut read_count = 0u64;
@@ -247,6 +311,7 @@ impl AbridgedTcpAdapter {
                                 handlers: handlers.clone(),
                                 streams: streams.clone(),
                                 is_connected: is_connected.clone(),
+                                read_buffer: read_buffer.clone(),
                             };
                             if let Err(e) = adapter.handle_data(data).await {
                                 tracing::error!("✗ handle_data error: {}", e);
@@ -372,10 +437,11 @@ impl TransportAdapter for AbridgedTcpAdapter {
         let h = self.handlers.clone();
         let st = self.streams.clone();
         let ic = self.is_connected.clone();
+        let rb = self.read_buffer.clone();
 
         tracing::info!("🔌 Spawning I/O loop...");
         tokio::spawn(async move {
-            Self::io_loop(tls, write_rx, ready_tx, h, st, ic).await;
+            Self::io_loop(tls, write_rx, ready_tx, h, st, ic, rb).await;
         });
 
         // Wait for I/O loop to signal readiness


### PR DESCRIPTION
## Problem
get_account (and all API calls over the shared TCP transport) always failed with either API error: code=255 or Request timed out. The RAW API response packet was consistently split across two TCP reads:

- Read 1: 7 bytes ff + cid_be_u16 + code_be_u32 (RAW header)
- Read 2: N bytes of protobuf payload

## Root causes (3 bugs)

- Missing payload_len on final chunks: The server does not send a 4-byte payload_len field for the final chunk (fin_flag = 0xff). The payload immediately follows the 7-byte header. The old code assumed payload_len was always present at bytes 7-10, computing PAYLOAD_HEADER_LENGTH = 11 — when the first 4 payload bytes were interpreted as a length, they produced a huge bogus value (~176MB), causing a permanent wait for data that never arrives.
- No TCP read buffering: handle_data processed each TCP read independently. When a packet was fragmented, partial reads were silently discarded. The next read started fresh, causing the fragments to be parsed as separate (incorrect) messages.
- code vs response_code in incomplete path: The original incomplete-packet fallback passed the raw code u32 (which packs both response_code and fin_flag) instead of the upper 16 bits. code = 0x000000ff was reported as API error: code=255 rather than response_code = 0 (success).

## Changes (crates/mezon-client/src/abridged_tcp_adapter.rs)

- Added persistent read buffer (Arc<Mutex<Vec<u8>>>): incoming data is appended across TCP reads, and a loop extracts complete messages from the buffer. This handles arbitrary TCP fragmentation.
- Distinguished final vs non-final chunk parsing:
- Final chunk (fin_flag == CODE_FIN): minimum header is 7 bytes. Payload = everything after byte 7. Only dispatch when payload data is present (buf.len() > 7).
- Non-final chunk (fin_flag != CODE_FIN): full header is 11 bytes (including 4-byte payload_len). Existing chunked reassembly preserved.
- Replaced PAYLOAD_HEADER_LENGTH = 11 with RAW_HEADER_LENGTH = 7 and RAW_CHUNK_HEADER_LENGTH = 11.
