### PR TITLE
feat(chat): attachment upload limits, video posters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ profile.json.gz
 scripts/*
 !scripts/linux-deps
 !scripts/build-deb.sh
+!scripts/perf-monitor-macos.sh
+!scripts/perf-monitor-windows.ps1
+!scripts/perf-compare.sh
+
+perf-report*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5567,6 +5567,7 @@ dependencies = [
  "flume",
  "gpui",
  "image",
+ "mezon-audio",
  "mezon-client",
  "mezon-proto",
  "mezon-voice",
@@ -5669,6 +5670,7 @@ dependencies = [
  "tokio",
  "tracing",
  "windows-capture 2.0.0",
+ "yuv",
  "zed-scap",
 ]
 
@@ -11792,6 +11794,15 @@ dependencies = [
  "quote",
  "syn 2.0.118",
  "synstructure",
+]
+
+[[package]]
+name = "yuv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85a782d94ee43f078bcfd6fa82d4e6a5b2d1cfbbad168e4df5a9f7b39ef48c"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,6 +236,7 @@ windows-core         = "0.61.2"
 windows-sys = { version = "0.61" }
 # ---------- Graphics ----------
 image                = "0.25.1"
+yuv                  = "0.8"
 qrcode               = { version = "0.14", default-features = false }
 wgpu                 = { git = "https://github.com/zed-industries/wgpu.git", branch = "v29", features = ["wgsl"] }
 naga                 = { version = "29.0", features = ["wgsl-in"] }

--- a/crates/mezon-client/src/app_api.rs
+++ b/crates/mezon-client/src/app_api.rs
@@ -65,6 +65,15 @@ pub struct UploadFile {
     pub filename: String,
     pub filetype: String,
     pub data: Vec<u8>,
+    pub width: i32,
+    pub height: i32,
+    pub thumbnail: Option<UploadThumbnail>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UploadThumbnail {
+    pub filename: String,
+    pub data: Vec<u8>,
 }
 
 #[derive(Debug, Clone)]
@@ -820,6 +829,9 @@ impl AppApi {
             filename,
             filetype,
             data,
+            width,
+            height,
+            thumbnail,
         } = file;
         let filename = sanitize_filename(&filename);
         let size = clamp_i32(data.len());
@@ -832,11 +844,18 @@ impl AppApi {
                 .await
                 .map_err(|e| anyhow::anyhow!("image dimensions task failed: {e}"))?
         } else {
-            (data, 0, 0)
+            (data, width, height)
         };
-        let url = self
-            .upload_bytes(&filename, &filetype, size, width, height, data)
-            .await?;
+        let (thumbnail_url, url) = futures::join!(
+            async {
+                match thumbnail {
+                    Some(thumb) => self.upload_thumbnail(thumb).await,
+                    None => String::new(),
+                }
+            },
+            self.upload_bytes(&filename, &filetype, size, width, height, data),
+        );
+        let url = url?;
         Ok(mezon_proto::api::MessageAttachment {
             filename,
             size,
@@ -844,9 +863,24 @@ impl AppApi {
             filetype,
             width,
             height,
-            thumbnail: String::new(),
+            thumbnail: thumbnail_url,
             duration: 0,
         })
+    }
+
+    async fn upload_thumbnail(&self, thumbnail: UploadThumbnail) -> String {
+        let filename = sanitize_filename(&thumbnail.filename);
+        let size = clamp_i32(thumbnail.data.len());
+        match self
+            .upload_bytes(&filename, "image/jpeg", size, 0, 0, thumbnail.data)
+            .await
+        {
+            Ok(url) => url,
+            Err(e) => {
+                tracing::error!("attachment poster upload failed: {e}");
+                String::new()
+            }
+        }
     }
 
     async fn upload_bytes(

--- a/crates/mezon-client/src/lib.rs
+++ b/crates/mezon-client/src/lib.rs
@@ -21,7 +21,7 @@ pub use attachment_download::{
     sanitize_filename, write_bytes_to_downloads,
 };
 pub use abridged_tcp_adapter::AbridgedTcpAdapter;
-pub use app_api::{AppApi, ConnectionStatus, UploadFile, UrlAttachment};
+pub use app_api::{AppApi, ConnectionStatus, UploadFile, UploadThumbnail, UrlAttachment};
 pub use auth::MezonClient;
 pub use auth::QrLoginId;
 pub use auth::{DEFAULT_API_HOST, DEFAULT_API_PORT, DEFAULT_API_SECURE, DEFAULT_SERVER_KEY};

--- a/crates/mezon-store/src/config.rs
+++ b/crates/mezon-store/src/config.rs
@@ -80,7 +80,7 @@ pub struct AppConfig {
 
 impl Default for AppConfig {
     fn default() -> Self {
-        Self::dev_defaults()
+        Self::prod_defaults()
     }
 }
 
@@ -150,14 +150,75 @@ impl AppConfig {
         }
     }
 
-    // pub fn prod_defaults() -> Self {
-    //     Self {
-    //     }
-    // }
+    pub fn prod_defaults() -> Self {
+        Self {
+            api_host: "api.mezon.ai".into(),
+            api_port: 443,
+            api_secure: true,
+            api_key: "HTTP3m3zonPr0dkey".into(),
+            api_gw_host: "gw.mezon.ai".into(),
+            api_gw_port: 443,
 
-    /// Load configuration from environment variables, falling back to [`dev_defaults`].
+            tcp_port: None,
+            stream_ws_url: "wss://stn.mezon.ai".into(),
+            meet_ws_url: "wss://meet.mezon.ai".into(),
+            notification_ws_url: "wss://gotify.mezon.ai".into(),
+
+            oauth2_authorize_url: "https://oauth2.mezon.ai/oauth2/auth".into(),
+            oauth2_client_id: "25f63a1f-16b8-488b-8b14-68520eeab77f".into(),
+            oauth2_redirect_uri: "http://127.0.0.1:4200/login/callback".into(),
+            oauth2_response_type: "code".into(),
+            oauth2_scope: "openid+offline".into(),
+            oauth2_code_challenge_method: "S256".into(),
+            oauth2_log_out: "https://oauth2.mezon.ai/oauth2/sessions/logout".into(),
+            oauth2_log_out_callback: "https://mezon.ai/logout/callback".into(),
+            google_client_id:
+                "391688022389-1k9kb377ea6dccpqii7m5pifjj0agsjc.apps.googleusercontent.com".into(),
+
+            domain_url: "https://mezon.ai".into(),
+            redirect_uri: "https://mezon.ai".into(),
+            logo_mezon: "https://cdn.mezon.ai/images/mezon_logo.png".into(),
+            base_img_url: "https://cdn.mezon.ai".into(),
+            profile_img_url: "https://profile.mezon.ai".into(),
+            imgproxy_base_url: "https://imgproxy.mezon.ai".into(),
+            imgproxy_key: "K0YUZRIosDOcz5lY6qrgC6UIXmQgWzLjZv7VJ1RAA8c".into(),
+
+            tenor_key: "AIzaSyA7PmFsiGws1XF-t6jXsVuF6O2DQLa8BpE".into(),
+            tenor_url_categories: "https://tenor.googleapis.com/v2/categories?key=".into(),
+            tenor_url_search: "https://tenor.googleapis.com/v2/search?q=".into(),
+            tenor_url_featured: "https://tenor.googleapis.com/v2/featured?key=".into(),
+
+            mezon_treasury_url: "https://withdraw-api.nccsoft.vn".into(),
+            mezon_treasury_key: "WTGYB2AJSHUBPAXZULT2Y7LGR4GQ".into(),
+            contract_address: "0x4F17a94dD6E1B2D6241C4D1956C6c7a07ba2Ec50".into(),
+            mezon_treasury_url_network: "https://sepolia.etherscan.io".into(),
+
+            webrtc_ice_servers_url: "turn:relay.mezon.ai:5349".into(),
+            webrtc_ice_servers_username: "turnmezon".into(),
+            webrtc_ice_servers_credential: "QuTs4zUEcbylWemXL7MK".into(),
+
+            fcm_api_key: "AIzaSyAzgF6LfHVWzlr9gGHWU7emix2768wSGHg".into(),
+            fcm_auth_domain: "mezon-772fa.firebaseapp.com".into(),
+            fcm_project_id: "mezon-772fa".into(),
+            fcm_storage_bucket: "mezon-772fa.appspot.com".into(),
+            fcm_messaging_sender_id: "285548761692".into(),
+            fcm_app_id: "1:285548761692:web:3ca531af1deecee74e0c99".into(),
+            fcm_measurement_id: "G-0WNQTXVMT3".into(),
+            fcm_vapid_key:
+                "BLHZ5mS8qWRxw4Psmpq9QEavz1B8rYgmkWeJ9CCSDR-g-NjfYWpmfi_t2IV4dJLx2X76p2sApyISytUVtD64nfs"
+                    .into(),
+
+            api_client_key_custom: "mezon.ai".into(),
+            sentry_dsn: "https://7aad12a70a52b6598fa5847153a13781@o4509763792404480.ingest.us.sentry.io/4509767257751552".into(),
+            anonymous_user_id: "1767478432163172999".into(),
+            max_length_name_allowed: 64,
+            update_url: "https://cdn.mezon.ai/release/".into()
+        }
+    }
+
+    /// Load configuration from environment variables, falling back to [`prod_defaults`].
     pub fn from_env() -> Self {
-        let defaults = Self::dev_defaults();
+        let defaults = Self::prod_defaults();
         Self {
             api_host: opt_str(option_env!("NX_CHAT_APP_API_HOST"), &defaults.api_host),
             api_port: opt_u16(option_env!("NX_CHAT_APP_API_PORT"), defaults.api_port),

--- a/crates/mezon-store/src/message.rs
+++ b/crates/mezon-store/src/message.rs
@@ -29,6 +29,7 @@ pub struct MessageAttachment {
     pub display_width: f32,
     pub display_height: f32,
     pub tenor_mp4: Option<SharedString>,
+    pub local_source: Option<std::path::PathBuf>,
 }
 
 pub fn format_file_size(bytes: u64) -> String {
@@ -183,6 +184,8 @@ pub struct MessageReference {
     pub content: String,
     pub content_preview: SharedString,
     pub has_attachment: bool,
+    pub has_embed: bool,
+    pub is_poll: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -14,7 +14,8 @@ use mezon_client::transport::{
     hashtag_content_tokens, markdown_content_tokens, mention_content_tokens,
 };
 use mezon_client::{
-    AppApi, ConnectionStatus, MezonTransport, RealtimeEvent, UploadFile, UrlAttachment,
+    AppApi, ConnectionStatus, MezonTransport, RealtimeEvent, UploadFile, UploadThumbnail,
+    UrlAttachment,
 };
 
 use crate::AppConfig;
@@ -93,6 +94,9 @@ pub enum MessagesEvent {
         index: usize,
         message_id: MessageId,
     },
+    /// The composer reply target was set or cleared. Lets the composer re-render
+    /// its "replying to" bar without the message list reacting to every change.
+    ReplyTargetChanged,
 }
 
 /// The message currently being replied to (composer state), mirroring React's
@@ -105,6 +109,8 @@ pub struct ReplyDraft {
     pub sender_avatar: String,
     pub content_preview: String,
     pub has_attachment: bool,
+    pub has_embed: bool,
+    pub is_poll: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -180,6 +186,9 @@ pub struct OutgoingAttachment {
     pub path: PathBuf,
     pub filename: String,
     pub filetype: String,
+    pub width: i32,
+    pub height: i32,
+    pub poster_jpeg: Option<Vec<u8>>,
 }
 
 #[derive(Default)]
@@ -1458,7 +1467,7 @@ impl MessagesStore {
     /// Set the composer reply target (from a "Reply" action on a message).
     pub fn set_reply(&mut self, draft: ReplyDraft, cx: &mut Context<Self>) {
         self.reply_target = Some(draft);
-        cx.emit(MessagesEvent::Updated { message_id: None });
+        cx.emit(MessagesEvent::ReplyTargetChanged);
         cx.notify();
     }
 
@@ -1477,6 +1486,8 @@ impl MessagesStore {
                 sender_avatar: msg.avatar_url.to_string(),
                 content_preview: msg.content.clone(),
                 has_attachment: !msg.attachments.is_empty(),
+                has_embed: msg.content.is_empty() && !msg.embeds.is_empty(),
+                is_poll: msg.poll.is_some(),
             })
         else {
             return;
@@ -1487,7 +1498,7 @@ impl MessagesStore {
     /// Clear the composer reply target.
     pub fn clear_reply(&mut self, cx: &mut Context<Self>) {
         if self.reply_target.take().is_some() {
-            cx.emit(MessagesEvent::Updated { message_id: None });
+            cx.emit(MessagesEvent::ReplyTargetChanged);
             cx.notify();
         }
     }
@@ -1965,6 +1976,9 @@ impl MessagesStore {
         let mode = self.mode;
         let has_attachments = !attachments.is_empty();
         let reply = self.reply_target.take();
+        if reply.is_some() {
+            cx.emit(MessagesEvent::ReplyTargetChanged);
+        }
 
         self.clear_last_read_message(channel_id);
         let Some(channel) = self.cache.get_mut(&channel_id) else {
@@ -2026,7 +2040,20 @@ impl MessagesStore {
                 content_preview: crate::message::reply_preview_line(&draft.content_preview).into(),
                 content: draft.content_preview.clone(),
                 has_attachment: draft.has_attachment,
+                has_embed: draft.has_embed,
+                is_poll: draft.is_poll,
             }]);
+        }
+        if has_attachments {
+            let optimistic_attachments: Vec<MessageAttachment> = attachments
+                .iter()
+                .map(MessageAttachment::optimistic_local)
+                .collect();
+            let (album_layout, viewer_media) =
+                build_media_presentation(&optimistic_attachments, AppConfig::try_global(cx));
+            optimistic = optimistic
+                .with_attachments(optimistic_attachments)
+                .with_media_presentation(album_layout, viewer_media);
         }
         let old_len = channel.messages.len();
         channel.messages.push_trim_regroup(optimistic);
@@ -2050,19 +2077,26 @@ impl MessagesStore {
                         attachments
                             .into_iter()
                             .filter_map(|att| {
-                                std::fs::read(&att.path)
+                                let data = std::fs::read(&att.path)
                                     .inspect_err(|e| {
                                         tracing::error!(
                                             "attachment read failed for {:?}: {e}",
                                             att.path
                                         )
                                     })
-                                    .ok()
-                                    .map(|data| UploadFile {
-                                        filename: att.filename,
-                                        filetype: att.filetype,
-                                        data,
-                                    })
+                                    .ok()?;
+                                let thumbnail = att.poster_jpeg.map(|jpeg| UploadThumbnail {
+                                    filename: format!("{}.jpg", att.filename),
+                                    data: jpeg,
+                                });
+                                Some(UploadFile {
+                                    filename: att.filename,
+                                    filetype: att.filetype,
+                                    data,
+                                    width: att.width,
+                                    height: att.height,
+                                    thumbnail,
+                                })
                             })
                             .collect::<Vec<_>>()
                     })
@@ -2597,6 +2631,7 @@ impl MessagesStore {
             .is_some_and(|draft| draft.message_ref_id == message_id)
         {
             self.reply_target = None;
+            cx.emit(MessagesEvent::ReplyTargetChanged);
         }
         self.retreat_last_message(storage_id, message_id);
 
@@ -3418,6 +3453,21 @@ fn outgoing_sender_profile(
 }
 
 /// Preserve optimistic/current-user metadata when send acks omit avatar/sender fields.
+fn carry_local_previews(prior: &Message, confirmed: &mut Message) {
+    if prior.attachments.len() != confirmed.attachments.len() {
+        return;
+    }
+    for (att, prior_att) in confirmed
+        .attachments
+        .iter_mut()
+        .zip(prior.attachments.iter())
+    {
+        if att.local_source.is_none() {
+            att.local_source = prior_att.local_source.clone();
+        }
+    }
+}
+
 fn merge_sparse_sender(prior: &Message, mut incoming: Message) -> Message {
     if incoming.sender_id.is_empty() || incoming.sender_id == "0" {
         incoming.sender_id = prior.sender_id.clone();
@@ -3435,6 +3485,10 @@ fn merge_sparse_sender(prior: &Message, mut incoming: Message) -> Message {
         incoming.day_label = prior.day_label.clone();
         incoming.row_anchor_id = prior.row_anchor_id;
     }
+    if incoming.references.is_empty() && !prior.references.is_empty() {
+        incoming.references = prior.references.clone();
+    }
+    carry_local_previews(prior, &mut incoming);
     incoming
 }
 
@@ -4095,10 +4149,19 @@ fn message_reference_from_api(
     } else {
         r.message_sender_username.clone()
     };
-    // The reference content is itself a JSON `IExtendedMessage`; extract its text.
-    let content = serde_json::from_str::<mezon_client::transport::ApiMessageContent>(&r.content)
-        .map(|c| c.t)
-        .unwrap_or_else(|_| r.content.clone());
+    // The reference content is itself a JSON `IExtendedMessage`; extract its text and embed.
+    let parsed =
+        serde_json::from_str::<mezon_client::transport::ApiMessageContent>(&r.content).ok();
+    let content = parsed
+        .as_ref()
+        .map(|c| c.t.clone())
+        .unwrap_or_else(|| r.content.clone());
+    let has_embed = parsed
+        .as_ref()
+        .is_some_and(|c| c.t.is_empty() && !c.embed.is_empty());
+    let is_poll = parsed
+        .as_ref()
+        .is_some_and(|c| c.poll_id.is_some() || (c.question.is_some() && !c.answers.is_empty()));
     let sender_avatar = cfg
         .map(|c| c.avatar_proxy(&r.message_sender_avatar))
         .unwrap_or_else(|| r.message_sender_avatar.clone());
@@ -4111,6 +4174,8 @@ fn message_reference_from_api(
         content,
         content_preview,
         has_attachment: r.has_attachment,
+        has_embed,
+        is_poll,
     }
 }
 
@@ -4159,6 +4224,33 @@ impl MessageAttachment {
             display_width,
             display_height,
             tenor_mp4,
+            local_source: None,
+        }
+    }
+
+    pub(crate) fn optimistic_local(att: &OutgoingAttachment) -> Self {
+        let width = att.width.max(0) as u32;
+        let height = att.height.max(0) as u32;
+        let (display_width, display_height) =
+            crate::config::attachment_display_dimensions(width, height);
+        let is_image = att.filetype.starts_with("image/");
+        Self {
+            url: String::new(),
+            filename: att.filename.clone(),
+            filetype: att.filetype.clone(),
+            width,
+            height,
+            thumbnail: String::new(),
+            duration: 0,
+            size: 0,
+            size_label: SharedString::default(),
+            presign_pending: false,
+            proxied_src: SharedString::default(),
+            thumbnail_proxied: SharedString::default(),
+            display_width,
+            display_height,
+            tenor_mp4: None,
+            local_source: is_image.then(|| att.path.clone()),
         }
     }
 }
@@ -4589,6 +4681,119 @@ mod tests {
     }
 
     #[test]
+    fn merge_sparse_sender_carries_local_preview() {
+        let optimistic = Message::new(MessageId::next_optimistic(), "", "42", "Me", 100)
+            .with_attachments(vec![MessageAttachment {
+                filename: "photo.png".into(),
+                local_source: Some(std::path::PathBuf::from("/tmp/photo.png")),
+                ..Default::default()
+            }]);
+        let confirmed = Message::new(MessageId(99), "", "42", "Me", 500).with_attachments(vec![
+            MessageAttachment {
+                filename: "sanitized_photo.png".into(),
+                url: "https://cdn.mezon.ai/photo.png".into(),
+                ..Default::default()
+            },
+        ]);
+        let merged = merge_sparse_sender(&optimistic, confirmed);
+        assert_eq!(
+            merged.attachments[0].local_source,
+            Some(std::path::PathBuf::from("/tmp/photo.png"))
+        );
+    }
+
+    #[test]
+    fn merge_sparse_sender_carries_reply_reference() {
+        let optimistic = Message::new(MessageId::next_optimistic(), "hi", "42", "Me", 100)
+            .with_references(vec![MessageReference {
+                message_ref_id: MessageId(7),
+                sender_name: "Alice".into(),
+                content: "original".into(),
+                content_preview: "original".into(),
+                ..Default::default()
+            }]);
+        let confirmed = Message::new(MessageId(99), "hi", "42", "Me", 500);
+        assert!(confirmed.references.is_empty());
+        let merged = merge_sparse_sender(&optimistic, confirmed);
+        assert_eq!(merged.references.len(), 1);
+        assert_eq!(merged.references[0].message_ref_id, MessageId(7));
+        assert_eq!(merged.references[0].sender_name, "Alice");
+    }
+
+    #[test]
+    fn merge_sparse_sender_keeps_confirmed_reference_when_present() {
+        let optimistic = Message::new(MessageId::next_optimistic(), "hi", "42", "Me", 100)
+            .with_references(vec![MessageReference {
+                message_ref_id: MessageId(7),
+                sender_name: "Stale".into(),
+                ..Default::default()
+            }]);
+        let confirmed = Message::new(MessageId(99), "hi", "42", "Me", 500).with_references(vec![
+            MessageReference {
+                message_ref_id: MessageId(7),
+                sender_name: "Fresh".into(),
+                ..Default::default()
+            },
+        ]);
+        let merged = merge_sparse_sender(&optimistic, confirmed);
+        assert_eq!(merged.references[0].sender_name, "Fresh");
+    }
+
+    #[test]
+    fn carry_local_previews_copies_local_path_by_index() {
+        let prior = Message::new(MessageId::next_optimistic(), "", "42", "Me", 100)
+            .with_attachments(vec![MessageAttachment {
+                filename: "photo.png".into(),
+                local_source: Some(std::path::PathBuf::from("/tmp/photo.png")),
+                ..Default::default()
+            }]);
+        let mut confirmed = Message::new(MessageId(7), "", "42", "Me", 500).with_attachments(vec![
+            MessageAttachment {
+                filename: "1700_0_photo.png".into(),
+                url: "https://cdn.mezon.ai/photo.png".into(),
+                ..Default::default()
+            },
+        ]);
+        carry_local_previews(&prior, &mut confirmed);
+        assert_eq!(
+            confirmed.attachments[0].local_source,
+            Some(std::path::PathBuf::from("/tmp/photo.png"))
+        );
+    }
+
+    #[test]
+    fn optimistic_multi_image_gets_album_layout() {
+        let outgoing = |name: &str| OutgoingAttachment {
+            path: format!("/tmp/{name}").into(),
+            filename: name.to_string(),
+            filetype: "image/png".to_string(),
+            width: 100,
+            height: 100,
+            poster_jpeg: None,
+        };
+        let atts = [outgoing("a.png"), outgoing("b.png")];
+        let optimistic: Vec<MessageAttachment> = atts
+            .iter()
+            .map(MessageAttachment::optimistic_local)
+            .collect();
+        let (album_layout, _) = build_media_presentation(&optimistic, None);
+        assert!(album_layout.is_some());
+        assert!(optimistic.iter().all(|a| a.local_source.is_some()));
+    }
+
+    #[test]
+    fn carry_local_previews_skips_on_count_mismatch() {
+        let prior = Message::new(MessageId::next_optimistic(), "", "42", "Me", 100)
+            .with_attachments(vec![MessageAttachment {
+                local_source: Some(std::path::PathBuf::from("/tmp/a.png")),
+                ..Default::default()
+            }]);
+        let mut confirmed = Message::new(MessageId(7), "", "42", "Me", 500);
+        carry_local_previews(&prior, &mut confirmed);
+        assert!(confirmed.attachments.is_empty());
+    }
+
+    #[test]
     fn optimistic_create_time_increments_within_same_sender_burst() {
         let now = 1_700_000_000i64;
         let mut list =
@@ -5004,6 +5209,8 @@ mod tests {
                     content: "orig".into(),
                     content_preview: "orig".into(),
                     has_attachment: false,
+                    has_embed: false,
+                    is_poll: false,
                 },
             ]),
         ]);

--- a/crates/mezon-ui/src/app/shell/mod.rs
+++ b/crates/mezon-ui/src/app/shell/mod.rs
@@ -15,8 +15,10 @@ use crate::components::primitives::{Toast, ToastKind};
 
 mod coming_soon_modal;
 mod confirm_delete_message_modal;
+mod upload_limit_modal;
 use coming_soon_modal::ComingSoonModal;
 use confirm_delete_message_modal::ConfirmDeleteMessageModal;
+use upload_limit_modal::UploadLimitModal;
 
 const TOAST_TTL: Duration = Duration::from_secs(4);
 
@@ -151,6 +153,25 @@ impl Shell {
             description,
             cancel_label,
             delete_label,
+        });
+        let focus_handle = view.read(cx).focus_handle.clone();
+        window.focus(&focus_handle, cx);
+        self.show_modal(view.into(), cx);
+    }
+
+    /// React's `TooManyUpload` popup: a red validation card shown when a drop/pick
+    /// exceeds the attachment count or per-file size limit.
+    pub fn show_upload_limit(
+        &mut self,
+        title: impl Into<SharedString>,
+        content: impl Into<SharedString>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let view = cx.new(|cx| UploadLimitModal {
+            focus_handle: cx.focus_handle(),
+            title: title.into(),
+            content: content.into(),
         });
         let focus_handle = view.read(cx).focus_handle.clone();
         window.focus(&focus_handle, cx);

--- a/crates/mezon-ui/src/app/shell/upload_limit_modal.rs
+++ b/crates/mezon-ui/src/app/shell/upload_limit_modal.rs
@@ -1,0 +1,78 @@
+use gpui::{Context, FocusHandle, SharedString, Window, div, img, prelude::*, px, rgb, white};
+
+use super::Shell;
+
+pub(super) struct UploadLimitModal {
+    pub(super) focus_handle: FocusHandle,
+    pub(super) title: SharedString,
+    pub(super) content: SharedString,
+}
+
+impl Render for UploadLimitModal {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .track_focus(&self.focus_handle)
+            .key_context("menu")
+            .on_action(cx.listener(|_, _: &::menu::Cancel, _window, cx| {
+                Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+            }))
+            .relative()
+            .w(px(400.))
+            .h(px(240.))
+            .flex()
+            .flex_row()
+            .items_center()
+            .justify_center()
+            .rounded_lg()
+            .bg(rgb(0xEF4444))
+            .child(
+                div()
+                    .w(px(360.))
+                    .h(px(206.))
+                    .rounded_lg()
+                    .border_2()
+                    .border_dashed()
+                    .border_color(white())
+                    .child(
+                        div()
+                            .mt(px(56.))
+                            .flex()
+                            .flex_col()
+                            .child(
+                                div().w_full().flex().justify_center().child(
+                                    div()
+                                        .mt(px(16.))
+                                        .text_2xl()
+                                        .font_weight(gpui::FontWeight::BOLD)
+                                        .text_center()
+                                        .text_color(white())
+                                        .child(self.title.clone()),
+                                ),
+                            )
+                            .child(
+                                div().w_full().flex().justify_center().mt(px(16.)).child(
+                                    div()
+                                        .w(px(306.))
+                                        .text_center()
+                                        .text_color(white())
+                                        .child(self.content.clone()),
+                                ),
+                            ),
+                    ),
+            )
+            .child(
+                div()
+                    .absolute()
+                    .top(px(-144.))
+                    .w_full()
+                    .flex()
+                    .justify_center()
+                    .child(
+                        img("icons/file-and-folder.svg")
+                            .w(px(250.))
+                            .h(px(225.))
+                            .flex_none(),
+                    ),
+            )
+    }
+}

--- a/crates/mezon-ui/src/chat/area.rs
+++ b/crates/mezon-ui/src/chat/area.rs
@@ -1,8 +1,10 @@
+use std::path::PathBuf;
+
 use gpui::{
-    AnyView, Context, Entity, SharedString, StyleRefinement, Subscription, Window, div, prelude::*,
-    px,
+    AnyView, App, Context, Entity, ExternalPaths, FontWeight, SharedString, StyleRefinement,
+    Subscription, Window, div, prelude::*, px, rgb, rgba,
 };
-use mezon_store::{ChannelId, Settings};
+use mezon_store::{ChannelId, MessagesEvent, MessagesStore, Settings};
 use ui::PopoverMenuHandle;
 
 use crate::chat::ReplyTarget;
@@ -14,6 +16,7 @@ use crate::chat::member_list::{MemberListPanel, MemberSource};
 use crate::chat::mention_input::{MentionInput, MentionInputEvent};
 use crate::chat::message::ChannelMessages;
 use crate::chat::pinned_popover::PinnedPopoverPanel;
+use crate::components::primitives::{Icon, IconName};
 use crate::image_cache::{
     AVATAR_ENTRY_MAX_BYTES, AVATAR_IMAGE_CACHE_BYTES, AVATAR_IMAGE_CACHE_CAPACITY, LruImageCache,
 };
@@ -25,12 +28,11 @@ pub struct ChatArea {
     member_panel: Option<Entity<MemberListPanel>>,
     member_source: Option<MemberSource>,
     member_avatar_cache: Entity<LruImageCache>,
-    #[allow(dead_code)]
-    replying_to: Option<ReplyTarget>,
     settings: Entity<Settings>,
     header: Entity<ChatHeader>,
     typing: Entity<ChannelTyping>,
     _submit_sub: Option<Subscription>,
+    _reply_sub: Option<Subscription>,
 }
 
 impl ChatArea {
@@ -57,11 +59,11 @@ impl ChatArea {
             member_panel: None,
             member_source: None,
             member_avatar_cache,
-            replying_to: None,
             settings,
             header,
             typing,
             _submit_sub: None,
+            _reply_sub: None,
         }
     }
 
@@ -111,7 +113,9 @@ impl ChatArea {
                 |this: &mut crate::ChatLayout, _, event: &MentionInputEvent, window, cx| match event
                 {
                     MentionInputEvent::Submit => this.send_current_message(window, cx),
-                    MentionInputEvent::Cancel => {}
+                    MentionInputEvent::Cancel => {
+                        MessagesStore::global(cx).update(cx, |store, cx| store.clear_reply(cx));
+                    }
                     MentionInputEvent::SendSticker { url, filename } => {
                         this.send_sticker(url.clone(), filename.clone(), cx)
                     }
@@ -119,6 +123,22 @@ impl ChatArea {
             );
             self._submit_sub = Some(submit_sub);
             self.mention_input = Some(mention_input);
+
+            let reply_sub = cx.subscribe_in(
+                &MessagesStore::global(cx),
+                window,
+                |this: &mut crate::ChatLayout, store, event: &MessagesEvent, window, cx| {
+                    if matches!(event, MessagesEvent::ReplyTargetChanged) {
+                        if store.read(cx).reply_target().is_some()
+                            && let Some(input) = this.chat_area.mention_input.clone()
+                        {
+                            input.update(cx, |input, cx| input.focus_input(window, cx));
+                        }
+                        cx.notify();
+                    }
+                },
+            );
+            self._reply_sub = Some(reply_sub);
         }
     }
 
@@ -169,7 +189,15 @@ impl ChatArea {
 
         let theme = cx.theme();
 
-        let input_bar = InputBar::new().with_mention_input(mention_input);
+        let replying_to = MessagesStore::global(cx)
+            .read(cx)
+            .reply_target()
+            .map(|draft| ReplyTarget {
+                sender_name: draft.sender_name.clone(),
+            });
+        let input_bar = InputBar::new()
+            .with_mention_input(mention_input.clone())
+            .replying_to(replying_to);
 
         let header = AnyView::from(self.header.clone()).cached(
             StyleRefinement::default()
@@ -178,18 +206,76 @@ impl ChatArea {
                 .flex_shrink_0(),
         );
 
+        let drop_input = mention_input.clone();
+        let drop_title = mezon_i18n::t(locale, "common.uploadToChannel")
+            .replace("{{channelName}}", channel_name.unwrap_or_default());
+        let drop_body = mezon_i18n::t(locale, "common.uploadInstructions");
+        let drop_overlay = div()
+            .absolute()
+            .inset_0()
+            .invisible()
+            .group_drag_over::<ExternalPaths>("chat-drop-zone", |style| style.visible())
+            .flex()
+            .items_center()
+            .justify_center()
+            .bg(rgba(0x000000e6))
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .justify_center()
+                    .gap(px(16.))
+                    .w(px(400.))
+                    .h(px(240.))
+                    .rounded(px(8.))
+                    .border_2()
+                    .border_dashed()
+                    .border_color(rgb(0xffffff))
+                    .bg(rgb(0x5865f2))
+                    .child(
+                        Icon::new(IconName::FileAndFolder)
+                            .size(px(48.))
+                            .text_color(rgb(0xffffff)),
+                    )
+                    .child(
+                        div()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_size(px(18.))
+                            .text_color(rgb(0xffffff))
+                            .child(SharedString::from(drop_title)),
+                    )
+                    .child(
+                        div()
+                            .px(px(24.))
+                            .text_center()
+                            .text_size(px(14.))
+                            .text_color(rgb(0xffffff))
+                            .child(SharedString::from(drop_body)),
+                    ),
+            );
+
         let message_column = div()
+            .relative()
+            .group("chat-drop-zone")
             .flex()
             .flex_col()
             .flex_1()
             .min_w_0()
             .min_h_0()
             .overflow_hidden()
+            .on_drop(
+                move |paths: &ExternalPaths, window: &mut Window, cx: &mut App| {
+                    let dropped: Vec<PathBuf> = paths.paths().to_vec();
+                    drop_input.update(cx, |input, cx| input.add_dropped_paths(dropped, window, cx));
+                },
+            )
             .child(div().flex_1().min_h_0().overflow_hidden().child(
                 AnyView::from(self.timeline.clone()).cached(StyleRefinement::default().size_full()),
             ))
             .child(self.typing.clone())
-            .child(input_bar.render(theme, locale));
+            .child(input_bar.render(theme, locale))
+            .child(drop_overlay);
 
         let body = div()
             .flex()

--- a/crates/mezon-ui/src/chat/input_bar.rs
+++ b/crates/mezon-ui/src/chat/input_bar.rs
@@ -2,10 +2,10 @@ use crate::chat::{MentionInput, ReplyTarget};
 use crate::components::primitives::{Icon, IconName};
 use crate::theme::Theme;
 use gpui::{div, prelude::*, px};
+use mezon_store::MessagesStore;
 
 pub struct InputBar {
     mention_input: Option<gpui::Entity<MentionInput>>,
-    // composer: on_cancel_reply: Option<SendHandler>,
     replying_to: Option<ReplyTarget>,
 }
 
@@ -19,15 +19,9 @@ impl InputBar {
     pub fn new() -> Self {
         Self {
             mention_input: None,
-            // composer: on_cancel_reply: None,
             replying_to: None,
         }
     }
-
-    // composer: pub fn on_cancel_reply(mut self, handler: SendHandler) -> Self {
-    // composer:     self.on_cancel_reply = Some(handler);
-    // composer:     self
-    // composer: }
 
     pub fn with_mention_input(mut self, mention_input: gpui::Entity<MentionInput>) -> Self {
         self.mention_input = Some(mention_input);
@@ -39,76 +33,57 @@ impl InputBar {
         self
     }
 
-    // composer: take `&self` and add `let on_cancel = self.on_cancel_reply.clone();` before the div.
     fn reply_preview_bar(theme: &Theme, locale: &str, target: &ReplyTarget) -> impl IntoElement {
         div()
             .id("reply-preview-bar")
             .flex()
             .flex_row()
             .items_center()
-            .gap_2()
-            .px_4()
-            .py_2()
-            .bg(theme.bg_hover)
-            .border_t_1()
-            .border_color(theme.border)
-            .child(
-                div()
-                    .w(px(3.))
-                    .h_full()
-                    .min_h(px(20.))
-                    .rounded(px(2.))
-                    .bg(theme.border),
-            )
+            .justify_between()
+            .w_full()
+            .p_2()
+            .rounded_tl_lg()
+            .rounded_tr_lg()
+            .bg(theme.tokens.theme_setting_nav)
+            .text_size(px(14.))
             .child(
                 div()
                     .flex()
-                    .flex_col()
-                    .flex_1()
+                    .flex_row()
+                    .items_center()
+                    .gap_1()
+                    .whitespace_nowrap()
+                    .text_color(theme.tokens.text_theme_primary)
+                    .child(mezon_i18n::t(locale, "chat.replyingTo").to_string())
                     .child(
                         div()
-                            .text_xs()
                             .font_weight(gpui::FontWeight::SEMIBOLD)
-                            .text_color(theme.text_primary)
-                            .child(format!(
-                                "{} {}",
-                                mezon_i18n::t(locale, "chat.replyingTo"),
-                                target.sender_name
-                            )),
-                    )
-                    .child(
-                        div()
-                            .text_xs()
-                            .text_color(theme.text_muted)
-                            .child(target.content_preview.clone()),
+                            .child(target.sender_name.clone()),
                     ),
             )
             .child(
-                div().cursor_pointer().child(
-                    Icon::new(IconName::Close)
-                        .size_4()
-                        .text_color(theme.text_muted),
-                ),
+                div()
+                    .id("reply-cancel")
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .flex_none()
+                    .size_5()
+                    .cursor_pointer()
+                    .hover(|s| s.opacity(0.7))
+                    .on_click(|_, _window, cx| {
+                        MessagesStore::global(cx).update(cx, |store, cx| store.clear_reply(cx));
+                    })
+                    .child(
+                        Icon::new(IconName::Close)
+                            .size_4()
+                            .text_color(theme.tokens.text_theme_primary),
+                    ),
             )
-        // composer: clickable cancel button — replace the .child(...) above with:
-        // composer: .child(
-        // composer:     div()
-        // composer:         .id("reply-cancel")
-        // composer:         .cursor_pointer()
-        // composer:         .on_click(move |_, window, cx| {
-        // composer:             if let Some(handler) = &on_cancel {
-        // composer:                 handler(window, cx);
-        // composer:             }
-        // composer:         })
-        // composer:         .child(
-        // composer:             Icon::new(IconName::Close)
-        // composer:                 .size_4()
-        // composer:                 .text_color(theme.text_muted),
-        // composer:         ),
-        // composer: )
     }
 
     pub fn render(&self, theme: &Theme, locale: &str) -> impl IntoElement {
+        let replying = self.replying_to.is_some();
         div()
             .flex()
             .flex_col()
@@ -116,14 +91,14 @@ impl InputBar {
             .pb_4()
             .when_some(self.replying_to.as_ref(), |d, target| {
                 d.child(Self::reply_preview_bar(theme, locale, target))
-                // composer: d.child(self.reply_preview_bar(theme, locale, target))
             })
             .child(
                 div()
                     .flex()
                     .flex_row()
                     .items_center()
-                    .rounded_lg()
+                    .when(replying, |d| d.rounded_bl_lg().rounded_br_lg())
+                    .when(!replying, |d| d.rounded_lg())
                     .border_1()
                     .border_color(theme.tokens.border_primary)
                     .bg(theme.tokens.bg_surface)

--- a/crates/mezon-ui/src/chat/mention_input/attachments.rs
+++ b/crates/mezon-ui/src/chat/mention_input/attachments.rs
@@ -4,6 +4,8 @@ pub const MAX_FILE_ATTACHMENTS: usize = 50;
 pub const IMAGE_MAX_FILE_SIZE: u64 = 50 * 1024 * 1024;
 pub const MAX_FILE_SIZE: u64 = 1024 * 1024 * 1024;
 
+pub const POSTER_MAX_EDGE: u32 = 480;
+
 #[derive(Debug, Clone)]
 pub struct PendingAttachment {
     pub path: PathBuf,
@@ -11,6 +13,15 @@ pub struct PendingAttachment {
     pub filetype: String,
     pub size: u64,
     pub is_image: bool,
+    pub is_video: bool,
+    pub width: u32,
+    pub height: u32,
+    pub poster_jpeg: Option<Vec<u8>>,
+}
+
+pub enum AttachmentLimit {
+    Count,
+    Size(u64),
 }
 
 pub fn mime_from_extension(path: &Path) -> String {
@@ -41,15 +52,6 @@ pub fn mime_from_extension(path: &Path) -> String {
     mime.to_string()
 }
 
-pub fn size_within_limit(size: u64, is_image: bool) -> bool {
-    let limit = if is_image {
-        IMAGE_MAX_FILE_SIZE
-    } else {
-        MAX_FILE_SIZE
-    };
-    size <= limit
-}
-
 pub fn build_pending(path: PathBuf) -> Option<PendingAttachment> {
     let meta = std::fs::metadata(&path).ok()?;
     if !meta.is_file() {
@@ -58,17 +60,53 @@ pub fn build_pending(path: PathBuf) -> Option<PendingAttachment> {
     let filename = path.file_name()?.to_str()?.to_string();
     let filetype = mime_from_extension(&path);
     let is_image = filetype.starts_with("image/");
+    let is_video = filetype.starts_with("video/");
+    let (width, height, poster_jpeg) = if is_video {
+        match mezon_video::probe_video(&path.to_string_lossy(), POSTER_MAX_EDGE) {
+            Some(probe) => (probe.width, probe.height, probe.poster_jpeg),
+            None => (0, 0, None),
+        }
+    } else if is_image {
+        let (w, h) = image::image_dimensions(&path).unwrap_or((0, 0));
+        (w, h, None)
+    } else {
+        (0, 0, None)
+    };
     Some(PendingAttachment {
         path,
         filename,
         filetype,
         size: meta.len(),
         is_image,
+        is_video,
+        width,
+        height,
+        poster_jpeg,
     })
 }
 
-pub fn acceptable(existing: usize, candidate: &PendingAttachment) -> bool {
-    existing < MAX_FILE_ATTACHMENTS && size_within_limit(candidate.size, candidate.is_image)
+pub fn size_limit_for(is_image: bool) -> u64 {
+    if is_image {
+        IMAGE_MAX_FILE_SIZE
+    } else {
+        MAX_FILE_SIZE
+    }
+}
+
+pub fn validate_batch(
+    existing: usize,
+    candidates: &[PendingAttachment],
+) -> Result<(), AttachmentLimit> {
+    if existing + candidates.len() > MAX_FILE_ATTACHMENTS {
+        return Err(AttachmentLimit::Count);
+    }
+    for candidate in candidates {
+        let limit = size_limit_for(candidate.is_image);
+        if candidate.size > limit {
+            return Err(AttachmentLimit::Size(limit));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -88,29 +126,36 @@ mod tests {
     }
 
     #[test]
-    fn size_limits_differ_for_image_vs_file() {
-        assert!(size_within_limit(IMAGE_MAX_FILE_SIZE, true));
-        assert!(!size_within_limit(IMAGE_MAX_FILE_SIZE + 1, true));
-        assert!(size_within_limit(IMAGE_MAX_FILE_SIZE + 1, false));
-        assert!(size_within_limit(MAX_FILE_SIZE, false));
-        assert!(!size_within_limit(MAX_FILE_SIZE + 1, false));
+    fn size_limit_differs_for_image_vs_file() {
+        assert_eq!(size_limit_for(true), IMAGE_MAX_FILE_SIZE);
+        assert_eq!(size_limit_for(false), MAX_FILE_SIZE);
     }
 
     #[test]
-    fn acceptable_enforces_count_and_size() {
+    fn validate_batch_enforces_count_and_size() {
         let img = PendingAttachment {
             path: PathBuf::from("a.png"),
             filename: "a.png".into(),
             filetype: "image/png".into(),
             size: 1024,
             is_image: true,
+            is_video: false,
+            width: 0,
+            height: 0,
+            poster_jpeg: None,
         };
-        assert!(acceptable(0, &img));
-        assert!(!acceptable(MAX_FILE_ATTACHMENTS, &img));
+        assert!(validate_batch(0, std::slice::from_ref(&img)).is_ok());
+        assert!(matches!(
+            validate_batch(MAX_FILE_ATTACHMENTS, std::slice::from_ref(&img)),
+            Err(AttachmentLimit::Count)
+        ));
         let big = PendingAttachment {
             size: IMAGE_MAX_FILE_SIZE + 1,
             ..img.clone()
         };
-        assert!(!acceptable(0, &big));
+        assert!(matches!(
+            validate_batch(0, std::slice::from_ref(&big)),
+            Err(AttachmentLimit::Size(IMAGE_MAX_FILE_SIZE))
+        ));
     }
 }

--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -1,6 +1,8 @@
 mod attachments;
 mod text_field;
 
+use std::path::PathBuf;
+
 use gpui::{
     AnyElement, App, Context, Entity, EventEmitter, Focusable, FontWeight, IntoElement, KeyBinding,
     PathPromptOptions, ScrollStrategy, SharedString, Subscription, UniformListScrollHandle, Window,
@@ -12,8 +14,11 @@ use mezon_store::{
     OutgoingMention, Settings, StickerEvent, StickerStore,
 };
 
-use attachments::{PendingAttachment, acceptable, build_pending};
+use attachments::{
+    AttachmentLimit, MAX_FILE_ATTACHMENTS, PendingAttachment, build_pending, validate_batch,
+};
 
+use crate::app::shell::Shell;
 use crate::chat::member_list::{MentionMemberRaw, mention_member_pool};
 use crate::components::primitives::{Avatar, Icon, IconName};
 use crate::image_cache::{
@@ -326,6 +331,9 @@ impl MentionInput {
                 path: p.path,
                 filename: p.filename,
                 filetype: p.filetype,
+                width: i32::try_from(p.width).unwrap_or(0),
+                height: i32::try_from(p.height).unwrap_or(0),
+                poster_jpeg: p.poster_jpeg,
             })
             .collect();
         self.committed.clear();
@@ -338,14 +346,14 @@ impl MentionInput {
         Some((text, content, attachments))
     }
 
-    fn open_file_picker(&mut self, cx: &mut Context<Self>) {
+    fn open_file_picker(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let rx = cx.prompt_for_paths(PathPromptOptions {
             files: true,
             directories: false,
             multiple: true,
             prompt: None,
         });
-        cx.spawn(async move |this, cx| {
+        cx.spawn_in(window, async move |this, cx| {
             let Ok(Ok(Some(paths))) = rx.await else {
                 return;
             };
@@ -357,23 +365,68 @@ impl MentionInput {
                         .collect::<Vec<_>>()
                 })
                 .await;
-            this.update(cx, |this, cx| this.add_pending(pending, cx))
+            this.update_in(cx, |this, window, cx| this.add_pending(pending, window, cx))
                 .ok();
         })
         .detach();
     }
 
-    fn add_pending(&mut self, candidates: Vec<PendingAttachment>, cx: &mut Context<Self>) {
-        let mut changed = false;
-        for candidate in candidates {
-            if acceptable(self.pending_attachments.len(), &candidate) {
-                self.pending_attachments.push(candidate);
-                changed = true;
+    pub fn add_dropped_paths(
+        &mut self,
+        paths: Vec<PathBuf>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if paths.is_empty() {
+            return;
+        }
+        cx.spawn_in(window, async move |this, cx| {
+            let pending = cx
+                .background_spawn(async move {
+                    paths
+                        .into_iter()
+                        .filter_map(build_pending)
+                        .collect::<Vec<_>>()
+                })
+                .await;
+            this.update_in(cx, |this, window, cx| this.add_pending(pending, window, cx))
+                .ok();
+        })
+        .detach();
+    }
+
+    fn add_pending(
+        &mut self,
+        candidates: Vec<PendingAttachment>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if candidates.is_empty() {
+            return;
+        }
+        match validate_batch(self.pending_attachments.len(), &candidates) {
+            Ok(()) => {
+                self.pending_attachments.extend(candidates);
+                cx.notify();
             }
+            Err(limit) => Self::show_upload_limit(limit, window, cx),
         }
-        if changed {
-            cx.notify();
-        }
+    }
+
+    fn show_upload_limit(limit: AttachmentLimit, window: &mut Window, cx: &mut Context<Self>) {
+        let (title, content) = match limit {
+            AttachmentLimit::Count => (
+                "Upload limit exceeded!".to_string(),
+                format!("You can only upload up to {MAX_FILE_ATTACHMENTS} files at a time."),
+            ),
+            AttachmentLimit::Size(bytes) => (
+                "Upload size limit exceeded!".to_string(),
+                format!("Maximum allowed size is {}MB", bytes / (1024 * 1024)),
+            ),
+        };
+        Shell::global(cx).update(cx, |shell, cx| {
+            shell.show_upload_limit(title, content, window, cx)
+        });
     }
 
     fn remove_attachment(&mut self, index: usize, cx: &mut Context<Self>) {
@@ -398,11 +451,23 @@ impl MentionInput {
             .pt(px(8.));
         for (index, att) in self.pending_attachments.iter().enumerate() {
             let preview = if att.is_image {
-                img(att.path.clone())
+                div()
                     .size(px(64.))
                     .rounded(px(6.))
+                    .bg(chip_bg)
+                    .overflow_hidden()
+                    .child(
+                        img(att.path.clone())
+                            .size_full()
+                            .object_fit(gpui::ObjectFit::Cover),
+                    )
                     .into_any_element()
             } else {
+                let icon = if att.is_video {
+                    IconName::PlayButton
+                } else {
+                    IconName::FileIcon
+                };
                 div()
                     .size(px(64.))
                     .rounded(px(6.))
@@ -410,7 +475,7 @@ impl MentionInput {
                     .flex()
                     .items_center()
                     .justify_center()
-                    .child(Icon::new(IconName::FileIcon).size_5().text_color(muted))
+                    .child(Icon::new(icon).size_5().text_color(muted))
                     .into_any_element()
             };
             row = row.child(
@@ -835,7 +900,11 @@ impl MentionInput {
     fn on_dismiss(&mut self, _: &MentionDismiss, _window: &mut Window, cx: &mut Context<Self>) {
         if self.popup_open() {
             self.hide(cx);
-        } else if self.compact {
+        } else if self.picker_open || self.sticker_picker_open {
+            self.picker_open = false;
+            self.sticker_picker_open = false;
+            cx.notify();
+        } else {
             cx.emit(MentionInputEvent::Cancel);
         }
     }
@@ -1374,11 +1443,9 @@ impl Render for MentionInput {
         let input_area = div()
             .relative()
             .w_full()
-            .when(open, |this| {
-                this.key_context(KEY_CONTEXT)
-                    .on_action(cx.listener(Self::on_accept))
-                    .on_action(cx.listener(Self::on_dismiss))
-            })
+            .key_context(KEY_CONTEXT)
+            .on_action(cx.listener(Self::on_dismiss))
+            .when(open, |this| this.on_action(cx.listener(Self::on_accept)))
             .child(MentionInputField::new(&self.input))
             .child(
                 div()
@@ -1397,7 +1464,9 @@ impl Render for MentionInput {
                             .size_5()
                             .text_color(plus_color),
                     )
-                    .on_click(cx.listener(|this, _event, _window, cx| this.open_file_picker(cx))),
+                    .on_click(
+                        cx.listener(|this, _event, window, cx| this.open_file_picker(window, cx)),
+                    ),
             )
             .child(
                 div()

--- a/crates/mezon-ui/src/chat/message/audio_player.rs
+++ b/crates/mezon-ui/src/chat/message/audio_player.rs
@@ -7,7 +7,7 @@ use gpui::{
 use mezon_audio::AudioPlayer;
 use mezon_store::PlatformStore;
 
-use crate::components::primitives::{Icon, IconName};
+use crate::components::primitives::{Icon, IconName, Sizable, Size, Spinner};
 
 const AUDIO_TICK_INTERVAL: Duration = Duration::from_millis(250);
 
@@ -295,6 +295,44 @@ pub(crate) fn audio_pill(
                                 .size(px(20.))
                                 .text_color(gpui::white()),
                         ),
+                ),
+        )
+        .into_any_element()
+}
+
+pub(crate) fn audio_sending_pill(duration: f64) -> gpui::AnyElement {
+    div()
+        .flex()
+        .w_full()
+        .child(
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_3()
+                .min_w(px(PILL_MIN_WIDTH))
+                .rounded_full()
+                .py(px(6.))
+                .pl(px(6.))
+                .pr(px(14.))
+                .bg(PILL_BG)
+                .text_color(gpui::white())
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .size(px(24.))
+                        .rounded_full()
+                        .bg(gpui::white())
+                        .child(Spinner::new().with_size(Size::Small).color(PILL_BG.into())),
+                )
+                .child(
+                    div()
+                        .ml_2()
+                        .text_size(px(14.))
+                        .whitespace_nowrap()
+                        .child(audio_time_label(0.0, duration)),
                 ),
         )
         .into_any_element()

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -429,6 +429,7 @@ impl ChannelMessages {
                         });
                     }));
                 }
+                MessagesEvent::ReplyTargetChanged => {}
             }
             if structural {
                 {

--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -9,7 +9,7 @@ use mezon_store::{
     MessageReference, MessagesStore, PlatformStore, Reaction, ViewerMedia, resolve_avatar_url,
 };
 
-use super::audio_player::{AudioActivation, audio_pill, audio_time_label};
+use super::audio_player::{AudioActivation, audio_pill, audio_sending_pill, audio_time_label};
 use super::context::{REPLY_USERNAME_COLOR, RowCtx};
 use super::gif_video::GifVideoView;
 use super::reaction_detail::{UserReactionPanel, emoji_error_fallback};
@@ -17,7 +17,7 @@ use super::time::format_message_time;
 use super::video_player::{VideoActivation, VideoFullscreenMode, VideoLayout};
 use crate::app::shell::Shell;
 use crate::chat::user_profile_popover::{ClickableContainer, profile_popover_menu};
-use crate::components::primitives::{Avatar, Icon, IconName, Sizable, Size};
+use crate::components::primitives::{Avatar, Icon, IconName, Sizable, Size, Spinner};
 use crate::theme::Theme;
 
 const DELETED_REPLY_PREVIEW: &str = "Original message was deleted";
@@ -160,16 +160,7 @@ pub fn render_reply(reference: &MessageReference, ctx: &RowCtx) -> AnyElement {
             .into_any_element();
     }
 
-    let preview: SharedString = if reference.content.is_empty() {
-        if reference.has_attachment {
-            mezon_i18n::t(ctx.locale, "chat.clickToSeeAttachment").into()
-        } else {
-            SharedString::default()
-        }
-    } else {
-        reference.content_preview.clone()
-    };
-
+    let has_attachment_ref = reference.has_attachment || reference.has_embed;
     let is_deleted = reference.content == DELETED_REPLY_PREVIEW;
     let avatar = if reference.sender_avatar.is_empty() {
         Avatar::new()
@@ -214,19 +205,52 @@ pub fn render_reply(reference: &MessageReference, ctx: &RowCtx) -> AnyElement {
         ))
         .child(
             div()
+                .id(("reply-name", reference.message_ref_id.0 as usize))
+                .flex_none()
+                .whitespace_nowrap()
                 .font_weight(FontWeight::BOLD)
                 .text_color(gpui::rgb(REPLY_USERNAME_COLOR))
+                .hover(|s| s.underline())
                 .child(reference.sender_name.clone()),
         )
-        .child(
+        .child(if has_attachment_ref {
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_1()
+                .text_color(theme.tokens.text_theme_primary)
+                .child(
+                    div()
+                        .italic()
+                        .child(mezon_i18n::t(ctx.locale, "chat.clickToSeeAttachment").to_string()),
+                )
+                .child(
+                    Icon::new(IconName::ImageThumbnail)
+                        .size_4()
+                        .text_color(theme.tokens.text_theme_primary),
+                )
+                .into_any_element()
+        } else if reference.is_poll {
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_1()
+                .text_color(theme.tokens.text_theme_message)
+                .child("📊")
+                .child(mezon_i18n::t(ctx.locale, "message.poll.pollLabel").to_string())
+                .into_any_element()
+        } else {
             div()
                 .flex_1()
                 .min_w_0()
                 .truncate()
                 .text_color(theme.tokens.text_theme_message)
                 .when(is_deleted, |d| d.italic())
-                .child(preview),
-        )
+                .child(reference.content_preview.clone())
+                .into_any_element()
+        })
         .into_any_element()
 }
 
@@ -301,10 +325,10 @@ pub fn render_attachments(msg: &Message, ctx: &RowCtx) -> Option<AnyElement> {
 
     let mut col = div().flex().flex_col().gap_2().mt_1().w_full();
     for (i, att) in videos.iter().enumerate() {
-        col = col.child(render_video(msg.id, i, att, ctx));
+        col = col.child(render_video(msg.id, i, att, ctx, sending));
     }
     for (i, att) in audios.iter().enumerate() {
-        col = col.child(render_audio(msg.id, i, att, ctx));
+        col = col.child(render_audio(msg.id, i, att, ctx, sending));
     }
     if images.len() >= 2
         && let Some(layout) = msg.album_layout.as_ref()
@@ -362,7 +386,11 @@ fn attachment_sending_overlay(theme: &Theme) -> impl IntoElement {
         .flex()
         .items_center()
         .justify_center()
-        .child(attachment_spinner(px(32.), theme))
+        .child(
+            Spinner::new()
+                .with_size(Size::Large)
+                .color(theme.text_secondary.into()),
+        )
 }
 
 fn render_audio(
@@ -370,11 +398,15 @@ fn render_audio(
     index: usize,
     att: &MessageAttachment,
     ctx: &RowCtx,
+    sending: bool,
 ) -> AnyElement {
+    let duration = att.duration.max(0) as f64;
+    if sending {
+        return audio_sending_pill(duration);
+    }
     if let Some(view) = ctx.active_audios.get(&(msg_id, index)) {
         return div().w_full().child(view.clone()).into_any_element();
     }
-    let duration = att.duration.max(0) as f64;
     let url = SharedString::from(att.url.clone());
     let host = ctx.video_host.clone();
     let download_url = url.clone();
@@ -443,7 +475,9 @@ fn render_album(
             .items_center()
             .justify_center()
             .bg(theme.bg_tertiary);
-        if att.presign_pending {
+        if let Some(path) = att.local_source.clone() {
+            tile_element = tile_element.child(img(path).size_full().object_fit(ObjectFit::Cover));
+        } else if att.presign_pending {
             tile_element = presign_child(tile_element, att, theme);
         } else {
             let src = att.proxied_src.clone();
@@ -506,6 +540,21 @@ fn render_photo(
             .into_any_element();
     }
     let theme = ctx.theme;
+    if let Some(path) = att.local_source.clone() {
+        let mut el = div()
+            .id(("msg-img", index))
+            .relative()
+            .w(px(att.display_width))
+            .h(px(att.display_height))
+            .rounded_md()
+            .overflow_hidden()
+            .bg(theme.bg_tertiary)
+            .child(img(path).size_full().object_fit(ObjectFit::Cover));
+        if sending {
+            el = el.child(attachment_sending_overlay(theme));
+        }
+        return el.into_any_element();
+    }
     if att.presign_pending {
         let mut placeholder = div()
             .id(("msg-img", index))
@@ -582,8 +631,9 @@ fn render_video(
     index: usize,
     att: &MessageAttachment,
     ctx: &RowCtx,
+    sending: bool,
 ) -> AnyElement {
-    if let Some(view) = ctx.active_videos.get(&(msg_id, index)) {
+    if !sending && let Some(view) = ctx.active_videos.get(&(msg_id, index)) {
         return div()
             .w(px(att.display_width))
             .h(px(att.display_height))
@@ -591,7 +641,7 @@ fn render_video(
             .child(view.clone())
             .into_any_element();
     }
-    render_video_poster(msg_id, index, att, ctx)
+    render_video_poster(msg_id, index, att, ctx, sending)
 }
 
 fn render_video_poster(
@@ -599,6 +649,7 @@ fn render_video_poster(
     index: usize,
     att: &MessageAttachment,
     ctx: &RowCtx,
+    sending: bool,
 ) -> AnyElement {
     let theme = ctx.theme;
     let url = SharedString::from(att.url.clone());
@@ -606,6 +657,30 @@ fn render_video_poster(
     let width = att.display_width;
     let height = att.display_height;
     let host = ctx.video_host.clone();
+    let container = div()
+        .id(("msg-video", index))
+        .relative()
+        .flex()
+        .items_center()
+        .justify_center()
+        .w(px(att.display_width))
+        .h(px(att.display_height))
+        .max_w_full()
+        .rounded_lg()
+        .overflow_hidden()
+        .bg(theme.bg_tertiary)
+        .when(!thumbnail.is_empty(), |d| {
+            d.child(
+                img(thumbnail.clone())
+                    .size_full()
+                    .object_fit(ObjectFit::Cover),
+            )
+        });
+    if sending {
+        return container
+            .child(attachment_sending_overlay(theme))
+            .into_any_element();
+    }
     let overlay = div()
         .absolute()
         .inset_0()
@@ -638,26 +713,8 @@ fn render_video_poster(
                         .text_color(gpui::white()),
                 ),
         );
-    div()
-        .id(("msg-video", index))
-        .relative()
-        .flex()
-        .items_center()
-        .justify_center()
-        .w(px(att.display_width))
-        .h(px(att.display_height))
-        .max_w_full()
-        .rounded_lg()
-        .overflow_hidden()
-        .bg(theme.bg_tertiary)
+    container
         .cursor_pointer()
-        .when(!thumbnail.is_empty(), |d| {
-            d.child(
-                img(thumbnail.clone())
-                    .size_full()
-                    .object_fit(ObjectFit::Cover),
-            )
-        })
         .child(overlay)
         .on_click(move |_, window, cx| {
             let activation = VideoActivation {
@@ -763,12 +820,20 @@ fn render_file_box(
                 .justify_center()
                 .w(px(32.))
                 .h(px(40.))
-                .child(
-                    Icon::new(file_icon_for(&att.filetype))
-                        .size(px(30.))
-                        .text_color(theme.tokens.text_theme_primary),
-                )
-                .when(sending, |d| d.child(attachment_sending_overlay(theme))),
+                .when(!sending, |d| {
+                    d.child(
+                        Icon::new(file_icon_for(&att.filetype))
+                            .size(px(30.))
+                            .text_color(theme.tokens.text_theme_primary),
+                    )
+                })
+                .when(sending, |d| {
+                    d.child(
+                        Spinner::new()
+                            .with_size(Size::Medium)
+                            .color(theme.tokens.text_theme_primary.into()),
+                    )
+                }),
         )
         .child(
             div()
@@ -778,14 +843,16 @@ fn render_file_box(
                 ))
                 .flex_1()
                 .min_w_0()
-                .cursor_pointer()
-                .on_click(move |_, _, cx| open_external(&body_url, cx))
+                .when(!sending, |d| {
+                    d.cursor_pointer()
+                        .on_click(move |_, _, cx| open_external(&body_url, cx))
+                })
                 .child(
                     div()
                         .truncate()
                         .text_size(px(16.))
                         .text_color(gpui::rgb(FILE_NAME_COLOR))
-                        .hover(|s| s.underline())
+                        .when(!sending, |d| d.hover(|s| s.underline()))
                         .child(filename),
                 )
                 .child(
@@ -795,51 +862,53 @@ fn render_file_box(
                         .child(size_line),
                 ),
         )
-        .child(
-            div()
-                .absolute()
-                .right(px(16.))
-                .top_0()
-                .bottom_0()
-                .flex()
-                .items_center()
-                .gap_2()
-                .opacity(0.)
-                .group_hover(group_name, |s| s.opacity(1.))
-                .child(file_box_action(
-                    SharedString::from(format!("file-dl-{}-{}", msg.id.0, index)),
-                    IconName::Download,
-                    theme,
-                    move |_, _, cx| {
-                        mezon_store::download_url_with_dialog(
-                            download_url.clone(),
-                            download_name.clone(),
-                            cx,
-                        )
-                    },
-                ))
-                .when(is_owner, |d| {
-                    let remove_msg_id = msg.id;
-                    d.child(file_box_action(
-                        SharedString::from(format!("file-rm-{}-{}", msg.id.0, index)),
-                        IconName::TrashIcon,
+        .when(!sending, |row| {
+            row.child(
+                div()
+                    .absolute()
+                    .right(px(16.))
+                    .top_0()
+                    .bottom_0()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .opacity(0.)
+                    .group_hover(group_name, |s| s.opacity(1.))
+                    .child(file_box_action(
+                        SharedString::from(format!("file-dl-{}-{}", msg.id.0, index)),
+                        IconName::Download,
                         theme,
                         move |_, _, cx| {
-                            mezon_store::MessagesStore::global(cx).update(cx, |store, cx| {
-                                store.remove_attachment(remove_msg_id, index, cx);
-                            });
+                            mezon_store::download_url_with_dialog(
+                                download_url.clone(),
+                                download_name.clone(),
+                                cx,
+                            )
                         },
                     ))
-                })
-                .when(is_pdf, |d| {
-                    d.child(file_box_action(
-                        SharedString::from(format!("file-pdf-{}-{}", msg.id.0, index)),
-                        IconName::FileIcon,
-                        theme,
-                        move |_, _, cx| open_external(&pdf_url, cx),
-                    ))
-                }),
-        )
+                    .when(is_owner, |d| {
+                        let remove_msg_id = msg.id;
+                        d.child(file_box_action(
+                            SharedString::from(format!("file-rm-{}-{}", msg.id.0, index)),
+                            IconName::TrashIcon,
+                            theme,
+                            move |_, _, cx| {
+                                mezon_store::MessagesStore::global(cx).update(cx, |store, cx| {
+                                    store.remove_attachment(remove_msg_id, index, cx);
+                                });
+                            },
+                        ))
+                    })
+                    .when(is_pdf, |d| {
+                        d.child(file_box_action(
+                            SharedString::from(format!("file-pdf-{}-{}", msg.id.0, index)),
+                            IconName::FileIcon,
+                            theme,
+                            move |_, _, cx| open_external(&pdf_url, cx),
+                        ))
+                    }),
+            )
+        })
         .into_any_element()
 }
 

--- a/crates/mezon-ui/src/chat/message/user_row.rs
+++ b/crates/mezon-ui/src/chat/message/user_row.rs
@@ -99,6 +99,12 @@ pub fn render_user_message(
         render_token_transaction_card(msg, ctx)
     } else if msg.poll.is_some() {
         render_poll_card(msg, ctx)
+    } else if sending {
+        div()
+            .w_full()
+            .opacity(0.5)
+            .child(render_message_content(msg, ctx))
+            .into_any_element()
     } else {
         render_message_content(msg, ctx)
     };

--- a/crates/mezon-ui/src/chat/mod.rs
+++ b/crates/mezon-ui/src/chat/mod.rs
@@ -31,5 +31,4 @@ pub use mezon_store::COMBINE_TIME_WINDOW;
 #[derive(Debug, Clone)]
 pub struct ReplyTarget {
     pub sender_name: String,
-    pub content_preview: String,
 }

--- a/crates/mezon-video/src/lib.rs
+++ b/crates/mezon-video/src/lib.rs
@@ -36,6 +36,32 @@ pub enum PlayerError {
     Open,
 }
 
+/// Natural pixel dimensions of a local video plus an optional downscaled JPEG poster
+/// frame, extracted from the file without full playback. The analog of the web app's
+/// `captureVideoPosterFromUrl` (hidden `<video>` + canvas): both feed a message
+/// attachment's `width`/`height`/`thumbnail` so a sent video renders at the right size
+/// with a preview frame instead of a tiny default box.
+#[derive(Debug, Clone)]
+pub struct VideoProbe {
+    pub width: u32,
+    pub height: u32,
+    pub poster_jpeg: Option<Vec<u8>>,
+}
+
+/// Read a local video's natural dimensions and a poster frame (bounded to
+/// `max_poster_edge` on its longest side). Returns `None` when the path is not a
+/// decodable video (or on platforms without a native probe); poster generation
+/// degrades to `None` independently so dimensions still come through.
+#[cfg(target_os = "macos")]
+pub fn probe_video(path: &str, max_poster_edge: u32) -> Option<VideoProbe> {
+    macos::probe_video(path, max_poster_edge)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn probe_video(_path: &str, _max_poster_edge: u32) -> Option<VideoProbe> {
+    None
+}
+
 pub struct VideoPlayer {
     inner: platform::PlayerImpl,
 }

--- a/crates/mezon-video/src/macos.rs
+++ b/crates/mezon-video/src/macos.rs
@@ -11,9 +11,56 @@ use objc::rc::StrongPtr;
 use objc::runtime::{BOOL, NO, Object, YES};
 use objc::{class, msg_send, sel, sel_impl};
 
-use crate::PlayerError;
+use crate::{PlayerError, VideoProbe};
 
 pub type VideoFrame = CVPixelBuffer;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct CgSize {
+    width: f64,
+    height: f64,
+}
+
+unsafe impl objc::Encode for CgSize {
+    fn encode() -> objc::Encoding {
+        unsafe { objc::Encoding::from_str("{CGSize=dd}") }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct CgAffineTransform {
+    a: f64,
+    b: f64,
+    c: f64,
+    d: f64,
+    tx: f64,
+    ty: f64,
+}
+
+unsafe impl objc::Encode for CgAffineTransform {
+    fn encode() -> objc::Encoding {
+        unsafe { objc::Encoding::from_str("{CGAffineTransform=dddddd}") }
+    }
+}
+
+#[link(name = "ImageIO", kind = "framework")]
+unsafe extern "C" {
+    fn CGImageDestinationCreateWithData(
+        data: *mut c_void,
+        uti: *const c_void,
+        count: usize,
+        options: *const c_void,
+    ) -> *mut c_void;
+    fn CGImageDestinationAddImage(dest: *mut c_void, image: *mut c_void, properties: *const c_void);
+    fn CGImageDestinationFinalize(dest: *mut c_void) -> u8;
+}
+
+#[link(name = "CoreFoundation", kind = "framework")]
+unsafe extern "C" {
+    fn CFRelease(cf: *const c_void);
+}
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -300,6 +347,149 @@ fn pixel_buffer_attributes(max_size: Option<(u32, u32)>) -> Result<StrongPtr, Pl
 
 fn frame_format_is_renderable(format: u32) -> bool {
     format == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
+}
+
+const POSTER_TIME_SECONDS: f64 = 1.0;
+
+pub fn probe_video(path: &str, max_poster_edge: u32) -> Option<VideoProbe> {
+    let c_path = CString::new(path).ok()?;
+    objc::rc::autoreleasepool(|| unsafe {
+        let ns_string = class!(NSString);
+        let path_string: *mut Object = msg_send![ns_string, stringWithUTF8String: c_path.as_ptr()];
+        if path_string.is_null() {
+            return None;
+        }
+        let ns_url_class = class!(NSURL);
+        let file_url: *mut Object = msg_send![ns_url_class, fileURLWithPath: path_string];
+        if file_url.is_null() {
+            return None;
+        }
+        let asset_class = class!(AVURLAsset);
+        let asset_alloc: *mut Object = msg_send![asset_class, alloc];
+        let asset: *mut Object =
+            msg_send![asset_alloc, initWithURL: file_url options: ptr::null::<Object>()];
+        if asset.is_null() {
+            return None;
+        }
+        let asset = StrongPtr::new(asset);
+
+        let (width, height) = video_natural_size(*asset)?;
+        let poster_jpeg = generate_poster(*asset, max_poster_edge);
+        Some(VideoProbe {
+            width,
+            height,
+            poster_jpeg,
+        })
+    })
+}
+
+fn video_natural_size(asset: *mut Object) -> Option<(u32, u32)> {
+    unsafe {
+        let ns_string = class!(NSString);
+        let media_type: *mut Object = msg_send![ns_string, stringWithUTF8String: c"vide".as_ptr()];
+        if media_type.is_null() {
+            return None;
+        }
+        let tracks: *mut Object = msg_send![asset, tracksWithMediaType: media_type];
+        if tracks.is_null() {
+            return None;
+        }
+        let count: usize = msg_send![tracks, count];
+        if count == 0 {
+            return None;
+        }
+        let track: *mut Object = msg_send![tracks, objectAtIndex: 0usize];
+        if track.is_null() {
+            return None;
+        }
+        let size: CgSize = msg_send![track, naturalSize];
+        let transform: CgAffineTransform = msg_send![track, preferredTransform];
+        let display_width = size.width * transform.a + size.height * transform.c;
+        let display_height = size.width * transform.b + size.height * transform.d;
+        let width = display_width.abs().round();
+        let height = display_height.abs().round();
+        if !(width.is_finite() && height.is_finite()) || width < 1.0 || height < 1.0 {
+            return None;
+        }
+        Some((width as u32, height as u32))
+    }
+}
+
+fn generate_poster(asset: *mut Object, max_edge: u32) -> Option<Vec<u8>> {
+    unsafe {
+        let generator_class = class!(AVAssetImageGenerator);
+        let generator_alloc: *mut Object = msg_send![generator_class, alloc];
+        let generator: *mut Object = msg_send![generator_alloc, initWithAsset: asset];
+        if generator.is_null() {
+            return None;
+        }
+        let generator = StrongPtr::new(generator);
+        let _: () = msg_send![*generator, setAppliesPreferredTrackTransform: YES];
+        if max_edge > 0 {
+            let size = CgSize {
+                width: max_edge as f64,
+                height: max_edge as f64,
+            };
+            let _: () = msg_send![*generator, setMaximumSize: size];
+        }
+        let time = CmTime {
+            value: (POSTER_TIME_SECONDS * SEEK_TIMESCALE as f64) as i64,
+            timescale: SEEK_TIMESCALE,
+            flags: CM_TIME_FLAG_VALID,
+            epoch: 0,
+        };
+        let cg_image: *mut c_void = msg_send![
+            *generator,
+            copyCGImageAtTime: time
+            actualTime: ptr::null_mut::<CmTime>()
+            error: ptr::null_mut::<*mut Object>()
+        ];
+        if cg_image.is_null() {
+            return None;
+        }
+        let jpeg = encode_cgimage_jpeg(cg_image);
+        CFRelease(cg_image);
+        jpeg
+    }
+}
+
+fn encode_cgimage_jpeg(cg_image: *mut c_void) -> Option<Vec<u8>> {
+    unsafe {
+        let data_class = class!(NSMutableData);
+        let data: *mut Object = msg_send![data_class, data];
+        if data.is_null() {
+            return None;
+        }
+        let ns_string = class!(NSString);
+        let uti: *mut Object = msg_send![ns_string, stringWithUTF8String: c"public.jpeg".as_ptr()];
+        if uti.is_null() {
+            return None;
+        }
+        let dest = CGImageDestinationCreateWithData(
+            data as *mut c_void,
+            uti as *const c_void,
+            1,
+            ptr::null(),
+        );
+        if dest.is_null() {
+            return None;
+        }
+        CGImageDestinationAddImage(dest, cg_image, ptr::null());
+        let finalized = CGImageDestinationFinalize(dest);
+        CFRelease(dest as *const c_void);
+        if finalized == 0 {
+            return None;
+        }
+        let length: usize = msg_send![data, length];
+        if length == 0 {
+            return None;
+        }
+        let bytes: *const u8 = msg_send![data, bytes];
+        if bytes.is_null() {
+            return None;
+        }
+        Some(std::slice::from_raw_parts(bytes, length).to_vec())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION

Enforce file count/size limits with an upload-limit modal and drag-drop into chat. Probe local videos on macOS to upload a JPEG poster alongside the file, and show local image previews plus album layout while sends are in flight. Wire reply-bar cancel/focus and carry optimistic reply references through server confirmation.