### PR TITLE
fix(gpui): stabilize list scroll rendering and message anchors

### DIFF
--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -1125,12 +1125,14 @@ impl MentionInput {
         if MENTION_HERE_NORM.contains(&needle) {
             out.push(Suggestion::Here);
         }
-        out.sort_by_cached_key(|item| {
-            let display = item.norm_keys().0;
-            let exact = u8::from(display != needle);
-            let index = display.find(&needle).map_or(i64::MAX, |i| i as i64);
-            (exact, index)
-        });
+        if !needle.is_empty() {
+            out.sort_by_cached_key(|item| {
+                let display = item.norm_keys().0;
+                let exact = u8::from(display != needle);
+                let index = display.find(&needle).map_or(i64::MAX, |i| i as i64);
+                (exact, index)
+            });
+        }
         out
     }
 

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -234,6 +234,17 @@ struct SavedScrollAnchor {
     offset_in_item: Pixels,
 }
 
+fn saved_message_scroll_anchor(
+    anchor: SavedScrollAnchor,
+    message_ix: usize,
+    header_shown: bool,
+) -> gpui::ListOffset {
+    gpui::ListOffset {
+        item_ix: usize::from(header_shown) + message_ix,
+        offset_in_item: anchor.offset_in_item,
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PaginationDirection {
     Top,
@@ -266,6 +277,15 @@ fn pagination_direction(
         Some(PaginationDirection::Top)
     } else if near_bottom && has_more_bottom && armed_bottom {
         Some(PaginationDirection::Bottom)
+    } else {
+        None
+    }
+}
+
+fn deadline_remaining(last_activity: Instant, now: Instant, delay: Duration) -> Option<Duration> {
+    let elapsed = now.saturating_duration_since(last_activity);
+    if elapsed < delay {
+        Some(delay - elapsed)
     } else {
         None
     }
@@ -497,6 +517,47 @@ mod pagination_tests {
     }
 }
 
+#[cfg(test)]
+mod scroll_idle_tests {
+    use super::*;
+
+    #[test]
+    fn memory_relief_waits_for_the_latest_scroll_activity() {
+        let started_at = Instant::now();
+        let before_idle = started_at + SCROLL_RELIEF_DELAY - Duration::from_millis(1);
+        assert_eq!(
+            deadline_remaining(started_at, before_idle, SCROLL_RELIEF_DELAY),
+            Some(Duration::from_millis(1))
+        );
+        assert_eq!(
+            deadline_remaining(
+                started_at,
+                started_at + SCROLL_RELIEF_DELAY,
+                SCROLL_RELIEF_DELAY
+            ),
+            None
+        );
+        assert_eq!(
+            deadline_remaining(
+                started_at,
+                started_at + SCROLL_RELIEF_DELAY + Duration::from_secs(1),
+                SCROLL_RELIEF_DELAY
+            ),
+            None
+        );
+
+        let latest_activity = started_at + Duration::from_millis(900);
+        assert_eq!(
+            deadline_remaining(
+                latest_activity,
+                started_at + SCROLL_RELIEF_DELAY,
+                SCROLL_RELIEF_DELAY
+            ),
+            Some(Duration::from_millis(900))
+        );
+    }
+}
+
 pub struct ChannelMessages {
     pub(crate) list_state: ListState,
     focus_handle: FocusHandle,
@@ -583,7 +644,9 @@ impl ChannelMessages {
             this.cached_locale = settings.read(cx).language.clone().into();
             this.cached_coming_soon =
                 mezon_i18n::t(&this.cached_locale, "common.comingSoon").into();
-            this.row_memo.borrow_mut().time_labels.clear();
+            let mut memo = this.row_memo.borrow_mut();
+            memo.time_labels.clear();
+            memo.rich_text.clear();
             cx.notify();
         })
         .detach();
@@ -739,6 +802,23 @@ impl ChannelMessages {
                 } => {
                     let prev_top = this.list_state.logical_scroll_top();
                     let prev_count = this.list_state.item_count();
+                    let preserved_message_anchor = {
+                        let store = _store.read(cx);
+                        store
+                            .active_channel_id()
+                            .and_then(|channel_id| this.scroll_anchors.get(&channel_id).copied())
+                            .and_then(|anchor| {
+                                store
+                                    .viewport_position(anchor.message_id)
+                                    .map(|message_ix| {
+                                        saved_message_scroll_anchor(
+                                            anchor,
+                                            message_ix,
+                                            this.header_shown,
+                                        )
+                                    })
+                            })
+                    };
                     let was_at_end = prev_top.item_ix >= prev_count;
                     let own_recent_send = *added_bottom > 0
                         && _store.read(cx).viewport_messages().last().is_some_and(|m| {
@@ -748,11 +828,17 @@ impl ChannelMessages {
                                     && chrono::Utc::now().timestamp() - m.create_time <= 1)
                         });
                     let h = usize::from(this.header_shown);
+                    let inserted_size_hint = this.list_state.average_measured_item_size();
                     if *removed_top > 0 {
                         this.list_state.splice(h..h + *removed_top, 0);
                     }
                     if *added_top > 0 {
-                        this.list_state.splice(h..h, *added_top);
+                        if let Some(size_hint) = inserted_size_hint {
+                            this.list_state
+                                .splice_with_size_hint(h..h, *added_top, size_hint);
+                        } else {
+                            this.list_state.splice(h..h, *added_top);
+                        }
                     }
                     if *removed_bottom > 0 {
                         let n = this.list_state.item_count();
@@ -761,7 +847,12 @@ impl ChannelMessages {
                     }
                     if *added_bottom > 0 {
                         let n = this.list_state.item_count();
-                        this.list_state.splice(n..n, *added_bottom);
+                        if let Some(size_hint) = inserted_size_hint {
+                            this.list_state
+                                .splice_with_size_hint(n..n, *added_bottom, size_hint);
+                        } else {
+                            this.list_state.splice(n..n, *added_bottom);
+                        }
                     }
                     let following_new = *added_bottom > 0
                         && (was_at_end || own_recent_send)
@@ -770,16 +861,19 @@ impl ChannelMessages {
                         this.list_state.scroll_to_end();
                         this.at_bottom = true;
                         this.sync_channel_seen(cx);
-                    } else if (*added_top > 0 || *removed_top > 0)
-                        && let Some(anchor) = shifted_scroll_anchor(
-                            prev_top,
-                            prev_count,
-                            this.header_shown,
-                            *added_top,
-                            *removed_top,
-                        )
-                    {
-                        this.list_state.scroll_to(anchor);
+                    } else if *added_top > 0 || *removed_top > 0 {
+                        let anchor = preserved_message_anchor.or_else(|| {
+                            shifted_scroll_anchor(
+                                prev_top,
+                                prev_count,
+                                this.header_shown,
+                                *added_top,
+                                *removed_top,
+                            )
+                        });
+                        if let Some(anchor) = anchor {
+                            this.list_state.scroll_to(anchor);
+                        }
                     } else if *added_bottom > 0 && prev_top.item_ix < prev_count {
                         this.list_state.scroll_to(prev_top);
                     }
@@ -850,6 +944,7 @@ impl ChannelMessages {
         let timeline = cx.weak_entity();
         list_state.set_scroll_handler(move |event, window, cx| {
             let at_bottom = !event.is_scrolled;
+            let scroll_top = event.scroll_top;
             let visible_start = event.visible_range.start;
             let visible_end = event.visible_range.end;
             let _ = timeline.update(cx, |this, cx| {
@@ -874,21 +969,26 @@ impl ChannelMessages {
                         this._reaction_picker_dismiss_sub = None;
                         cx.notify();
                     }
-                    if !this.scroll_relief_armed {
-                        this.scroll_relief_armed = true;
-                        cx.spawn(async move |this, cx| {
-                            cx.background_executor().timer(SCROLL_RELIEF_DELAY).await;
-                            this.update(cx, |this, cx| {
-                                this.scroll_relief_armed = false;
-                                crate::image_cache::release_freed_memory_to_os(cx);
-                            })
-                            .ok();
-                        })
-                        .detach();
-                    }
                 }
 
                 let store_entity = MessagesStore::global(cx);
+                let live_anchor = {
+                    let store = store_entity.read(cx);
+                    store.active_channel_id().map(|channel_id| {
+                        (
+                            channel_id,
+                            capture_anchor(
+                                store.viewport_messages(),
+                                at_bottom,
+                                scroll_top,
+                                this.header_shown,
+                            ),
+                        )
+                    })
+                };
+                if let Some((channel_id, anchor_update)) = live_anchor {
+                    this.apply_scroll_anchor(channel_id, anchor_update);
+                }
                 if at_bottom_changed {
                     if let Some(channel_id) = store_entity.read(cx).active_channel_id() {
                         store_entity.update(cx, |store, _cx| {
@@ -1649,6 +1749,7 @@ impl ChannelMessages {
             let mut memo = self.row_memo.borrow_mut();
             memo.avatars.clear();
             memo.time_labels.clear();
+            memo.rich_text.clear();
         }
         self.image_cache
             .update(cx, |cache, cx| cache.clear(window, cx));
@@ -1662,7 +1763,9 @@ impl ChannelMessages {
                 self.scroll_anchors.remove(&channel_id);
             }
             AnchorUpdate::Set(anchor) => {
-                self.scroll_anchors.insert(channel_id, anchor);
+                if self.scroll_anchors.get(&channel_id) != Some(&anchor) {
+                    self.scroll_anchors.insert(channel_id, anchor);
+                }
             }
             AnchorUpdate::Keep => {}
         }
@@ -2036,6 +2139,7 @@ impl ChannelMessages {
 impl ChannelMessages {
     fn mark_scroll_activity(&mut self, cx: &mut Context<Self>) {
         self.last_scroll_at = Some(Instant::now());
+        self.arm_scroll_memory_relief(cx);
         if self.scroll_idle_armed {
             return;
         }
@@ -2057,6 +2161,37 @@ impl ChannelMessages {
                         } else {
                             Some(SCROLL_ACTIVITY_GRACE - elapsed)
                         }
+                    })
+                    .ok()
+                    .flatten();
+                let Some(next) = next else {
+                    break;
+                };
+                remaining = next;
+            }
+        })
+        .detach();
+    }
+
+    fn arm_scroll_memory_relief(&mut self, cx: &mut Context<Self>) {
+        if self.scroll_relief_armed {
+            return;
+        }
+        self.scroll_relief_armed = true;
+        cx.spawn(async move |this, cx| {
+            let mut remaining = SCROLL_RELIEF_DELAY;
+            loop {
+                cx.background_executor().timer(remaining).await;
+                let next = this
+                    .update(cx, |this, cx| {
+                        let next = this.last_scroll_at.and_then(|last_activity| {
+                            deadline_remaining(last_activity, Instant::now(), SCROLL_RELIEF_DELAY)
+                        });
+                        if next.is_none() {
+                            this.scroll_relief_armed = false;
+                            crate::image_cache::release_freed_memory_to_os(cx);
+                        }
+                        next
                     })
                     .ok()
                     .flatten();
@@ -2289,6 +2424,7 @@ impl Render for ChannelMessages {
                         welcome: welcome.clone(),
                         onboarding: onboarding.clone(),
                         suppress_hover,
+                        scroll_active,
                         hovered_row,
                         avatar_cache: small_avatar_image_cache.clone(),
                         large_avatar_cache: avatar_image_cache.clone(),
@@ -2790,7 +2926,7 @@ mod skeleton_tests {
 mod scroll_restore_tests {
     use super::{
         AnchorUpdate, ResetScroll, ResetTransition, SavedScrollAnchor, capture_anchor,
-        decide_reset_scroll, reset_transition, shifted_scroll_anchor,
+        decide_reset_scroll, reset_transition, saved_message_scroll_anchor, shifted_scroll_anchor,
     };
     use gpui::{ListOffset, px};
     use mezon_store::{ChannelId, Message, MessageId};
@@ -2979,7 +3115,7 @@ mod scroll_restore_tests {
     }
 
     #[test]
-    fn prepend_keeps_old_first_row_when_loading_header_is_visible() {
+    fn prepend_fallback_keeps_old_first_row_when_loading_header_is_visible() {
         assert_offset(
             shifted_scroll_anchor(
                 ListOffset {
@@ -2994,6 +3130,25 @@ mod scroll_restore_tests {
             21,
             0.,
         );
+    }
+
+    #[test]
+    fn prepend_restores_the_same_message_id_and_offset() {
+        let before = rows(&[40, 41, 42, 43]);
+        let captured = capture_anchor(&before, false, list_offset(2, 9.), true);
+        let AnchorUpdate::Set(anchor) = captured else {
+            panic!("expected a message anchor");
+        };
+        let after = rows(&[20, 21, 22, 40, 41, 42, 43]);
+        let message_ix = after
+            .iter()
+            .position(|message| message.id == anchor.message_id)
+            .unwrap();
+        let restored = saved_message_scroll_anchor(anchor, message_ix, true);
+
+        assert_eq!(anchor.message_id, MessageId(41));
+        assert_eq!(restored.item_ix, 5);
+        assert_eq!(restored.offset_in_item, px(9.));
     }
 
     #[test]

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -11,7 +11,7 @@ use mezon_store::{
 
 use ui::Clickable;
 
-use super::context::RowCtx;
+use super::context::{RichTextRenderPlan, RowCtx};
 use super::inline_content::{ClickRegion, IconOverlay, InlineContent, StyledRun};
 use crate::app::shell::Shell;
 use crate::chat::user_profile_popover::{ClickableContainer, UserProfilePopover};
@@ -31,6 +31,7 @@ const SOCIAL_CARD_BG: u32 = 0x2b_2d_31;
 const EMOJI_SIZE: f32 = 24.;
 const EMOJI_JUMBO_SIZE: f32 = 48.;
 const INLINE_ICON_PLACEHOLDER: char = '\u{2800}';
+const RICH_TEXT_PLAN_LIMIT: usize = 512;
 
 struct ContentRenderOptions {
     body_color: gpui::Rgba,
@@ -239,11 +240,13 @@ fn render_deleted_placeholder(msg: &Message, theme: &Theme) -> AnyElement {
         .into_any_element()
 }
 
-#[derive(Clone)]
-enum SpanAction {
-    Mention(UserId),
-    Channel(ChannelId),
-    Link(SharedString),
+fn rich_text_plan_matches(
+    plan: &RichTextRenderPlan,
+    layout: &std::sync::Arc<mezon_store::RichLayout>,
+    colors: [Hsla; 5],
+    edited: bool,
+) -> bool {
+    std::sync::Arc::ptr_eq(&plan.layout, layout) && plan.colors == colors && plan.edited == edited
 }
 
 fn render_rich_styled(msg: &Message, ctx: &RowCtx, body_color: gpui::Rgba) -> AnyElement {
@@ -252,109 +255,144 @@ fn render_rich_styled(msg: &Message, ctx: &RowCtx, body_color: gpui::Rgba) -> An
     let mention_bg: Hsla = theme.tokens.mention_primary.into();
     let code_bg: Hsla = theme.tokens.bg_markdown_code.into();
     let link_color: Hsla = theme.tokens.mention_color.into();
-
-    let layout = msg.rich_layout.as_deref();
-    let base_text: SharedString = layout.map(|l| l.text.clone()).unwrap_or_default();
-
-    let mut highlights: Vec<(Range<usize>, HighlightStyle)> = Vec::new();
-    let mut font_overrides: Vec<(Range<usize>, SharedString)> = Vec::new();
-    let mut click_ranges: Vec<Range<usize>> = Vec::new();
-    let mut actions: Vec<SpanAction> = Vec::new();
-
-    if let Some(layout) = layout {
-        for run in layout.runs.iter() {
-            match run.kind {
-                RichRunKind::Bold => highlights.push((
-                    run.range.clone(),
-                    HighlightStyle {
-                        font_weight: Some(FontWeight::BOLD),
-                        ..Default::default()
-                    },
-                )),
-                RichRunKind::Code => {
-                    highlights.push((
+    let colors = [
+        mention_color,
+        mention_bg,
+        code_bg,
+        link_color,
+        theme.text_muted.into(),
+    ];
+    let Some(layout) = msg.rich_layout.as_ref() else {
+        return div().into_any_element();
+    };
+    let cached = ctx.row_memo.borrow().rich_text.get(&msg.id).cloned();
+    let plan = match cached {
+        Some(plan) if rich_text_plan_matches(&plan, layout, colors, msg.is_edited) => plan,
+        _ => {
+            let mut highlights: Vec<(Range<usize>, HighlightStyle)> =
+                Vec::with_capacity(layout.runs.len() + usize::from(msg.is_edited));
+            let mut font_overrides: Vec<(Range<usize>, SharedString)> = Vec::new();
+            let mut click_ranges: Vec<Range<usize>> = Vec::new();
+            let mut actions: Vec<RichClick> = Vec::new();
+            for run in layout.runs.iter() {
+                match run.kind {
+                    RichRunKind::Bold => highlights.push((
                         run.range.clone(),
                         HighlightStyle {
-                            background_color: Some(code_bg),
+                            font_weight: Some(FontWeight::BOLD),
                             ..Default::default()
                         },
-                    ));
-                    font_overrides.push((run.range.clone(), "monospace".into()));
-                }
-                RichRunKind::Link => highlights.push((
-                    run.range.clone(),
-                    HighlightStyle {
-                        color: Some(link_color),
-                        underline: Some(UnderlineStyle {
-                            thickness: px(1.),
+                    )),
+                    RichRunKind::Code => {
+                        highlights.push((
+                            run.range.clone(),
+                            HighlightStyle {
+                                background_color: Some(code_bg),
+                                ..Default::default()
+                            },
+                        ));
+                        font_overrides.push((run.range.clone(), "monospace".into()));
+                    }
+                    RichRunKind::Link => highlights.push((
+                        run.range.clone(),
+                        HighlightStyle {
                             color: Some(link_color),
-                            wavy: false,
-                        }),
-                        ..Default::default()
-                    },
-                )),
-                RichRunKind::Mention | RichRunKind::Hashtag => highlights.push((
-                    run.range.clone(),
-                    HighlightStyle {
-                        color: Some(mention_color),
-                        background_color: Some(mention_bg),
-                        ..Default::default()
-                    },
-                )),
+                            underline: Some(UnderlineStyle {
+                                thickness: px(1.),
+                                color: Some(link_color),
+                                wavy: false,
+                            }),
+                            ..Default::default()
+                        },
+                    )),
+                    RichRunKind::Mention | RichRunKind::Hashtag => highlights.push((
+                        run.range.clone(),
+                        HighlightStyle {
+                            color: Some(mention_color),
+                            background_color: Some(mention_bg),
+                            ..Default::default()
+                        },
+                    )),
+                }
+                if let Some(click) = run.click.clone() {
+                    click_ranges.push(run.range.clone());
+                    actions.push(click);
+                }
             }
-            if let Some(click) = run.click.clone() {
-                click_ranges.push(run.range.clone());
-                actions.push(match click {
-                    RichClick::Link(url) => SpanAction::Link(url),
-                    RichClick::Mention(user_id) => SpanAction::Mention(user_id),
-                    RichClick::Channel(channel_id) => SpanAction::Channel(channel_id),
-                });
-            }
-        }
-    }
 
-    let text: SharedString = if msg.is_edited {
-        let marker = mezon_i18n::t(ctx.locale, "message.edited");
-        let mut edited = String::with_capacity(base_text.len() + 1 + marker.len());
-        edited.push_str(&base_text);
-        edited.push(' ');
-        let start = edited.len();
-        edited.push_str(marker);
-        highlights.push((
-            start..edited.len(),
-            HighlightStyle {
-                color: Some(theme.text_muted.into()),
-                ..Default::default()
-            },
-        ));
-        edited.into()
-    } else {
-        base_text
+            let text = if msg.is_edited {
+                let marker = mezon_i18n::t(ctx.locale, "message.edited");
+                let mut edited = String::with_capacity(layout.text.len() + 1 + marker.len());
+                edited.push_str(&layout.text);
+                edited.push(' ');
+                let start = edited.len();
+                edited.push_str(marker);
+                highlights.push((
+                    start..edited.len(),
+                    HighlightStyle {
+                        color: Some(colors[4]),
+                        ..Default::default()
+                    },
+                ));
+                edited.into()
+            } else {
+                layout.text.clone()
+            };
+            let plan = RichTextRenderPlan {
+                layout: layout.clone(),
+                colors,
+                edited: msg.is_edited,
+                text,
+                highlights: highlights.into(),
+                font_overrides: font_overrides.into(),
+                click_ranges: click_ranges.into(),
+                actions: actions.into(),
+                locale: SharedString::from(ctx.locale),
+            };
+            let mut memo = ctx.row_memo.borrow_mut();
+            if memo.rich_text.len() >= RICH_TEXT_PLAN_LIMIT && !memo.rich_text.contains_key(&msg.id)
+            {
+                memo.rich_text.clear();
+            }
+            memo.rich_text.insert(msg.id, plan.clone());
+            plan
+        }
     };
 
-    let mut styled = StyledText::new(text).with_highlights(highlights);
-    if !font_overrides.is_empty() {
-        styled = styled.with_font_family_overrides(font_overrides);
+    let mut styled =
+        StyledText::new(plan.text.clone()).with_shared_highlights(plan.highlights.clone());
+    if !plan.font_overrides.is_empty() {
+        styled = styled.with_shared_font_family_overrides(plan.font_overrides.clone());
+    }
+
+    if plan.actions.is_empty() {
+        return div()
+            .w_full()
+            .min_w_0()
+            .text_base()
+            .line_height(rems(1.375))
+            .text_color(body_color)
+            .child(styled)
+            .into_any_element();
     }
 
     let profile_context = ctx.profile_context;
     let settings = ctx.settings.clone();
     let host = ctx.video_host.clone();
     let avatar_cache = ctx.large_avatar_cache.clone();
-    let locale = if actions.iter().any(|a| matches!(a, SpanAction::Channel(_))) {
-        ctx.locale.to_string()
-    } else {
-        String::new()
-    };
+    let actions = plan.actions.clone();
+    let locale = plan.locale.clone();
     let interactive = InteractiveText::new(("msg-itext", msg.row_anchor_id.0 as usize), styled)
-        .on_click(click_ranges, move |range_ix, window, cx| {
+        .on_click_shared(plan.click_ranges.clone(), move |range_ix, window, cx| {
             let Some(action) = actions.get(range_ix) else {
                 return;
             };
             match action {
-                SpanAction::Link(url) => open_message_link(url.to_string(), cx),
-                SpanAction::Channel(channel_id) => navigate_to_channel(*channel_id, &locale, cx),
-                SpanAction::Mention(user_id) => {
+                RichClick::Link(url) => open_message_link(url.to_string(), cx),
+                RichClick::Channel(channel_id) => {
+                    navigate_to_channel(*channel_id, locale.as_ref(), cx)
+                }
+                RichClick::Mention(user_id) => {
                     let Some(context) = profile_context else {
                         return;
                     };
@@ -1274,13 +1312,37 @@ fn split_unbreakable(text: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_channel_id;
-    use mezon_store::ChannelId;
+    use super::{RichTextRenderPlan, parse_channel_id, rich_text_plan_matches};
+    use gpui::{Hsla, SharedString};
+    use mezon_store::{ChannelId, MessageSpan, build_rich_layout};
 
     #[test]
     fn parse_channel_id_rejects_zero() {
         assert_eq!(parse_channel_id("0"), None);
         assert_eq!(parse_channel_id("12345"), Some(ChannelId(12345)));
+    }
+
+    #[test]
+    fn rich_text_plan_reuses_only_the_same_layout_and_style() {
+        let layout = build_rich_layout(&[MessageSpan::Bold("hello".into())]).unwrap();
+        let colors = [Hsla::default(); 5];
+        let plan = RichTextRenderPlan {
+            layout: layout.clone(),
+            colors,
+            edited: false,
+            text: SharedString::from("hello"),
+            highlights: Vec::new().into(),
+            font_overrides: Vec::new().into(),
+            click_ranges: Vec::new().into(),
+            actions: Vec::new().into(),
+            locale: SharedString::from("en"),
+        };
+
+        assert!(rich_text_plan_matches(&plan, &layout, colors, false));
+        assert!(!rich_text_plan_matches(&plan, &layout, colors, true));
+
+        let replacement = std::sync::Arc::new((*layout).clone());
+        assert!(!rich_text_plan_matches(&plan, &replacement, colors, false));
     }
 }
 

--- a/crates/mezon-ui/src/chat/message/context.rs
+++ b/crates/mezon-ui/src/chat/message/context.rs
@@ -1,9 +1,13 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::ops::Range;
 use std::rc::Rc;
+use std::sync::Arc;
 
-use gpui::{App, Entity, SharedString, WeakEntity};
-use mezon_store::{ChannelType, ClanId, Emoji, MessageId, ProfileContext, Settings, UserId};
+use gpui::{App, Entity, HighlightStyle, Hsla, SharedString, WeakEntity};
+use mezon_store::{
+    ChannelType, ClanId, Emoji, MessageId, ProfileContext, RichClick, RichLayout, Settings, UserId,
+};
 
 use super::audio_player::AudioPlayerView;
 use super::channel_messages::ChannelMessages;
@@ -53,6 +57,7 @@ pub struct RowCtx<'a> {
     pub welcome: Option<WelcomeContext>,
     pub onboarding: Option<OnboardingContext>,
     pub suppress_hover: bool,
+    pub scroll_active: bool,
     /// Message whose hover toolbar should show, after the React-style hover-intent
     /// delay (fast mouse sweeps never latch it). `None` = no toolbar visible.
     pub hovered_row: Option<MessageId>,
@@ -97,6 +102,20 @@ pub struct RowMemo {
     pub avatars: HashMap<UserId, Option<(SharedString, SharedString)>>,
     /// message -> formatted head time label ("14:03" / "Yesterday at 14:03").
     pub time_labels: HashMap<MessageId, SharedString>,
+    pub rich_text: HashMap<MessageId, RichTextRenderPlan>,
+}
+
+#[derive(Clone)]
+pub struct RichTextRenderPlan {
+    pub layout: Arc<RichLayout>,
+    pub colors: [Hsla; 5],
+    pub edited: bool,
+    pub text: SharedString,
+    pub highlights: Arc<[(Range<usize>, HighlightStyle)]>,
+    pub font_overrides: Arc<[(Range<usize>, SharedString)]>,
+    pub click_ranges: Arc<[Range<usize>]>,
+    pub actions: Arc<[RichClick]>,
+    pub locale: SharedString,
 }
 
 pub const DEFAULT_DISPLAY_NAME_COLOR: u32 = 0x17_ac_86;

--- a/crates/mezon-ui/src/chat/message/embed_card.rs
+++ b/crates/mezon-ui/src/chat/message/embed_card.rs
@@ -12,6 +12,7 @@ const ACCENT_BAR_WIDTH: f32 = 4.0;
 const AUTHOR_ICON_SIZE: f32 = 24.0;
 const THUMBNAIL_SIZE: f32 = 64.0;
 const FOOTER_ICON_SIZE: f32 = 20.0;
+const EMBED_IMAGE_MAX_HEIGHT: f32 = 300.0;
 const SHARE_CONTACT_KEY: &str = "share_contact";
 
 pub fn render_embeds(msg: &Message, ctx: &RowCtx) -> AnyElement {
@@ -158,7 +159,12 @@ fn render_embed_thumbnail(url: &SharedString, ctx: &RowCtx) -> AnyElement {
 
 fn render_embed_image(image: &EmbedImage) -> AnyElement {
     let has_aspect = matches!((image.width, image.height), (Some(w), Some(h)) if w > 0 && h > 0);
-    let mut container = div().mt_2().w_full().rounded(px(4.)).overflow_hidden();
+    let mut container = div()
+        .mt_2()
+        .w_full()
+        .max_h(px(EMBED_IMAGE_MAX_HEIGHT))
+        .rounded(px(4.))
+        .overflow_hidden();
     if let (Some(w), Some(h)) = (image.width, image.height) {
         if w > 0 && h > 0 {
             container = container.aspect_ratio(w as f32 / h as f32);
@@ -173,6 +179,7 @@ fn render_embed_image(image: &EmbedImage) -> AnyElement {
     } else {
         img(image.url_proxied.clone())
             .w_full()
+            .max_h(px(EMBED_IMAGE_MAX_HEIGHT))
             .object_fit(ObjectFit::Contain)
     };
     container.child(image_element).into_any_element()

--- a/crates/mezon-ui/src/chat/message/forward_modal.rs
+++ b/crates/mezon-ui/src/chat/message/forward_modal.rs
@@ -337,19 +337,65 @@ fn build_options(cx: &App) -> Vec<ForwardOption> {
 /// rebuild when one of them actually gains or loses rows. DM traffic notifies
 /// the direct store on every incoming message — without this the modal would
 /// rebuild its whole option list on each one.
-fn rendered_rows_equal(a: &[ForwardOption], b: &[ForwardOption]) -> bool {
-    a.len() == b.len()
-        && a.iter().zip(b.iter()).all(|(new, old)| {
-            new.key == old.key
-                && new.label == old.label
-                && new.avatar == old.avatar
-                && new.avatar_raw == old.avatar_raw
-                && new.filter_key == old.filter_key
-                && new.sort_key == old.sort_key
-        })
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+fn fold_bytes(hash: &mut u64, bytes: &[u8]) {
+    for byte in bytes {
+        *hash ^= u64::from(*byte);
+        *hash = hash.wrapping_mul(FNV_PRIME);
+    }
+}
+
+fn fold_str(hash: &mut u64, value: &str) {
+    fold_bytes(hash, value.as_bytes());
+    fold_bytes(hash, &[0xff]);
+}
+
+fn fold_u64(hash: &mut u64, value: u64) {
+    fold_bytes(hash, &value.to_le_bytes());
+}
+
+fn fold_i64(hash: &mut u64, value: i64) {
+    fold_bytes(hash, &value.to_le_bytes());
+}
+
+/// Everything `build_options` reads that can change a rendered row, folded without
+/// allocating. `build_options` itself costs a `format!` plus several `String`
+/// clones per row, so it must not run on every store notify just to be discarded.
+fn source_fingerprint(cx: &App) -> u64 {
+    let mut hash = FNV_OFFSET;
+    for dm in DirectMessageStore::global(cx).read(cx).channels() {
+        fold_i64(&mut hash, dm.id.get());
+        fold_str(&mut hash, &dm.label);
+        fold_str(&mut hash, &dm.avatar);
+        fold_str(&mut hash, &dm.peer_username);
+        fold_i64(&mut hash, dm.last_sent_timestamp);
+        fold_i64(&mut hash, dm.peer_user_id.map_or(0, |id| id.get()));
+    }
+    for friend in FriendStore::global(cx).read(cx).friends() {
+        fold_i64(&mut hash, friend.id.get());
+        fold_u64(&mut hash, u64::from(friend.state == FriendState::Friend));
+        fold_str(&mut hash, friend.label());
+        fold_str(&mut hash, &friend.username);
+        fold_str(&mut hash, &friend.avatar_url);
+    }
+    for channel in ChannelList::global(cx).read(cx).user_channels() {
+        fold_i64(&mut hash, channel.id.get());
+        fold_str(&mut hash, &channel.name);
+        fold_str(&mut hash, &channel.clan_name);
+        fold_i64(&mut hash, channel.clan_id.get());
+        fold_i64(&mut hash, channel.last_sent_timestamp);
+    }
+    for clan in &ClanList::global(cx).read(cx).clans {
+        fold_i64(&mut hash, clan.id.get());
+        fold_str(&mut hash, &clan.name);
+    }
+    hash
 }
 
 pub struct ForwardMessageModal {
+    fingerprint: u64,
     focus_handle: FocusHandle,
     locale: SharedString,
     message_ids: Vec<MessageId>,
@@ -466,6 +512,7 @@ impl ForwardMessageModal {
             let options = build_options(cx);
             let filtered = (0..options.len().min(MAX_RESULTS)).collect();
             Self {
+                fingerprint: source_fingerprint(cx),
                 focus_handle: cx.focus_handle(),
                 shared: build_shared_content(&message_ids, cx),
                 locale,
@@ -544,11 +591,12 @@ impl ForwardMessageModal {
     /// notifies (it emits no event) when `user_channels` arrive, hence observe
     /// rather than subscribe.
     fn refresh_options(&mut self, cx: &mut Context<Self>) {
-        let options = build_options(cx);
-        if rendered_rows_equal(&options, &self.options) {
+        let fingerprint = source_fingerprint(cx);
+        if fingerprint == self.fingerprint {
             return;
         }
-        self.options = options;
+        self.fingerprint = fingerprint;
+        self.options = build_options(cx);
         self.selected
             .retain(|key| self.options.iter().any(|o| o.key == *key));
         self.recompute_filtered(cx);

--- a/crates/mezon-ui/src/chat/message/ogp_embed.rs
+++ b/crates/mezon-ui/src/chat/message/ogp_embed.rs
@@ -50,6 +50,7 @@ pub fn render_ogp_preview(
 
     let image_box = div()
         .w_full()
+        .h(px(200.))
         .flex_shrink_0()
         .mt_1()
         .rounded(px(4.))
@@ -68,6 +69,7 @@ pub fn render_ogp_preview(
             .mt_1()
             .mb_1()
             .rounded(px(8.))
+            .overflow_hidden()
             .border_l(px(3.))
             .border_color(theme.tokens.border_left_highlight)
             .bg(theme.tokens.theme_setting_nav)
@@ -94,7 +96,7 @@ fn ogp_image(src: SharedString, fallback_fg: gpui::Rgba) -> AnyElement {
     img(src)
         .w_full()
         .max_h(px(200.))
-        .object_fit(ObjectFit::Cover)
+        .object_fit(ObjectFit::Contain)
         .with_fallback(move || ogp_image_fallback(fallback_fg))
         .into_any_element()
 }
@@ -102,7 +104,7 @@ fn ogp_image(src: SharedString, fallback_fg: gpui::Rgba) -> AnyElement {
 fn ogp_image_fallback(fallback_fg: gpui::Rgba) -> AnyElement {
     div()
         .w_full()
-        .h(px(120.))
+        .h_full()
         .flex()
         .items_center()
         .justify_center()

--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -1159,11 +1159,6 @@ fn reaction_pill(reaction: &Reaction, message_id: MessageId, ctx: &RowCtx) -> An
     let reacted = !ctx.current_user_id.is_empty() && reaction.has_sender(ctx.current_user_id);
     let count_label = reaction.count_label.clone();
     let src = reaction.emoji_proxied.clone();
-    let add_emoji_id = reaction.emoji_id.clone();
-    let add_emoji = reaction.emoji.clone();
-    let panel_emoji_id = reaction.emoji_id.clone();
-    let panel_emoji = reaction.emoji.clone();
-    let avatar_cache = ctx.avatar_cache.clone();
 
     let mut pill = div()
         .id(super::content::hashed_element_id(
@@ -1182,30 +1177,38 @@ fn reaction_pill(reaction: &Reaction, message_id: MessageId, ctx: &RowCtx) -> An
         .rounded_md()
         .text_sm()
         .font_weight(FontWeight::MEDIUM)
-        .cursor_pointer()
-        .text_color(theme.tokens.text_theme_primary)
-        .on_click(move |_, _, cx| {
-            MessagesStore::global(cx).update(cx, |store, cx| {
-                store.add_reaction(
-                    message_id,
-                    add_emoji_id.to_string(),
-                    add_emoji.to_string(),
-                    cx,
-                );
-            });
-        })
-        .hoverable_tooltip(move |_window, cx| {
-            cx.new(|cx| {
-                UserReactionPanel::new(
-                    message_id,
-                    panel_emoji_id.clone(),
-                    panel_emoji.clone(),
-                    avatar_cache.clone(),
-                    cx,
-                )
+        .text_color(theme.tokens.text_theme_primary);
+    if !ctx.scroll_active {
+        let add_emoji_id = reaction.emoji_id.clone();
+        let add_emoji = reaction.emoji.clone();
+        let panel_emoji_id = reaction.emoji_id.clone();
+        let panel_emoji = reaction.emoji.clone();
+        let avatar_cache = ctx.avatar_cache.clone();
+        pill = pill
+            .cursor_pointer()
+            .on_click(move |_, _, cx| {
+                MessagesStore::global(cx).update(cx, |store, cx| {
+                    store.add_reaction(
+                        message_id,
+                        add_emoji_id.to_string(),
+                        add_emoji.to_string(),
+                        cx,
+                    );
+                });
             })
-            .into()
-        });
+            .hoverable_tooltip(move |_window, cx| {
+                cx.new(|cx| {
+                    UserReactionPanel::new(
+                        message_id,
+                        panel_emoji_id.clone(),
+                        panel_emoji.clone(),
+                        avatar_cache.clone(),
+                        cx,
+                    )
+                })
+                .into()
+            });
+    }
     if reacted {
         pill = pill
             .bg(gpui::Rgba {

--- a/crates/vendor/gpui/src/elements/list.rs
+++ b/crates/vendor/gpui/src/elements/list.rs
@@ -72,11 +72,13 @@ const WHEEL_SCROLL_MIN_DELTA: f32 = 120.;
 const WHEEL_SCROLL_MAX_DELTA: f32 = 480.;
 const WHEEL_SCROLL_MIN_DURATION: f32 = 0.1;
 const WHEEL_SCROLL_MAX_DURATION: f32 = 0.16;
+const OVERDRAW_MEASURE_ITEM_BUDGET: usize = 4;
 
 #[derive(Clone, Copy, Debug)]
 struct WheelScrollAnimation {
     start: f32,
     target: f32,
+    applied: f32,
     started_at: Instant,
     duration: Duration,
     initial_slope: f32,
@@ -104,6 +106,7 @@ impl WheelScrollAnimation {
         Self {
             start,
             target,
+            applied: start,
             started_at,
             duration,
             initial_slope,
@@ -219,21 +222,22 @@ fn start_smooth_wheel_scroll(
         let now = Instant::now();
         let current = state.scrollbar_offset().as_f32();
         let previous = state.wheel_scroll_animation;
-        let base = previous.map_or(current, |animation| animation.target);
-        let target = (base + delta.as_f32()).clamp(-state.max_scroll_offset().as_f32(), 0.);
-        if (target - base).abs() <= f32::EPSILON {
+        let (remaining, velocity) = previous.map_or((0., 0.), |animation| {
+            let (_, velocity, _) = animation.sample(now);
+            (animation.target - animation.applied, velocity)
+        });
+        let target = (current + remaining + delta.as_f32())
+            .clamp(-state.max_scroll_offset().as_f32(), 0.);
+        if (target - current).abs() <= f32::EPSILON {
+            state.wheel_scroll_animation = None;
             return;
         }
-        let (start, velocity) = previous.map_or((current, 0.), |animation| {
-            let (position, velocity, _) = animation.sample(now);
-            (position, velocity)
-        });
         state.wheel_scroll_animation = Some(WheelScrollAnimation::new(
-            start,
+            current,
             target,
             velocity,
             now,
-            wheel_scroll_duration(px(target - start)),
+            wheel_scroll_duration(px(target - current)),
         ));
         if state.wheel_frame_scheduled {
             false
@@ -243,8 +247,8 @@ fn start_smooth_wheel_scroll(
         }
     };
 
-    cx.notify(current_view);
     if should_schedule {
+        cx.notify(current_view);
         schedule_smooth_wheel_frame(list_state.clone(), current_view, window);
     }
 }
@@ -258,16 +262,18 @@ fn schedule_smooth_wheel_frame(
         let continue_animation = {
             let state = &mut *list_state.0.borrow_mut();
             state.wheel_frame_scheduled = false;
-            let Some(animation) = state.wheel_scroll_animation else {
+            let Some(mut animation) = state.wheel_scroll_animation else {
                 return;
             };
 
             let (position, _, finished) = animation.sample(Instant::now());
-            let pixel_delta = px(position) - state.scrollbar_offset();
+            let pixel_delta = px(position - animation.applied);
+            animation.applied = position;
             let height = state.last_layout_bounds.unwrap_or_default().size.height;
             if finished {
                 state.wheel_scroll_animation = None;
             } else {
+                state.wheel_scroll_animation = Some(animation);
                 state.wheel_frame_scheduled = true;
             }
             state.scroll(
@@ -382,6 +388,9 @@ pub enum ListAlignment {
 
 /// A scroll event that has been converted to be in terms of the list's items.
 pub struct ListScrollEvent {
+    #[allow(missing_docs)]
+    pub scroll_top: ListOffset,
+
     /// The range of items currently visible in the list, after applying the scroll event.
     pub visible_range: Range<usize>,
 
@@ -696,6 +705,20 @@ impl ListState {
         self.splice_focusable(old_range, (0..count).map(|_| None))
     }
 
+    #[allow(missing_docs)]
+    pub fn splice_with_size_hint(
+        &self,
+        old_range: Range<usize>,
+        count: usize,
+        size_hint: Size<Pixels>,
+    ) {
+        self.splice_focusable_with_size_hint(
+            old_range,
+            (0..count).map(|_| None),
+            Some(size_hint),
+        )
+    }
+
     /// Register with the list state that the items in `old_range` have been replaced
     /// by new items. As opposed to [`Self::splice`], this method allows an iterator of optional focus handles
     /// to be supplied to properly integrate with items in the list that can be focused. If a focused item
@@ -704,6 +727,15 @@ impl ListState {
         &self,
         old_range: Range<usize>,
         focus_handles: impl IntoIterator<Item = Option<FocusHandle>>,
+    ) {
+        self.splice_focusable_with_size_hint(old_range, focus_handles, None)
+    }
+
+    fn splice_focusable_with_size_hint(
+        &self,
+        old_range: Range<usize>,
+        focus_handles: impl IntoIterator<Item = Option<FocusHandle>>,
+        size_hint: Option<Size<Pixels>>,
     ) {
         let state = &mut *self.0.borrow_mut();
 
@@ -716,7 +748,7 @@ impl ListState {
             focus_handles.into_iter().map(|focus_handle| {
                 spliced_count += 1;
                 ListItem::Unmeasured {
-                    size_hint: None,
+                    size_hint,
                     focus_handle,
                 }
             }),
@@ -738,6 +770,23 @@ impl ListState {
                 *item_ix = *item_ix - (old_range.end - old_range.start) + spliced_count;
             }
         }
+    }
+
+    #[allow(missing_docs)]
+    pub fn average_measured_item_size(&self) -> Option<Size<Pixels>> {
+        let state = self.0.borrow();
+        let mut count = 0usize;
+        let mut height = px(0.);
+        let mut width = px(0.);
+        for item in state.items.iter() {
+            let Some(size) = item.size() else {
+                continue;
+            };
+            count += 1;
+            height += size.height;
+            width = width.max(size.width);
+        }
+        (count > 0).then(|| size(width, height / count as f32))
     }
 
     /// Set a handler that will be called when the list is scrolled.
@@ -1136,6 +1185,7 @@ impl StateInner {
             let visible_range = Self::visible_range(&self.items, height, &current_scroll_top);
             handler(
                 &ListScrollEvent {
+                    scroll_top: current_scroll_top,
                     visible_range,
                     count: self.items.summary().count,
                     is_scrolled: self.logical_scroll_top.is_some(),
@@ -1233,6 +1283,7 @@ impl StateInner {
         let mut rendered_height = padding.top;
         let mut max_item_width = px(0.);
         let mut scroll_top = self.logical_scroll_top();
+        let mut overdraw_measurements_remaining = OVERDRAW_MEASURE_ITEM_BUDGET;
 
         if self.follow_state.is_following() {
             scroll_top = ListOffset {
@@ -1266,6 +1317,15 @@ impl StateInner {
 
             // If we're within the visible area or the height wasn't cached, render and measure the item's element
             if visible_height < available_height || size.is_none() {
+                if visible_height >= available_height
+                    && size.is_none()
+                    && item.size_hint().is_some()
+                {
+                    if overdraw_measurements_remaining == 0 {
+                        break;
+                    }
+                    overdraw_measurements_remaining -= 1;
+                }
                 let item_index = scroll_top.item_ix + ix;
                 let mut element = render_item(item_index, window, cx);
                 let element_size = element.layout_as_root(available_item_space, window, cx);
@@ -1377,6 +1437,12 @@ impl StateInner {
                 let size = if let ListItem::Measured { size, .. } = item {
                     *size
                 } else {
+                    if item.size_hint().is_some() {
+                        if overdraw_measurements_remaining == 0 {
+                            break;
+                        }
+                        overdraw_measurements_remaining -= 1;
+                    }
                     let mut element = render_item(cursor.start().0, window, cx);
                     element.layout_as_root(available_item_space, window, cx)
                 };

--- a/crates/vendor/gpui/src/elements/text.rs
+++ b/crates/vendor/gpui/src/elements/text.rs
@@ -12,7 +12,6 @@ use smallvec::SmallVec;
 use std::{
     borrow::Cow,
     cell::{Cell, RefCell},
-    mem,
     ops::{Deref, DerefMut, Range},
     rc::Rc,
     sync::Arc,
@@ -391,8 +390,8 @@ impl IntoElement for SharedString {
 pub struct StyledText {
     text: SharedString,
     runs: Option<Vec<TextRun>>,
-    delayed_highlights: Option<Vec<(Range<usize>, HighlightStyle)>>,
-    delayed_font_family_overrides: Option<Vec<(Range<usize>, SharedString)>>,
+    delayed_highlights: Option<Arc<[(Range<usize>, HighlightStyle)]>>,
+    delayed_font_family_overrides: Option<Arc<[(Range<usize>, SharedString)]>>,
     layout: TextLayout,
 }
 
@@ -445,8 +444,22 @@ impl StyledText {
                     debug_assert!(self.text.is_char_boundary(run.start));
                     debug_assert!(self.text.is_char_boundary(run.end));
                 })
-                .collect::<Vec<_>>(),
+                .collect::<Vec<_>>()
+                .into(),
         );
+        self
+    }
+
+    #[allow(missing_docs)]
+    pub fn with_shared_highlights(
+        mut self,
+        highlights: Arc<[(Range<usize>, HighlightStyle)]>,
+    ) -> Self {
+        debug_assert!(self.runs.is_none());
+        debug_assert!(highlights.iter().all(|(range, _)| {
+            self.text.is_char_boundary(range.start) && self.text.is_char_boundary(range.end)
+        }));
+        self.delayed_highlights = Some(highlights);
         self
     }
 
@@ -496,8 +509,21 @@ impl StyledText {
                     debug_assert!(self.text.is_char_boundary(range.start));
                     debug_assert!(self.text.is_char_boundary(range.end));
                 })
-                .collect(),
+                .collect::<Vec<_>>()
+                .into(),
         );
+        self
+    }
+
+    #[allow(missing_docs)]
+    pub fn with_shared_font_family_overrides(
+        mut self,
+        overrides: Arc<[(Range<usize>, SharedString)]>,
+    ) -> Self {
+        debug_assert!(overrides.iter().all(|(range, _)| {
+            self.text.is_char_boundary(range.start) && self.text.is_char_boundary(range.end)
+        }));
+        self.delayed_font_family_overrides = Some(overrides);
         self
     }
 
@@ -561,7 +587,11 @@ impl Element for StyledText {
         let font_family_overrides = self.delayed_font_family_overrides.take();
         let mut runs = self.runs.take().or_else(|| {
             self.delayed_highlights.take().map(|delayed_highlights| {
-                Self::compute_runs(&self.text, &window.text_style(), delayed_highlights)
+                Self::compute_runs(
+                    &self.text,
+                    &window.text_style(),
+                    delayed_highlights.iter().cloned(),
+                )
             })
         });
 
@@ -959,7 +989,7 @@ pub struct InteractiveText {
     hover_listener: Option<Box<dyn Fn(Option<usize>, MouseMoveEvent, &mut Window, &mut App)>>,
     tooltip_builder: Option<Rc<dyn Fn(usize, &mut Window, &mut App) -> Option<AnyView>>>,
     tooltip_id: Option<TooltipId>,
-    clickable_ranges: Vec<Range<usize>>,
+    clickable_ranges: Arc<[Range<usize>]>,
 }
 
 struct InteractiveTextClickEvent {
@@ -986,7 +1016,7 @@ impl InteractiveText {
             hover_listener: None,
             tooltip_builder: None,
             tooltip_id: None,
-            clickable_ranges: Vec::new(),
+            clickable_ranges: Arc::new([]),
         }
     }
 
@@ -995,6 +1025,24 @@ impl InteractiveText {
     pub fn on_click(
         mut self,
         ranges: Vec<Range<usize>>,
+        listener: impl Fn(usize, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.click_listener = Some(Box::new(move |ranges, event, window, cx| {
+            for (range_ix, range) in ranges.iter().enumerate() {
+                if range.contains(&event.mouse_down_index) && range.contains(&event.mouse_up_index)
+                {
+                    listener(range_ix, window, cx);
+                }
+            }
+        }));
+        self.clickable_ranges = ranges.into();
+        self
+    }
+
+    #[allow(missing_docs)]
+    pub fn on_click_shared(
+        mut self,
+        ranges: Arc<[Range<usize>]>,
         listener: impl Fn(usize, &mut Window, &mut App) + 'static,
     ) -> Self {
         self.click_listener = Some(Box::new(move |ranges, event, window, cx| {
@@ -1123,7 +1171,7 @@ impl Element for InteractiveText {
                     let mouse_down = interactive_state.mouse_down_index.clone();
                     if let Some(mouse_down_index) = mouse_down.get() {
                         let hitbox = hitbox.clone();
-                        let clickable_ranges = mem::take(&mut self.clickable_ranges);
+                        let clickable_ranges = self.clickable_ranges.clone();
                         window.on_mouse_event(
                             move |event: &MouseUpEvent, phase, window: &mut Window, cx| {
                                 if phase == DispatchPhase::Bubble && hitbox.is_hovered(window) {


### PR DESCRIPTION
## Summary
- Fix vendored GPUI `list` wheel-scroll delta accounting and add `splice_with_size_hint` / `scroll_top` for stable virtualized rendering
- Patch `text` element layout helpers used by list rows
- Align channel message list scroll relief, anchors, and related message UI (content, parts, forward modal, mention input)

## Test plan
- [ ] Scroll channel message list rapidly — no jump/flicker at list boundaries
- [ ] Load older/newer messages while scrolled — anchor position preserved
- [ ] `just lint` + `just test -p mezon-ui` green
- [ ] macOS + Windows CI pass

Made with [Cursor](https://cursor.com)