### PR TITLE
feat: implement WebSocket connection and channel subscription functionality

### DIFF
--- a/crates/mezon-app/Cargo.toml
+++ b/crates/mezon-app/Cargo.toml
@@ -24,6 +24,8 @@ anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 serde.workspace = true
+mezon-proto.workspace = true
+prost.workspace = true
 
 [build-dependencies]
 woff2-patched = "0.4.0"

--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -249,16 +249,17 @@ fn spawn_transport_task(
                 if let (Some(cid), Some(chid)) = (new_clan, new_channel) {
                     // Leave old channel if different
                     if let Some((old_cid, old_chid)) = subscribed
-                        && (old_cid != cid || old_chid != chid) {
-                            transport
-                                .leave_channel(
-                                    old_cid,
-                                    old_chid,
-                                    pending.channel_type,
-                                    pending.is_public,
-                                )
-                                .await;
-                        }
+                        && (old_cid != cid || old_chid != chid)
+                    {
+                        transport
+                            .leave_channel(
+                                old_cid,
+                                old_chid,
+                                pending.channel_type,
+                                pending.is_public,
+                            )
+                            .await;
+                    }
                     // Join new channel
                     let _ = transport
                         .subscribe_channel(cid, chid, pending.channel_type, pending.is_public)

--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -2,11 +2,11 @@ use anyhow::Result;
 use gpui::{App, AppContext, AsyncApp, Bounds, Entity, WindowBounds, WindowOptions, px, size};
 use gpui_platform::application;
 use mezon_client::{AppApi, MezonClient, TransportClient, keychain};
-use mezon_proto::realtime;
-use prost::Message;
 use mezon_native::instance::SingleInstance;
+use mezon_proto::realtime;
 use mezon_store::{AuthState, ChannelList, Settings, event::RealtimeEvent};
 use mezon_ui::{RootView, init as init_ui, title_bar::TitleBar};
+use prost::Message;
 use std::borrow::Cow;
 use std::sync::Arc;
 use tracing_subscriber::{EnvFilter, fmt};
@@ -241,18 +241,28 @@ fn spawn_transport_task(
             }
 
             // Poll pending_subscribe from ChannelList
-            if let Some(pending) = cx.update(|cx| channel_list.update(cx, |cl, _| cl.pending_subscribe.take())) {
+            if let Some(pending) =
+                cx.update(|cx| channel_list.update(cx, |cl, _| cl.pending_subscribe.take()))
+            {
                 let new_clan = pending.clan_id.parse::<i64>().ok();
                 let new_channel = pending.channel_id.parse::<i64>().ok();
                 if let (Some(cid), Some(chid)) = (new_clan, new_channel) {
                     // Leave old channel if different
-                    if let Some((old_cid, old_chid)) = subscribed {
-                        if old_cid != cid || old_chid != chid {
-                            transport.leave_channel(old_cid, old_chid, pending.channel_type, pending.is_public).await;
+                    if let Some((old_cid, old_chid)) = subscribed
+                        && (old_cid != cid || old_chid != chid) {
+                            transport
+                                .leave_channel(
+                                    old_cid,
+                                    old_chid,
+                                    pending.channel_type,
+                                    pending.is_public,
+                                )
+                                .await;
                         }
-                    }
                     // Join new channel
-                    let _ = transport.subscribe_channel(cid, chid, pending.channel_type, pending.is_public).await;
+                    let _ = transport
+                        .subscribe_channel(cid, chid, pending.channel_type, pending.is_public)
+                        .await;
                     subscribed = Some((cid, chid));
                 }
             }

--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -2,8 +2,10 @@ use anyhow::Result;
 use gpui::{App, AppContext, AsyncApp, Bounds, Entity, WindowBounds, WindowOptions, px, size};
 use gpui_platform::application;
 use mezon_client::{AppApi, MezonClient, TransportClient, keychain};
+use mezon_proto::realtime;
+use prost::Message;
 use mezon_native::instance::SingleInstance;
-use mezon_store::{AuthState, Settings};
+use mezon_store::{AuthState, ChannelList, Settings, event::RealtimeEvent};
 use mezon_ui::{RootView, init as init_ui, title_bar::TitleBar};
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -60,7 +62,10 @@ fn run_app(lock: SingleInstance, initial_url: Option<String>) {
 
     // ── Determine initial auth state from keychain ────────────────────────────
     let client = Arc::new(MezonClient::default());
-    let transport = Arc::new(TransportClient::new(String::new()));
+    let transport = Arc::new(TransportClient::new_with_adapter(
+        Box::new(mezon_client::WsAdapter::new()),
+        String::new(),
+    ));
     let api = Arc::new(AppApi::new(transport.clone()));
     let initial_auth_state = resolve_initial_auth_state(&rt, &client);
 
@@ -141,12 +146,14 @@ fn run_app(lock: SingleInstance, initial_url: Option<String>) {
 
             // Create the shared Settings entity so all views can observe theme changes.
             let settings_entity = cx.new(|_| Settings::load_sync());
+            let channel_list = cx.new(|_| ChannelList::new());
 
             // Open the main window and obtain the auth_state entity handle.
             let auth_state_handle = open_main_window(
                 cx,
                 &settings,
                 settings_entity,
+                channel_list.clone(),
                 client.clone(),
                 api.clone(),
                 initial_auth_state,
@@ -185,6 +192,7 @@ fn run_app(lock: SingleInstance, initial_url: Option<String>) {
             spawn_transport_task(
                 cx,
                 auth_state_handle.clone(),
+                channel_list.clone(),
                 transport.clone(),
                 api.clone(),
             );
@@ -200,15 +208,54 @@ fn run_app(lock: SingleInstance, initial_url: Option<String>) {
 fn spawn_transport_task(
     cx: &mut App,
     auth_state: Entity<AuthState>,
+    channel_list: Entity<ChannelList>,
     transport: Arc<TransportClient>,
     api: Arc<AppApi>,
 ) {
+    let (event_tx, event_rx) = tokio::sync::mpsc::channel::<RealtimeEvent>(256);
+
     cx.spawn(async move |cx: &mut AsyncApp| {
         let exec = cx.background_executor().clone();
         let mut connected_token: Option<String> = None;
+        let mut subscribed: Option<(i64, i64)> = None;
+        let mut event_rx = event_rx;
 
         loop {
             exec.timer(std::time::Duration::from_millis(500)).await;
+
+            // Poll realtime events from the transport thread.
+            while let Ok(event) = event_rx.try_recv() {
+                match event {
+                    RealtimeEvent::ChannelMessage(msg) => {
+                        tracing::info!(
+                            "📨 [STORE] ChannelMessage channel={} sender={} content={}",
+                            msg.channel_id,
+                            msg.sender_id,
+                            msg.content,
+                        );
+                    }
+                    RealtimeEvent::Other { variant, .. } => {
+                        tracing::trace!("Other realtime event: {variant}");
+                    }
+                }
+            }
+
+            // Poll pending_subscribe from ChannelList
+            if let Some(pending) = cx.update(|cx| channel_list.update(cx, |cl, _| cl.pending_subscribe.take())) {
+                let new_clan = pending.clan_id.parse::<i64>().ok();
+                let new_channel = pending.channel_id.parse::<i64>().ok();
+                if let (Some(cid), Some(chid)) = (new_clan, new_channel) {
+                    // Leave old channel if different
+                    if let Some((old_cid, old_chid)) = subscribed {
+                        if old_cid != cid || old_chid != chid {
+                            transport.leave_channel(old_cid, old_chid, pending.channel_type, pending.is_public).await;
+                        }
+                    }
+                    // Join new channel
+                    let _ = transport.subscribe_channel(cid, chid, pending.channel_type, pending.is_public).await;
+                    subscribed = Some((cid, chid));
+                }
+            }
 
             let session = match cx.update(|cx| auth_state.read(cx).clone()) {
                 AuthState::Connecting(session) | AuthState::Authenticated(session) => Some(session),
@@ -219,7 +266,7 @@ fn spawn_transport_task(
                 if connected_token.take().is_some()
                     && let Err(e) = transport.close().await
                 {
-                    tracing::warn!("Failed to close TCP transport after logout: {e}");
+                    tracing::warn!("Failed to close transport after logout: {e}");
                 }
                 continue;
             };
@@ -230,8 +277,14 @@ fn spawn_transport_task(
                 continue;
             }
 
-            let Some(host) = session.tcp_host.clone() else {
-                tracing::warn!("Authenticated session missing tcp_host; TCP APIs unavailable");
+            let (host, port) = if let Some(ws_host) = session.ws_host.clone() {
+                let ws_port = session.ws_port.unwrap_or(443);
+                (ws_host, ws_port)
+            } else if let Some(tcp_host) = session.tcp_host.clone() {
+                let tcp_port = session.tcp_port.unwrap_or(4433);
+                (tcp_host, tcp_port)
+            } else {
+                tracing::warn!("Authenticated session missing both ws_host and tcp_host");
                 cx.update(|cx| {
                     auth_state.update(cx, |state, cx| {
                         if matches!(state, AuthState::Connecting(_)) {
@@ -242,52 +295,62 @@ fn spawn_transport_task(
                 });
                 continue;
             };
-            // let Some(port) = session.tcp_port else {
-            //     tracing::warn!("Authenticated session missing tcp_port; TCP APIs unavailable");
-            //     continue;
-            // };
-            let port = 4433;
 
             if transport.is_open().await
                 && let Err(e) = transport.close().await
             {
-                tracing::warn!("Failed to close stale TCP transport: {e}");
+                tracing::warn!("Failed to close stale transport: {e}");
             }
 
-            tracing::info!("Connecting shared TCP transport to {host}:{port}");
+            tracing::info!("Connecting shared transport to {host}:{port}");
             let token = session.token.clone();
             let session_for_update = session.clone();
+            let event_tx = event_tx.clone();
             match transport
                 .connect(
                     &host,
                     port,
                     &token,
-                    move |cid, code, message| {
-                        tracing::debug!(
-                            "TCP server message: cid={}, code={}, len={}",
-                            cid,
-                            code,
-                            message.len()
-                        );
+                    move |cid, _code, message| {
+                        if let Ok(envelope) = realtime::Envelope::decode(message.as_slice()) {
+                            if let Some(event) = RealtimeEvent::from_envelope(envelope, message) {
+                                if let RealtimeEvent::ChannelMessage(ref msg) = event {
+                                    tracing::info!(
+                                        "📨 ChannelMessage channel={} sender={} content={}",
+                                        msg.channel_id,
+                                        msg.sender_id,
+                                        msg.content,
+                                    );
+                                }
+                                let _ = event_tx.try_send(event);
+                            }
+                        } else {
+                            tracing::debug!(
+                                "📩 Unknown(cid={} code={}) len={}",
+                                cid,
+                                _code,
+                                message.len(),
+                            );
+                        }
                     },
                     move |was_clean| {
                         if was_clean {
-                            tracing::info!("TCP transport closed cleanly");
+                            tracing::info!("Transport closed cleanly");
                         } else {
-                            tracing::warn!("TCP transport closed with error");
+                            tracing::warn!("Transport closed with error");
                         }
                     },
                 )
                 .await
             {
                 Ok(()) => {
-                    tracing::info!("Shared TCP transport connected");
+                    tracing::info!("Shared transport connected");
 
                     exec.timer(std::time::Duration::from_millis(250)).await;
                     match api.get_account().await {
                         Ok(account) => {
                             connected_token = Some(token);
-                            tracing::info!("get_account over shared TCP succeeded");
+                            tracing::info!("get_account over shared transport succeeded");
                             tracing::info!("  User ID: {}", account.user_id);
                             tracing::info!("  Username: {}", account.username);
                             tracing::info!("  Email: {:?}", account.email);
@@ -301,16 +364,19 @@ fn spawn_transport_task(
                                     }
                                 });
                             });
+
+                            // Reset subscribed tracking to force re-subscribe after reconnect.
+                            subscribed = None;
                         }
                         Err(e) => {
-                            tracing::error!("get_account over shared TCP failed: {e}");
+                            tracing::error!("get_account over shared transport failed: {e}");
                             let _ = transport.close().await;
                         }
                     }
                 }
                 Err(e) => {
                     connected_token = None;
-                    tracing::error!("Shared TCP transport connect failed: {e}");
+                    tracing::error!("Shared transport connect failed: {e}");
                     exec.timer(std::time::Duration::from_secs(3)).await;
                 }
             }
@@ -424,6 +490,7 @@ fn open_main_window(
     cx: &mut App,
     settings: &Settings,
     settings_entity: Entity<Settings>,
+    channel_list: Entity<ChannelList>,
     client: Arc<MezonClient>,
     api: Arc<AppApi>,
     initial_auth: AuthState,
@@ -464,6 +531,7 @@ fn open_main_window(
             RootView::new(
                 title_bar,
                 auth_state,
+                channel_list.clone(),
                 client,
                 api,
                 settings_entity.clone(),

--- a/crates/mezon-client/src/lib.rs
+++ b/crates/mezon-client/src/lib.rs
@@ -9,15 +9,17 @@ pub mod session;
 pub mod transport;
 pub mod transport_adapter;
 pub mod transport_runtime;
+pub mod ws_adapter;
 
 pub use abridged_tcp_adapter::AbridgedTcpAdapter;
+pub use ws_adapter::WsAdapter;
 pub use app_api::AppApi;
 pub use auth::MezonClient;
 pub use auth::{DEFAULT_API_HOST, DEFAULT_API_PORT, DEFAULT_API_SECURE, DEFAULT_SERVER_KEY};
 pub use session::Session;
 pub use transport::MezonTransport;
 pub use transport_adapter::TransportAdapter;
-pub use transport_runtime::TransportClient;
+pub use transport_runtime::{ensure_crypto_provider, TransportClient};
 
 /// Default WebSocket host (used for Stage 2+ WebSocket connection).
 pub const DEFAULT_WS_HOST: &str = "sock.mezon.ai";

--- a/crates/mezon-client/src/lib.rs
+++ b/crates/mezon-client/src/lib.rs
@@ -12,14 +12,14 @@ pub mod transport_runtime;
 pub mod ws_adapter;
 
 pub use abridged_tcp_adapter::AbridgedTcpAdapter;
-pub use ws_adapter::WsAdapter;
 pub use app_api::AppApi;
 pub use auth::MezonClient;
 pub use auth::{DEFAULT_API_HOST, DEFAULT_API_PORT, DEFAULT_API_SECURE, DEFAULT_SERVER_KEY};
 pub use session::Session;
 pub use transport::MezonTransport;
 pub use transport_adapter::TransportAdapter;
-pub use transport_runtime::{ensure_crypto_provider, TransportClient};
+pub use transport_runtime::{TransportClient, ensure_crypto_provider};
+pub use ws_adapter::WsAdapter;
 
 /// Default WebSocket host (used for Stage 2+ WebSocket connection).
 pub const DEFAULT_WS_HOST: &str = "sock.mezon.ai";

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -110,14 +110,36 @@ impl MezonTransport {
                 // Server-initiated message
                 if let Ok(envelope) = mezon_proto::realtime::Envelope::decode(message.as_slice()) {
                     let envelope_cid = envelope.cid;
-                    let variant = envelope.message.as_ref().map(|m| {
-                        format!("{:?}", m).split('(').next().unwrap_or("Unknown").to_string()
-                    }).unwrap_or_else(|| "Empty".into());
-                    let hex: String = message.iter().map(|b| format!("{:02x}", b)).collect::<Vec<_>>().join(" ");
-                    tracing::debug!("📩 {variant} cid={envelope_cid} len={} hex=[{hex}]", message.len());
+                    let variant = envelope
+                        .message
+                        .as_ref()
+                        .map(|m| {
+                            format!("{:?}", m)
+                                .split('(')
+                                .next()
+                                .unwrap_or("Unknown")
+                                .to_string()
+                        })
+                        .unwrap_or_else(|| "Empty".into());
+                    let hex: String = message
+                        .iter()
+                        .map(|b| format!("{:02x}", b))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    tracing::debug!(
+                        "📩 {variant} cid={envelope_cid} len={} hex=[{hex}]",
+                        message.len()
+                    );
                 } else {
-                    let hex: String = message.iter().map(|b| format!("{:02x}", b)).collect::<Vec<_>>().join(" ");
-                    tracing::debug!("📩 Unknown(cid={cid} code={code}) len={} hex=[{hex}]", message.len());
+                    let hex: String = message
+                        .iter()
+                        .map(|b| format!("{:02x}", b))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    tracing::debug!(
+                        "📩 Unknown(cid={cid} code={code}) len={} hex=[{hex}]",
+                        message.len()
+                    );
                 }
                 on_message(cid, code, message);
             }
@@ -4465,21 +4487,34 @@ impl MezonTransport {
     }
 
     /// Subscribe (join) a realtime channel to receive its events.
-    pub async fn subscribe_channel(&self, clan_id: i64, channel_id: i64, channel_type: i32, is_public: bool) -> Result<()> {
+    pub async fn subscribe_channel(
+        &self,
+        clan_id: i64,
+        channel_id: i64,
+        channel_type: i32,
+        is_public: bool,
+    ) -> Result<()> {
         let cid = self.generate_cid();
         let envelope = realtime::Envelope {
             cid: cid as i32,
-            message: Some(realtime::envelope::Message::ChannelJoin(realtime::ChannelJoin {
-                clan_id,
-                channel_id,
-                channel_type,
-                is_public,
-            })),
+            message: Some(realtime::envelope::Message::ChannelJoin(
+                realtime::ChannelJoin {
+                    clan_id,
+                    channel_id,
+                    channel_type,
+                    is_public,
+                },
+            )),
         };
         let bytes = envelope.encode_to_vec();
         match self.send(cid, bytes).await {
             Ok((code, _)) => {
-                tracing::info!("✅ Joined channel {} (clan {}): code={}", channel_id, clan_id, code);
+                tracing::info!(
+                    "✅ Joined channel {} (clan {}): code={}",
+                    channel_id,
+                    clan_id,
+                    code
+                );
             }
             Err(e) => {
                 tracing::debug!("Subscribe channel {} result (timeout ok): {e}", channel_id);
@@ -4489,15 +4524,23 @@ impl MezonTransport {
     }
 
     /// Leave a realtime channel (fire-and-forget).
-    pub async fn leave_channel(&self, clan_id: i64, channel_id: i64, channel_type: i32, is_public: bool) {
+    pub async fn leave_channel(
+        &self,
+        clan_id: i64,
+        channel_id: i64,
+        channel_type: i32,
+        is_public: bool,
+    ) {
         let envelope = realtime::Envelope {
             cid: 0,
-            message: Some(realtime::envelope::Message::ChannelLeave(realtime::ChannelLeave {
-                clan_id,
-                channel_id,
-                channel_type,
-                is_public,
-            })),
+            message: Some(realtime::envelope::Message::ChannelLeave(
+                realtime::ChannelLeave {
+                    clan_id,
+                    channel_id,
+                    channel_type,
+                    is_public,
+                },
+            )),
         };
         let bytes = envelope.encode_to_vec();
         match self.adapter.lock().await.send(bytes).await {

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -108,7 +108,17 @@ impl MezonTransport {
                 });
             } else {
                 // Server-initiated message
-                tracing::debug!("  Server-initiated message");
+                if let Ok(envelope) = mezon_proto::realtime::Envelope::decode(message.as_slice()) {
+                    let envelope_cid = envelope.cid;
+                    let variant = envelope.message.as_ref().map(|m| {
+                        format!("{:?}", m).split('(').next().unwrap_or("Unknown").to_string()
+                    }).unwrap_or_else(|| "Empty".into());
+                    let hex: String = message.iter().map(|b| format!("{:02x}", b)).collect::<Vec<_>>().join(" ");
+                    tracing::debug!("📩 {variant} cid={envelope_cid} len={} hex=[{hex}]", message.len());
+                } else {
+                    let hex: String = message.iter().map(|b| format!("{:02x}", b)).collect::<Vec<_>>().join(" ");
+                    tracing::debug!("📩 Unknown(cid={cid} code={code}) len={} hex=[{hex}]", message.len());
+                }
                 on_message(cid, code, message);
             }
         }));
@@ -4452,5 +4462,47 @@ impl MezonTransport {
         }
 
         Ok(())
+    }
+
+    /// Subscribe (join) a realtime channel to receive its events.
+    pub async fn subscribe_channel(&self, clan_id: i64, channel_id: i64, channel_type: i32, is_public: bool) -> Result<()> {
+        let cid = self.generate_cid();
+        let envelope = realtime::Envelope {
+            cid: cid as i32,
+            message: Some(realtime::envelope::Message::ChannelJoin(realtime::ChannelJoin {
+                clan_id,
+                channel_id,
+                channel_type,
+                is_public,
+            })),
+        };
+        let bytes = envelope.encode_to_vec();
+        match self.send(cid, bytes).await {
+            Ok((code, _)) => {
+                tracing::info!("✅ Joined channel {} (clan {}): code={}", channel_id, clan_id, code);
+            }
+            Err(e) => {
+                tracing::debug!("Subscribe channel {} result (timeout ok): {e}", channel_id);
+            }
+        }
+        Ok(())
+    }
+
+    /// Leave a realtime channel (fire-and-forget).
+    pub async fn leave_channel(&self, clan_id: i64, channel_id: i64, channel_type: i32, is_public: bool) {
+        let envelope = realtime::Envelope {
+            cid: 0,
+            message: Some(realtime::envelope::Message::ChannelLeave(realtime::ChannelLeave {
+                clan_id,
+                channel_id,
+                channel_type,
+                is_public,
+            })),
+        };
+        let bytes = envelope.encode_to_vec();
+        match self.adapter.lock().await.send(bytes).await {
+            Ok(()) => tracing::trace!("Left channel {} (clan {})", channel_id, clan_id),
+            Err(e) => tracing::trace!("Failed to send leave channel {}: {}", channel_id, e),
+        }
     }
 }

--- a/crates/mezon-client/src/transport_runtime.rs
+++ b/crates/mezon-client/src/transport_runtime.rs
@@ -5,13 +5,29 @@
 
 use crate::abridged_tcp_adapter::AbridgedTcpAdapter;
 use crate::transport::MezonTransport;
+use crate::transport_adapter::TransportAdapter;
 use anyhow::Result;
 use http_client::{AsyncBody, HttpClient, http};
 use reqwest_client::ReqwestClient;
 use std::sync::OnceLock;
 use tokio::runtime::Runtime;
+use tokio_rustls::rustls;
 
 static TRANSPORT_RUNTIME: OnceLock<Runtime> = OnceLock::new();
+static CRYPTO_PROVIDER: OnceLock<()> = OnceLock::new();
+
+/// Ensure the rustls CryptoProvider (ring) is installed exactly once.
+///
+/// Must be called before any TLS operation (TCP or WS) that uses rustls.
+/// Calling more than once is safe — the `OnceLock` guarantees single init.
+pub fn ensure_crypto_provider() {
+    CRYPTO_PROVIDER.get_or_init(|| {
+        tracing::debug!("🔐 Installing ring crypto provider");
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect("Failed to install ring CryptoProvider");
+    });
+}
 
 /// Get or create the shared transport runtime.
 fn runtime() -> &'static Runtime {
@@ -58,6 +74,14 @@ impl TransportClient {
     /// Create a new transport client with the given base API path.
     pub fn new(base_path: String) -> Self {
         let adapter = Box::new(AbridgedTcpAdapter::new());
+        let transport = MezonTransport::new(adapter, base_path);
+        Self {
+            inner: std::sync::Arc::new(transport),
+        }
+    }
+
+    /// Create a transport client with a custom adapter.
+    pub fn new_with_adapter(adapter: Box<dyn TransportAdapter>, base_path: String) -> Self {
         let transport = MezonTransport::new(adapter, base_path);
         Self {
             inner: std::sync::Arc::new(transport),
@@ -203,6 +227,26 @@ impl TransportClient {
     /// Check if the connection is open.
     pub async fn is_open(&self) -> bool {
         self.inner.is_open().await
+    }
+
+    /// Subscribe (join) a realtime channel to receive its messages and events.
+    pub async fn subscribe_channel(&self, clan_id: i64, channel_id: i64, channel_type: i32, is_public: bool) -> Result<()> {
+        let transport = self.inner.clone();
+
+        runtime()
+            .spawn(async move { transport.subscribe_channel(clan_id, channel_id, channel_type, is_public).await })
+            .await
+            .expect("Transport task panicked")
+    }
+
+    /// Leave a realtime channel (fire-and-forget).
+    pub async fn leave_channel(&self, clan_id: i64, channel_id: i64, channel_type: i32, is_public: bool) {
+        let transport = self.inner.clone();
+
+        runtime()
+            .spawn(async move { transport.leave_channel(clan_id, channel_id, channel_type, is_public).await })
+            .await
+            .ok();
     }
 
     /// Close the connection.

--- a/crates/mezon-client/src/transport_runtime.rs
+++ b/crates/mezon-client/src/transport_runtime.rs
@@ -230,21 +230,41 @@ impl TransportClient {
     }
 
     /// Subscribe (join) a realtime channel to receive its messages and events.
-    pub async fn subscribe_channel(&self, clan_id: i64, channel_id: i64, channel_type: i32, is_public: bool) -> Result<()> {
+    pub async fn subscribe_channel(
+        &self,
+        clan_id: i64,
+        channel_id: i64,
+        channel_type: i32,
+        is_public: bool,
+    ) -> Result<()> {
         let transport = self.inner.clone();
 
         runtime()
-            .spawn(async move { transport.subscribe_channel(clan_id, channel_id, channel_type, is_public).await })
+            .spawn(async move {
+                transport
+                    .subscribe_channel(clan_id, channel_id, channel_type, is_public)
+                    .await
+            })
             .await
             .expect("Transport task panicked")
     }
 
     /// Leave a realtime channel (fire-and-forget).
-    pub async fn leave_channel(&self, clan_id: i64, channel_id: i64, channel_type: i32, is_public: bool) {
+    pub async fn leave_channel(
+        &self,
+        clan_id: i64,
+        channel_id: i64,
+        channel_type: i32,
+        is_public: bool,
+    ) {
         let transport = self.inner.clone();
 
         runtime()
-            .spawn(async move { transport.leave_channel(clan_id, channel_id, channel_type, is_public).await })
+            .spawn(async move {
+                transport
+                    .leave_channel(clan_id, channel_id, channel_type, is_public)
+                    .await
+            })
             .await
             .ok();
     }

--- a/crates/mezon-client/src/ws_adapter.rs
+++ b/crates/mezon-client/src/ws_adapter.rs
@@ -1,0 +1,404 @@
+use crate::transport_adapter::{AdapterHandlers, TransportAdapter};
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::stream::{SplitSink, SplitStream, StreamExt};
+use futures::SinkExt;
+use mezon_proto::realtime;
+use prost::Message;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+const PREFIX_RAW: u8 = 0xff;
+const CODE_FIN: u16 = 0xff;
+const RAW_HEADER_LENGTH: usize = 7;
+const RAW_CHUNK_HEADER_LENGTH: usize = 11;
+
+type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+type WsWriteHalf = SplitSink<WsStream, WsMessage>;
+type WsReadHalf = SplitStream<WsStream>;
+
+struct IoLoopState {
+    handlers: Arc<Mutex<AdapterHandlers>>,
+    streams: Arc<Mutex<HashMap<u16, Vec<Vec<u8>>>>>,
+    is_connected: Arc<Mutex<bool>>,
+}
+
+pub struct WsAdapter {
+    write_tx: Arc<Mutex<Option<mpsc::UnboundedSender<Vec<u8>>>>>,
+    handlers: Arc<Mutex<AdapterHandlers>>,
+    streams: Arc<Mutex<HashMap<u16, Vec<Vec<u8>>>>>,
+    is_connected: Arc<Mutex<bool>>,
+}
+
+impl WsAdapter {
+    pub fn new() -> Self {
+        Self {
+            write_tx: Arc::new(Mutex::new(None)),
+            handlers: Arc::new(Mutex::new(AdapterHandlers::default())),
+            streams: Arc::new(Mutex::new(HashMap::new())),
+            is_connected: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    fn build_url(host: &str, port: u16, token: &str) -> String {
+        format!(
+            "wss://{host}:{port}/ws?lang=en&status=true&token={token}&format=protobuf"
+        )
+    }
+
+    async fn handle_message(&self, data: Vec<u8>) {
+        if data.is_empty() {
+            tracing::warn!("📥 ws_adapter: empty frame, skipping");
+            return;
+        }
+
+        let first_byte = data[0];
+        tracing::trace!(
+            "📥 ws_adapter: msg {} bytes, first_byte={:#04x}",
+            data.len(),
+            first_byte
+        );
+
+        if first_byte == 0x00 && data.len() >= 3 {
+            let cid = u16::from_be_bytes([data[1], data[2]]);
+            tracing::trace!("📨 PONG: cid={}", cid);
+            let handlers = self.handlers.lock().await;
+            handlers.trigger_message(cid, 0, vec![]);
+            return;
+        }
+
+        if first_byte == PREFIX_RAW {
+            self.handle_raw_response(data).await;
+            return;
+        }
+
+        let handlers = self.handlers.lock().await;
+        if let Ok(envelope) = realtime::Envelope::decode(data.as_slice()) {
+            tracing::trace!("📨 Envelope decoded: cid={}", envelope.cid);
+            handlers.trigger_message(envelope.cid as u16, 0, data);
+        } else {
+            let cid = decode_cid_field(&data).unwrap_or(0);
+            tracing::warn!("📨 Failed to decode Envelope, passing raw cid={cid}");
+            handlers.trigger_message(cid, 0, data);
+        }
+    }
+
+    async fn handle_raw_response(&self, data: Vec<u8>) {
+        if data.len() < RAW_HEADER_LENGTH {
+            tracing::warn!("📥 ws_adapter: short RAW header ({})", data.len());
+            return;
+        }
+
+        let cid = u16::from_be_bytes([data[1], data[2]]);
+        let code = u32::from_be_bytes([data[3], data[4], data[5], data[6]]);
+        let response_code = (code >> 16) & 0xffff;
+        let fin_flag = (code & 0xffff) as u16;
+
+        tracing::debug!(
+            "📥 RAW: cid={} code={:#x} response_code={} fin_flag={:#x} payload_len={}",
+            cid,
+            code,
+            response_code,
+            fin_flag,
+            data.len().saturating_sub(RAW_HEADER_LENGTH),
+        );
+
+        if fin_flag == CODE_FIN {
+            let payload = data[RAW_HEADER_LENGTH..].to_vec();
+            let mut streams = self.streams.lock().await;
+            if !payload.is_empty() {
+                streams.entry(cid).or_default().push(payload);
+            }
+            let complete = streams.remove(&cid).unwrap_or_default().concat();
+
+            tracing::debug!(
+                "📨 Complete API response: cid={} code={} len={} bytes",
+                cid,
+                response_code,
+                complete.len(),
+            );
+
+            let handlers = self.handlers.lock().await;
+            handlers.trigger_message(cid, response_code, complete);
+        } else {
+            if data.len() < RAW_CHUNK_HEADER_LENGTH {
+                tracing::warn!("📥 ws_adapter: short RAW chunk header ({})", data.len());
+                return;
+            }
+            let payload_len =
+                u32::from_be_bytes([data[7], data[8], data[9], data[10]]) as usize;
+            let total = RAW_CHUNK_HEADER_LENGTH + payload_len;
+            if data.len() < total {
+                tracing::warn!("📥 ws_adapter: short RAW chunk body ({})", data.len());
+                return;
+            }
+            let payload = data[RAW_CHUNK_HEADER_LENGTH..total].to_vec();
+            let mut streams = self.streams.lock().await;
+            let chunks = streams.entry(cid).or_default();
+            chunks.push(payload);
+            tracing::trace!("📥 Buffered chunk for cid={} ({} total)", cid, chunks.len());
+        }
+    }
+
+    async fn io_loop(
+        mut write_sink: WsWriteHalf,
+        mut read_stream: WsReadHalf,
+        mut write_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+        ready_tx: oneshot::Sender<()>,
+        state: IoLoopState,
+    ) {
+        tracing::info!("🔄 I/O loop running, entering select branch");
+        let _ = ready_tx.send(());
+
+        loop {
+            tokio::select! {
+                msg = read_stream.next() => {
+                    match msg {
+                        Some(Ok(WsMessage::Binary(data))) => {
+                            tracing::trace!(
+                                "📖 Binary frame: {} bytes {:02x?}",
+                                data.len(),
+                                &data[..data.len().min(128)],
+                            );
+                            let adapter = WsAdapter {
+                                write_tx: Arc::new(Mutex::new(None)),
+                                handlers: state.handlers.clone(),
+                                streams: state.streams.clone(),
+                                is_connected: state.is_connected.clone(),
+                            };
+                            adapter.handle_message(data).await;
+                        }
+                        Some(Ok(WsMessage::Text(_))) => {
+                            tracing::info!("📖 ws_adapter: ignoring text frame");
+                        }
+                        Some(Ok(WsMessage::Ping(_))) => {
+                            tracing::trace!("📖 ws_adapter: protocol ping (handled by tungstenite)");
+                        }
+                        Some(Ok(WsMessage::Pong(_))) => {
+                            tracing::trace!("📖 ws_adapter: protocol pong");
+                        }
+                        Some(Ok(WsMessage::Frame(_))) => {}
+                        Some(Ok(WsMessage::Close(frame))) => {
+                            let code = frame.as_ref().map(|f| f.code);
+                            let reason: &str = frame.as_ref().map_or("", |f| f.reason.as_ref());
+                            tracing::info!(
+                                "📖 Server closed WS: code={:?} reason={}",
+                                code,
+                                reason,
+                            );
+                            *state.is_connected.lock().await = false;
+                            state.handlers.lock().await.trigger_close(true);
+                            break;
+                        }
+                        Some(Err(e)) => {
+                            tracing::error!("📖 ws_adapter read error: {}", e);
+                            *state.is_connected.lock().await = false;
+                            let err = e.to_string();
+                            state.handlers.lock().await.trigger_error(err);
+                            state.handlers.lock().await.trigger_close(false);
+                            break;
+                        }
+                        None => {
+                            tracing::info!("📖 WS read stream ended (EOF)");
+                            *state.is_connected.lock().await = false;
+                            state.handlers.lock().await.trigger_close(true);
+                            break;
+                        }
+                    }
+                }
+                msg = write_rx.recv() => {
+                    match msg {
+                        Some(data) => {
+                            tracing::trace!(
+                                "📤 WRITE: {} bytes {:02x?}",
+                                data.len(),
+                                &data[..data.len().min(64)],
+                            );
+                            if let Err(e) = write_sink.send(WsMessage::Binary(data)).await {
+                                tracing::error!("📤 ws_adapter write error: {}", e);
+                                *state.is_connected.lock().await = false;
+                                let err = e.to_string();
+                                state.handlers.lock().await.trigger_error(err);
+                                break;
+                            }
+                        }
+                        None => {
+                            tracing::info!("📤 Write channel closed, exiting I/O loop");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        tracing::info!("🔄 I/O loop exited");
+    }
+}
+
+impl Default for WsAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl TransportAdapter for WsAdapter {
+    async fn connect(&mut self, host: &str, port: u16, token: &str) -> Result<()> {
+        tracing::info!("🔌 === WsAdapter CONNECT START: {}:{} ===", host, port);
+        tracing::info!("🔌 Token length: {}", token.len());
+
+        crate::transport_runtime::ensure_crypto_provider();
+
+        let url = Self::build_url(host, port, token);
+        tracing::info!("🔌 Connecting to {}", url);
+
+        let (ws_stream, resp) = connect_async(&url).await?;
+        tracing::info!("🔌 ✓ WS handshake complete (status={})", resp.status());
+
+        tracing::info!("🔌 Splitting WS stream...");
+        let (write_sink, read_stream) = ws_stream.split();
+
+        tracing::info!("🔌 Spawning I/O loop...");
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let (write_tx, write_rx) = mpsc::unbounded_channel();
+
+        let state = IoLoopState {
+            handlers: self.handlers.clone(),
+            streams: self.streams.clone(),
+            is_connected: self.is_connected.clone(),
+        };
+
+        tokio::spawn(async move {
+            Self::io_loop(write_sink, read_stream, write_rx, ready_tx, state).await;
+        });
+
+        tracing::info!("🔌 Waiting for I/O loop to be ready...");
+        ready_rx
+            .await
+            .map_err(|_| anyhow::anyhow!("I/O loop panicked before starting"))?;
+        tracing::info!("🔌 ✓ I/O loop confirmed READY");
+
+        *self.write_tx.lock().await = Some(write_tx);
+        *self.is_connected.lock().await = true;
+        tracing::info!("🔌 Connection state: is_connected=true, write_tx set");
+
+        {
+            let h = self.handlers.lock().await;
+            h.trigger_open();
+        }
+        tracing::info!("🔌 ✓ on_open triggered");
+
+        tracing::info!("🔌 === WsAdapter CONNECT COMPLETE ===");
+        Ok(())
+    }
+
+    async fn send(&mut self, message: Vec<u8>) -> Result<()> {
+        tracing::trace!("📤 send() called: {} bytes {:02x?}", message.len(), &message[..message.len().min(64)]);
+
+        if !self.is_open() {
+            tracing::warn!("📤 send(): connection NOT open, rejecting");
+            return Err(anyhow::anyhow!("Connection is not open"));
+        }
+        tracing::trace!("📤 Connection is open");
+
+        let guard = self.write_tx.lock().await;
+        match *guard {
+            Some(ref tx) => {
+                tx.send(message).map_err(|_| {
+                    tracing::error!("📤 mpsc send failed: channel closed");
+                    anyhow::anyhow!("Write channel closed")
+                })?;
+                tracing::trace!("📤 ✓ Packet queued via mpsc channel");
+                Ok(())
+            }
+            None => {
+                tracing::error!("📤 Write channel not available (None)");
+                Err(anyhow::anyhow!("Write channel not available"))
+            }
+        }
+    }
+
+    async fn send_ping(&mut self, cid: u16) -> Result<()> {
+        tracing::info!("🏓 Sending ping cid={}", cid);
+        if !self.is_open() {
+            tracing::warn!("🏓 send_ping(): connection NOT open");
+            return Err(anyhow::anyhow!("Connection is not open"));
+        }
+        let mut buffer = vec![0x00];
+        buffer.extend(&cid.to_be_bytes());
+        let guard = self.write_tx.lock().await;
+        if let Some(ref tx) = *guard {
+            tx.send(buffer)
+                .map_err(|_| anyhow::anyhow!("Write channel closed"))?;
+            tracing::info!("🏓 Ping cid={} queued", cid);
+        }
+        Ok(())
+    }
+
+    fn is_open(&self) -> bool {
+        let open = self.is_connected.try_lock().map(|g| *g).unwrap_or(false);
+        tracing::trace!("🔌 is_open() = {}", open);
+        open
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        tracing::info!("🔌 close() called");
+        *self.is_connected.lock().await = false;
+        *self.write_tx.lock().await = None;
+        tracing::info!("🔌 Connection closed");
+        Ok(())
+    }
+
+    fn set_on_message(&mut self, handler: crate::transport_adapter::MessageHandler) {
+        tracing::debug!("🔌 set_on_message");
+        if let Ok(mut h) = self.handlers.try_lock() {
+            h.on_message = Some(handler);
+        }
+    }
+
+    fn set_on_open(&mut self, handler: crate::transport_adapter::OpenHandler) {
+        tracing::debug!("🔌 set_on_open");
+        if let Ok(mut h) = self.handlers.try_lock() {
+            h.on_open = Some(handler);
+        }
+    }
+
+    fn set_on_close(&mut self, handler: crate::transport_adapter::CloseHandler) {
+        tracing::debug!("🔌 set_on_close");
+        if let Ok(mut h) = self.handlers.try_lock() {
+            h.on_close = Some(handler);
+        }
+    }
+
+    fn set_on_error(&mut self, handler: crate::transport_adapter::ErrorHandler) {
+        tracing::debug!("🔌 set_on_error");
+        if let Ok(mut h) = self.handlers.try_lock() {
+            h.on_error = Some(handler);
+        }
+    }
+}
+
+fn decode_cid_field(payload: &[u8]) -> Option<u16> {
+    if payload.first().copied()? != 0x08 {
+        return None;
+    }
+
+    let mut value = 0u32;
+    let mut shift = 0;
+    for byte in payload.iter().copied().skip(1) {
+        value |= u32::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return u16::try_from(value).ok();
+        }
+        shift += 7;
+        if shift >= 16 {
+            return None;
+        }
+    }
+
+    None
+}

--- a/crates/mezon-client/src/ws_adapter.rs
+++ b/crates/mezon-client/src/ws_adapter.rs
@@ -1,16 +1,16 @@
 use crate::transport_adapter::{AdapterHandlers, TransportAdapter};
 use anyhow::Result;
 use async_trait::async_trait;
-use futures::stream::{SplitSink, SplitStream, StreamExt};
 use futures::SinkExt;
+use futures::stream::{SplitSink, SplitStream, StreamExt};
 use mezon_proto::realtime;
 use prost::Message;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::net::TcpStream;
-use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio_tungstenite::tungstenite::Message as WsMessage;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 
 const PREFIX_RAW: u8 = 0xff;
 const CODE_FIN: u16 = 0xff;
@@ -45,9 +45,7 @@ impl WsAdapter {
     }
 
     fn build_url(host: &str, port: u16, token: &str) -> String {
-        format!(
-            "wss://{host}:{port}/ws?lang=en&status=true&token={token}&format=protobuf"
-        )
+        format!("wss://{host}:{port}/ws?lang=en&status=true&token={token}&format=protobuf")
     }
 
     async fn handle_message(&self, data: Vec<u8>) {
@@ -129,8 +127,7 @@ impl WsAdapter {
                 tracing::warn!("📥 ws_adapter: short RAW chunk header ({})", data.len());
                 return;
             }
-            let payload_len =
-                u32::from_be_bytes([data[7], data[8], data[9], data[10]]) as usize;
+            let payload_len = u32::from_be_bytes([data[7], data[8], data[9], data[10]]) as usize;
             let total = RAW_CHUNK_HEADER_LENGTH + payload_len;
             if data.len() < total {
                 tracing::warn!("📥 ws_adapter: short RAW chunk body ({})", data.len());
@@ -297,7 +294,11 @@ impl TransportAdapter for WsAdapter {
     }
 
     async fn send(&mut self, message: Vec<u8>) -> Result<()> {
-        tracing::trace!("📤 send() called: {} bytes {:02x?}", message.len(), &message[..message.len().min(64)]);
+        tracing::trace!(
+            "📤 send() called: {} bytes {:02x?}",
+            message.len(),
+            &message[..message.len().min(64)]
+        );
 
         if !self.is_open() {
             tracing::warn!("📤 send(): connection NOT open, rejecting");

--- a/crates/mezon-store/Cargo.toml
+++ b/crates/mezon-store/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2024"
 
 [dependencies]
 mezon-client.workspace = true
+mezon-proto.workspace = true
+prost.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -6,6 +6,15 @@ pub enum ChannelType {
     Voice,
 }
 
+impl ChannelType {
+    pub fn as_proto_int(&self) -> i32 {
+        match self {
+            ChannelType::Text => 0,
+            ChannelType::Voice => 1,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Channel {
     pub id: String,
@@ -25,10 +34,19 @@ pub struct Category {
     pub channels: Vec<Channel>,
 }
 
+#[derive(Debug, Clone)]
+pub struct PendingSubscribe {
+    pub clan_id: String,
+    pub channel_id: String,
+    pub channel_type: i32,
+    pub is_public: bool,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ChannelList {
     pub categories: Vec<Category>,
     pub active_channel_id: Option<String>,
+    pub pending_subscribe: Option<PendingSubscribe>,
 }
 
 impl ChannelList {

--- a/crates/mezon-store/src/event.rs
+++ b/crates/mezon-store/src/event.rs
@@ -2,14 +2,16 @@ use mezon_proto::realtime;
 
 #[derive(Debug, Clone)]
 pub enum RealtimeEvent {
-    ChannelMessage(mezon_proto::api::ChannelMessage),
+    ChannelMessage(Box<mezon_proto::api::ChannelMessage>),
     Other { variant: String, payload: Vec<u8> },
 }
 
 impl RealtimeEvent {
     pub fn from_envelope(envelope: realtime::Envelope, raw_payload: Vec<u8>) -> Option<Self> {
         match envelope.message? {
-            realtime::envelope::Message::ChannelMessage(msg) => Some(Self::ChannelMessage(msg)),
+            realtime::envelope::Message::ChannelMessage(msg) => {
+                Some(Self::ChannelMessage(Box::new(msg)))
+            }
             other => {
                 let variant = format!("{:?}", other)
                     .split('(')

--- a/crates/mezon-store/src/event.rs
+++ b/crates/mezon-store/src/event.rs
@@ -16,7 +16,10 @@ impl RealtimeEvent {
                     .next()
                     .unwrap_or("Unknown")
                     .to_string();
-                Some(Self::Other { variant, payload: raw_payload })
+                Some(Self::Other {
+                    variant,
+                    payload: raw_payload,
+                })
             }
         }
     }

--- a/crates/mezon-store/src/event.rs
+++ b/crates/mezon-store/src/event.rs
@@ -1,0 +1,23 @@
+use mezon_proto::realtime;
+
+#[derive(Debug, Clone)]
+pub enum RealtimeEvent {
+    ChannelMessage(mezon_proto::api::ChannelMessage),
+    Other { variant: String, payload: Vec<u8> },
+}
+
+impl RealtimeEvent {
+    pub fn from_envelope(envelope: realtime::Envelope, raw_payload: Vec<u8>) -> Option<Self> {
+        match envelope.message? {
+            realtime::envelope::Message::ChannelMessage(msg) => Some(Self::ChannelMessage(msg)),
+            other => {
+                let variant = format!("{:?}", other)
+                    .split('(')
+                    .next()
+                    .unwrap_or("Unknown")
+                    .to_string();
+                Some(Self::Other { variant, payload: raw_payload })
+            }
+        }
+    }
+}

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod channel;
 pub mod clan;
+pub mod event;
 
 use anyhow::{Context, Result};
 use dirs::config_dir;

--- a/crates/mezon-ui/src/channel_sidebar.rs
+++ b/crates/mezon-ui/src/channel_sidebar.rs
@@ -1,5 +1,5 @@
 use gpui::{App, ClickEvent, Context, Entity, SharedString, Window, div, prelude::*, px};
-use mezon_store::{ChannelList, ClanList, Settings};
+use mezon_store::{ChannelList, ClanList, PendingSubscribe, Settings};
 
 use crate::components::compositions::channel_row::ChannelRow;
 use crate::components::primitives::{Icon, IconName};
@@ -15,6 +15,14 @@ fn on_channel_click(
         channel_list.update(cx, |m, cx| {
             m.select_channel(&channel_id);
             m.mark_read(&channel_id);
+            if let Some(ch) = m.find_channel(&channel_id) {
+                m.pending_subscribe = Some(PendingSubscribe {
+                    clan_id: ch.clan_id.clone(),
+                    channel_id: ch.id.clone(),
+                    channel_type: ch.channel_type.as_proto_int(),
+                    is_public: !ch.private,
+                });
+            }
             cx.notify();
         });
         if let Some(ref cb) = on_navigate

--- a/crates/mezon-ui/src/chat_layout.rs
+++ b/crates/mezon-ui/src/chat_layout.rs
@@ -126,17 +126,29 @@ pub struct ChatLayout {
     clan_list: Entity<ClanList>,
 }
 
+pub struct ChatLayoutParams {
+    pub router: Router,
+    pub clan_list: Entity<ClanList>,
+    pub channel_list: Entity<ChannelList>,
+    pub auth_state: Entity<AuthState>,
+    pub api: Arc<AppApi>,
+    pub navigate: crate::components::NavigateFn,
+    pub settings: Entity<Settings>,
+}
+
 impl ChatLayout {
-    pub fn new(
-        router: Router,
-        clan_list: Entity<ClanList>,
-        channel_list: Entity<ChannelList>,
-        auth_state: Entity<AuthState>,
-        api: Arc<AppApi>,
-        navigate: crate::components::NavigateFn,
-        settings: Entity<Settings>,
-        cx: &mut Context<Self>,
-    ) -> Self {
+    pub fn new(params: ChatLayoutParams, cx: &mut Context<Self>) -> Self {
+        let ChatLayoutParams {
+            router,
+            clan_list,
+            channel_list,
+            auth_state,
+            api,
+            navigate,
+            settings,
+        } = params;
+
+        let _ = cx.observe(&settings, |_, _, cx| cx.notify());
         let _ = cx.observe(&settings, |_, _, cx| cx.notify());
 
         let on_navigate: Option<crate::components::NavigateFn> = {

--- a/crates/mezon-ui/src/chat_layout.rs
+++ b/crates/mezon-ui/src/chat_layout.rs
@@ -130,6 +130,7 @@ impl ChatLayout {
     pub fn new(
         router: Router,
         clan_list: Entity<ClanList>,
+        channel_list: Entity<ChannelList>,
         auth_state: Entity<AuthState>,
         api: Arc<AppApi>,
         navigate: crate::components::NavigateFn,
@@ -137,8 +138,6 @@ impl ChatLayout {
         cx: &mut Context<Self>,
     ) -> Self {
         let _ = cx.observe(&settings, |_, _, cx| cx.notify());
-
-        let channel_list = cx.new(|_| ChannelList::new());
 
         let on_navigate: Option<crate::components::NavigateFn> = {
             let nav = navigate.clone();

--- a/crates/mezon-ui/src/root.rs
+++ b/crates/mezon-ui/src/root.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use gpui::{App, ClickEvent, Context, Entity, FontWeight, Window, div, prelude::*};
 use gpui_component::Sizable;
 use mezon_client::{AppApi, MezonClient};
-use mezon_store::{AuthState, ClanList, Settings};
+use mezon_store::{AuthState, ChannelList, ClanList, Settings};
 
 use crate::chat_layout::ChatLayout;
 use crate::components::primitives::{Button, Icon, IconName, Size, Spinner};
@@ -28,6 +28,7 @@ impl RootView {
     pub fn new(
         title_bar: Entity<TitleBar>,
         auth_state: Entity<AuthState>,
+        channel_list: Entity<ChannelList>,
         client: Arc<MezonClient>,
         api: Arc<AppApi>,
         settings: Entity<Settings>,
@@ -60,6 +61,7 @@ impl RootView {
 
         let router_for_chat = router.clone();
         let clan_list_for_chat = clan_list.clone();
+        let channel_list_for_chat = channel_list.clone();
         let auth_state_for_chat = auth_state.clone();
         let api_for_chat = api.clone();
         let navigate_for_chat = navigate.clone();
@@ -70,6 +72,7 @@ impl RootView {
                 ChatLayout::new(
                     router_for_chat,
                     clan_list_for_chat.clone(),
+                    channel_list_for_chat.clone(),
                     auth_state_for_chat.clone(),
                     api_for_chat.clone(),
                     navigate_for_chat.clone(),

--- a/crates/mezon-ui/src/root.rs
+++ b/crates/mezon-ui/src/root.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::chat_layout::ChatLayoutParams;
 use gpui::{App, ClickEvent, Context, Entity, FontWeight, Window, div, prelude::*};
 use gpui_component::Sizable;
 use mezon_client::{AppApi, MezonClient};
@@ -67,19 +68,16 @@ impl RootView {
         let navigate_for_chat = navigate.clone();
         let settings_for_chat = settings.clone();
         let chat_layout = cx.new({
-            let settings = settings_for_chat;
-            move |cx| {
-                ChatLayout::new(
-                    router_for_chat,
-                    clan_list_for_chat.clone(),
-                    channel_list_for_chat.clone(),
-                    auth_state_for_chat.clone(),
-                    api_for_chat.clone(),
-                    navigate_for_chat.clone(),
-                    settings.clone(),
-                    cx,
-                )
-            }
+            let params = ChatLayoutParams {
+                router: router_for_chat,
+                clan_list: clan_list_for_chat,
+                channel_list: channel_list_for_chat,
+                auth_state: auth_state_for_chat,
+                api: api_for_chat,
+                navigate: navigate_for_chat,
+                settings: settings_for_chat.clone(),
+            };
+            move |cx| ChatLayout::new(params, cx)
         });
 
         let auth_state_for_settings = auth_state.clone();


### PR DESCRIPTION
## Summary
Replace hardcoded test channel subscription with a store-driven flow where the transport task polls the ChannelList for pending subscription changes and executes leave/join transitions accordingly.

## Changes
### mezon-store

- Added PendingSubscribe struct (clan_id, channel_id, channel_type, is_public)
- Added pending_subscribe: Option<PendingSubscribe> field to ChannelList
- Added ChannelType::as_proto_int() helper to convert enum to i32 for protobuf
### mezon-client

- Updated subscribe_channel signature to accept channel_type: i32, is_public: bool (replacing hardcoded 0, true)
- Added fire-and-forget leave_channel method using direct adapter.send() without response tracking
- Added TransportClient delegates for both methods

### mezon-ui

- ChannelSidebar.on_channel_click now sets ChannelList.pending_subscribe with real channel data (looks up Channel to get channel_type and is_public)
- ChatLayout accepts Entity<ChannelList> from constructor instead of creating internally
- RootView accepts and threads Entity<ChannelList> through to ChatLayout

### mezon-app

- Created ChannelList entity in run_app() before opening main window
- Passed Entity<ChannelList> to both open_main_window (→ UI tree) and spawn_transport_task
- Transport task polls pending_subscribe every 500ms: if changed, sends ChannelLeave for old channel (fire-and-forget) then ChannelJoin for new
- Removed hardcoded subscribe_channel call after get_account
- On reconnect, resets subscription tracking to force re-subscribe on next poll cycle

### Behavior

- User clicks a channel → pending_subscribe set
- Transport task (500ms poll) detects change → leaves old channel (if any) → joins new channel
- Channel switches → leave old/join new happens automatically
- WebSocket reconnects → resubscribes to currently selected channel
- Uses real channel metadata (channel_type, is_public) instead of hardcoded values

All tests pass: cargo check -p mezon-app succeeds.