### PR TITLE
perf(ui): bound image cache RAM and reduce chat re-renders

### DIFF
--- a/crates/mezon-store/src/config.rs
+++ b/crates/mezon-store/src/config.rs
@@ -307,6 +307,13 @@ impl AppConfig {
         cx.try_global::<GlobalAppConfig>().map(|g| g.0.as_ref())
     }
 
+    /// Whether we are pointed at the dev image proxy. The dev proxy currently
+    /// rejects avatar source URLs (404 "Invalid source URL"), so callers may
+    /// choose to skip it and use the raw URL directly.
+    pub fn is_dev_imgproxy(&self) -> bool {
+        self.imgproxy_base_url.contains("dev-imgproxy")
+    }
+
     pub fn imgproxy_url(
         &self,
         source_image_url: &str,

--- a/crates/mezon-ui/src/app/root.rs
+++ b/crates/mezon-ui/src/app/root.rs
@@ -9,6 +9,9 @@ use crate::app::title_bar::TitleBar;
 use crate::auth::login_view::LoginView;
 use crate::chat::layout::ChatLayout;
 use crate::components::primitives::{Button, Icon, IconName, Size, Spinner};
+use crate::image_cache::{
+    LruImageCache, SHARED_ENTRY_MAX_BYTES, SHARED_IMAGE_CACHE_BYTES, SHARED_IMAGE_CACHE_CAPACITY,
+};
 use crate::router::{Route, Router};
 use crate::settings::SettingsScreen;
 use crate::theme::{ActiveTheme, Theme, resolve_theme};
@@ -22,6 +25,7 @@ pub struct RootView {
     settings: Entity<Settings>,
     applied_theme: String,
     initial_route_restored: bool,
+    image_cache: Entity<LruImageCache>,
 }
 
 impl RootView {
@@ -132,6 +136,15 @@ impl RootView {
         });
 
         let applied_theme = settings.read(cx).theme.clone();
+        let image_cache = cx.new(|cx| {
+            LruImageCache::labeled(
+                "shared",
+                SHARED_IMAGE_CACHE_CAPACITY,
+                SHARED_IMAGE_CACHE_BYTES,
+                SHARED_ENTRY_MAX_BYTES,
+                cx,
+            )
+        });
         Self {
             title_bar,
             auth_state,
@@ -141,6 +154,7 @@ impl RootView {
             settings,
             applied_theme,
             initial_route_restored: false,
+            image_cache,
         }
     }
 
@@ -205,6 +219,7 @@ impl Render for RootView {
             .size_full()
             .bg(theme.bg_primary)
             .text_color(theme.text_primary)
+            .image_cache(self.image_cache.clone())
             .on_action(cx.listener(|_, _: &crate::ToggleInspector, window, cx| {
                 window.toggle_inspector(cx);
             }))

--- a/crates/mezon-ui/src/chat/area.rs
+++ b/crates/mezon-ui/src/chat/area.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::components::primitives::{InputEvent, InputState};
-use gpui::{AnyView, App, Context, Entity, Window, div, prelude::*};
+use gpui::{AnyView, App, Context, Entity, StyleRefinement, Window, div, prelude::*, px};
 use mezon_store::Settings;
 
 use crate::chat::ReplyTarget;
@@ -137,12 +137,15 @@ impl ChatArea {
             .flex_1()
             .min_w_0()
             .min_h_0()
-            .child(
-                div()
-                    .flex_1()
-                    .min_h_0()
-                    .child(AnyView::from(self.timeline.clone())),
-            )
+            .child(div().flex_1().min_h_0().child(
+                // Cache the message list so an unrelated sibling/parent notify
+                // (presence in the member panel, typing indicator, user info
+                // bar, theme change…) does not force a full re-layout of every
+                // row. It self-invalidates whenever the timeline itself
+                // notifies (scroll, new message, GIF animation), so behaviour
+                // is unchanged — only redundant re-renders are skipped.
+                AnyView::from(self.timeline.clone()).cached(StyleRefinement::default().size_full()),
+            ))
             .child(input_bar.render(theme, locale));
 
         let body = div()
@@ -152,7 +155,20 @@ impl ChatArea {
             .min_h_0()
             .child(message_column)
             .when(show_member_panel, |row| match &self.member_panel {
-                Some(panel) => row.child(panel.clone()),
+                // Cache the member panel so it is not re-rendered (and its avatars
+                // re-painted) every frame the message timeline notifies during
+                // scroll/load-more. GPUI marks the whole ancestor chain of a
+                // notified view dirty, so the timeline's churn forces chat_layout
+                // to re-render its subtree; caching keeps the panel reused unless
+                // the panel itself is notified (member/presence change or scroll).
+                Some(panel) => row.child(
+                    AnyView::from(panel.clone()).cached(
+                        StyleRefinement::default()
+                            .w(px(245.))
+                            .h_full()
+                            .flex_shrink_0(),
+                    ),
+                ),
                 None => row,
             });
 

--- a/crates/mezon-ui/src/chat/layout.rs
+++ b/crates/mezon-ui/src/chat/layout.rs
@@ -314,7 +314,15 @@ impl Render for ChatLayout {
                             .child(div().w(px(272.0)).h_full().child(nav_body)),
                     )
                     .children(voice_mini_bar)
-                    .child(self.user_info_bar.clone()),
+                    .child(
+                        AnyView::from(self.user_info_bar.clone()).cached(
+                            StyleRefinement::default()
+                                .absolute()
+                                .left(px(12.0))
+                                .right(px(8.0))
+                                .bottom(px(12.0)),
+                        ),
+                    ),
             )
             .child(
                 div()
@@ -463,7 +471,10 @@ impl ChatLayout {
                 let channel = ch.clone();
                 let (input_device_id, output_device_id) = {
                     let settings = self.settings.read(cx);
-                    (settings.input_device_id.clone(), settings.output_device_id.clone())
+                    (
+                        settings.input_device_id.clone(),
+                        settings.output_device_id.clone(),
+                    )
                 };
                 return crate::chat::voice::render_voice_channel(
                     theme,

--- a/crates/mezon-ui/src/chat/member_list.rs
+++ b/crates/mezon-ui/src/chat/member_list.rs
@@ -10,6 +10,9 @@ use mezon_store::{
 };
 
 use crate::components::primitives::Avatar;
+use crate::image_cache::{
+    AVATAR_ENTRY_MAX_BYTES, AVATAR_IMAGE_CACHE_BYTES, AVATAR_IMAGE_CACHE_CAPACITY, LruImageCache,
+};
 use crate::router::{Route, Router};
 use crate::theme::{ActiveTheme, Theme};
 use crate::util::reactive::Derived;
@@ -52,6 +55,7 @@ pub struct MemberListPanel {
     settings: Entity<Settings>,
     rows: Derived<Vec<Row>>,
     list_scroll: UniformListScrollHandle,
+    avatar_image_cache: Entity<LruImageCache>,
 }
 
 impl MemberListPanel {
@@ -100,11 +104,21 @@ impl MemberListPanel {
             }
         }
 
+        let avatar_image_cache = cx.new(|cx| {
+            LruImageCache::avatar_thumbnail(
+                "member-avatar",
+                AVATAR_IMAGE_CACHE_CAPACITY,
+                AVATAR_IMAGE_CACHE_BYTES,
+                AVATAR_ENTRY_MAX_BYTES,
+                cx,
+            )
+        });
         let mut this = Self {
             source,
             settings,
             rows: Derived::default(),
             list_scroll: UniformListScrollHandle::new(),
+            avatar_image_cache,
         };
         this.rebuild(cx);
         this
@@ -267,8 +281,17 @@ fn group_raw_members(cx: &App, direct_id: ChannelId) -> Vec<RawMember> {
 }
 
 fn make_member_row(cx: &App, raw: RawMember) -> Row {
+    // The dev image proxy 404s on avatar source URLs, forcing a fallback to the
+    // raw (full-resolution) file. For the member list we skip the proxy on dev
+    // and use the raw URL directly: it avoids the wasted 404 round-trip, and the
+    // dev server already serves avatars at avatar size.
+    let skip_proxy = mezon_store::AppConfig::try_global(cx)
+        .map(|cfg| cfg.is_dev_imgproxy())
+        .unwrap_or(false);
     let avatar_src = if raw.avatar_raw.is_empty() {
         SharedString::default()
+    } else if skip_proxy {
+        SharedString::from(raw.avatar_raw.clone())
     } else {
         SharedString::from(crate::util::imgproxy::avatar_url(cx, &raw.avatar_raw))
     };
@@ -307,16 +330,20 @@ fn render_header(theme: &Theme, locale: &str, kind: &HeaderKind, count: usize) -
         .into_any_element()
 }
 
-fn render_member(theme: &Theme, member: &MemberRow) -> AnyElement {
-    let avatar = {
-        let base = Avatar::new().name(member.name.clone()).size_px(px(32.));
-        if member.avatar_src.is_empty() {
-            base
-        } else {
-            base.src(member.avatar_src.clone())
-                .fallback_src(member.avatar_raw.clone())
-        }
-    };
+fn render_member(
+    theme: &Theme,
+    member: &MemberRow,
+    avatar_image_cache: &Entity<LruImageCache>,
+) -> AnyElement {
+    let mut avatar = Avatar::new()
+        .name(member.name.clone())
+        .size_px(px(32.))
+        .image_cache(avatar_image_cache.clone());
+    if !member.avatar_src.is_empty() {
+        avatar = avatar
+            .src(member.avatar_src.clone())
+            .fallback_src(member.avatar_raw.clone());
+    }
 
     let dot_color = if member.online {
         theme.status_online
@@ -358,10 +385,14 @@ fn render_member(theme: &Theme, member: &MemberRow) -> AnyElement {
 impl Render for MemberListPanel {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         crate::trace_render!("MemberListPanel");
+        // Avatars use a plain byte-budget LRU (no per-frame viewport sweep):
+        // they are small, disk-cached, and reused, so sweeping them would force
+        // constant re-fetches (and re-trigger failed loads) on every re-render.
         let theme = cx.theme();
         let locale = self.settings.read(cx).language.clone();
         let count = self.rows.get().len();
         let entity = cx.entity();
+        let avatar_image_cache = self.avatar_image_cache.clone();
 
         let list = uniform_list("member-list", count, move |range, _window, cx| {
             let theme = cx.theme().clone();
@@ -372,7 +403,7 @@ impl Render for MemberListPanel {
                     Some(Row::Header { kind, count }) => {
                         render_header(&theme, &locale, kind, *count)
                     }
-                    Some(Row::Member(member)) => render_member(&theme, member),
+                    Some(Row::Member(member)) => render_member(&theme, member, &avatar_image_cache),
                     None => div().into_any_element(),
                 })
                 .collect::<Vec<_>>()

--- a/crates/mezon-ui/src/chat/message_list.rs
+++ b/crates/mezon-ui/src/chat/message_list.rs
@@ -8,7 +8,8 @@ use mezon_store::{ChannelId, ChannelList, Message, MessagesEvent, MessagesStore,
 
 use crate::chat::message_row::{MessageAttachmentView, MessageRow};
 use crate::image_cache::{
-    AVATAR_IMAGE_CACHE_CAPACITY, LruImageCache, MESSAGE_IMAGE_CACHE_CAPACITY,
+    AVATAR_ENTRY_MAX_BYTES, AVATAR_IMAGE_CACHE_BYTES, AVATAR_IMAGE_CACHE_CAPACITY, LruImageCache,
+    MESSAGE_ENTRY_MAX_BYTES, MESSAGE_IMAGE_CACHE_BYTES, MESSAGE_IMAGE_CACHE_CAPACITY,
 };
 use crate::theme::{ActiveTheme, Theme};
 
@@ -64,11 +65,10 @@ impl MessageTimeline {
                 MessagesStore::global(cx).update(cx, |store, cx| store.load_more(cx));
             }
             let _ = timeline.update(cx, |this, cx| {
-                let was_suppressed = this.suppress_hover;
                 this.suppress_hover = true;
-                if !was_suppressed {
-                    cx.notify();
-                }
+                // Re-render on every scroll tick so the image cache sweep runs
+                // and releases attachments that just left the viewport.
+                cx.notify();
                 this._hover_release_task = Some(cx.spawn(async move |this, cx| {
                     cx.background_executor()
                         .timer(std::time::Duration::from_millis(SCROLL_HOVER_RELEASE_MS))
@@ -82,8 +82,24 @@ impl MessageTimeline {
                 }));
             });
         });
-        let image_cache = cx.new(|cx| LruImageCache::new(MESSAGE_IMAGE_CACHE_CAPACITY, cx));
-        let avatar_image_cache = cx.new(|cx| LruImageCache::new(AVATAR_IMAGE_CACHE_CAPACITY, cx));
+        let image_cache = cx.new(|cx| {
+            LruImageCache::labeled(
+                "msg-image",
+                MESSAGE_IMAGE_CACHE_CAPACITY,
+                MESSAGE_IMAGE_CACHE_BYTES,
+                MESSAGE_ENTRY_MAX_BYTES,
+                cx,
+            )
+        });
+        let avatar_image_cache = cx.new(|cx| {
+            LruImageCache::avatar_thumbnail(
+                "msg-avatar",
+                AVATAR_IMAGE_CACHE_CAPACITY,
+                AVATAR_IMAGE_CACHE_BYTES,
+                AVATAR_ENTRY_MAX_BYTES,
+                cx,
+            )
+        });
         Self {
             list_state,
             settings,
@@ -119,6 +135,10 @@ impl Render for MessageTimeline {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         crate::trace_render!("MessageTimeline");
         self.clear_image_cache_if_channel_changed(window, cx);
+        // Keep only the images visible this frame; anything scrolled out of the
+        // viewport stops being requested and is dropped here on the next render.
+        self.image_cache
+            .update(cx, |cache, cx| cache.sweep(window, cx));
 
         let store = MessagesStore::global(cx);
         let channel_id = ChannelList::global(cx).read(cx).active_channel_id;

--- a/crates/mezon-ui/src/chat/message_row.rs
+++ b/crates/mezon-ui/src/chat/message_row.rs
@@ -207,7 +207,7 @@ impl<'a> MessageRow<'a> {
             })
             .when(!self.attachments.is_empty(), |d| {
                 d.child(div().flex().flex_col().gap_2().mt_1().children(
-                    self.attachments.iter().map(|view| {
+                    self.attachments.iter().enumerate().map(|(i, view)| {
                         match view {
                             MessageAttachmentView::Image {
                                 src,
@@ -225,7 +225,12 @@ impl<'a> MessageRow<'a> {
                                     )
                                     .into_any_element()
                                 } else {
+                                    // A stable id makes the img stateful, which is
+                                    // what lets GPUI advance animated GIF/WebP
+                                    // frames (a stateless img only ever shows the
+                                    // first frame).
                                     img(src.clone())
+                                        .id(SharedString::from(format!("msg-img-{}-{}", msg.id, i)))
                                         .w(*width)
                                         .h(*height)
                                         .max_w(px(400.))

--- a/crates/mezon-ui/src/chat/screen_share_modal.rs
+++ b/crates/mezon-ui/src/chat/screen_share_modal.rs
@@ -192,9 +192,10 @@ impl ScreenShareModal {
     fn set_tab(&mut self, tab: ShareTab, cx: &mut Context<Self>) {
         self.tab = tab;
         if let Some(selected) = self.selected {
-            let still_valid = self.options.iter().any(|option| {
-                option_kind(option) == selected.kind && option.id == selected.id
-            });
+            let still_valid = self
+                .options
+                .iter()
+                .any(|option| option_kind(option) == selected.kind && option.id == selected.id);
             if !still_valid {
                 self.selected = None;
             }
@@ -206,9 +207,11 @@ impl ScreenShareModal {
         let Some(selected) = self.selected else {
             return;
         };
-        let Some(option) = self.options.iter().find(|option| {
-            option_kind(option) == selected.kind && option.id == selected.id
-        }) else {
+        let Some(option) = self
+            .options
+            .iter()
+            .find(|option| option_kind(option) == selected.kind && option.id == selected.id)
+        else {
             return;
         };
         let pick = PickedScreen::Target(option.target.clone());
@@ -231,9 +234,9 @@ impl ScreenShareModal {
 
 fn preview_to_render_image(preview: ScreenSharePreview) -> Option<Arc<RenderImage>> {
     let buffer = image::RgbaImage::from_raw(preview.width, preview.height, preview.rgba)?;
-    Some(Arc::new(RenderImage::new(smallvec::smallvec![image::Frame::new(
-        buffer,
-    )])))
+    Some(Arc::new(RenderImage::new(smallvec::smallvec![
+        image::Frame::new(buffer,)
+    ])))
 }
 
 fn option_kind(option: &ScreenShareOption) -> ScreenShareKind {
@@ -262,8 +265,7 @@ impl Render for ScreenShareModal {
             mezon_i18n::t(&locale, "screenShare.alsoShareSystemAudio").into();
         let cancel_label: SharedString = mezon_i18n::t(&locale, "screenShare.cancel").into();
         let share_label: SharedString = mezon_i18n::t(&locale, "screenShare.share").into();
-        let loading_label: SharedString =
-            mezon_i18n::t(&locale, "screenShare.loading").into();
+        let loading_label: SharedString = mezon_i18n::t(&locale, "screenShare.loading").into();
         let empty_label: SharedString = mezon_i18n::t(&locale, "screenShare.selectScreen").into();
 
         let filtered = self.filtered_options();
@@ -360,33 +362,25 @@ impl Render for ScreenShareModal {
                         this.flex()
                             .items_center()
                             .justify_center()
-                            .child(
-                                div()
-                                    .text_sm()
-                                    .text_color(text_muted)
-                                    .child(loading_label),
-                            )
+                            .child(div().text_sm().text_color(text_muted).child(loading_label))
                     })
                     .when(!self.loading, |this| {
                         this.when_some(self.load_error.clone(), |el, message| {
                             el.flex()
                                 .items_center()
                                 .justify_center()
-                                .child(
-                                    div()
-                                        .text_sm()
-                                        .text_color(status_dnd)
-                                        .child(message),
-                                )
+                                .child(div().text_sm().text_color(status_dnd).child(message))
                         })
                         .when(self.load_error.is_none(), |el| {
                             el.when(filtered.is_empty(), |empty| {
-                                empty.flex().items_center().justify_center().py(px(40.)).child(
-                                    div()
-                                        .text_sm()
-                                        .text_color(text_muted)
-                                        .child(empty_label),
-                                )
+                                empty
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .py(px(40.))
+                                    .child(
+                                        div().text_sm().text_color(text_muted).child(empty_label),
+                                    )
                             })
                             .when(!filtered.is_empty(), |grid| {
                                 grid.child(target_grid(
@@ -441,9 +435,7 @@ impl Render for ScreenShareModal {
                                 Button::new("screen-share-cancel")
                                     .label(cancel_label)
                                     .ghost()
-                                    .on_click(
-                                    cx.listener(|this, _, _window, cx| this.close(cx)),
-                                ),
+                                    .on_click(cx.listener(|this, _, _window, cx| this.close(cx))),
                             )
                             .child(
                                 Button::new("screen-share-confirm")
@@ -475,7 +467,8 @@ fn tab_button(
         .rounded(px(8.))
         .cursor_pointer()
         .when(active, |this| {
-            this.bg(accent).text_color(gpui::Hsla::from(gpui::rgb(0xffffff)))
+            this.bg(accent)
+                .text_color(gpui::Hsla::from(gpui::rgb(0xffffff)))
         })
         .when(!active, |this| {
             this.text_color(text_muted)
@@ -510,10 +503,11 @@ fn target_grid(
                 kind,
                 id: option.id,
             };
-            let is_selected = selected == Some(SelectedTarget {
-                kind,
-                id: option.id,
-            });
+            let is_selected = selected
+                == Some(SelectedTarget {
+                    kind,
+                    id: option.id,
+                });
             let title = option.title.clone();
             let id = option.id;
             let tile_id = SharedString::from(format!("screen-share-tile-{index}"));

--- a/crates/mezon-ui/src/chat/voice.rs
+++ b/crates/mezon-ui/src/chat/voice.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    AnyElement, Context, Entity, FontWeight, Hsla, ObjectFit, SharedString,
-    StyledImage, div, img, prelude::*, px,
+    AnyElement, Context, Entity, FontWeight, Hsla, ObjectFit, SharedString, StyledImage, div, img,
+    prelude::*, px,
 };
 use mezon_store::{
     Channel, Settings, VoiceCallStatus, VoiceConnection, VoiceMember, VoiceParticipant, VoiceStore,
@@ -33,9 +33,10 @@ pub fn render_voice_channel(
     }
 
     let error = match store.connection() {
-        VoiceConnection::Failed { channel_id, message } if *channel_id == channel.id.to_string() => {
-            Some(message.clone())
-        }
+        VoiceConnection::Failed {
+            channel_id,
+            message,
+        } if *channel_id == channel.id.to_string() => Some(message.clone()),
         _ => None,
     };
 
@@ -307,12 +308,7 @@ fn render_pre_join(
                 .child(subtitle.to_string()),
         )
         .when_some(error, |this, message| {
-            this.child(
-                div()
-                    .text_color(theme.status_dnd)
-                    .text_sm()
-                    .child(message),
-            )
+            this.child(div().text_color(theme.status_dnd).text_sm().child(message))
         })
         .child(join);
 
@@ -405,16 +401,12 @@ fn render_in_call(
     } else {
         match store.call_status() {
             VoiceCallStatus::Reconnecting => Some((
-                SharedString::from(
-                    mezon_i18n::t(locale, "channelVoice.reconnecting").to_string(),
-                ),
+                SharedString::from(mezon_i18n::t(locale, "channelVoice.reconnecting").to_string()),
                 theme.status_idle.into(),
                 theme.bg_hover.into(),
             )),
             VoiceCallStatus::WeakNetwork => Some((
-                SharedString::from(
-                    mezon_i18n::t(locale, "channelVoice.weakNetwork").to_string(),
-                ),
+                SharedString::from(mezon_i18n::t(locale, "channelVoice.weakNetwork").to_string()),
                 theme.status_idle.into(),
                 theme.bg_hover.into(),
             )),
@@ -456,7 +448,9 @@ fn render_grid(
                 .p_3()
                 .bg(theme.bg_tertiary)
                 .children(room_members.iter().map(|member| {
-                    let mut avatar = Avatar::new().name(member.display_name.clone()).size_px(px(80.));
+                    let mut avatar = Avatar::new()
+                        .name(member.display_name.clone())
+                        .size_px(px(80.));
                     if !member.avatar_url.is_empty() {
                         avatar = avatar.src(member.avatar_url.clone());
                     }
@@ -481,7 +475,11 @@ fn render_grid(
                 .into_any_element();
         }
 
-        let key = if connecting { "channelVoice.connecting" } else { "channelVoice.noOneInRoom" };
+        let key = if connecting {
+            "channelVoice.connecting"
+        } else {
+            "channelVoice.noOneInRoom"
+        };
         return div()
             .flex()
             .flex_col()
@@ -665,12 +663,7 @@ fn video_tile(
         .into_any_element()
 }
 
-fn tile_inner(
-    theme: &Theme,
-    store: &VoiceStore,
-    cell: &VideoCell,
-    large: bool,
-) -> AnyElement {
+fn tile_inner(theme: &Theme, store: &VoiceStore, cell: &VideoCell, large: bool) -> AnyElement {
     if let Some(key) = cell.key
         && let Some(image) = store.render_image(key)
     {
@@ -689,9 +682,10 @@ fn tile_inner(
             .into_any_element();
     }
 
-    let mut avatar = Avatar::new()
-        .name(cell.name.clone())
-        .size_px(if large { px(120.) } else { px(80.) });
+    let mut avatar =
+        Avatar::new()
+            .name(cell.name.clone())
+            .size_px(if large { px(120.) } else { px(80.) });
     if cell.speaking {
         avatar = avatar.border_color(theme.status_online);
     }
@@ -731,12 +725,7 @@ fn tile_label(theme: &Theme, cell: &VideoCell) -> AnyElement {
                     .text_color(gpui::rgb(0xffffff)),
             )
         })
-        .child(
-            div()
-                .text_xs()
-                .text_color(gpui::rgb(0xffffff))
-                .child(label),
-        )
+        .child(div().text_xs().text_color(gpui::rgb(0xffffff)).child(label))
         .into_any_element()
 }
 
@@ -897,11 +886,7 @@ fn decorative_circle(theme: &Theme, icon: IconName) -> AnyElement {
         .h(px(44.))
         .rounded_full()
         .bg(theme.bg_secondary)
-        .child(
-            Icon::new(icon)
-                .size(px(20.))
-                .text_color(theme.text_muted),
-        )
+        .child(Icon::new(icon).size(px(20.)).text_color(theme.text_muted))
         .into_any_element()
 }
 

--- a/crates/mezon-ui/src/components/compositions/channel_row.rs
+++ b/crates/mezon-ui/src/components/compositions/channel_row.rs
@@ -105,22 +105,25 @@ impl ChannelRow {
                         })
                         .child(self.name),
                 )
-                .when(self.badge_count > 0 && !self.muted, move |el| {
-                    el.child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .justify_center()
-                            .min_w(px(16.0))
-                            .h(px(16.0))
-                            .px_1()
-                            .rounded_full()
-                            .bg(brand)
-                            .text_color(text_primary)
-                            .text_xs()
-                            .child(self.badge_label.clone()),
-                    )
-                })
+                .when(
+                    crate::SHOW_UNREAD_BADGE_COUNT && self.badge_count > 0 && !self.muted,
+                    move |el| {
+                        el.child(
+                            div()
+                                .flex()
+                                .items_center()
+                                .justify_center()
+                                .min_w(px(16.0))
+                                .h(px(16.0))
+                                .px_1()
+                                .rounded_full()
+                                .bg(brand)
+                                .text_color(text_primary)
+                                .text_xs()
+                                .child(self.badge_label.clone()),
+                        )
+                    },
+                )
                 .when(
                     self.badge_count == 0 && self.unread && !self.muted,
                     move |el| el.child(div().size_2().rounded_full().bg(brand)),

--- a/crates/mezon-ui/src/components/compositions/dm_row.rs
+++ b/crates/mezon-ui/src/components/compositions/dm_row.rs
@@ -137,6 +137,7 @@ impl DmRow {
                 .size(size)
                 .flex_shrink_0()
                 .rounded_full()
+                .overflow_hidden()
                 .child(
                     gpui::img(crate::util::assets::AVATAR_GROUP)
                         .size(size)

--- a/crates/mezon-ui/src/components/compositions/user_info_bar.rs
+++ b/crates/mezon-ui/src/components/compositions/user_info_bar.rs
@@ -88,11 +88,11 @@ impl Render for UserInfoBar {
             );
         settings_btn.interactivity().on_click(on_settings_click());
 
+        // Positioning (absolute / insets) is applied by the cached wrapper in
+        // the chat layout so this view can be `.cached()`; keep only the visual
+        // box here.
         div()
-            .absolute()
-            .left(px(12.0))
-            .right(px(8.0))
-            .bottom(px(12.0))
+            .w_full()
             .min_h(px(56.0))
             .overflow_hidden()
             .rounded(px(12.0))

--- a/crates/mezon-ui/src/components/primitives/avatar.rs
+++ b/crates/mezon-ui/src/components/primitives/avatar.rs
@@ -122,6 +122,7 @@ fn clipped_image(
         .size(size)
         .flex_shrink_0()
         .rounded_full()
+        .overflow_hidden()
         .child(
             img(src)
                 .size(size)

--- a/crates/mezon-ui/src/image_cache.rs
+++ b/crates/mezon-ui/src/image_cache.rs
@@ -1,28 +1,137 @@
+use std::future::Future;
 use std::sync::Arc;
 
-use futures::FutureExt;
 use futures::future::{AbortHandle, Abortable};
+use futures::{AsyncReadExt as _, FutureExt};
 use gpui::{
     App, Asset, AssetLogger, Context, ImageAssetLoader, ImageCache, ImageCacheError,
     ImageCacheItem, RenderImage, Resource, Window, hash,
 };
 use indexmap::IndexMap;
 
-pub const MESSAGE_IMAGE_CACHE_CAPACITY: usize = 96;
+pub const MESSAGE_IMAGE_CACHE_CAPACITY: usize = 48;
+pub const MESSAGE_IMAGE_CACHE_BYTES: u64 = 48 * 1024 * 1024;
 pub const AVATAR_IMAGE_CACHE_CAPACITY: usize = 256;
+pub const AVATAR_IMAGE_CACHE_BYTES: u64 = 16 * 1024 * 1024;
+
+/// App-wide fallback cache attached at the root, so any `img`/avatar that does
+/// not declare its own cache uses this bounded LRU instead of GPUI's unbounded
+/// global asset cache (which never evicts and leaks RAM for every URL seen).
+pub const SHARED_IMAGE_CACHE_CAPACITY: usize = 384;
+pub const SHARED_IMAGE_CACHE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Per-image decoded-size caps. A compressed file is tiny on the wire but is
+/// stored uncompressed in RAM as `width * height * 4` bytes *per frame*. An
+/// animated GIF/WebP therefore explodes: a ~400 KB animated avatar can decode
+/// to hundreds of MB once every frame is expanded. When the resizing image
+/// proxy is unavailable (dev, or a prod outage) we fall back to the raw,
+/// full-resolution file, so we guard against a single pathological image
+/// blowing up RAM by refusing to retain anything decoded larger than this and
+/// negatively caching it (shown as the initials fallback instead).
+pub const AVATAR_ENTRY_MAX_BYTES: u64 = 8 * 1024 * 1024;
+pub const MESSAGE_ENTRY_MAX_BYTES: u64 = 64 * 1024 * 1024;
+pub const SHARED_ENTRY_MAX_BYTES: u64 = 16 * 1024 * 1024;
 
 struct CacheEntry {
     item: ImageCacheItem,
     abort: AbortHandle,
+    /// Decoded size in bytes, once the image has finished loading.
+    bytes: Option<u64>,
+    /// The sweep epoch in which this entry was last requested.
+    touched_epoch: u64,
+}
+
+/// Sum of the decoded byte size across all frames of an image.
+fn image_bytes(image: &RenderImage) -> u64 {
+    (0..image.frame_count())
+        .filter_map(|frame| image.as_bytes(frame))
+        .map(|buf| buf.len() as u64)
+        .sum()
+}
+
+/// An LRU image cache bounded by both an item count and a decoded-byte budget.
+///
+/// The byte budget is what actually keeps RAM in check: large attachments are
+/// evicted as soon as the total decoded size exceeds `max_bytes`, instead of
+/// lingering until the (much larger) item count or a channel switch clears them.
+static CACHE_INSTANCE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Which decoder a cache uses to turn a resource into a `RenderImage`.
+#[derive(Clone, Copy)]
+enum LoaderKind {
+    /// GPUI's stock loader: decodes the image at full resolution and keeps every
+    /// frame of animated GIF/WebP. Used for message attachments that must render
+    /// full-size and animated.
+    Full,
+    /// Decodes only the first frame and downscales to avatar size, so even an
+    /// animated full-resolution source costs ~100 KB of RAM. Used for avatars.
+    AvatarThumbnail,
 }
 
 pub struct LruImageCache {
+    label: &'static str,
+    instance: u64,
+    loader: LoaderKind,
     max_items: usize,
+    max_bytes: u64,
+    /// Largest decoded size (bytes, summed across frames) a single entry may
+    /// have before it is dropped and negatively cached. Protects against a
+    /// single huge/animated image consuming hundreds of MB.
+    max_entry_bytes: u64,
+    total_bytes: u64,
+    epoch: u64,
     cache: IndexMap<u64, CacheEntry>,
 }
 
 impl LruImageCache {
-    pub fn new(max_items: usize, cx: &mut Context<Self>) -> Self {
+    pub fn new(max_items: usize, max_bytes: u64, cx: &mut Context<Self>) -> Self {
+        Self::labeled("image", max_items, max_bytes, u64::MAX, cx)
+    }
+
+    pub fn labeled(
+        label: &'static str,
+        max_items: usize,
+        max_bytes: u64,
+        max_entry_bytes: u64,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self::with_loader(
+            label,
+            LoaderKind::Full,
+            max_items,
+            max_bytes,
+            max_entry_bytes,
+            cx,
+        )
+    }
+
+    /// A cache for avatars: decodes only the first frame and downscales to
+    /// avatar size, so animated or oversized sources can never blow up RAM.
+    pub fn avatar_thumbnail(
+        label: &'static str,
+        max_items: usize,
+        max_bytes: u64,
+        max_entry_bytes: u64,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self::with_loader(
+            label,
+            LoaderKind::AvatarThumbnail,
+            max_items,
+            max_bytes,
+            max_entry_bytes,
+            cx,
+        )
+    }
+
+    fn with_loader(
+        label: &'static str,
+        loader: LoaderKind,
+        max_items: usize,
+        max_bytes: u64,
+        max_entry_bytes: u64,
+        cx: &mut Context<Self>,
+    ) -> Self {
         cx.on_release(|cache, cx| {
             for (_, mut entry) in std::mem::take(&mut cache.cache) {
                 entry.abort.abort();
@@ -33,8 +142,16 @@ impl LruImageCache {
         })
         .detach();
 
+        let instance = CACHE_INSTANCE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Self {
+            label,
+            instance,
+            loader,
             max_items,
+            max_bytes,
+            max_entry_bytes,
+            total_bytes: 0,
+            epoch: 0,
             cache: IndexMap::with_capacity(max_items),
         }
     }
@@ -43,6 +160,53 @@ impl LruImageCache {
         for (_, mut entry) in std::mem::take(&mut self.cache) {
             entry.abort.abort();
             if let Some(Ok(image)) = entry.item.get() {
+                cx.drop_image(image, Some(window));
+            }
+        }
+        self.total_bytes = 0;
+    }
+
+    /// Drop every image that was not requested during the most recent frame,
+    /// then advance the epoch. Call this once per render: anything that has
+    /// scrolled out of the viewport stops being requested and is freed on the
+    /// next sweep, so only the currently-visible images stay in RAM.
+    pub fn sweep(&mut self, window: &mut Window, cx: &mut App) {
+        let epoch = self.epoch;
+        let stale: Vec<u64> = self
+            .cache
+            .iter()
+            .filter(|(_, entry)| entry.touched_epoch != epoch)
+            .map(|(key, _)| *key)
+            .collect();
+        for key in stale {
+            if let Some(mut entry) = self.cache.shift_remove(&key) {
+                entry.abort.abort();
+                if let Some(bytes) = entry.bytes {
+                    self.total_bytes = self.total_bytes.saturating_sub(bytes);
+                }
+                if let Some(Ok(image)) = entry.item.get() {
+                    cx.drop_image(image, Some(window));
+                }
+            }
+        }
+        self.epoch = self.epoch.wrapping_add(1);
+    }
+
+    /// Evict least-recently-used entries until both the item-count and
+    /// byte budgets are satisfied. The most-recently-used entry (back of the
+    /// map) is never evicted, so the image requested this frame stays resident.
+    fn evict_to_budget(&mut self, window: &mut Window, cx: &mut App) {
+        while self.cache.len() > self.max_items
+            || (self.total_bytes > self.max_bytes && self.cache.len() > 1)
+        {
+            let Some((_, mut evicted)) = self.cache.shift_remove_index(0) else {
+                break;
+            };
+            evicted.abort.abort();
+            if let Some(bytes) = evicted.bytes {
+                self.total_bytes = self.total_bytes.saturating_sub(bytes);
+            }
+            if let Some(Ok(image)) = evicted.item.get() {
                 cx.drop_image(image, Some(window));
             }
         }
@@ -58,19 +222,68 @@ impl LruImageCache {
 
         if let Some(entry) = self.cache.shift_remove(&hash) {
             self.cache.insert(hash, entry);
-            return self.cache.get_mut(&hash).and_then(|e| e.item.get());
-        }
 
-        if self.cache.len() == self.max_items
-            && let Some((_, mut evicted)) = self.cache.shift_remove_index(0)
-        {
-            evicted.abort.abort();
-            if let Some(Ok(image)) = evicted.item.get() {
-                cx.drop_image(image, Some(window));
+            enum Measured {
+                /// Nothing new to account for (already measured, or still loading).
+                None,
+                /// Newly decoded image of the given size, kept in the cache.
+                Kept(u64),
+                /// Newly decoded image exceeded the per-entry cap: dropped and
+                /// negatively cached. Carries the image to free + the error.
+                TooLarge(Arc<RenderImage>, ImageCacheError),
+            }
+
+            let (res, measured) = {
+                let entry = self.cache.get_mut(&hash).expect("just re-inserted");
+                entry.touched_epoch = self.epoch;
+                let res = entry.item.get();
+                let measured = if entry.bytes.is_none()
+                    && let Some(Ok(image)) = res.as_ref()
+                {
+                    let bytes = image_bytes(image);
+                    if bytes > self.max_entry_bytes {
+                        let err = ImageCacheError::Other(Arc::new(anyhow::anyhow!(
+                            "image decoded to {bytes} bytes, exceeds per-entry cap of {} bytes",
+                            self.max_entry_bytes
+                        )));
+                        entry.item = ImageCacheItem::Loaded(Err(err.clone()));
+                        entry.bytes = Some(0);
+                        Measured::TooLarge(image.clone(), err)
+                    } else {
+                        entry.bytes = Some(bytes);
+                        Measured::Kept(bytes)
+                    }
+                } else {
+                    Measured::None
+                };
+                (res, measured)
+            };
+            match measured {
+                Measured::Kept(bytes) => {
+                    self.total_bytes = self.total_bytes.saturating_add(bytes);
+                    self.evict_to_budget(window, cx);
+                    return res;
+                }
+                Measured::TooLarge(image, err) => {
+                    tracing::warn!(
+                        "[imgcache:{}#{}] dropping oversized image: {}",
+                        self.label,
+                        self.instance,
+                        err
+                    );
+                    cx.drop_image(image, Some(window));
+                    return Some(Err(err));
+                }
+                Measured::None => return res,
             }
         }
 
-        let fut = AssetLogger::<ImageAssetLoader>::load(resource.clone(), cx);
+        let fut = match self.loader {
+            LoaderKind::Full => AssetLogger::<ImageAssetLoader>::load(resource.clone(), cx).boxed(),
+            LoaderKind::AvatarThumbnail => {
+                AssetLogger::<AvatarImageLoader>::load(resource.clone(), cx).boxed()
+            }
+        };
         let task = cx.background_executor().spawn(fut).shared();
         let (abort_handle, abort_reg) = AbortHandle::new_pair();
 
@@ -79,8 +292,11 @@ impl LruImageCache {
             CacheEntry {
                 item: ImageCacheItem::Loading(task.clone()),
                 abort: abort_handle,
+                bytes: None,
+                touched_epoch: self.epoch,
             },
         );
+        self.evict_to_budget(window, cx);
 
         let entity = window.current_view();
         let notify_task = task.clone();
@@ -105,5 +321,98 @@ impl ImageCache for LruImageCache {
         cx: &mut App,
     ) -> Option<Result<Arc<RenderImage>, ImageCacheError>> {
         LruImageCache::load(self, resource, window, cx)
+    }
+}
+
+/// Largest dimension (device pixels) an avatar is ever drawn at: the biggest
+/// avatar is 80px logical, which is 160px on a 2x display. Decoding to this size
+/// keeps a single avatar at ~100 KB regardless of the source file.
+const AVATAR_DECODE_MAX_PX: u32 = 160;
+
+/// An [`Asset`] loader for avatars that, unlike GPUI's stock [`ImageAssetLoader`],
+/// decodes **only the first frame** and **downscales** to avatar size before
+/// building the `RenderImage`.
+///
+/// GPUI's loader expands every frame of an animated GIF/WebP to
+/// `width * height * 4` uncompressed bytes and keeps them all, so a ~400 KB
+/// animated avatar can decode to hundreds of MB. Avatars never need animation
+/// or full resolution, so we sidestep that entirely: `image::load_from_memory`
+/// reads a single frame even for animated formats, and we shrink it to at most
+/// [`AVATAR_DECODE_MAX_PX`]. The result is a tiny, static image that cannot blow
+/// up RAM even when the resizing image proxy is unavailable and we fall back to
+/// the raw source file.
+pub enum AvatarImageLoader {}
+
+impl Asset for AvatarImageLoader {
+    type Source = Resource;
+    type Output = Result<Arc<RenderImage>, ImageCacheError>;
+
+    fn load(
+        source: Self::Source,
+        cx: &mut App,
+    ) -> impl Future<Output = Self::Output> + Send + 'static {
+        let client = cx.http_client();
+        let svg_renderer = cx.svg_renderer();
+        let asset_source = cx.asset_source().clone();
+        async move {
+            let bytes = match source.clone() {
+                Resource::Path(uri) => std::fs::read(uri.as_ref())?,
+                Resource::Uri(uri) => {
+                    use anyhow::Context as _;
+
+                    let mut response = client
+                        .get(uri.as_ref(), ().into(), true)
+                        .await
+                        .with_context(|| format!("loading avatar from {uri:?}"))?;
+                    let mut body = Vec::new();
+                    response.body_mut().read_to_end(&mut body).await?;
+                    if !response.status().is_success() {
+                        let mut body = String::from_utf8_lossy(&body).into_owned();
+                        let first_line = body.lines().next().unwrap_or("").trim_end();
+                        body.truncate(first_line.len());
+                        return Err(ImageCacheError::BadStatus {
+                            uri,
+                            status: response.status(),
+                            body,
+                        });
+                    }
+                    body
+                }
+                Resource::Embedded(path) => match asset_source.load(&path).ok().flatten() {
+                    Some(data) => data.to_vec(),
+                    None => {
+                        return Err(ImageCacheError::Asset(
+                            format!("Embedded resource not found: {path}").into(),
+                        ));
+                    }
+                },
+            };
+
+            if image::guess_format(&bytes).is_ok() {
+                // `load_from_memory` decodes a single frame even for animated
+                // GIF/WebP, so this never expands the whole animation.
+                let decoded = image::load_from_memory(&bytes)?;
+                // Center-crop to a square (cover), so non-square sources render
+                // as a clean circle/rounded box instead of overflowing the
+                // avatar bounds. Cap the side so we only ever downscale.
+                let side = decoded
+                    .width()
+                    .min(decoded.height())
+                    .min(AVATAR_DECODE_MAX_PX)
+                    .max(1);
+                let mut data = decoded
+                    .resize_to_fill(side, side, image::imageops::FilterType::Triangle)
+                    .into_rgba8();
+                // GPUI expects BGRA, so swap the red and blue channels.
+                for pixel in data.chunks_exact_mut(4) {
+                    pixel.swap(0, 2);
+                }
+                Ok(Arc::new(RenderImage::new(vec![image::Frame::new(data)])))
+            } else {
+                svg_renderer
+                    .render_single_frame(&bytes, 1.0)
+                    .map_err(Into::into)
+            }
+        }
     }
 }

--- a/crates/mezon-ui/src/lib.rs
+++ b/crates/mezon-ui/src/lib.rs
@@ -25,6 +25,8 @@ pub use sidebar::direct_sidebar::DirectSidebar;
 pub use theme::Theme;
 pub use theme::tokens::ThemeTokens;
 
+pub(crate) const SHOW_UNREAD_BADGE_COUNT: bool = false;
+
 gpui::actions!(mezon, [ToggleInspector, Quit]);
 
 #[macro_export]

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
@@ -183,7 +183,10 @@ impl ChannelSidebar {
                                 SharedString::from("")
                             };
                             items.push(SidebarItem::Channel {
-                                elem_id: SharedString::from(format!("ch-{}", &ch.id)),
+                                elem_id: SharedString::from(format!(
+                                    "ch-{}-{}",
+                                    &category.id, &ch.id
+                                )),
                                 id: ch.id.to_string(),
                                 name: truncate_channel_label(&ch.name),
                                 channel_type: ch.channel_type,
@@ -413,7 +416,7 @@ fn render_banner_and_events(
 
     if let Some(url) = banner_url {
         col = col.child(
-            div().w_full().h(px(136.)).mb_2().child(
+            div().w_full().h(px(136.)).mb_2().overflow_hidden().child(
                 gpui::img(crate::util::imgproxy::proxied(cx, url, 300, 300, "fit"))
                     .w_full()
                     .h_full()
@@ -662,22 +665,25 @@ fn render_sidebar_item(
                                 el.font_weight(gpui::FontWeight::BOLD)
                             })
                             .child(div().flex_1().child(name.clone()))
-                            .when(*badge_count > 0 && !*muted, move |el| {
-                                el.child(
-                                    div()
-                                        .flex()
-                                        .items_center()
-                                        .justify_center()
-                                        .min_w(px(16.))
-                                        .h(px(16.))
-                                        .px_1()
-                                        .rounded_full()
-                                        .bg(brand)
-                                        .text_color(text_primary)
-                                        .text_xs()
-                                        .child(badge_label.clone()),
-                                )
-                            }),
+                            .when(
+                                crate::SHOW_UNREAD_BADGE_COUNT && *badge_count > 0 && !*muted,
+                                move |el| {
+                                    el.child(
+                                        div()
+                                            .flex()
+                                            .items_center()
+                                            .justify_center()
+                                            .min_w(px(16.))
+                                            .h(px(16.))
+                                            .px_1()
+                                            .rounded_full()
+                                            .bg(brand)
+                                            .text_color(text_primary)
+                                            .text_xs()
+                                            .child(badge_label.clone()),
+                                    )
+                                },
+                            ),
                     )
                     .into_any_element()
             } else {

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
@@ -99,17 +99,18 @@ pub(super) fn render_clan_row(
         .read(cx)
         .is_active_clan(clan.id.parse().unwrap_or_default())
         && !dm_active;
-    let show_badge = clan.badge_count > 0 && !clan.muted;
+    let show_badge = crate::SHOW_UNREAD_BADGE_COUNT && clan.badge_count > 0 && !clan.muted;
     let show_nub = clan.has_unread && clan.badge_count == 0 && !clan.muted && !is_active;
     let badge_count = clan.badge_count;
     let muted = clan.muted;
     let pill_color = theme.tokens.text_theme_primary;
 
     let avatar: AnyElement = if let Some(ref url) = clan.avatar_url {
-        let proxied = crate::util::imgproxy::proxied(cx, url, 100, 100, "fill-down");
+        let proxied = crate::util::imgproxy::proxied(cx, url, 100, 100, "fill");
         let mut el = img(SharedString::from(proxied))
             .size(px(40.))
             .rounded(px(8.))
+            .overflow_hidden()
             .object_fit(gpui::ObjectFit::Cover);
         if muted {
             el = el.grayscale(true);


### PR DESCRIPTION
Add byte-budget LRU, per-entry size caps, viewport sweep, and avatar thumbnail decoding. Wire a shared root cache and cache chat subviews so scroll/presence updates do not repaint the whole timeline. Skip dev imgproxy for avatars and hide numeric unread badges until counts are stable.