### PR TITLE
fix(voice): improve screen capture and voice performance on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5704,6 +5704,7 @@ dependencies = [
  "block",
  "cocoa 0.25.0",
  "core-graphics-helmer-fork",
+ "core-video",
  "cpal",
  "flume",
  "futures",
@@ -12094,7 +12095,9 @@ version = "0.0.8-zed"
 dependencies = [
  "anyhow",
  "cocoa 0.25.0",
+ "core-foundation 0.10.0",
  "core-graphics-helmer-fork",
+ "core-video",
  "dbus",
  "log",
  "objc",

--- a/crates/mezon-store/src/config.rs
+++ b/crates/mezon-store/src/config.rs
@@ -88,21 +88,21 @@ impl AppConfig {
     /// Development defaults (matches pre-env hardcoded values).
     pub fn dev_defaults() -> Self {
         Self {
-            api_host: "api.mezon.ai".into(),
-            api_port: 443,
+            api_host: "dev-mezon.nccsoft.vn".into(),
+            api_port: 8088,
             api_secure: true,
-            api_key: "HTTP3m3zonPr0dkey".into(),
-            api_gw_host: "gw.mezon.ai".into(),
-            api_gw_port: 443,
+            api_key: "defaultkey".into(),
+            api_gw_host: "dev-mezon.nccsoft.vn".into(),
+            api_gw_port: 8088,
 
-            tcp_port: None,
-            stream_ws_url: "wss://stn.mezon.ai".into(),
-            meet_ws_url: "wss://meet.mezon.ai".into(),
+            tcp_port: Some(7349),
+            stream_ws_url: "wss://stn.nccsoft.vn".into(),
+            meet_ws_url: "wss://meet.nccsoft.vn".into(),
             notification_ws_url: "wss://gotify.mezon.ai".into(),
 
             oauth2_authorize_url: "https://oauth2.mezon.ai/oauth2/auth".into(),
-            oauth2_client_id: "25f63a1f-16b8-488b-8b14-68520eeab77f".into(),
-            oauth2_redirect_uri: "http://127.0.0.1:4200/login/callback".into(),
+            oauth2_client_id: "f049f29e-12a9-464c-938f-0a2f60c3210b".into(),
+            oauth2_redirect_uri: "https://dev-mezon.nccsoft.vn/login/callback".into(),
             oauth2_response_type: "code".into(),
             oauth2_scope: "openid+offline".into(),
             oauth2_code_challenge_method: "S256".into(),
@@ -116,39 +116,37 @@ impl AppConfig {
             logo_mezon: "https://cdn.mezon.ai/images/mezon_logo.png".into(),
             base_img_url: "https://cdn.mezon.ai".into(),
             profile_img_url: "https://profile.mezon.ai".into(),
-            imgproxy_base_url: "https://imgproxy.mezon.ai".into(),
-            imgproxy_key: "K0YUZRIosDOcz5lY6qrgC6UIXmQgWzLjZv7VJ1RAA8c".into(),
+            imgproxy_base_url: "https://dev-imgproxy.nccsoft.vn".into(),
+            imgproxy_key: "_AEhOrrckkG-NjqIdVLtzc-dtLFuE4u6ClM0P46ICEY".into(),
 
-            tenor_key: "AIzaSyA7PmFsiGws1XF-t6jXsVuF6O2DQLa8BpE".into(),
+            tenor_key: String::new(),
             tenor_url_categories: "https://tenor.googleapis.com/v2/categories?key=".into(),
             tenor_url_search: "https://tenor.googleapis.com/v2/search?q=".into(),
             tenor_url_featured: "https://tenor.googleapis.com/v2/featured?key=".into(),
 
             mezon_treasury_url: "https://withdraw-api.nccsoft.vn".into(),
-            mezon_treasury_key: "WTGYB2AJSHUBPAXZULT2Y7LGR4GQ".into(),
-            contract_address: "0x4F17a94dD6E1B2D6241C4D1956C6c7a07ba2Ec50".into(),
-            mezon_treasury_url_network: "https://sepolia.etherscan.io".into(),
+            mezon_treasury_key: String::new(),
+            contract_address: String::new(),
+            mezon_treasury_url_network: "https://polygonscan.com".into(),
 
-            webrtc_ice_servers_url: "turn:relay.mezon.ai:5349".into(),
+            webrtc_ice_servers_url: "turn:relay.mezon.vn:5349".into(),
             webrtc_ice_servers_username: "turnmezon".into(),
-            webrtc_ice_servers_credential: "QuTs4zUEcbylWemXL7MK".into(),
+            webrtc_ice_servers_credential: String::new(),
 
-            fcm_api_key: "AIzaSyAzgF6LfHVWzlr9gGHWU7emix2768wSGHg".into(),
+            fcm_api_key: String::new(),
             fcm_auth_domain: "mezon-772fa.firebaseapp.com".into(),
             fcm_project_id: "mezon-772fa".into(),
             fcm_storage_bucket: "mezon-772fa.appspot.com".into(),
             fcm_messaging_sender_id: "285548761692".into(),
-            fcm_app_id: "1:285548761692:web:3ca531af1deecee74e0c99".into(),
-            fcm_measurement_id: "G-0WNQTXVMT3".into(),
-            fcm_vapid_key:
-                "BLHZ5mS8qWRxw4Psmpq9QEavz1B8rYgmkWeJ9CCSDR-g-NjfYWpmfi_t2IV4dJLx2X76p2sApyISytUVtD64nfs"
-                    .into(),
+            fcm_app_id: String::new(),
+            fcm_measurement_id: String::new(),
+            fcm_vapid_key: String::new(),
 
             api_client_key_custom: "mezon.ai".into(),
-            sentry_dsn: "https://7aad12a70a52b6598fa5847153a13781@o4509763792404480.ingest.us.sentry.io/4509767257751552".into(),
-            anonymous_user_id: "1767478432163172999".into(),
+            sentry_dsn: String::new(),
+            anonymous_user_id: String::new(),
             max_length_name_allowed: 64,
-            update_url: "https://cdn.mezon.ai/release/".into()
+            update_url: "https://cdn.mezon.ai/release/".into(),
         }
     }
 

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -124,9 +124,9 @@ pub use users_by_user::{UsersByUserEvent, UsersByUserStore};
 pub use voice::{
     DisplayedReaction, NetworkQuality, PickedScreen, ScreenShareKind, ScreenShareListError,
     ScreenShareOption, ScreenSharePreview, VideoFrameData, VideoFrameStore, VoiceCallStatus,
-    VoiceConnection, VoiceModerationError, VoiceParticipant, VoiceStore, camera_tile_id,
-    capture_screen_share_preview, list_screen_share_options, peek_screen_share_options,
-    screen_tile_id,
+    VoiceConnection, VoiceModerationError, VoiceParticipant, VoiceRenderFrame, VoiceStore,
+    camera_tile_id, capture_screen_share_preview, list_screen_share_options,
+    peek_screen_share_options, screen_tile_id,
 };
 
 pub const CACHE_TTL: Duration = Duration::from_secs(20 * 60);

--- a/crates/mezon-store/src/voice.rs
+++ b/crates/mezon-store/src/voice.rs
@@ -53,9 +53,16 @@ struct CachedMeetToken {
     fetched_at: Instant,
 }
 
-struct CachedRenderImage {
+#[derive(Clone)]
+pub enum VoiceRenderFrame {
+    Image(Arc<RenderImage>),
+    #[cfg(target_os = "macos")]
+    Surface(mezon_voice::VideoSurface),
+}
+
+struct CachedRenderFrame {
     seq: u64,
-    image: Arc<RenderImage>,
+    frame: VoiceRenderFrame,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -147,7 +154,7 @@ pub struct VoiceStore {
     last_emoji_at: Option<Instant>,
     session: Option<VoiceSession>,
     frame_store: Option<Arc<VideoFrameStore>>,
-    render_cache: Mutex<HashMap<u64, CachedRenderImage>>,
+    render_cache: Mutex<HashMap<u64, CachedRenderFrame>>,
     pending_texture_drops: Mutex<Vec<Arc<RenderImage>>>,
     pending_texture_replaces: Mutex<Vec<Arc<RenderImage>>>,
     cached_meet_token: Option<CachedMeetToken>,
@@ -368,7 +375,7 @@ impl VoiceStore {
         self.frame_store.clone()
     }
 
-    pub fn render_image(&self, key: u64) -> Option<Arc<RenderImage>> {
+    pub fn render_frame(&self, key: u64) -> Option<VoiceRenderFrame> {
         let store = self.frame_store.as_ref()?;
         let cached_seq = self.render_cache.lock().get(&key).map(|entry| entry.seq);
         let Some(frame) = store.take_new(key, cached_seq) else {
@@ -376,25 +383,55 @@ impl VoiceStore {
                 .render_cache
                 .lock()
                 .get(&key)
-                .map(|entry| entry.image.clone());
+                .map(|entry| entry.frame.clone());
         };
         let seq = frame.seq;
+        #[cfg(target_os = "macos")]
+        if let Some(surface) = frame.surface {
+            let rendered = VoiceRenderFrame::Surface(surface);
+            let previous = self.render_cache.lock().insert(
+                key,
+                CachedRenderFrame {
+                    seq,
+                    frame: rendered.clone(),
+                },
+            );
+            if let Some(CachedRenderFrame {
+                frame: VoiceRenderFrame::Image(image),
+                ..
+            }) = previous
+            {
+                self.pending_texture_drops.lock().push(image);
+            }
+            return Some(rendered);
+        }
         let buffer = image::RgbaImage::from_raw(frame.width, frame.height, frame.bgra)?;
-        let mut render_image = RenderImage::new(smallvec::smallvec![image::Frame::new(buffer)]);
+        let weak_store = Arc::downgrade(store);
+        let recycler = Arc::new(move |buffer| {
+            if let Some(store) = weak_store.upgrade() {
+                store.recycle(key, buffer);
+            }
+        });
+        let mut render_image = RenderImage::new_recyclable(image::Frame::new(buffer), recycler);
         let previous_id = self
             .render_cache
             .lock()
             .get(&key)
-            .map(|entry| entry.image.id);
+            .and_then(|entry| match &entry.frame {
+                VoiceRenderFrame::Image(image) => Some(image.id),
+                #[cfg(target_os = "macos")]
+                VoiceRenderFrame::Surface(_) => None,
+            });
         if let Some(id) = previous_id {
             render_image = render_image.with_id(id);
         }
         let image = Arc::new(render_image);
+        let rendered = VoiceRenderFrame::Image(image.clone());
         let previous = self.render_cache.lock().insert(
             key,
-            CachedRenderImage {
+            CachedRenderFrame {
                 seq,
-                image: image.clone(),
+                frame: rendered.clone(),
             },
         );
         if previous_id.is_some() {
@@ -404,10 +441,14 @@ impl VoiceStore {
             } else {
                 replaces.push(image.clone());
             }
-        } else if let Some(previous) = previous {
-            self.pending_texture_drops.lock().push(previous.image);
+        } else if let Some(CachedRenderFrame {
+            frame: VoiceRenderFrame::Image(previous),
+            ..
+        }) = previous
+        {
+            self.pending_texture_drops.lock().push(previous);
         }
-        Some(image)
+        Some(rendered)
     }
 
     fn evict_stale_render_cache(&self) {
@@ -429,7 +470,11 @@ impl VoiceStore {
             if live_keys.contains(key) {
                 true
             } else {
-                drops.push(entry.image.clone());
+                match &entry.frame {
+                    VoiceRenderFrame::Image(image) => drops.push(image.clone()),
+                    #[cfg(target_os = "macos")]
+                    VoiceRenderFrame::Surface(_) => {}
+                }
                 false
             }
         });
@@ -1530,7 +1575,14 @@ impl VoiceStore {
         self.frame_store = None;
         let stale: Vec<Arc<RenderImage>> = {
             let mut cache = self.render_cache.lock();
-            cache.drain().map(|(_, entry)| entry.image).collect()
+            cache
+                .drain()
+                .filter_map(|(_, entry)| match entry.frame {
+                    VoiceRenderFrame::Image(image) => Some(image),
+                    #[cfg(target_os = "macos")]
+                    VoiceRenderFrame::Surface(_) => None,
+                })
+                .collect()
         };
         for image in stale {
             cx.drop_image(image, window.as_deref_mut());
@@ -1570,6 +1622,11 @@ impl VoiceStore {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use gpui::RenderImage;
+    use parking_lot::Mutex;
+
     use super::parse_raise_token;
 
     #[test]
@@ -1579,5 +1636,16 @@ mod tests {
         assert_eq!(parse_raise_token("sound:https://x.mp3"), None);
         assert_eq!(parse_raise_token(":smile:"), None);
         assert_eq!(parse_raise_token(""), None);
+    }
+
+    #[test]
+    fn recyclable_render_image_returns_owned_pixels() {
+        let returned = Arc::new(Mutex::new(Vec::new()));
+        let sink = returned.clone();
+        let recycler = Arc::new(move |pixels| sink.lock().push(pixels));
+        let buffer = image::RgbaImage::from_raw(2, 2, vec![7; 16]).expect("rgba");
+        let image = RenderImage::new_recyclable(image::Frame::new(buffer), recycler);
+        drop(image);
+        assert_eq!(returned.lock().as_slice(), &[vec![7; 16]]);
     }
 }

--- a/crates/mezon-ui/src/chat/screen_share_pip.rs
+++ b/crates/mezon-ui/src/chat/screen_share_pip.rs
@@ -2,7 +2,7 @@ use gpui::{
     AnyWindowHandle, App, Bounds, Context, Entity, MouseButton, ObjectFit, Window, WindowBounds,
     WindowKind, WindowOptions, div, img, prelude::*, px, rgb, rgba, size,
 };
-use mezon_store::VoiceStore;
+use mezon_store::{VoiceRenderFrame, VoiceStore};
 
 use crate::app::window_controls::linux_app_id;
 use crate::components::primitives::{Icon, IconName};
@@ -58,11 +58,16 @@ impl ScreenSharePipView {
 
 impl Render for ScreenSharePipView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let image = self.voice.read(cx).render_image(self.key);
+        let frame = self.voice.read(cx).render_frame(self.key);
         self.voice
             .update(cx, |store, cx| store.flush_texture_drops(Some(window), cx));
-        let content = match image {
-            Some(image) => img(image)
+        let content = match frame {
+            Some(VoiceRenderFrame::Image(image)) => img(image)
+                .size_full()
+                .object_fit(ObjectFit::Contain)
+                .into_any_element(),
+            #[cfg(target_os = "macos")]
+            Some(VoiceRenderFrame::Surface(surface)) => gpui::surface(surface.into_inner())
                 .size_full()
                 .object_fit(ObjectFit::Contain)
                 .into_any_element(),

--- a/crates/mezon-ui/src/chat/voice.rs
+++ b/crates/mezon-ui/src/chat/voice.rs
@@ -5,7 +5,8 @@ use gpui::{
 };
 use mezon_store::{
     AppConfig, Channel, ChannelId, ClanId, ClanMembersStore, DisplayedReaction, NetworkQuality,
-    Settings, UserId, VoiceCallStatus, VoiceConnection, VoiceMember, VoiceParticipant, VoiceStore,
+    Settings, UserId, VoiceCallStatus, VoiceConnection, VoiceMember, VoiceParticipant,
+    VoiceRenderFrame, VoiceStore,
 };
 
 use crate::ChatLayout;
@@ -904,11 +905,8 @@ pub(crate) fn render_screen_fullscreen_overlay(
     let exit_voice = voice.clone();
     let bg_voice = voice.clone();
 
-    let media = match store.render_image(key) {
-        Some(image) => img(image)
-            .size_full()
-            .object_fit(ObjectFit::Contain)
-            .into_any_element(),
+    let media = match store.render_frame(key) {
+        Some(frame) => render_voice_frame(frame, ObjectFit::Contain),
         None => Icon::new(IconName::VoiceScreenShareIcon)
             .size(px(64.))
             .text_color(theme.text_muted)
@@ -1544,14 +1542,14 @@ fn video_tile(
 
 fn tile_inner(theme: &Theme, store: &VoiceStore, cell: &VideoCell, large: bool) -> AnyElement {
     if let Some(key) = cell.key
-        && let Some(image) = store.render_image(key)
+        && let Some(frame) = store.render_frame(key)
     {
         let fit = if cell.is_screen {
             ObjectFit::Contain
         } else {
             ObjectFit::Cover
         };
-        return img(image).size_full().object_fit(fit).into_any_element();
+        return render_voice_frame(frame, fit);
     }
 
     if cell.is_screen {
@@ -1569,6 +1567,17 @@ fn tile_inner(theme: &Theme, store: &VoiceStore, cell: &VideoCell, large: bool) 
         avatar = avatar.src(cell.avatar_url.clone());
     }
     avatar.into_any_element()
+}
+
+fn render_voice_frame(frame: VoiceRenderFrame, fit: ObjectFit) -> AnyElement {
+    match frame {
+        VoiceRenderFrame::Image(image) => img(image).size_full().object_fit(fit).into_any_element(),
+        #[cfg(target_os = "macos")]
+        VoiceRenderFrame::Surface(surface) => gpui::surface(surface.into_inner())
+            .size_full()
+            .object_fit(fit)
+            .into_any_element(),
+    }
 }
 
 fn tile_label(locale: &str, cell: &VideoCell) -> AnyElement {

--- a/crates/mezon-voice/Cargo.toml
+++ b/crates/mezon-voice/Cargo.toml
@@ -32,6 +32,7 @@ scap = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 nokhwa = { version = "0.10", default-features = false, features = ["input-avfoundation"] }
+core-video.workspace = true
 screencapturekit = "0.2.8"
 screencapturekit-sys = "0.2.8"
 core-graphics-helmer-fork = "0.24.0"

--- a/crates/mezon-voice/src/camera.rs
+++ b/crates/mezon-voice/src/camera.rs
@@ -19,6 +19,8 @@ use crate::video::{VideoFrameStore, local_camera_key, rgb_to_i420, yuyv422_to_i4
 const TARGET_WIDTH: u32 = 640;
 const TARGET_HEIGHT: u32 = 480;
 const TARGET_FPS: u32 = 30;
+const MAX_CAMERA_WIDTH: u32 = 1280;
+const MAX_CAMERA_HEIGHT: u32 = 720;
 
 pub struct CameraStopper {
     stop: Arc<AtomicBool>,
@@ -211,10 +213,21 @@ fn open_camera() -> Result<Camera, String> {
             match try_open_camera(index, *requested) {
                 Ok(camera) => {
                     let format = camera.camera_format();
+                    let resolution = camera.resolution();
+                    if resolution.width() > MAX_CAMERA_WIDTH
+                        || resolution.height() > MAX_CAMERA_HEIGHT
+                    {
+                        last_err = format!(
+                            "camera format {}x{} exceeds {MAX_CAMERA_WIDTH}x{MAX_CAMERA_HEIGHT}",
+                            resolution.width(),
+                            resolution.height(),
+                        );
+                        continue;
+                    }
                     tracing::info!(
                         "camera opened: {}x{} {:?} @ {}fps",
-                        camera.resolution().width(),
-                        camera.resolution().height(),
+                        resolution.width(),
+                        resolution.height(),
                         format.format(),
                         format.frame_rate(),
                     );

--- a/crates/mezon-voice/src/lib.rs
+++ b/crates/mezon-voice/src/lib.rs
@@ -38,11 +38,16 @@ pub use screen_targets::{
     ScreenShareKind, ScreenShareListError, ScreenShareOption, list_screen_share_options,
     peek_screen_share_options,
 };
+#[cfg(target_os = "macos")]
+pub use video::VideoSurface;
 pub use video::{VideoFrameData, VideoFrameStore};
 
 use crate::camera::CameraStopper;
 use crate::screen::ScreenStopper;
 use crate::video::{i420_to_bgra_into, local_camera_key, local_screen_key, track_frame_key};
+
+const MAX_REMOTE_VIDEO_WIDTH: u32 = 1920;
+const MAX_REMOTE_VIDEO_HEIGHT: u32 = 1080;
 
 #[derive(Clone, Debug, Default)]
 pub struct IceServerConfig {
@@ -541,7 +546,8 @@ async fn session_main(
                     Ok(Command::SetCameraEnabled(false)) => {
                         let mut changed = false;
                         camera_gen = camera_gen.wrapping_add(1);
-                        if camera_task.take().is_some() {
+                        if let Some(task) = camera_task.take() {
+                            task.abort();
                             changed = true;
                         }
                         if let Some(session) = camera_session.take() {
@@ -579,7 +585,8 @@ async fn session_main(
                     Ok(Command::StopScreenShare) => {
                         let mut changed = false;
                         screen_gen = screen_gen.wrapping_add(1);
-                        if screen_task.take().is_some() {
+                        if let Some(task) = screen_task.take() {
+                            task.abort();
                             changed = true;
                         }
                         if let Some(session) = screen_session.take() {
@@ -935,12 +942,33 @@ fn spawn_video(
     let task = runtime::runtime().spawn(async move {
         let mut stream = NativeVideoStream::new(rtc_track);
         while let Some(frame) = stream.next().await {
-            task_slot.put(frame.buffer.to_i420());
+            let mut buffer = frame.buffer.to_i420();
+            let (width, height) = bounded_dimensions(
+                buffer.width(),
+                buffer.height(),
+                MAX_REMOTE_VIDEO_WIDTH,
+                MAX_REMOTE_VIDEO_HEIGHT,
+            );
+            if width != buffer.width() || height != buffer.height() {
+                buffer = buffer.scale(width as i32, height as i32);
+            }
+            task_slot.put(buffer);
         }
         task_slot.close();
     });
 
     VideoTrackHandle { task, slot }
+}
+
+fn bounded_dimensions(width: u32, height: u32, max_width: u32, max_height: u32) -> (u32, u32) {
+    if width <= max_width && height <= max_height {
+        return (width, height);
+    }
+    let scale =
+        (max_width as f64 / width.max(1) as f64).min(max_height as f64 / height.max(1) as f64);
+    let width = ((width as f64 * scale).floor() as u32 & !1).max(2);
+    let height = ((height as f64 * scale).floor() as u32 & !1).max(2);
+    (width, height)
 }
 
 fn emit_participants(
@@ -1044,5 +1072,21 @@ fn display_name(name: &str, identity: &str) -> String {
         identity.to_string()
     } else {
         name.to_string()
+    }
+}
+
+#[cfg(test)]
+mod remote_video_tests {
+    use super::bounded_dimensions;
+
+    #[test]
+    fn bounded_dimensions_preserve_small_frames() {
+        assert_eq!(bounded_dimensions(1280, 720, 1920, 1080), (1280, 720));
+    }
+
+    #[test]
+    fn bounded_dimensions_cap_large_frames_evenly() {
+        assert_eq!(bounded_dimensions(3840, 2160, 1920, 1080), (1920, 1080));
+        assert_eq!(bounded_dimensions(2560, 1600, 1920, 1080), (1728, 1080));
     }
 }

--- a/crates/mezon-voice/src/screen.rs
+++ b/crates/mezon-voice/src/screen.rs
@@ -8,19 +8,30 @@ use livekit::webrtc::video_source::native::NativeVideoSource;
 use livekit::webrtc::video_source::{RtcVideoSource, VideoResolution};
 use parking_lot::{Condvar, Mutex};
 use scap::capturer::{Capturer, Options, Resolution};
-use scap::frame::{BGRAFrame, Frame, FrameType};
+use scap::frame::FrameType;
+#[cfg(any(not(target_os = "macos"), test))]
+use scap::frame::{BGRAFrame, Frame};
+
+#[cfg(target_os = "macos")]
+type CapturedScreenFrame = scap::capturer::engine::mac::PixelBuffer;
+#[cfg(not(target_os = "macos"))]
+type CapturedScreenFrame = BGRAFrame;
 
 use crate::screen_picker::{PickedScreen, scap_target_for_pick};
-use crate::video::{VideoFrameStore, bgra_to_i420, local_screen_key};
+#[cfg(not(target_os = "macos"))]
+use crate::video::bgra_to_i420;
+use crate::video::{VideoFrameStore, local_screen_key, nv12_full_to_i420};
 
 const CAPTURE_FPS: u32 = 15;
+#[cfg(not(target_os = "macos"))]
 const PREVIEW_MAX_WIDTH: u32 = 1280;
+#[cfg(not(target_os = "macos"))]
 const PREVIEW_MAX_HEIGHT: u32 = 800;
 const SLOT_WAIT: Duration = Duration::from_millis(250);
 
 #[derive(Default)]
 struct SlotState {
-    frame: Option<BGRAFrame>,
+    frame: Option<CapturedScreenFrame>,
     closed: bool,
     error: Option<String>,
 }
@@ -32,7 +43,7 @@ struct LatestFrameSlot {
 }
 
 impl LatestFrameSlot {
-    fn publish(&self, frame: BGRAFrame) {
+    fn publish(&self, frame: CapturedScreenFrame) {
         self.state.lock().frame = Some(frame);
         self.cond.notify_one();
     }
@@ -53,7 +64,7 @@ impl LatestFrameSlot {
         self.state.lock().error.take()
     }
 
-    fn take_latest(&self, stop: &AtomicBool) -> Option<BGRAFrame> {
+    fn take_latest(&self, stop: &AtomicBool) -> Option<CapturedScreenFrame> {
         let mut state = self.state.lock();
         loop {
             if stop.load(Ordering::Relaxed) {
@@ -89,7 +100,7 @@ impl Drop for ScreenStopper {
 pub fn start_screen(
     identity: String,
     frame_store: Arc<VideoFrameStore>,
-    full_res: Arc<AtomicBool>,
+    _full_res: Arc<AtomicBool>,
     pick: PickedScreen,
 ) -> (
     ScreenStopper,
@@ -127,6 +138,9 @@ pub fn start_screen(
                 show_cursor: true,
                 show_highlight: false,
                 excluded_targets: None,
+                #[cfg(target_os = "macos")]
+                output_type: FrameType::YUVFrameFullRange,
+                #[cfg(not(target_os = "macos"))]
                 output_type: FrameType::BGRAFrame,
                 output_resolution: Resolution::_1080p,
                 ..Default::default()
@@ -146,6 +160,17 @@ pub fn start_screen(
                         }
                     };
                     capturer.start_capture();
+                    #[cfg(target_os = "macos")]
+                    while !pump_stop.load(Ordering::Relaxed) {
+                        match capturer.raw().get_next_pixel_buffer() {
+                            Ok(frame) => pump_slot.publish(frame),
+                            Err(e) => {
+                                pump_slot.fail(format!("screen capture failed: {e}"));
+                                break;
+                            }
+                        }
+                    }
+                    #[cfg(not(target_os = "macos"))]
                     while !pump_stop.load(Ordering::Relaxed) {
                         match capturer.get_next_frame() {
                             Ok(frame) => {
@@ -175,12 +200,19 @@ pub fn start_screen(
             let mut src_w = 0u32;
             let mut src_h = 0u32;
             let mut sent_track = false;
+            #[cfg(not(target_os = "macos"))]
             let mut display_buf = Vec::new();
 
-            while let Some(bgra) = slot.take_latest(&thread_stop) {
-                let width = (bgra.width as u32 & !1).max(2);
-                let height = (bgra.height as u32 & !1).max(2);
-                if width == 0 || height == 0 || bgra.data.is_empty() {
+            while let Some(captured) = slot.take_latest(&thread_stop) {
+                #[cfg(target_os = "macos")]
+                let (width, height) = (captured.width() as u32 & !1, captured.height() as u32 & !1);
+                #[cfg(not(target_os = "macos"))]
+                let (width, height, row_stride) = (
+                    captured.width as u32 & !1,
+                    captured.height as u32 & !1,
+                    captured.data.len() / captured.height.max(1) as usize,
+                );
+                if width < 2 || height < 2 {
                     continue;
                 }
 
@@ -211,23 +243,48 @@ pub fn start_screen(
                     src_h = height;
                 }
 
-                let row_stride = bgra.data.len() / bgra.height.max(1) as usize;
                 let mut i420 = I420Buffer::new(src_w, src_h);
                 {
                     let (sy, su, sv) = i420.strides();
                     let (dy, du, dv) = i420.data_mut();
-                    bgra_to_i420(
-                        &bgra.data,
-                        src_w as usize,
-                        src_h as usize,
-                        row_stride,
-                        dy,
-                        du,
-                        dv,
-                        sy as usize,
-                        su as usize,
-                        sv as usize,
-                    );
+                    #[cfg(target_os = "macos")]
+                    {
+                        let planes = captured.planes();
+                        if planes.len() < 2 {
+                            continue;
+                        }
+                        let y = planes[0].data();
+                        let uv = planes[1].data();
+                        nv12_full_to_i420(
+                            &y,
+                            &uv,
+                            planes[0].bytes_per_row(),
+                            planes[1].bytes_per_row(),
+                            src_w as usize,
+                            src_h as usize,
+                            dy,
+                            du,
+                            dv,
+                            sy as usize,
+                            su as usize,
+                            sv as usize,
+                        );
+                    }
+                    #[cfg(not(target_os = "macos"))]
+                    {
+                        bgra_to_i420(
+                            &captured.data,
+                            src_w as usize,
+                            src_h as usize,
+                            row_stride,
+                            dy,
+                            du,
+                            dv,
+                            sy as usize,
+                            su as usize,
+                            sv as usize,
+                        );
+                    }
                 }
                 if let Some(source) = &source {
                     let frame = VideoFrame {
@@ -239,21 +296,28 @@ pub fn start_screen(
                     source.capture_frame(&frame);
                 }
 
-                let (pw, ph) = if full_res.load(Ordering::Relaxed) {
+                #[cfg(target_os = "macos")]
+                frame_store.publish_surface(key, src_w, src_h, captured.core_video_buffer());
+
+                #[cfg(not(target_os = "macos"))]
+                let (pw, ph) = if _full_res.load(Ordering::Relaxed) {
                     (src_w, src_h)
                 } else {
                     scaled_dims(src_w, src_h, PREVIEW_MAX_WIDTH, PREVIEW_MAX_HEIGHT)
                 };
+                #[cfg(not(target_os = "macos"))]
                 display_buf.resize((pw * ph * 4) as usize, 0);
+                #[cfg(not(target_os = "macos"))]
                 downscale_bgra_into(
                     &mut display_buf,
-                    &bgra.data,
+                    &captured.data,
                     src_w as usize,
                     src_h as usize,
                     row_stride,
                     pw as usize,
                     ph as usize,
                 );
+                #[cfg(not(target_os = "macos"))]
                 if let Some(recycled) =
                     frame_store.publish(key, pw, ph, std::mem::take(&mut display_buf))
                 {
@@ -277,6 +341,7 @@ pub fn start_screen(
     (ScreenStopper { stop }, track_rx)
 }
 
+#[cfg(any(not(target_os = "macos"), test))]
 fn frame_to_bgra(frame: Frame) -> Option<BGRAFrame> {
     match frame {
         Frame::BGRA(frame) => Some(frame),
@@ -346,6 +411,7 @@ fn frame_to_bgra(frame: Frame) -> Option<BGRAFrame> {
     }
 }
 
+#[cfg(not(target_os = "macos"))]
 fn scaled_dims(width: u32, height: u32, max_width: u32, max_height: u32) -> (u32, u32) {
     let scale = (max_width as f32 / width.max(1) as f32)
         .min(max_height as f32 / height.max(1) as f32)
@@ -356,6 +422,7 @@ fn scaled_dims(width: u32, height: u32, max_width: u32, max_height: u32) -> (u32
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(not(target_os = "macos"))]
 fn downscale_bgra_into(
     dst: &mut [u8],
     src: &[u8],

--- a/crates/mezon-voice/src/video.rs
+++ b/crates/mezon-voice/src/video.rs
@@ -1,40 +1,98 @@
-use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use parking_lot::Mutex;
 
+#[cfg(target_os = "macos")]
+#[derive(Clone)]
+pub struct VideoSurface(core_video::pixel_buffer::CVPixelBuffer);
+
+#[cfg(target_os = "macos")]
+unsafe impl Send for VideoSurface {}
+#[cfg(target_os = "macos")]
+unsafe impl Sync for VideoSurface {}
+
+#[cfg(target_os = "macos")]
+impl VideoSurface {
+    #[allow(missing_docs)]
+    pub fn into_inner(self) -> core_video::pixel_buffer::CVPixelBuffer {
+        self.0
+    }
+}
+
 #[derive(Clone)]
 pub struct VideoFrameData {
     pub width: u32,
     pub height: u32,
     pub bgra: Vec<u8>,
+    #[cfg(target_os = "macos")]
+    pub surface: Option<VideoSurface>,
     pub seq: u64,
 }
 
 #[derive(Default)]
 pub struct VideoFrameStore {
-    frames: Mutex<HashMap<u64, Arc<VideoFrameData>>>,
+    state: Mutex<VideoFrameState>,
     seq: AtomicU64,
+}
+
+#[derive(Default)]
+struct VideoFrameState {
+    frames: HashMap<u64, Arc<VideoFrameData>>,
+    recycled: HashMap<u64, Vec<Vec<u8>>>,
+    active: HashSet<u64>,
 }
 
 impl VideoFrameStore {
     pub fn publish(&self, key: u64, width: u32, height: u32, bgra: Vec<u8>) -> Option<Vec<u8>> {
         let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+        let required = bgra.len();
         let frame = Arc::new(VideoFrameData {
             width,
             height,
             bgra,
+            #[cfg(target_os = "macos")]
+            surface: None,
             seq,
         });
-        let prev = self.frames.lock().insert(key, frame)?;
-        Arc::try_unwrap(prev).ok().map(|f| f.bgra)
+        let mut state = self.state.lock();
+        state.active.insert(key);
+        let previous = state.frames.insert(key, frame);
+        if let Some(buffer) = previous
+            .and_then(|frame| Arc::try_unwrap(frame).ok())
+            .map(|frame| frame.bgra)
+        {
+            return Some(buffer);
+        }
+        take_recycled(&mut state, key, required)
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn publish_surface(
+        &self,
+        key: u64,
+        width: u32,
+        height: u32,
+        surface: core_video::pixel_buffer::CVPixelBuffer,
+    ) {
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+        let frame = Arc::new(VideoFrameData {
+            width,
+            height,
+            bgra: Vec::new(),
+            surface: Some(VideoSurface(surface)),
+            seq,
+        });
+        let mut state = self.state.lock();
+        state.active.insert(key);
+        state.frames.insert(key, frame);
     }
 
     pub fn get(&self, key: u64) -> Option<Arc<VideoFrameData>> {
-        self.frames.lock().get(&key).cloned()
+        self.state.lock().frames.get(&key).cloned()
     }
 
     pub fn publish_seq(&self) -> u64 {
@@ -42,21 +100,48 @@ impl VideoFrameStore {
     }
 
     pub fn take_new(&self, key: u64, since: Option<u64>) -> Option<VideoFrameData> {
-        let mut frames = self.frames.lock();
-        let is_new = match frames.get(&key) {
+        let mut state = self.state.lock();
+        let is_new = match state.frames.get(&key) {
             Some(frame) => Some(frame.seq) != since,
             None => false,
         };
         if !is_new {
             return None;
         }
-        let frame = frames.remove(&key)?;
+        let frame = state.frames.remove(&key)?;
         Some(Arc::try_unwrap(frame).unwrap_or_else(|frame| (*frame).clone()))
     }
 
-    pub fn remove(&self, key: u64) {
-        self.frames.lock().remove(&key);
+    pub fn recycle(&self, key: u64, mut buffer: Vec<u8>) {
+        let mut state = self.state.lock();
+        if !state.active.contains(&key) {
+            return;
+        }
+        buffer.clear();
+        let buffers = state.recycled.entry(key).or_default();
+        if buffers.len() < 3 {
+            buffers.push(buffer);
+        }
     }
+
+    pub fn remove(&self, key: u64) {
+        let mut state = self.state.lock();
+        state.frames.remove(&key);
+        state.recycled.remove(&key);
+        state.active.remove(&key);
+    }
+}
+
+fn take_recycled(state: &mut VideoFrameState, key: u64, required: usize) -> Option<Vec<u8>> {
+    let buffers = state.recycled.get_mut(&key)?;
+    let index = buffers
+        .iter()
+        .position(|buffer| buffer.capacity() >= required && buffer.capacity() <= required * 2)?;
+    let buffer = buffers.swap_remove(index);
+    if buffers.is_empty() {
+        state.recycled.remove(&key);
+    }
+    Some(buffer)
 }
 
 pub fn track_frame_key(identity: &str, track_sid: &str) -> u64 {
@@ -146,6 +231,7 @@ fn pack_to_i420(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(not(target_os = "macos"))]
 pub fn bgra_to_i420(
     bgra: &[u8],
     width: usize,
@@ -220,6 +306,55 @@ pub fn i420_to_bgra_into(
     i420_to_bgra_scalar(
         out, y_plane, u_plane, v_plane, stride_y, stride_u, stride_v, width, height,
     );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn nv12_full_to_i420(
+    src_y: &[u8],
+    src_uv: &[u8],
+    src_stride_y: usize,
+    src_stride_uv: usize,
+    width: usize,
+    height: usize,
+    dst_y: &mut [u8],
+    dst_u: &mut [u8],
+    dst_v: &mut [u8],
+    dst_stride_y: usize,
+    dst_stride_u: usize,
+    dst_stride_v: usize,
+) {
+    for row in 0..height {
+        let src_start = row * src_stride_y;
+        let dst_start = row * dst_stride_y;
+        if src_start + width > src_y.len() || dst_start + width > dst_y.len() {
+            break;
+        }
+        for (dst, src) in dst_y[dst_start..dst_start + width]
+            .iter_mut()
+            .zip(&src_y[src_start..src_start + width])
+        {
+            *dst = 16 + ((*src as u16 * 219 + 127) / 255) as u8;
+        }
+    }
+
+    let chroma_width = width.div_ceil(2);
+    let chroma_height = height.div_ceil(2);
+    for row in 0..chroma_height {
+        let src_start = row * src_stride_uv;
+        let u_start = row * dst_stride_u;
+        let v_start = row * dst_stride_v;
+        if src_start + chroma_width * 2 > src_uv.len()
+            || u_start + chroma_width > dst_u.len()
+            || v_start + chroma_width > dst_v.len()
+        {
+            break;
+        }
+        for column in 0..chroma_width {
+            let src = src_start + column * 2;
+            dst_u[u_start + column] = 16 + ((src_uv[src] as u16 * 224 + 127) / 255) as u8;
+            dst_v[v_start + column] = 16 + ((src_uv[src + 1] as u16 * 224 + 127) / 255) as u8;
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -565,5 +700,33 @@ mod tests {
             .take_new(key, Some(current_seq.wrapping_sub(1)))
             .expect("inequality not ordering");
         assert_eq!(third.bgra, vec![3]);
+    }
+
+    #[test]
+    fn recycled_render_buffer_returns_to_producer() {
+        let store = VideoFrameStore::default();
+        let key = 9;
+        store.publish(key, 2, 2, vec![1; 16]);
+        let frame = store.take_new(key, None).expect("frame");
+        store.recycle(key, frame.bgra);
+
+        let recycled = store
+            .publish(key, 2, 2, vec![2; 16])
+            .expect("recycled buffer");
+        assert!(recycled.capacity() >= 16);
+        assert!(recycled.is_empty());
+    }
+
+    #[test]
+    fn nv12_full_range_converts_to_limited_i420() {
+        let src_y = [0, 255, 128, 64];
+        let src_uv = [0, 255];
+        let mut y = [0; 4];
+        let mut u = [0; 1];
+        let mut v = [0; 1];
+        nv12_full_to_i420(&src_y, &src_uv, 2, 2, 2, 2, &mut y, &mut u, &mut v, 2, 1, 1);
+        assert_eq!(y, [16, 235, 126, 71]);
+        assert_eq!(u, [16]);
+        assert_eq!(v, [240]);
     }
 }

--- a/crates/vendor/gpui/src/assets.rs
+++ b/crates/vendor/gpui/src/assets.rs
@@ -6,6 +6,7 @@ use std::{
     borrow::Cow,
     fmt,
     hash::Hash,
+    sync::Arc,
     sync::atomic::{AtomicUsize, Ordering::SeqCst},
 };
 
@@ -46,6 +47,7 @@ pub struct RenderImage {
     /// The scale factor of this image on render.
     pub(crate) scale_factor: f32,
     data: SmallVec<[Frame; 1]>,
+    recycler: Option<Arc<dyn Fn(Vec<u8>) + Send + Sync>>,
 }
 
 impl PartialEq for RenderImage {
@@ -75,7 +77,18 @@ impl RenderImage {
             id: ImageId(NEXT_ID.fetch_add(1, SeqCst)),
             scale_factor: 1.0,
             data: data.into(),
+            recycler: None,
         }
+    }
+
+    #[allow(missing_docs)]
+    pub fn new_recyclable(
+        frame: Frame,
+        recycler: Arc<dyn Fn(Vec<u8>) + Send + Sync>,
+    ) -> Self {
+        let mut image = Self::new(SmallVec::from_const([frame]));
+        image.recycler = Some(recycler);
+        image
     }
 
     /// Convert this image into a byte slice.
@@ -113,6 +126,17 @@ impl RenderImage {
     /// Get the number of frames for this image.
     pub fn frame_count(&self) -> usize {
         self.data.len()
+    }
+}
+
+impl Drop for RenderImage {
+    fn drop(&mut self) {
+        let Some(recycler) = self.recycler.take() else {
+            return;
+        };
+        for frame in self.data.drain(..) {
+            recycler(frame.into_buffer().into_raw());
+        }
     }
 }
 

--- a/crates/vendor/zed-scap/Cargo.toml
+++ b/crates/vendor/zed-scap/Cargo.toml
@@ -39,6 +39,8 @@ windows = { version = "0.61", features = [
 
 [target.'cfg(target_os = "macos")'.dependencies]
 tao-core-video-sys = "0.2.0"
+core-foundation = "0.10.0"
+core-video = "0.5.2"
 core-graphics-helmer-fork = "0.24.0"
 screencapturekit = "0.2.8"
 screencapturekit-sys = "0.2.8"

--- a/crates/vendor/zed-scap/src/capturer/engine/mac/mod.rs
+++ b/crates/vendor/zed-scap/src/capturer/engine/mac/mod.rs
@@ -45,24 +45,24 @@ impl StreamErrorHandler for ErrorHandler {
 }
 
 pub struct Capturer {
-    pub tx: mpsc::Sender<anyhow::Result<ChannelItem>>,
+    pub tx: mpsc::SyncSender<anyhow::Result<ChannelItem>>,
 }
 
 impl Capturer {
-    pub fn new(tx: mpsc::Sender<anyhow::Result<ChannelItem>>) -> Self {
+    pub fn new(tx: mpsc::SyncSender<anyhow::Result<ChannelItem>>) -> Self {
         Capturer { tx }
     }
 }
 
 impl StreamOutput for Capturer {
     fn did_output_sample_buffer(&self, sample: CMSampleBuffer, of_type: SCStreamOutputType) {
-        self.tx.send(Ok((sample, of_type))).unwrap_or(());
+        let _ = self.tx.try_send(Ok((sample, of_type)));
     }
 }
 
 pub fn create_capturer(
     options: &Options,
-    tx: mpsc::Sender<anyhow::Result<ChannelItem>>,
+    tx: mpsc::SyncSender<anyhow::Result<ChannelItem>>,
     error_flag: Arc<AtomicBool>,
 ) -> (SCStream, Target) {
     let target = options
@@ -130,6 +130,7 @@ pub fn create_capturer(
 
     let pixel_format = match options.output_type {
         FrameType::YUVFrame => PixelFormat::YCbCr420v,
+        FrameType::YUVFrameFullRange => PixelFormat::YCbCr420f,
         FrameType::BGR0 => PixelFormat::ARGB8888,
         FrameType::RGB => PixelFormat::ARGB8888,
         FrameType::BGRAFrame => PixelFormat::ARGB8888,
@@ -232,7 +233,7 @@ pub fn process_sample_buffer(
         match frame_status {
             SCFrameStatus::Complete | SCFrameStatus::Started => unsafe {
                 return Some(match output_type {
-                    FrameType::YUVFrame => {
+                    FrameType::YUVFrame | FrameType::YUVFrameFullRange => {
                         let yuvframe = pixelformat::create_yuv_frame(sample).unwrap();
                         Frame::YUVFrame(yuvframe)
                     }

--- a/crates/vendor/zed-scap/src/capturer/engine/mac/pixel_buffer.rs
+++ b/crates/vendor/zed-scap/src/capturer/engine/mac/pixel_buffer.rs
@@ -1,4 +1,6 @@
 use core::slice;
+use core_foundation::base::TCFType;
+use core_video::pixel_buffer::CVPixelBuffer as CoreVideoPixelBuffer;
 use core_video_sys::{
     CVPixelBufferGetBaseAddress, CVPixelBufferGetBaseAddressOfPlane, CVPixelBufferGetBytesPerRow,
     CVPixelBufferGetBytesPerRowOfPlane, CVPixelBufferGetHeight, CVPixelBufferGetHeightOfPlane,
@@ -40,6 +42,12 @@ impl PixelBuffer {
         self.bytes_per_row
     }
 
+    #[allow(missing_docs)]
+    pub fn core_video_buffer(&self) -> CoreVideoPixelBuffer {
+        let buffer = unsafe { sample_buffer_to_pixel_buffer(&self.buffer) };
+        unsafe { CoreVideoPixelBuffer::wrap_under_get_rule(buffer.cast()) }
+    }
+
     pub fn data(&self) -> PixelBufferData<'_> {
         unsafe {
             let pixel_buffer = sample_buffer_to_pixel_buffer(&self.buffer);
@@ -62,8 +70,6 @@ impl PixelBuffer {
         unsafe {
             let pixel_buffer = sample_buffer_to_pixel_buffer(&self.buffer);
             let count = CVPixelBufferGetPlaneCount(pixel_buffer);
-
-            CVPixelBufferLockBaseAddress(pixel_buffer, 0);
 
             (0..count)
                 .map(|i| Plane {

--- a/crates/vendor/zed-scap/src/capturer/engine/mod.rs
+++ b/crates/vendor/zed-scap/src/capturer/engine/mod.rs
@@ -22,6 +22,11 @@ pub type ChannelItem = (
 #[cfg(not(target_os = "macos"))]
 pub type ChannelItem = Frame;
 
+#[cfg(target_os = "macos")]
+pub type ChannelSender = mpsc::SyncSender<Result<ChannelItem>>;
+#[cfg(not(target_os = "macos"))]
+pub type ChannelSender = mpsc::Sender<Result<ChannelItem>>;
+
 pub fn get_output_frame_size(options: &Options) -> [u32; 2] {
     #[cfg(target_os = "macos")]
     {
@@ -55,7 +60,7 @@ pub struct Engine {
 }
 
 impl Engine {
-    pub fn new(options: &Options, tx: mpsc::Sender<Result<ChannelItem>>) -> Result<Engine> {
+    pub fn new(options: &Options, tx: ChannelSender) -> Result<Engine> {
         #[cfg(target_os = "macos")]
         {
             let error_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));

--- a/crates/vendor/zed-scap/src/capturer/mod.rs
+++ b/crates/vendor/zed-scap/src/capturer/mod.rs
@@ -4,7 +4,7 @@ use std::{error::Error, sync::mpsc};
 
 use anyhow::anyhow;
 
-use engine::ChannelItem;
+use engine::{ChannelItem, ChannelSender};
 
 use crate::{
     frame::{Frame, FrameType},
@@ -102,7 +102,7 @@ impl Capturer {
         note = "Use `build` instead of `new` to create a new capturer instance."
     )]
     pub fn new(options: Options) -> anyhow::Result<Capturer> {
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = capture_channel();
         let engine = engine::Engine::new(&options, tx)?;
 
         Ok(Capturer { engine, rx })
@@ -117,7 +117,7 @@ impl Capturer {
             return Err(anyhow!(CapturerBuildError::PermissionNotGranted));
         }
 
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = capture_channel();
         let engine = engine::Engine::new(&options, tx)?;
 
         Ok(Capturer { engine, rx })
@@ -152,6 +152,22 @@ impl Capturer {
     pub fn target(&self) -> Option<&Target> {
         self.engine.target()
     }
+}
+
+#[cfg(target_os = "macos")]
+fn capture_channel() -> (
+    ChannelSender,
+    mpsc::Receiver<anyhow::Result<ChannelItem>>,
+) {
+    mpsc::sync_channel(2)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn capture_channel() -> (
+    ChannelSender,
+    mpsc::Receiver<anyhow::Result<ChannelItem>>,
+) {
+    mpsc::channel()
 }
 
 pub struct RawCapturer<'a> {

--- a/crates/vendor/zed-scap/src/frame/mod.rs
+++ b/crates/vendor/zed-scap/src/frame/mod.rs
@@ -68,6 +68,7 @@ pub struct BGRAFrame {
 pub enum FrameType {
     #[default]
     YUVFrame,
+    YUVFrameFullRange,
     BGR0,
     RGB, // Prefer BGR0 because RGB is slower
     BGRAFrame,


### PR DESCRIPTION
## Summary
- Improve macOS screen capture pipeline (zed-scap pixel buffer, capturer engine)
- Voice store/UI updates for screen share PIP and camera/video tracks
- Store helper follow-up from image cache merge (`global_arc`, avatar proxy fit)

## Test plan
- [ ] `cargo check -p mezon-voice -p mezon-store -p mezon-ui`
- [ ] macOS: join voice channel, start screen share, verify capture FPS and preview
- [ ] macOS: camera on/off in voice without frame stalls