### PR TITLE
feat(store): route channel badge counts through BadgeService

### DIFF
--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -413,6 +413,7 @@ fn open_main_window(
     mezon_store::ClanList::init(api.clone(), cx);
     mezon_store::ChannelList::init(api.clone(), cx);
     mezon_store::DirectMessageStore::init(api.clone(), cx);
+    mezon_store::BadgeService::init(auth_state.clone(), cx);
     mezon_store::MessagesStore::init(api.clone(), cx);
     mezon_store::PresenceStore::init(api.clone(), cx);
     mezon_store::VoiceStore::init(api.clone(), cx);

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -43,6 +43,7 @@ pub enum RealtimeEvent {
     CustomStatus(realtime::CustomStatusEvent),
     MessageReaction(api::MessageReaction),
     MarkAsRead(realtime::MarkAsRead),
+    LastSeenUpdated(realtime::LastSeenMessageEvent),
     ChannelCreated(realtime::ChannelCreatedEvent),
     ChannelUpdated(realtime::ChannelUpdatedEvent),
     ChannelDeleted(realtime::ChannelDeletedEvent),
@@ -77,6 +78,7 @@ impl TryFrom<realtime::envelope::Message> for RealtimeEvent {
             realtime::envelope::Message::CustomStatusEvent(m) => Ok(Self::CustomStatus(m)),
             realtime::envelope::Message::MessageReactionEvent(m) => Ok(Self::MessageReaction(m)),
             realtime::envelope::Message::MarkAsRead(m) => Ok(Self::MarkAsRead(m)),
+            realtime::envelope::Message::LastSeenMessageEvent(m) => Ok(Self::LastSeenUpdated(m)),
             realtime::envelope::Message::ChannelCreatedEvent(m) => Ok(Self::ChannelCreated(m)),
             realtime::envelope::Message::ChannelUpdatedEvent(m) => Ok(Self::ChannelUpdated(m)),
             realtime::envelope::Message::ChannelDeletedEvent(m) => Ok(Self::ChannelDeleted(m)),
@@ -480,6 +482,104 @@ fn parse_message_attachments(bytes: &[u8]) -> Vec<ApiAttachment> {
             Vec::new()
         }
     }
+}
+
+fn parse_message_references(bytes: &[u8]) -> Vec<ApiMessageRef> {
+    if bytes.is_empty() {
+        return Vec::new();
+    }
+    match api::MessageRefList::decode(bytes) {
+        Ok(list) => list
+            .refs
+            .into_iter()
+            .map(|r| ApiMessageRef {
+                message_ref_id: r.message_ref_id,
+                content: r.content,
+                has_attachment: r.has_attachment,
+                message_sender_id: r.message_sender_id,
+                message_sender_username: r.message_sender_username,
+                message_sender_avatar: r.message_sender_avatar,
+                message_sender_clan_nick: r.message_sender_clan_nick,
+                message_sender_display_name: r.message_sender_display_name,
+            })
+            .collect(),
+        Err(e) => {
+            tracing::warn!(
+                "failed to decode message references ({} bytes): {e}",
+                bytes.len()
+            );
+            Vec::new()
+        }
+    }
+}
+
+/// A single inline content token from a message's JSON `content` payload.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ContentToken {
+    #[serde(default)]
+    pub s: Option<i64>,
+    #[serde(default)]
+    pub e: Option<i64>,
+    #[serde(default)]
+    pub user_id: Option<String>,
+    #[serde(default)]
+    pub role_id: Option<String>,
+}
+
+/// Parsed `content` JSON of a message (the mezon `IExtendedMessage` shape).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ApiMessageContent {
+    #[serde(default)]
+    pub t: String,
+    #[serde(default)]
+    pub mentions: Vec<ContentToken>,
+}
+
+/// A reply/reference attached to a message (mezon `MessageRef`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ApiMessageRef {
+    pub message_ref_id: i64,
+    pub content: String,
+    pub has_attachment: bool,
+    pub message_sender_id: i64,
+    pub message_sender_username: String,
+    pub message_sender_avatar: String,
+    pub message_sender_clan_nick: String,
+    pub message_sender_display_name: String,
+}
+
+pub const MENTION_HERE_ID: &str = "here";
+
+pub fn is_mention_or_reply(
+    content: &str,
+    references: &[u8],
+    user_id: i64,
+    role_ids: &[i64],
+) -> bool {
+    if let Ok(parsed) = serde_json::from_str::<ApiMessageContent>(content)
+        && parsed
+            .mentions
+            .iter()
+            .any(|token| mention_targets_user(token, user_id, role_ids))
+    {
+        return true;
+    }
+    parse_message_references(references)
+        .iter()
+        .any(|reference| reference.message_sender_id == user_id)
+}
+
+fn mention_targets_user(token: &ContentToken, user_id: i64, role_ids: &[i64]) -> bool {
+    if let Some(uid) = token.user_id.as_deref()
+        && (uid == MENTION_HERE_ID || uid.parse::<i64>().is_ok_and(|id| id == user_id))
+    {
+        return true;
+    }
+    token
+        .role_id
+        .as_deref()
+        .and_then(|rid| rid.parse::<i64>().ok())
+        .is_some_and(|rid| role_ids.contains(&rid))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -5169,5 +5269,54 @@ mod tests {
         assert_eq!(t.get_api_index("ListChannelMessages"), Some(30));
         assert_eq!(t.get_api_index("UploadBatchAttachmentFile"), Some(209));
         assert_eq!(t.get_api_index("DefinitelyNotAnApi"), None);
+    }
+
+    fn reply_reference_bytes(message_sender_id: i64) -> Vec<u8> {
+        api::MessageRefList {
+            refs: vec![api::MessageRef {
+                message_sender_id,
+                ..Default::default()
+            }],
+        }
+        .encode_to_vec()
+    }
+
+    #[test]
+    fn mention_or_reply_plain_message_is_false() {
+        let content = r#"{"t":"hello world"}"#;
+        assert!(!is_mention_or_reply(content, &[], 42, &[]));
+    }
+
+    #[test]
+    fn mention_or_reply_detects_here() {
+        let content = r#"{"t":"@here","mentions":[{"user_id":"here","s":0,"e":5}]}"#;
+        assert!(is_mention_or_reply(content, &[], 42, &[]));
+    }
+
+    #[test]
+    fn mention_or_reply_detects_current_user_only() {
+        let content = r#"{"t":"@bob","mentions":[{"user_id":"42","s":0,"e":4}]}"#;
+        assert!(is_mention_or_reply(content, &[], 42, &[]));
+        assert!(!is_mention_or_reply(content, &[], 7, &[]));
+    }
+
+    #[test]
+    fn mention_or_reply_detects_matching_role_only() {
+        let content = r#"{"t":"@mods","mentions":[{"role_id":"99","s":0,"e":5}]}"#;
+        assert!(is_mention_or_reply(content, &[], 42, &[99]));
+        assert!(!is_mention_or_reply(content, &[], 42, &[100]));
+    }
+
+    #[test]
+    fn mention_or_reply_detects_reply_to_user() {
+        let refs = reply_reference_bytes(42);
+        let content = r#"{"t":"re"}"#;
+        assert!(is_mention_or_reply(content, &refs, 42, &[]));
+        assert!(!is_mention_or_reply(content, &refs, 7, &[]));
+    }
+
+    #[test]
+    fn mention_or_reply_malformed_content_is_false() {
+        assert!(!is_mention_or_reply("not json", &[], 42, &[]));
     }
 }

--- a/crates/mezon-store/src/badge.rs
+++ b/crates/mezon-store/src/badge.rs
@@ -1,0 +1,134 @@
+use gpui::{App, AppContext, Context, Entity, Global};
+use mezon_client::RealtimeEvent;
+
+use crate::AuthState;
+use crate::channel::ChannelList;
+use crate::clan::ClanList;
+use crate::clan_members::ClanMembersStore;
+use crate::direct::DirectMessageStore;
+use crate::ids::{ChannelId, ClanId, UserId};
+use crate::realtime::{RealtimeDispatch, RealtimeKind};
+
+const STREAM_MODE_GROUP: i32 = 3;
+const STREAM_MODE_DM: i32 = 4;
+
+pub struct BadgeService {
+    auth_state: Entity<AuthState>,
+}
+
+struct GlobalBadgeService(Entity<BadgeService>);
+impl Global for GlobalBadgeService {}
+
+impl BadgeService {
+    pub fn init(auth_state: Entity<AuthState>, cx: &mut App) -> Entity<Self> {
+        let entity = cx.new(|cx| Self::new(auth_state, cx));
+        cx.set_global(GlobalBadgeService(entity.clone()));
+        entity
+    }
+
+    pub fn global(cx: &App) -> Entity<Self> {
+        cx.global::<GlobalBadgeService>().0.clone()
+    }
+
+    fn new(auth_state: Entity<AuthState>, cx: &mut Context<Self>) -> Self {
+        let entity = cx.entity();
+        RealtimeDispatch::global(cx).update(cx, |dispatch, _| {
+            for kind in [
+                RealtimeKind::ChannelMessage,
+                RealtimeKind::MarkAsRead,
+                RealtimeKind::LastSeenUpdated,
+            ] {
+                dispatch.on(kind, &entity, |this, event, cx| {
+                    this.handle_event(event, cx)
+                });
+            }
+        });
+        Self { auth_state }
+    }
+
+    fn current_user_id(&self, cx: &App) -> Option<i64> {
+        match self.auth_state.read(cx) {
+            AuthState::Authenticated(session) | AuthState::Connecting(session) => {
+                session.user_id.parse::<i64>().ok()
+            }
+            _ => None,
+        }
+    }
+
+    fn is_mention(
+        &self,
+        content: &str,
+        references: &[u8],
+        user_id: i64,
+        clan_id: ClanId,
+        cx: &App,
+    ) -> bool {
+        let role_ids: Vec<i64> = ClanMembersStore::global(cx)
+            .read(cx)
+            .member(clan_id, UserId(user_id))
+            .map(|member| member.role_ids.iter().map(|role| role.get()).collect())
+            .unwrap_or_default();
+        mezon_client::transport::is_mention_or_reply(content, references, user_id, &role_ids)
+    }
+
+    fn handle_event(&mut self, event: &RealtimeEvent, cx: &mut Context<Self>) {
+        match event {
+            RealtimeEvent::ChannelMessage(m) => {
+                let channel_id = ChannelId(m.channel_id);
+                let ts = if m.create_time_seconds > 0 {
+                    i64::from(m.create_time_seconds)
+                } else {
+                    0
+                };
+                let user_id = self.current_user_id(cx);
+                let from_me = matches!(user_id, Some(uid) if uid == m.sender_id);
+
+                if m.mode == STREAM_MODE_GROUP || m.mode == STREAM_MODE_DM {
+                    DirectMessageStore::global(cx).update(cx, |dm, cx| {
+                        dm.note_message(channel_id, ts, from_me, cx);
+                    });
+                } else {
+                    let clan_id = ClanId(m.clan_id);
+                    let is_active =
+                        ChannelList::global(cx).read(cx).active_channel_id == Some(channel_id);
+                    let app_focused = cx.active_window().is_some();
+                    let seen = from_me || (is_active && app_focused);
+                    let is_mention = if seen {
+                        false
+                    } else {
+                        user_id
+                            .map(|uid| self.is_mention(&m.content, &m.references, uid, clan_id, cx))
+                            .unwrap_or(false)
+                    };
+                    ChannelList::global(cx).update(cx, |cl, cx| {
+                        cl.note_channel_message(clan_id, channel_id, is_mention, seen, ts, cx)
+                    });
+                    if !seen {
+                        ClanList::global(cx).update(cx, |cls, cx| {
+                            cls.note_channel_message(clan_id, is_mention, cx)
+                        });
+                    }
+                }
+            }
+            RealtimeEvent::MarkAsRead(e) => {
+                let channel_id = ChannelId(e.channel_id);
+                let clan_id = ClanId(e.clan_id);
+                DirectMessageStore::global(cx).update(cx, |dm, cx| {
+                    dm.note_read(channel_id, cx);
+                });
+                ChannelList::global(cx).update(cx, |cl, cx| cl.apply_read(clan_id, channel_id, cx));
+                ClanList::global(cx).update(cx, |cls, cx| cls.apply_badge_read(clan_id, cx));
+            }
+            RealtimeEvent::LastSeenUpdated(e) => {
+                let channel_id = ChannelId(e.channel_id);
+                let clan_id = ClanId(e.clan_id);
+                let new_badge = e.badge_count.max(0) as u32;
+                let seen_ts = i64::from(e.timestamp_seconds);
+                ChannelList::global(cx).update(cx, |cl, cx| {
+                    cl.apply_last_seen(clan_id, channel_id, new_badge, seen_ts, cx)
+                });
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -329,13 +329,11 @@ impl ChannelList {
         let entity = cx.entity();
         RealtimeDispatch::global(cx).update(cx, |dispatch, _| {
             for kind in [
-                RealtimeKind::ChannelMessage,
                 RealtimeKind::ChannelCreated,
                 RealtimeKind::ChannelUpdated,
                 RealtimeKind::ChannelDeleted,
                 RealtimeKind::VoiceJoined,
                 RealtimeKind::VoiceLeaved,
-                RealtimeKind::MarkAsRead,
                 RealtimeKind::UserChannelAdded,
                 RealtimeKind::UserChannelRemoved,
             ] {
@@ -489,51 +487,96 @@ impl ChannelList {
         ))
     }
 
+    fn notify_if_active(&self, clan_id: ClanId, cx: &mut Context<Self>) {
+        if self.active_clan_id == Some(clan_id) {
+            cx.notify();
+        }
+    }
+
+    pub fn note_channel_message(
+        &mut self,
+        clan_id: ClanId,
+        channel_id: ChannelId,
+        is_mention: bool,
+        seen: bool,
+        ts: i64,
+        cx: &mut Context<Self>,
+    ) {
+        let mut visible_changed = false;
+        if let Some(categories) = self.cache.get_mut(&clan_id) {
+            if let Some(ch) = categories
+                .iter_mut()
+                .flat_map(|c| &mut c.channels)
+                .find(|ch| ch.id == channel_id)
+            {
+                let was_unread = ch.is_unread();
+                let was_badge_zero = ch.badge_count == 0;
+                if ts > 0 {
+                    ch.last_sent_timestamp = ts;
+                    if seen {
+                        ch.last_seen_timestamp = ts;
+                    }
+                }
+                if is_mention && !seen {
+                    ch.badge_count = ch.badge_count.saturating_add(1);
+                }
+                visible_changed =
+                    was_unread != ch.is_unread() || was_badge_zero != (ch.badge_count == 0);
+            }
+        }
+        if visible_changed {
+            self.notify_if_active(clan_id, cx);
+        }
+    }
+
+    pub fn apply_read(&mut self, clan_id: ClanId, channel_id: ChannelId, cx: &mut Context<Self>) {
+        let mut became_read = false;
+        if let Some(categories) = self.cache.get_mut(&clan_id) {
+            if let Some(ch) = categories
+                .iter_mut()
+                .flat_map(|c| &mut c.channels)
+                .find(|ch| ch.id == channel_id)
+            {
+                became_read = ch.is_unread();
+                ch.badge_count = 0;
+                ch.last_seen_timestamp = ch.last_sent_timestamp;
+            }
+        }
+        if became_read {
+            self.notify_if_active(clan_id, cx);
+        }
+    }
+
+    pub fn apply_last_seen(
+        &mut self,
+        clan_id: ClanId,
+        channel_id: ChannelId,
+        new_badge: u32,
+        seen_ts: i64,
+        cx: &mut Context<Self>,
+    ) {
+        let mut visible_changed = false;
+        if let Some(categories) = self.cache.get_mut(&clan_id) {
+            if let Some(ch) = categories
+                .iter_mut()
+                .flat_map(|c| &mut c.channels)
+                .find(|ch| ch.id == channel_id)
+            {
+                let was_unread = ch.is_unread();
+                ch.badge_count = new_badge;
+                if seen_ts > ch.last_seen_timestamp {
+                    ch.last_seen_timestamp = seen_ts;
+                }
+                visible_changed = was_unread != ch.is_unread();
+            }
+        }
+        if visible_changed {
+            self.notify_if_active(clan_id, cx);
+        }
+    }
+
     fn handle_event(&mut self, event: &RealtimeEvent, cx: &mut Context<Self>) {
         match event {
-            RealtimeEvent::ChannelMessage(m) => {
-                let id = ChannelId(m.channel_id);
-                if self.active_channel_id != Some(id) {
-                    let mut changed = false;
-                    for cats in self.cache.values_mut() {
-                        if let Some(ch) = cats
-                            .iter_mut()
-                            .flat_map(|c| &mut c.channels)
-                            .find(|ch| ch.id == id)
-                        {
-                            ch.badge_count = ch.badge_count.saturating_add(1);
-                            if m.create_time_seconds > 0 {
-                                ch.last_sent_timestamp = i64::from(m.create_time_seconds);
-                            }
-                            changed = true;
-                            break;
-                        }
-                    }
-                    if changed {
-                        cx.emit(ChannelEvent::Unread(id));
-                        cx.notify();
-                    }
-                }
-            }
-            RealtimeEvent::MarkAsRead(e) => {
-                let id = ChannelId(e.channel_id);
-                let mut changed = false;
-                for cats in self.cache.values_mut() {
-                    if let Some(ch) = cats
-                        .iter_mut()
-                        .flat_map(|c| &mut c.channels)
-                        .find(|ch| ch.id == id)
-                    {
-                        ch.badge_count = 0;
-                        ch.last_seen_timestamp = ch.last_sent_timestamp;
-                        changed = true;
-                        break;
-                    }
-                }
-                if changed {
-                    cx.notify();
-                }
-            }
             RealtimeEvent::ChannelCreated(e) => {
                 let clan_id = ClanId(e.clan_id);
                 if self.cache.contains(&clan_id) {

--- a/crates/mezon-store/src/clan.rs
+++ b/crates/mezon-store/src/clan.rs
@@ -114,8 +114,6 @@ impl ClanList {
                 RealtimeKind::ClanDeleted,
                 RealtimeKind::AddClanUser,
                 RealtimeKind::UserClanRemoved,
-                RealtimeKind::ChannelMessage,
-                RealtimeKind::MarkAsRead,
             ] {
                 dispatch.on(kind, &entity, |this, event, cx| {
                     this.handle_event(event, cx)
@@ -252,27 +250,38 @@ impl ClanList {
                     cx.notify();
                 }
             }
-            RealtimeEvent::ChannelMessage(m) => {
-                let clan_id = ClanId(m.clan_id);
-                if let Some(clan) = self.clans.iter_mut().find(|c| c.id == clan_id)
-                    && !clan.muted
-                {
-                    clan.badge_count = clan.badge_count.saturating_add(1);
-                    clan.has_unread = true;
-                    cx.notify();
-                }
-            }
-            RealtimeEvent::MarkAsRead(m) => {
-                let clan_id = ClanId(m.clan_id);
-                if let Some(clan) = self.clans.iter_mut().find(|c| c.id == clan_id)
-                    && (clan.badge_count > 0 || clan.has_unread)
-                {
-                    clan.badge_count = 0;
-                    clan.has_unread = false;
-                    cx.notify();
-                }
-            }
             _ => {}
+        }
+    }
+
+    pub fn note_channel_message(
+        &mut self,
+        clan_id: ClanId,
+        is_mention: bool,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(clan) = self.clans.iter_mut().find(|c| c.id == clan_id)
+            && !clan.muted
+        {
+            let was_unread = clan.has_unread;
+            let was_badge_zero = clan.badge_count == 0;
+            clan.has_unread = true;
+            if is_mention {
+                clan.badge_count = clan.badge_count.saturating_add(1);
+            }
+            if !was_unread || was_badge_zero != (clan.badge_count == 0) {
+                cx.notify();
+            }
+        }
+    }
+
+    pub fn apply_badge_read(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+        if let Some(clan) = self.clans.iter_mut().find(|c| c.id == clan_id)
+            && (clan.badge_count > 0 || clan.has_unread)
+        {
+            clan.badge_count = 0;
+            clan.has_unread = false;
+            cx.notify();
         }
     }
 

--- a/crates/mezon-store/src/direct.rs
+++ b/crates/mezon-store/src/direct.rs
@@ -119,12 +119,7 @@ impl DirectMessageStore {
     fn register_realtime(cx: &mut Context<Self>) {
         let entity = cx.entity();
         RealtimeDispatch::global(cx).update(cx, |dispatch, _| {
-            for kind in [
-                RealtimeKind::ChannelMessage,
-                RealtimeKind::UserChannelAdded,
-                RealtimeKind::ChannelUpdated,
-                RealtimeKind::MarkAsRead,
-            ] {
+            for kind in [RealtimeKind::UserChannelAdded, RealtimeKind::ChannelUpdated] {
                 dispatch.on(kind, &entity, |this, event, cx| {
                     this.handle_event(event, cx)
                 });
@@ -240,18 +235,6 @@ impl DirectMessageStore {
 
     fn handle_event(&mut self, event: &RealtimeEvent, cx: &mut Context<Self>) {
         match event {
-            RealtimeEvent::ChannelMessage(m) => {
-                let id = ChannelId(m.channel_id);
-                let Some(pos) = self.channels.iter().position(|c| c.id == id) else {
-                    return;
-                };
-                if m.create_time_seconds > 0 {
-                    self.channels[pos].last_sent_timestamp = i64::from(m.create_time_seconds);
-                }
-                sort_by_recent(&mut self.channels);
-                cx.emit(DirectEvent::Changed);
-                cx.notify();
-            }
             RealtimeEvent::ChannelUpdated(e) => {
                 let id = ChannelId(e.channel_id);
                 let Some(ch) = self.channels.iter_mut().find(|c| c.id == id) else {
@@ -263,16 +246,6 @@ impl DirectMessageStore {
                 if !e.channel_avatar.is_empty() {
                     ch.avatar = e.channel_avatar.clone();
                 }
-                cx.emit(DirectEvent::Changed);
-                cx.notify();
-            }
-            RealtimeEvent::MarkAsRead(e) => {
-                let id = ChannelId(e.channel_id);
-                let Some(ch) = self.channels.iter_mut().find(|c| c.id == id) else {
-                    return;
-                };
-                ch.unread_count = 0;
-                ch.last_seen_timestamp = ch.last_sent_timestamp;
                 cx.emit(DirectEvent::Changed);
                 cx.notify();
             }
@@ -296,6 +269,44 @@ impl DirectMessageStore {
             }
             _ => {}
         }
+    }
+
+    pub fn note_message(
+        &mut self,
+        channel_id: ChannelId,
+        ts: i64,
+        from_me: bool,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(pos) = self.channels.iter().position(|c| c.id == channel_id) else {
+            return false;
+        };
+        let channel = &mut self.channels[pos];
+        if ts > 0 {
+            channel.last_sent_timestamp = ts;
+        }
+        if from_me {
+            if ts > 0 {
+                channel.last_seen_timestamp = ts;
+            }
+        } else {
+            channel.unread_count = channel.unread_count.saturating_add(1);
+        }
+        sort_by_recent(&mut self.channels);
+        cx.emit(DirectEvent::Changed);
+        cx.notify();
+        true
+    }
+
+    pub fn note_read(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) -> bool {
+        let Some(ch) = self.channels.iter_mut().find(|c| c.id == channel_id) else {
+            return false;
+        };
+        ch.unread_count = 0;
+        ch.last_seen_timestamp = ch.last_sent_timestamp;
+        cx.emit(DirectEvent::Changed);
+        cx.notify();
+        true
     }
 }
 

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod account;
 pub mod audio;
+pub mod badge;
 pub mod cache;
 pub mod channel;
 pub mod channel_members;
@@ -29,6 +30,7 @@ use tokio::fs;
 
 pub use account::*;
 pub use audio::{AudioDeviceInfo, AudioStore, MicCaptureFactory, MicCaptureHandle};
+pub use badge::BadgeService;
 pub use cache::KeyedCache;
 pub use channel::*;
 pub use channel_members::{ChannelMember, ChannelMembersEvent, ChannelMembersStore};

--- a/crates/mezon-store/src/realtime.rs
+++ b/crates/mezon-store/src/realtime.rs
@@ -33,6 +33,7 @@ pub enum RealtimeKind {
     VoiceJoined,
     VoiceLeaved,
     MarkAsRead,
+    LastSeenUpdated,
     UserChannelAdded,
     UserChannelRemoved,
 }
@@ -57,6 +58,7 @@ impl RealtimeKind {
             RealtimeEvent::VoiceJoined(_) => Self::VoiceJoined,
             RealtimeEvent::VoiceLeaved(_) => Self::VoiceLeaved,
             RealtimeEvent::MarkAsRead(_) => Self::MarkAsRead,
+            RealtimeEvent::LastSeenUpdated(_) => Self::LastSeenUpdated,
             RealtimeEvent::UserChannelAdded(_) => Self::UserChannelAdded,
             RealtimeEvent::UserChannelRemoved(_) => Self::UserChannelRemoved,
             _ => return None,


### PR DESCRIPTION
Centralize unread and mention badge updates in BadgeService with mention-gated counts, LastSeenUpdated sync, and active-clan render gating to match React parity.