### PR TITLE
fix(gpui): smooth scroll and suppress hover while scrolling

### DIFF
--- a/crates/mezon-ui/src/chat/member_list.rs
+++ b/crates/mezon-ui/src/chat/member_list.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use gpui::{
     AnyElement, App, Context, DismissEvent, Entity, Focusable, FontWeight, Hsla, Pixels, Point,
     SharedString, Subscription, Task, UniformListScrollHandle, WeakEntity, Window, anchored,
-    deferred, div, prelude::*, px, rgb, uniform_list,
+    deferred, div, prelude::*, px, rgb, size, uniform_list,
 };
 use mezon_store::{
     AccountStore, BadgeService, ChannelEvent, ChannelId, ChannelList, ChannelMembersEvent,
@@ -957,6 +957,9 @@ impl Render for MemberListPanel {
                 })
                 .collect::<Vec<_>>()
         })
+        .with_item_size(size(px(245.), px(48.)))
+        .smooth_line_scroll()
+        .suppress_hover_while_scrolling()
         .track_scroll(&self.list_scroll)
         .flex_1()
         .min_h_0()
@@ -1062,4 +1065,171 @@ fn build_member_menu(
     }
 
     menu
+}
+
+#[cfg(test)]
+mod scroll_tests {
+    use std::cell::Cell;
+    use std::ops::Range;
+    use std::rc::Rc;
+    use std::time::Duration;
+
+    use gpui::{
+        AppContext, Context, IntoElement, ListAlignment, ListState, MouseMoveEvent, Render,
+        ScrollDelta, ScrollWheelEvent, Styled, TestAppContext, UniformListScrollHandle, Window,
+        div, list, point, px, size, uniform_list,
+    };
+
+    struct TestView {
+        scroll: UniformListScrollHandle,
+        probes: Rc<Cell<usize>>,
+    }
+
+    struct VariableTestView {
+        scroll: ListState,
+    }
+
+    impl Render for TestView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            let probes = self.probes.clone();
+            uniform_list(
+                "member-list-scroll-test",
+                10,
+                move |range: Range<usize>, _, _| {
+                    if range == (0..1) {
+                        probes.set(probes.get() + 1);
+                    }
+                    range.map(|_| div().h(px(48.)).w_full()).collect::<Vec<_>>()
+                },
+            )
+            .with_item_size(size(px(100.), px(48.)))
+            .smooth_line_scroll()
+            .suppress_hover_while_scrolling()
+            .track_scroll(&self.scroll)
+            .size_full()
+        }
+    }
+
+    impl Render for VariableTestView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            list(self.scroll.clone(), |_, _, _| {
+                div().h(px(48.)).w_full().into_any_element()
+            })
+            .size_full()
+        }
+    }
+
+    #[gpui::test]
+    fn member_list_skips_size_probe_and_smooths_only_line_wheel(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let scroll = UniformListScrollHandle::new();
+        let probes = Rc::new(Cell::new(0));
+        cx.draw(point(px(0.), px(0.)), size(px(100.), px(200.)), |_, cx| {
+            cx.new(|_| TestView {
+                scroll: scroll.clone(),
+                probes: probes.clone(),
+            })
+            .into_any_element()
+        });
+
+        assert_eq!(probes.get(), 0);
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(50.), px(100.)),
+            delta: ScrollDelta::Lines(point(0., -3.)),
+            ..Default::default()
+        });
+        assert!(scroll.is_smooth_wheel_scrolling());
+        assert!(scroll.is_scroll_hover_suppressed());
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(50.), px(100.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-10.))),
+            ..Default::default()
+        });
+        assert!(!scroll.is_smooth_wheel_scrolling());
+        assert!(scroll.is_scroll_hover_suppressed());
+
+        cx.draw(point(px(0.), px(0.)), size(px(100.), px(200.)), |_, cx| {
+            cx.new(|_| TestView {
+                scroll: scroll.clone(),
+                probes: probes.clone(),
+            })
+            .into_any_element()
+        });
+        cx.executor().advance_clock(Duration::from_millis(350));
+        cx.run_until_parked();
+        assert!(!scroll.is_scroll_hover_active());
+        assert!(scroll.is_scroll_hover_suppressed());
+        cx.simulate_event(MouseMoveEvent {
+            position: point(px(51.), px(100.)),
+            ..Default::default()
+        });
+        assert!(!scroll.is_scroll_hover_suppressed());
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(50.), px(100.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-10.))),
+            ..Default::default()
+        });
+        assert!(scroll.is_scroll_hover_suppressed());
+        cx.draw(point(px(0.), px(0.)), size(px(100.), px(200.)), |_, cx| {
+            cx.new(|_| TestView {
+                scroll: scroll.clone(),
+                probes: probes.clone(),
+            })
+            .into_any_element()
+        });
+        cx.executor().advance_clock(Duration::from_millis(350));
+        cx.run_until_parked();
+        assert!(!scroll.is_scroll_hover_active());
+        assert!(scroll.is_scroll_hover_suppressed());
+        cx.simulate_event(MouseMoveEvent {
+            position: point(px(52.), px(100.)),
+            ..Default::default()
+        });
+        assert!(!scroll.is_scroll_hover_suppressed());
+    }
+
+    #[gpui::test]
+    fn variable_list_suppresses_hover_for_the_scroll_gesture(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let scroll = ListState::new(10, ListAlignment::Top, px(0.))
+            .smooth_line_scroll()
+            .suppress_hover_while_scrolling();
+        cx.draw(point(px(0.), px(0.)), size(px(100.), px(200.)), |_, cx| {
+            cx.new(|_| VariableTestView {
+                scroll: scroll.clone(),
+            })
+            .into_any_element()
+        });
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(50.), px(100.)),
+            delta: ScrollDelta::Lines(point(0., -3.)),
+            ..Default::default()
+        });
+        assert!(scroll.is_scroll_hover_suppressed());
+
+        cx.simulate_event(ScrollWheelEvent {
+            position: point(px(50.), px(100.)),
+            delta: ScrollDelta::Pixels(point(px(0.), px(-10.))),
+            ..Default::default()
+        });
+
+        cx.draw(point(px(0.), px(0.)), size(px(100.), px(200.)), |_, cx| {
+            cx.new(|_| VariableTestView {
+                scroll: scroll.clone(),
+            })
+            .into_any_element()
+        });
+        cx.executor().advance_clock(Duration::from_millis(350));
+        cx.run_until_parked();
+        assert!(!scroll.is_scroll_hover_active());
+        assert!(scroll.is_scroll_hover_suppressed());
+        cx.simulate_event(MouseMoveEvent {
+            position: point(px(51.), px(100.)),
+            ..Default::default()
+        });
+        assert!(!scroll.is_scroll_hover_suppressed());
+    }
 }

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -45,8 +45,6 @@ const BOTTOM_THRESHOLD_PX: f32 = 100.;
 const KEY_SCROLL_BEZIER_X1: f32 = 0.42;
 const KEY_SCROLL_BEZIER_X2: f32 = 0.58;
 const IDLE_CACHE_SWEEP_INTERVAL: Duration = Duration::from_millis(100);
-const SCROLL_ACTIVITY_GRACE: Duration = Duration::from_millis(150);
-const SCROLL_HOVER_RELEASE_MS: u64 = 150;
 const HOVER_SHOW_DELAY_MS: u64 = 200;
 const HOVER_HIDE_DELAY_MS: u64 = 100;
 const SCROLL_RELIEF_DELAY: Duration = Duration::from_millis(1500);
@@ -576,7 +574,6 @@ pub struct ChannelMessages {
     _channel_list_observe: Subscription,
     _clan_list_observe: Subscription,
     _skeleton_timer: Option<Task<()>>,
-    suppress_hover: bool,
     hovered_row: Option<MessageId>,
     raw_hover: Option<MessageId>,
     _hover_show_task: Option<Task<()>>,
@@ -591,7 +588,6 @@ pub struct ChannelMessages {
         Option<mezon_store::MessageId>,
     ),
     last_scroll_at: Option<Instant>,
-    scroll_idle_armed: bool,
     at_bottom: bool,
     last_visible_start: usize,
     last_visible_end: usize,
@@ -718,7 +714,6 @@ impl ChannelMessages {
                     this.mention_popover = None;
                     this._mention_popover_sub = None;
                     this.context_menu_target = None;
-                    this.suppress_hover = false;
                     this.hovered_row = None;
                     this.raw_hover = None;
                     this._hover_show_task = None;
@@ -939,8 +934,9 @@ impl ChannelMessages {
         })
         .detach();
 
-        let list_state =
-            ListState::new(0, ListAlignment::Bottom, px(LIST_OVERDRAW)).smooth_line_scroll();
+        let list_state = ListState::new(0, ListAlignment::Bottom, px(LIST_OVERDRAW))
+            .smooth_line_scroll()
+            .suppress_hover_while_scrolling();
         let timeline = cx.weak_entity();
         list_state.set_scroll_handler(move |event, window, cx| {
             let at_bottom = !event.is_scrolled;
@@ -1004,13 +1000,15 @@ impl ChannelMessages {
                 if visible_range_changed {
                     this.schedule_pagination_check(window, cx);
                 }
-                if !this.suppress_hover {
-                    this.suppress_hover = true;
+                if this.hovered_row.is_some()
+                    || this.raw_hover.is_some()
+                    || this._hover_show_task.is_some()
+                    || this._hover_hide_task.is_some()
+                {
                     this.hovered_row = None;
                     this.raw_hover = None;
                     this._hover_show_task = None;
                     this._hover_hide_task = None;
-                    cx.notify();
                 }
             });
         });
@@ -1081,7 +1079,6 @@ impl ChannelMessages {
             _channel_list_observe: channel_list_observe,
             _clan_list_observe: clan_list_observe,
             _skeleton_timer: None,
-            suppress_hover: false,
             hovered_row: None,
             raw_hover: None,
             _hover_show_task: None,
@@ -1093,7 +1090,6 @@ impl ChannelMessages {
             last_paginate_count: 0,
             last_paginate_edges: (None, None),
             last_scroll_at: None,
-            scroll_idle_armed: false,
             at_bottom: true,
             last_visible_start: 0,
             last_visible_end: 0,
@@ -2140,37 +2136,6 @@ impl ChannelMessages {
     fn mark_scroll_activity(&mut self, cx: &mut Context<Self>) {
         self.last_scroll_at = Some(Instant::now());
         self.arm_scroll_memory_relief(cx);
-        if self.scroll_idle_armed {
-            return;
-        }
-
-        self.scroll_idle_armed = true;
-        cx.spawn(async move |this, cx| {
-            let mut remaining = SCROLL_ACTIVITY_GRACE;
-            loop {
-                cx.background_executor().timer(remaining).await;
-                let next = this
-                    .update(cx, |this, cx| {
-                        let elapsed = this.last_scroll_at.map_or(SCROLL_ACTIVITY_GRACE, |at| {
-                            at.elapsed().min(SCROLL_ACTIVITY_GRACE)
-                        });
-                        if elapsed >= SCROLL_ACTIVITY_GRACE {
-                            this.scroll_idle_armed = false;
-                            cx.notify();
-                            None
-                        } else {
-                            Some(SCROLL_ACTIVITY_GRACE - elapsed)
-                        }
-                    })
-                    .ok()
-                    .flatten();
-                let Some(next) = next else {
-                    break;
-                };
-                remaining = next;
-            }
-        })
-        .detach();
     }
 
     fn arm_scroll_memory_relief(&mut self, cx: &mut Context<Self>) {
@@ -2302,12 +2267,9 @@ impl Render for ChannelMessages {
         self.clear_image_cache_if_channel_changed(window, cx);
         self.sync_render_identity(cx);
         self.drive_scroll_anim(window);
-        let scroll_active = self.keyboard_scroll.is_some()
-            || self.list_state.is_smooth_wheel_scrolling()
-            || self.list_state.is_scrollbar_dragging()
-            || self
-                .last_scroll_at
-                .is_some_and(|at| at.elapsed() < SCROLL_ACTIVITY_GRACE);
+        let suppress_hover = self.list_state.is_scroll_hover_suppressed();
+        let scroll_active =
+            self.keyboard_scroll.is_some() || self.list_state.is_scroll_hover_active();
         if !scroll_active
             && self
                 .last_image_cache_sweep
@@ -2365,7 +2327,6 @@ impl Render for ChannelMessages {
         }
         let row_memo = self.row_memo.clone();
         let list_state = self.list_state.clone();
-        let suppress_hover = self.suppress_hover;
         let hovered_row = self.hovered_row;
         let avatar_image_cache = self.avatar_image_cache.clone();
         let small_avatar_image_cache = self.small_avatar_image_cache.clone();
@@ -2456,16 +2417,6 @@ impl Render for ChannelMessages {
             )
             .children(skeleton_overlay)
             .child(scroll_down_fab)
-            .on_mouse_move(cx.listener(|this, _event, _window, cx| {
-                if this.suppress_hover
-                    && this.last_scroll_at.is_none_or(|t| {
-                        t.elapsed() >= Duration::from_millis(SCROLL_HOVER_RELEASE_MS)
-                    })
-                {
-                    this.suppress_hover = false;
-                    cx.notify();
-                }
-            }))
             .when_some(self.mention_popover.clone(), |el, (popover, position)| {
                 el.child(deferred(
                     anchored().position(position).snap_to_window().child(

--- a/crates/mezon-ui/src/components/compositions/dm_row.rs
+++ b/crates/mezon-ui/src/components/compositions/dm_row.rs
@@ -5,6 +5,8 @@ use crate::components::primitives::Avatar;
 use crate::router::{Route, navigate};
 use crate::theme::Theme;
 
+pub const DM_ROW_HEIGHT: f32 = 42.;
+
 pub struct DmRow {
     id: SharedString,
     label: SharedString,
@@ -135,7 +137,7 @@ impl DmRow {
             .flex_row()
             .items_center()
             .gap_2()
-            .h(px(42.))
+            .h(px(DM_ROW_HEIGHT))
             .w_full()
             .px_2()
             .rounded_md()

--- a/crates/mezon-ui/src/components/compositions/mod.rs
+++ b/crates/mezon-ui/src/components/compositions/mod.rs
@@ -5,7 +5,7 @@ pub mod form_field;
 pub mod otp_input;
 pub mod user_info_bar;
 
-pub use dm_row::DmRow;
+pub use dm_row::{DM_ROW_HEIGHT, DmRow};
 pub use form_field::FormField;
 pub use otp_input::OtpInput;
 pub use user_info_bar::UserInfoBar;

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
@@ -1,8 +1,6 @@
 use std::collections::HashSet;
 use std::rc::Rc;
-use std::time::{Duration, Instant};
-
-const SCROLL_HOVER_RELEASE_MS: u64 = 150;
+use std::time::Duration;
 
 use gpui::{
     Animation, AnimationExt as _, AnyElement, App, Context, Entity, ListState, MouseButton,
@@ -70,8 +68,6 @@ pub struct ChannelSidebar {
     skeleton_phase: skeleton::Phase,
     skeleton_clan: Option<ClanId>,
     _skeleton_timer: Option<Task<()>>,
-    suppress_hover: bool,
-    last_scroll_at: Option<Instant>,
     last_locale: String,
     last_route_channel: Option<ChannelId>,
     last_clan_inputs: (Option<ClanId>, u64),
@@ -91,18 +87,10 @@ impl ChannelSidebar {
     ) -> Self {
         let channel_list_handle = channel_list.clone();
 
-        let list_state = ListState::new(0, gpui::ListAlignment::Top, px(32.)).measure_all();
-        let weak = cx.weak_entity();
-        list_state.set_scroll_handler(move |_event, _window, cx| {
-            weak.update(cx, |this, cx| {
-                this.last_scroll_at = Some(Instant::now());
-                if !this.suppress_hover {
-                    this.suppress_hover = true;
-                    cx.notify();
-                }
-            })
-            .ok();
-        });
+        let list_state = ListState::new(0, gpui::ListAlignment::Top, px(32.))
+            .measure_all()
+            .smooth_line_scroll()
+            .suppress_hover_while_scrolling();
 
         let clan_observe = cx.observe(&clan_list, |this, clan_list, cx| {
             let inputs = clan_inputs_fingerprint(clan_list.read(cx));
@@ -169,8 +157,6 @@ impl ChannelSidebar {
             skeleton_phase: skeleton::Phase::default(),
             skeleton_clan: None,
             _skeleton_timer: None,
-            suppress_hover: false,
-            last_scroll_at: None,
             last_locale: initial_locale,
             last_route_channel: initial_route_channel,
             last_clan_inputs: initial_clan_inputs,
@@ -195,7 +181,6 @@ impl ChannelSidebar {
         let clan_changed = self.active_clan_id != new_clan_id;
         if clan_changed {
             self.clan_menu_open = false;
-            self.suppress_hover = false;
         }
 
         let new_clan_name = clans
@@ -430,7 +415,7 @@ impl Render for ChannelSidebar {
         let items = self.items.clone();
         let channel_list_handle = self.channel_list_handle.clone();
         let active_clan_id_for_nav = self.active_clan_id;
-        let suppress_hover = self.suppress_hover;
+        let suppress_hover = self.list_state.is_scroll_hover_suppressed();
         let list_state = self.list_state.clone();
         let sidebar = cx.entity().downgrade();
         let sidebar_for_channel_menu = sidebar.clone();
@@ -625,16 +610,6 @@ impl Render for ChannelSidebar {
                     .flex_1()
                     .min_h_0()
                     .relative()
-                    .on_mouse_move(cx.listener(|this, _event, _window, cx| {
-                        if this.suppress_hover
-                            && this.last_scroll_at.is_none_or(|t| {
-                                t.elapsed() >= Duration::from_millis(SCROLL_HOVER_RELEASE_MS)
-                            })
-                        {
-                            this.suppress_hover = false;
-                            cx.notify();
-                        }
-                    }))
                     .child(list_element)
                     .children(skeleton_overlay)
                     .custom_scrollbars(
@@ -788,6 +763,7 @@ fn render_banner_and_events(
     banner_url: Option<&str>,
     app_channels: &[AppChannelSlot],
     cx: &App,
+    suppress_hover: bool,
 ) -> AnyElement {
     let theme = cx.theme();
     let divider_color = theme.border;
@@ -863,7 +839,7 @@ fn render_banner_and_events(
                     .items_center()
                     .justify_center()
                     .cursor_pointer()
-                    .hover(|s| s.bg(hover_bg))
+                    .when(!suppress_hover, |app| app.hover(|s| s.bg(hover_bg)))
                     .child(icon_el),
             );
         }
@@ -879,7 +855,7 @@ fn render_banner_and_events(
                     .items_center()
                     .justify_center()
                     .cursor_pointer()
-                    .hover(|s| s.bg(hover_bg))
+                    .when(!suppress_hover, |more| more.hover(|s| s.bg(hover_bg)))
                     .child(
                         Icon::new(IconName::RightIcon)
                             .size(px(24.))
@@ -914,7 +890,7 @@ fn render_sidebar_item(
         SidebarItem::BannerAndEvents {
             banner_url,
             app_channels,
-        } => render_banner_and_events(banner_url.as_deref(), app_channels, cx),
+        } => render_banner_and_events(banner_url.as_deref(), app_channels, cx, suppress_hover),
 
         SidebarItem::Category {
             elem_id,

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
@@ -80,6 +80,7 @@ pub(super) fn render_clan_row(
     ix: usize,
     cx: &App,
     clan_list_handle: Entity<ClanList>,
+    suppress_hover: bool,
 ) -> AnyElement {
     let theme = cx.theme();
     let dm_active = matches!(
@@ -126,9 +127,11 @@ pub(super) fn render_clan_row(
             .justify_center()
             .text_color(theme.tokens.text_theme_primary)
             .text_size(px(20.))
-            .hover(|s| {
-                s.bg(theme.tokens.bg_button_add_friend)
-                    .text_color(gpui::white())
+            .when(!suppress_hover, |avatar| {
+                avatar.hover(|s| {
+                    s.bg(theme.tokens.bg_button_add_friend)
+                        .text_color(gpui::white())
+                })
             })
             .child(SharedString::from(first))
             .into_any_element()
@@ -176,12 +179,14 @@ pub(super) fn render_clan_row(
                     ),
             )
         })
-        .on_hover(move |hovered, _window, cx| {
-            if *hovered {
-                ChannelList::global(cx).update(cx, |channels, cx| {
-                    channels.load_for_clan(prefetch_clan_id, cx)
-                });
-            }
+        .when(!suppress_hover, |row| {
+            row.on_hover(move |hovered, _window, cx| {
+                if *hovered {
+                    ChannelList::global(cx).update(cx, |channels, cx| {
+                        channels.load_for_clan(prefetch_clan_id, cx)
+                    });
+                }
+            })
         })
         .on_click(on_clan_click(clan_list_handle, clan_id))
         .child(avatar_with_badge)

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/mod.rs
@@ -48,6 +48,9 @@ impl ClanSidebar {
         cx: &mut Context<Self>,
     ) -> Self {
         let direct_store = DirectMessageStore::global(cx);
+        let list_state = ListState::new(0, gpui::ListAlignment::Top, px(48.))
+            .smooth_line_scroll()
+            .suppress_hover_while_scrolling();
         let direct_sub = cx.observe(&direct_store, |this, store, cx| {
             let fingerprint = direct_unread_fingerprint(store.read(cx));
             if this.direct_unread_fingerprint == Some(fingerprint) {
@@ -107,7 +110,7 @@ impl ClanSidebar {
                 cx,
             )),
             direct_unread_fingerprint: Some(direct_unread_fingerprint(direct_store.read(cx))),
-            list_state: ListState::new(0, gpui::ListAlignment::Top, px(48.)),
+            list_state,
             dm_active: initial_dm_active,
             can_go_back: initial_can_go_back,
             can_go_forward: initial_can_go_forward,
@@ -215,6 +218,7 @@ impl Render for ClanSidebar {
         let rows = self.rows.clone();
         let clan_list_handle = self.clan_list.clone();
         let list_state = self.list_state.clone();
+        let suppress_hover = self.list_state.is_scroll_hover_suppressed();
         let locale = self.settings.read(cx).language.clone();
         let discover_title = self.discover_title.clone();
         let create_clan_title = self.create_clan_title.clone();
@@ -225,7 +229,7 @@ impl Render for ClanSidebar {
         let clan_count = rows.len();
         let list_element = list(list_state, move |ix, _window, cx| {
             if ix < clan_count {
-                render_clan_row(&rows, ix, cx, clan_list_handle.clone())
+                render_clan_row(&rows, ix, cx, clan_list_handle.clone(), suppress_hover)
             } else {
                 render_clan_footer(
                     cx,
@@ -234,6 +238,7 @@ impl Render for ClanSidebar {
                     create_clan_title.clone(),
                     clan_list_for_modal.clone(),
                     settings_for_modal.clone(),
+                    suppress_hover,
                 )
             }
         })
@@ -361,6 +366,7 @@ fn render_clan_footer(
     create_clan_title: SharedString,
     clan_list_for_modal: Entity<ClanList>,
     settings_for_modal: Entity<Settings>,
+    suppress_hover: bool,
 ) -> AnyElement {
     let theme = cx.theme();
     div()
@@ -379,11 +385,14 @@ fn render_clan_footer(
                 .items_center()
                 .justify_center()
                 .cursor_pointer()
-                .hover(|s| {
-                    s.bg(theme.tokens.bg_button_add_friend)
-                        .text_color(gpui::white())
+                .when(!suppress_hover, |button| {
+                    button
+                        .hover(|s| {
+                            s.bg(theme.tokens.bg_button_add_friend)
+                                .text_color(gpui::white())
+                        })
+                        .tooltip(Tooltip::text(discover_title))
                 })
-                .tooltip(Tooltip::text(discover_title))
                 .on_click({
                     let locale = locale.to_string();
                     move |_, _, cx| {
@@ -410,11 +419,14 @@ fn render_clan_footer(
                 .items_center()
                 .justify_center()
                 .cursor_pointer()
-                .hover(|s| {
-                    s.bg(theme.tokens.bg_button_add_friend)
-                        .text_color(gpui::white())
+                .when(!suppress_hover, |button| {
+                    button
+                        .hover(|s| {
+                            s.bg(theme.tokens.bg_button_add_friend)
+                                .text_color(gpui::white())
+                        })
+                        .tooltip(Tooltip::text(create_clan_title))
                 })
-                .tooltip(Tooltip::text(create_clan_title))
                 .on_click(move |_, window, cx| {
                     use crate::clan::create_clan_modal::CreateClanModal;
                     let modal = cx.new(|cx| {

--- a/crates/mezon-ui/src/sidebar/direct_sidebar.rs
+++ b/crates/mezon-ui/src/sidebar/direct_sidebar.rs
@@ -1,18 +1,16 @@
 use std::rc::Rc;
-use std::time::{Duration, Instant};
 
 use gpui::{
     App, Context, Entity, FontWeight, SharedString, UniformListScrollHandle, Window, div, img,
-    prelude::*, px, uniform_list,
+    prelude::*, px, size, uniform_list,
 };
 use mezon_store::{ChannelId, DirectKind, DirectMessageStore, Settings};
+use ui::{ScrollAxes, Scrollbars, WithScrollbar};
 
-use crate::components::compositions::DmRow;
+use crate::components::compositions::{DM_ROW_HEIGHT, DmRow};
 use crate::components::primitives::{Icon, IconName};
 use crate::router::{Route, Router, navigate};
 use crate::theme::{ActiveTheme, Theme};
-
-const SCROLL_HOVER_RELEASE_MS: u64 = 150;
 
 #[derive(PartialEq)]
 struct DmItem {
@@ -35,8 +33,6 @@ pub struct DirectSidebar {
     dm_items: Rc<Vec<DmItem>>,
     dm_items_fingerprint: u64,
     pending_rebuild: bool,
-    suppress_hover: bool,
-    last_scroll_at: Option<Instant>,
     image_cache: Entity<crate::image_cache::LruImageCache>,
 }
 
@@ -130,8 +126,6 @@ impl DirectSidebar {
             dm_items,
             dm_items_fingerprint,
             pending_rebuild: false,
-            suppress_hover: false,
-            last_scroll_at: None,
             image_cache: cx.new(|cx| {
                 crate::image_cache::LruImageCache::avatar_thumbnail_small(
                     "dm-list",
@@ -141,26 +135,6 @@ impl DirectSidebar {
                     cx,
                 )
             }),
-        }
-    }
-
-    fn on_scroll(&mut self, cx: &mut Context<Self>) {
-        self.last_scroll_at = Some(Instant::now());
-        if self.suppress_hover {
-            return;
-        }
-        self.suppress_hover = true;
-        cx.notify();
-    }
-
-    fn on_mouse_move_release(&mut self, cx: &mut Context<Self>) {
-        if self.suppress_hover
-            && self
-                .last_scroll_at
-                .is_none_or(|t| t.elapsed() >= Duration::from_millis(SCROLL_HOVER_RELEASE_MS))
-        {
-            self.suppress_hover = false;
-            cx.notify();
         }
     }
 
@@ -255,7 +229,7 @@ impl DirectSidebar {
 }
 
 impl Render for DirectSidebar {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         crate::trace_render!("DirectSidebar");
         let theme = cx.theme();
         let locale = self.settings.read(cx).language.clone();
@@ -266,7 +240,7 @@ impl Render for DirectSidebar {
             _ => None,
         };
         let items = self.dm_items.clone();
-        let suppress_hover = self.suppress_hover;
+        let suppress_hover = self.list_scroll.is_scroll_hover_suppressed();
         let image_cache = self.image_cache.clone();
 
         let list = uniform_list("dm-list", count, move |range, _window, cx| {
@@ -298,10 +272,12 @@ impl Render for DirectSidebar {
                 })
                 .collect::<Vec<_>>()
         })
+        .with_item_size(size(px(240.), px(DM_ROW_HEIGHT)))
+        .smooth_line_scroll()
+        .suppress_hover_while_scrolling()
         .track_scroll(&self.list_scroll)
-        .on_scroll_wheel(cx.listener(|this, _event, _window, cx| this.on_scroll(cx)))
-        .on_mouse_move(cx.listener(|this, _event, _window, cx| this.on_mouse_move_release(cx)))
         .flex_1()
+        .h_full()
         .min_h_0()
         .px_2();
 
@@ -321,6 +297,18 @@ impl Render for DirectSidebar {
                     .child(self.render_friends_button(theme, &locale, on_friends)),
             )
             .child(self.render_section_header(theme, &locale))
-            .child(list)
+            .child(
+                div()
+                    .flex_1()
+                    .min_h_0()
+                    .relative()
+                    .child(list)
+                    .custom_scrollbars(
+                        Scrollbars::always_visible(ScrollAxes::Vertical)
+                            .tracked_scroll_handle(&self.list_scroll),
+                        window,
+                        cx,
+                    ),
+            )
     }
 }

--- a/crates/vendor/gpui/src/elements/div.rs
+++ b/crates/vendor/gpui/src/elements/div.rs
@@ -38,16 +38,20 @@ use std::{
     fmt::Debug,
     marker::PhantomData,
     mem,
-    rc::Rc,
+    rc::{Rc, Weak},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
-use super::ImageCacheProvider;
+use super::{
+    ImageCacheProvider,
+    list::{WheelScrollAnimation, wheel_scroll_duration},
+};
 
 const DRAG_THRESHOLD: f64 = 2.;
 const DEFAULT_TOOLTIP_SHOW_DELAY: Duration = Duration::from_millis(500);
 const HOVERABLE_TOOLTIP_HIDE_DELAY: Duration = Duration::from_millis(500);
+const SCROLL_HOVER_RELEASE_DELAY: Duration = Duration::from_millis(300);
 
 /// The styling information for a given group.
 pub struct GroupStyle {
@@ -1817,6 +1821,8 @@ pub struct Interactivity {
     pub(crate) focusable: bool,
     pub(crate) tracked_focus_handle: Option<FocusHandle>,
     pub(crate) tracked_scroll_handle: Option<ScrollHandle>,
+    pub(crate) smooth_line_scroll: bool,
+    pub(crate) suppress_hover_while_scrolling: bool,
     pub(crate) scroll_anchor: Option<ScrollAnchor>,
     pub(crate) scroll_offset: Option<Rc<RefCell<Point<Pixels>>>>,
     pub(crate) group: Option<SharedString>,
@@ -1883,6 +1889,149 @@ pub struct Interactivity {
 
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) debug_selector: Option<String>,
+}
+
+fn start_smooth_scroll_handle(
+    handle: ScrollHandle,
+    delta: Pixels,
+    current_view: EntityId,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    if delta == px(0.) {
+        return;
+    }
+
+    let should_schedule = {
+        let state = &mut *handle.0.borrow_mut();
+        let now = Instant::now();
+        let current = state.offset.borrow().y.as_f32();
+        let previous = state.wheel_scroll_animation;
+        let (remaining, velocity) = previous.map_or((0., 0.), |animation| {
+            let (_, velocity, _) = animation.sample(now);
+            (animation.target - animation.applied, velocity)
+        });
+        let target = (current + remaining + delta.as_f32())
+            .clamp(-state.max_offset.y.as_f32(), 0.);
+        if (target - current).abs() <= f32::EPSILON {
+            state.wheel_scroll_animation = None;
+            return;
+        }
+        state.touch_scroll_hover_activity();
+        state.wheel_scroll_animation = Some(WheelScrollAnimation::new(
+            current,
+            target,
+            velocity,
+            now,
+            wheel_scroll_duration(px(target - current)),
+        ));
+        if state.wheel_frame_scheduled {
+            false
+        } else {
+            state.wheel_frame_scheduled = true;
+            true
+        }
+    };
+
+    if should_schedule {
+        cx.notify(current_view);
+        schedule_smooth_scroll_handle_frame(handle, current_view, window);
+    }
+}
+
+fn ensure_scroll_handle_hover_release_task(
+    handle: &ScrollHandle,
+    current_view: EntityId,
+    window: &Window,
+    cx: &App,
+) {
+    let should_spawn = {
+        let state = handle.0.borrow();
+        state.suppress_hover_while_scrolling
+            && state.scroll_hover_last_activity.is_some()
+            && state
+                .scroll_hover_release_task
+                .as_ref()
+                .is_none_or(Task::is_ready)
+    };
+    if !should_spawn {
+        return;
+    }
+
+    let weak_state = Rc::downgrade(&handle.0);
+    let task = window.spawn(cx, async move |cx| {
+        let mut remaining = SCROLL_HOVER_RELEASE_DELAY;
+        loop {
+            cx.background_executor().timer(remaining).await;
+            let next = cx
+                .update(|_, cx| {
+                    let Some(state) = Weak::upgrade(&weak_state) else {
+                        return None;
+                    };
+                    let mut state = state.borrow_mut();
+                    let Some(last_activity) = state.scroll_hover_last_activity else {
+                        return None;
+                    };
+                    let elapsed = cx
+                        .background_executor()
+                        .now()
+                        .saturating_duration_since(last_activity);
+                    if elapsed >= SCROLL_HOVER_RELEASE_DELAY {
+                        state.scroll_hover_last_activity = None;
+                        cx.notify(current_view);
+                        None
+                    } else {
+                        Some(SCROLL_HOVER_RELEASE_DELAY - elapsed)
+                    }
+                })
+                .ok()
+                .flatten();
+            let Some(next) = next else {
+                break;
+            };
+            remaining = next;
+        }
+    });
+    handle.0.borrow_mut().scroll_hover_release_task = Some(task);
+}
+
+fn schedule_smooth_scroll_handle_frame(
+    handle: ScrollHandle,
+    current_view: EntityId,
+    window: &mut Window,
+) {
+    window.on_next_frame(move |window, cx| {
+        let continue_animation = {
+            let state = &mut *handle.0.borrow_mut();
+            state.wheel_frame_scheduled = false;
+            let Some(mut animation) = state.wheel_scroll_animation else {
+                return;
+            };
+
+            let (position, _, finished) = animation.sample(Instant::now());
+            let pixel_delta = px(position - animation.applied);
+            animation.applied = position;
+            {
+                let mut offset = state.offset.borrow_mut();
+                let next = (offset.y + pixel_delta).clamp(-state.max_offset.y, px(0.));
+                if next != offset.y {
+                    offset.y = next;
+                }
+            }
+            if finished {
+                state.wheel_scroll_animation = None;
+            } else {
+                state.wheel_scroll_animation = Some(animation);
+                state.wheel_frame_scheduled = true;
+            }
+            cx.notify(current_view);
+            !finished
+        };
+
+        if continue_animation {
+            schedule_smooth_scroll_handle_frame(handle, current_view, window);
+        }
+    });
 }
 
 impl Interactivity {
@@ -1983,6 +2132,17 @@ impl Interactivity {
         f: impl FnOnce(&Style, Point<Pixels>, Option<Hitbox>, &mut Window, &mut App) -> R,
     ) -> R {
         self.content_size = content_size;
+        if self.suppress_hover_while_scrolling
+            && let Some(handle) = self.tracked_scroll_handle.as_ref()
+        {
+            handle.0.borrow_mut().suppress_hover_while_scrolling = true;
+            ensure_scroll_handle_hover_release_task(
+                handle,
+                window.current_view(),
+                window,
+                cx,
+            );
+        }
 
         #[cfg(any(feature = "inspector", debug_assertions))]
         window.with_inspector_state(
@@ -2049,6 +2209,16 @@ impl Interactivity {
                             let scroll_offset =
                                 self.clamp_scroll_position(bounds, &style, window, cx);
                             let result = f(&style, scroll_offset, hitbox, window, cx);
+                            if self.suppress_hover_while_scrolling
+                                && self.tracked_scroll_handle.as_ref().is_some_and(|handle| {
+                                    handle.0.borrow().is_scroll_hover_suppressed()
+                                })
+                            {
+                                window.insert_hitbox(
+                                    bounds,
+                                    HitboxBehavior::BlockMouseExceptScroll,
+                                );
+                            }
                             (result, element_state)
                         },
                     )
@@ -2875,10 +3045,37 @@ impl Interactivity {
             let line_height = window.line_height();
             let hitbox = hitbox.clone();
             let current_view = window.current_view();
+            let smooth_line_scroll = self.smooth_line_scroll;
+            let suppress_hover_while_scrolling = self.suppress_hover_while_scrolling;
+            let tracked_scroll_handle = self.tracked_scroll_handle.clone();
+            let hover_scroll_handle = tracked_scroll_handle.clone().filter(|handle| {
+                suppress_hover_while_scrolling
+                    && handle.0.borrow().scroll_hover_waiting_for_pointer_move
+            });
+            if let Some(handle) = hover_scroll_handle {
+                let bounds = hitbox.bounds;
+                window.on_mouse_event(move |event: &MouseMoveEvent, phase, _window, cx| {
+                    if phase != DispatchPhase::Bubble || !bounds.contains(&event.position) {
+                        return;
+                    }
+                    let should_release = {
+                        let mut state = handle.0.borrow_mut();
+                        if state.scroll_hover_waiting_for_pointer_move
+                            && !state.is_scroll_hover_active()
+                        {
+                            state.scroll_hover_waiting_for_pointer_move = false;
+                            true
+                        } else {
+                            false
+                        }
+                    };
+                    if should_release {
+                        cx.notify(current_view);
+                    }
+                });
+            }
             window.on_mouse_event(move |event: &ScrollWheelEvent, phase, window, cx| {
                 if phase == DispatchPhase::Bubble && hitbox.should_handle_scroll(window) {
-                    let mut scroll_offset = scroll_offset.borrow_mut();
-                    let old_scroll_offset = *scroll_offset;
                     let delta = event.delta.pixel_delta(line_height);
 
                     let mut delta_x = Pixels::ZERO;
@@ -2904,9 +3101,29 @@ impl Interactivity {
                             delta_x = Pixels::ZERO;
                         }
                     }
+                    if smooth_line_scroll
+                        && !event.delta.precise()
+                        && delta_x.is_zero()
+                        && !delta_y.is_zero()
+                        && let Some(handle) = tracked_scroll_handle.clone()
+                    {
+                        start_smooth_scroll_handle(handle, delta_y, current_view, window, cx);
+                        return;
+                    }
+                    if let Some(handle) = tracked_scroll_handle.as_ref() {
+                        handle.cancel_smooth_wheel_scroll();
+                    }
+                    let mut scroll_offset = scroll_offset.borrow_mut();
+                    let old_scroll_offset = *scroll_offset;
                     scroll_offset.y += delta_y;
                     scroll_offset.x += delta_x;
                     if *scroll_offset != old_scroll_offset {
+                        drop(scroll_offset);
+                        if suppress_hover_while_scrolling
+                            && let Some(handle) = tracked_scroll_handle.as_ref()
+                        {
+                            handle.0.borrow_mut().touch_scroll_hover_activity();
+                        }
                         cx.notify(current_view);
                     }
                 }
@@ -3650,10 +3867,41 @@ struct ScrollHandleState {
     offset: Rc<RefCell<Point<Pixels>>>,
     bounds: Bounds<Pixels>,
     max_offset: Point<Pixels>,
+    wheel_scroll_animation: Option<WheelScrollAnimation>,
+    wheel_frame_scheduled: bool,
+    suppress_hover_while_scrolling: bool,
+    scroll_hover_last_activity: Option<Instant>,
+    scroll_hover_waiting_for_pointer_move: bool,
+    scroll_hover_release_task: Option<Task<()>>,
+    scrollbar_dragging: bool,
     child_bounds: Vec<Bounds<Pixels>>,
     scroll_to_bottom: bool,
     overflow: Point<Overflow>,
     active_item: Option<ScrollActiveItem>,
+}
+
+impl ScrollHandleState {
+    fn touch_scroll_hover_activity(&mut self) {
+        if self.suppress_hover_while_scrolling {
+            self.scroll_hover_last_activity = Some(Instant::now());
+            self.scroll_hover_waiting_for_pointer_move = true;
+        }
+    }
+
+    fn is_scroll_hover_suppressed(&self) -> bool {
+        self.suppress_hover_while_scrolling
+            && (self.scroll_hover_last_activity.is_some()
+                || self.wheel_scroll_animation.is_some()
+                || self.scrollbar_dragging
+                || self.scroll_hover_waiting_for_pointer_move)
+    }
+
+    fn is_scroll_hover_active(&self) -> bool {
+        self.suppress_hover_while_scrolling
+            && (self.scroll_hover_last_activity.is_some()
+                || self.wheel_scroll_animation.is_some()
+                || self.scrollbar_dragging)
+    }
 }
 
 #[derive(Default, Debug, Clone, Copy)]
@@ -3685,6 +3933,34 @@ impl ScrollHandle {
     /// Construct a new scroll handle.
     pub fn new() -> Self {
         Self(Rc::default())
+    }
+
+    pub(crate) fn cancel_smooth_wheel_scroll(&self) {
+        self.0.borrow_mut().wheel_scroll_animation = None;
+    }
+
+    pub(crate) fn is_smooth_wheel_scrolling(&self) -> bool {
+        self.0.borrow().wheel_scroll_animation.is_some()
+    }
+
+    pub(crate) fn is_scroll_hover_suppressed(&self) -> bool {
+        self.0.borrow().is_scroll_hover_suppressed()
+    }
+
+    pub(crate) fn is_scroll_hover_active(&self) -> bool {
+        self.0.borrow().is_scroll_hover_active()
+    }
+
+    #[allow(missing_docs)]
+    pub fn scrollbar_drag_started(&self) {
+        let mut state = self.0.borrow_mut();
+        state.wheel_scroll_animation = None;
+        state.scrollbar_dragging = true;
+    }
+
+    #[allow(missing_docs)]
+    pub fn scrollbar_drag_ended(&self) {
+        self.0.borrow_mut().scrollbar_dragging = false;
     }
 
     /// Get the current scroll offset.
@@ -3748,6 +4024,7 @@ impl ScrollHandle {
     /// Update [ScrollHandleState]'s active item for scrolling to in prepaint
     pub fn scroll_to_item(&self, ix: usize) {
         let mut state = self.0.borrow_mut();
+        state.wheel_scroll_animation = None;
         state.active_item = Some(ScrollActiveItem {
             index: ix,
             strategy: ScrollStrategy::default(),
@@ -3758,6 +4035,7 @@ impl ScrollHandle {
     /// This scrolls the minimal amount to ensure that the child is the first visible element
     pub fn scroll_to_top_of_item(&self, ix: usize) {
         let mut state = self.0.borrow_mut();
+        state.wheel_scroll_animation = None;
         state.active_item = Some(ScrollActiveItem {
             index: ix,
             strategy: ScrollStrategy::Top,
@@ -3818,6 +4096,7 @@ impl ScrollHandle {
     /// Scrolls to the bottom.
     pub fn scroll_to_bottom(&self) {
         let mut state = self.0.borrow_mut();
+        state.wheel_scroll_animation = None;
         state.scroll_to_bottom = true;
     }
 
@@ -3825,8 +4104,13 @@ impl ScrollHandle {
     /// parent container to the top left of the first child.
     /// As you scroll further down the offset becomes more negative.
     pub fn set_offset(&self, mut position: Point<Pixels>) {
-        let state = self.0.borrow();
+        let mut state = self.0.borrow_mut();
+        state.wheel_scroll_animation = None;
+        let changed = *state.offset.borrow() != position;
         *state.offset.borrow_mut() = position;
+        if changed {
+            state.touch_scroll_hover_activity();
+        }
     }
 
     /// Get the logical scroll top, based on a child index and a pixel offset.

--- a/crates/vendor/gpui/src/elements/list.rs
+++ b/crates/vendor/gpui/src/elements/list.rs
@@ -10,15 +10,15 @@
 use crate::{
     AnyElement, App, AvailableSpace, Bounds, ContentMask, DispatchPhase, Edges, Element, EntityId,
     FocusHandle, GlobalElementId, Hitbox, HitboxBehavior, InspectorElementId, IntoElement,
-    Overflow, Pixels, Point, ScrollWheelEvent, Size, Style, StyleRefinement, Styled,
-    Window, point, px, size,
+    MouseMoveEvent, Overflow, Pixels, Point, ScrollWheelEvent, Size, Style, StyleRefinement, Styled,
+    Task, Window, point, px, size,
 };
 use collections::VecDeque;
 use refineable::Refineable as _;
 use std::{
     cell::RefCell,
     ops::Range,
-    rc::Rc,
+    rc::{Rc, Weak},
     time::{Duration, Instant},
 };
 use sum_tree::{Bias, Dimensions, SumTree};
@@ -73,19 +73,20 @@ const WHEEL_SCROLL_MAX_DELTA: f32 = 480.;
 const WHEEL_SCROLL_MIN_DURATION: f32 = 0.1;
 const WHEEL_SCROLL_MAX_DURATION: f32 = 0.16;
 const OVERDRAW_MEASURE_ITEM_BUDGET: usize = 4;
+const SCROLL_HOVER_RELEASE_DELAY: Duration = Duration::from_millis(300);
 
 #[derive(Clone, Copy, Debug)]
-struct WheelScrollAnimation {
+pub(super) struct WheelScrollAnimation {
     start: f32,
-    target: f32,
-    applied: f32,
+    pub(super) target: f32,
+    pub(super) applied: f32,
     started_at: Instant,
     duration: Duration,
     initial_slope: f32,
 }
 
 impl WheelScrollAnimation {
-    fn new(
+    pub(super) fn new(
         start: f32,
         target: f32,
         initial_velocity: f32,
@@ -113,7 +114,7 @@ impl WheelScrollAnimation {
         }
     }
 
-    fn sample(self, now: Instant) -> (f32, f32, bool) {
+    pub(super) fn sample(self, now: Instant) -> (f32, f32, bool) {
         let duration = self.duration.as_secs_f32();
         let elapsed = now.saturating_duration_since(self.started_at).as_secs_f32();
         if elapsed >= duration {
@@ -141,7 +142,7 @@ impl WheelScrollAnimation {
     }
 }
 
-fn wheel_scroll_duration(delta: Pixels) -> Duration {
+pub(super) fn wheel_scroll_duration(delta: Pixels) -> Duration {
     let progress = ((delta.abs().as_f32() - WHEEL_SCROLL_MIN_DELTA)
         / (WHEEL_SCROLL_MAX_DELTA - WHEEL_SCROLL_MIN_DELTA))
         .clamp(0., 1.);
@@ -204,6 +205,66 @@ struct StateInner {
     smooth_line_scroll: bool,
     wheel_scroll_animation: Option<WheelScrollAnimation>,
     wheel_frame_scheduled: bool,
+    suppress_hover_while_scrolling: bool,
+    scroll_hover_last_activity: Option<Instant>,
+    scroll_hover_waiting_for_pointer_move: bool,
+    scroll_hover_release_task: Option<Task<()>>,
+}
+
+fn ensure_scroll_hover_release_task(
+    list_state: &ListState,
+    current_view: EntityId,
+    window: &Window,
+    cx: &App,
+) {
+    let should_spawn = {
+        let state = list_state.0.borrow();
+        state.suppress_hover_while_scrolling
+            && state.scroll_hover_last_activity.is_some()
+            && state
+                .scroll_hover_release_task
+                .as_ref()
+                .is_none_or(Task::is_ready)
+    };
+    if !should_spawn {
+        return;
+    }
+
+    let weak_state = Rc::downgrade(&list_state.0);
+    let task = window.spawn(cx, async move |cx| {
+        let mut remaining = SCROLL_HOVER_RELEASE_DELAY;
+        loop {
+            cx.background_executor().timer(remaining).await;
+            let next = cx
+                .update(|_, cx| {
+                    let Some(state) = Weak::upgrade(&weak_state) else {
+                        return None;
+                    };
+                    let mut state = state.borrow_mut();
+                    let Some(last_activity) = state.scroll_hover_last_activity else {
+                        return None;
+                    };
+                    let elapsed = cx
+                        .background_executor()
+                        .now()
+                        .saturating_duration_since(last_activity);
+                    if elapsed >= SCROLL_HOVER_RELEASE_DELAY {
+                        state.scroll_hover_last_activity = None;
+                        cx.notify(current_view);
+                        None
+                    } else {
+                        Some(SCROLL_HOVER_RELEASE_DELAY - elapsed)
+                    }
+                })
+                .ok()
+                .flatten();
+            let Some(next) = next else {
+                break;
+            };
+            remaining = next;
+        }
+    });
+    list_state.0.borrow_mut().scroll_hover_release_task = Some(task);
 }
 
 fn start_smooth_wheel_scroll(
@@ -232,6 +293,7 @@ fn start_smooth_wheel_scroll(
             state.wheel_scroll_animation = None;
             return;
         }
+        state.touch_scroll_hover_activity();
         state.wheel_scroll_animation = Some(WheelScrollAnimation::new(
             current,
             target,
@@ -283,6 +345,7 @@ fn schedule_smooth_wheel_frame(
                 window,
                 cx,
                 true,
+                false,
             );
             !finished
         };
@@ -550,6 +613,10 @@ impl ListState {
             smooth_line_scroll: false,
             wheel_scroll_animation: None,
             wheel_frame_scheduled: false,
+            suppress_hover_while_scrolling: false,
+            scroll_hover_last_activity: None,
+            scroll_hover_waiting_for_pointer_move: false,
+            scroll_hover_release_task: None,
         })));
         this.splice(0..0, item_count);
         this
@@ -570,6 +637,22 @@ impl ListState {
         self
     }
 
+    #[allow(missing_docs)]
+    pub fn suppress_hover_while_scrolling(self) -> Self {
+        self.0.borrow_mut().suppress_hover_while_scrolling = true;
+        self
+    }
+
+    #[allow(missing_docs)]
+    pub fn is_scroll_hover_suppressed(&self) -> bool {
+        self.0.borrow().is_scroll_hover_suppressed()
+    }
+
+    #[allow(missing_docs)]
+    pub fn is_scroll_hover_active(&self) -> bool {
+        self.0.borrow().is_scroll_hover_active()
+    }
+
     /// Returns whether a discrete mouse-wheel animation is active.
     pub fn is_smooth_wheel_scrolling(&self) -> bool {
         self.0.borrow().wheel_scroll_animation.is_some()
@@ -588,6 +671,9 @@ impl ListState {
             state.scrollbar_drag_start_height = None;
             state.wheel_scroll_animation = None;
             state.wheel_frame_scheduled = false;
+            state.scroll_hover_last_activity = None;
+            state.scroll_hover_waiting_for_pointer_move = false;
+            state.scroll_hover_release_task = None;
             state.items.summary().count
         };
 
@@ -1064,6 +1150,28 @@ impl ListState {
 }
 
 impl StateInner {
+    fn touch_scroll_hover_activity(&mut self) {
+        if self.suppress_hover_while_scrolling {
+            self.scroll_hover_last_activity = Some(Instant::now());
+            self.scroll_hover_waiting_for_pointer_move = true;
+        }
+    }
+
+    fn is_scroll_hover_suppressed(&self) -> bool {
+        self.suppress_hover_while_scrolling
+            && (self.scroll_hover_last_activity.is_some()
+                || self.wheel_scroll_animation.is_some()
+                || self.scrollbar_drag_start_height.is_some()
+                || self.scroll_hover_waiting_for_pointer_move)
+    }
+
+    fn is_scroll_hover_active(&self) -> bool {
+        self.suppress_hover_while_scrolling
+            && (self.scroll_hover_last_activity.is_some()
+                || self.wheel_scroll_animation.is_some()
+                || self.scrollbar_drag_start_height.is_some())
+    }
+
     /// Re-anchor a pending scroll adjustment from a remeasure onto a newly set
     /// scroll position, so it clamps to the remeasured item's new height on
     /// the next layout instead of reverting the scroll.
@@ -1138,6 +1246,7 @@ impl StateInner {
         window: &mut Window,
         cx: &mut App,
         dispatch_scroll_handler: bool,
+        mark_hover_activity: bool,
     ) {
         // Drop scroll events after a reset, since we can't calculate
         // the new logical scroll top without the item heights
@@ -1157,6 +1266,9 @@ impl StateInner {
         let new_scroll_top = (current_scroll_top - delta.y)
             .max(px(0.))
             .min(scroll_max);
+        if mark_hover_activity && new_scroll_top != current_scroll_top {
+            self.touch_scroll_hover_activity();
+        }
 
         if self.alignment == ListAlignment::Bottom && new_scroll_top == scroll_max {
             self.pending_scroll = None;
@@ -1614,6 +1726,10 @@ impl StateInner {
             .unwrap_or_else(|| self.items.summary().height);
         let scroll_max = (content_height + padding.top + padding.bottom - height).max(px(0.));
         let new_scroll_top = (-point.y).max(px(0.)).min(scroll_max);
+        let previous_scroll_top = -self.scrollbar_offset();
+        if new_scroll_top != previous_scroll_top {
+            self.touch_scroll_hover_activity();
+        }
 
         // If content grew during the drag, the frozen bottom is below the
         // live bottom. Treat dragging to the frozen end as resuming tail follow.
@@ -1764,6 +1880,12 @@ impl Element for List {
         window: &mut Window,
         cx: &mut App,
     ) -> ListPrepaintState {
+        ensure_scroll_hover_release_task(
+            &self.state,
+            window.current_view(),
+            window,
+            cx,
+        );
         let state = &mut *self.state.0.borrow_mut();
         state.reset = false;
 
@@ -1805,6 +1927,9 @@ impl Element for List {
 
         state.last_layout_bounds = Some(bounds);
         state.last_padding = Some(padding);
+        if state.is_scroll_hover_suppressed() {
+            window.insert_hitbox(bounds, HitboxBehavior::BlockMouseExceptScroll);
+        }
         ListPrepaintState { hitbox, layout }
     }
 
@@ -1851,10 +1976,39 @@ impl Element for List {
                         window,
                         cx,
                         true,
+                        true,
                     );
                 }
             }
         });
+
+        let should_listen_for_pointer_move = self
+            .state
+            .0
+            .borrow()
+            .scroll_hover_waiting_for_pointer_move;
+        if should_listen_for_pointer_move {
+            let list_state = self.state.clone();
+            window.on_mouse_event(move |event: &MouseMoveEvent, phase, _window, cx| {
+                if phase != DispatchPhase::Bubble || !bounds.contains(&event.position) {
+                    return;
+                }
+                let should_release = {
+                    let mut state = list_state.0.borrow_mut();
+                    if state.scroll_hover_waiting_for_pointer_move
+                        && !state.is_scroll_hover_active()
+                    {
+                        state.scroll_hover_waiting_for_pointer_move = false;
+                        true
+                    } else {
+                        false
+                    }
+                };
+                if should_release {
+                    cx.notify(current_view);
+                }
+            });
+        }
     }
 }
 

--- a/crates/vendor/gpui/src/elements/uniform_list.rs
+++ b/crates/vendor/gpui/src/elements/uniform_list.rs
@@ -41,6 +41,7 @@ where
     UniformList {
         item_count,
         item_to_measure_index: 0,
+        known_item_size: None,
         measured_item_size: None,
         render_items: Box::new(render_range),
         decorations: Vec::new(),
@@ -59,6 +60,7 @@ where
 pub struct UniformList {
     item_count: usize,
     item_to_measure_index: usize,
+    known_item_size: Option<Size<Pixels>>,
     measured_item_size: Option<Size<Pixels>>,
     render_items: Box<
         dyn for<'a> Fn(Range<usize>, &'a mut Window, &'a mut App) -> SmallVec<[AnyElement; 64]>,
@@ -150,7 +152,9 @@ impl UniformListScrollHandle {
     /// If the item is out of view, it scrolls the minimum amount to bring it into view according
     /// to the strategy.
     pub fn scroll_to_item(&self, ix: usize, strategy: ScrollStrategy) {
-        self.0.borrow_mut().deferred_scroll_to_item = Some(DeferredScrollToItem {
+        let mut state = self.0.borrow_mut();
+        state.base_handle.cancel_smooth_wheel_scroll();
+        state.deferred_scroll_to_item = Some(DeferredScrollToItem {
             item_index: ix,
             strategy,
             offset: 0,
@@ -163,7 +167,9 @@ impl UniformListScrollHandle {
     /// This uses strict scrolling: the item will always be scrolled to match the strategy position,
     /// even if it's already visible. Use this when you need precise positioning.
     pub fn scroll_to_item_strict(&self, ix: usize, strategy: ScrollStrategy) {
-        self.0.borrow_mut().deferred_scroll_to_item = Some(DeferredScrollToItem {
+        let mut state = self.0.borrow_mut();
+        state.base_handle.cancel_smooth_wheel_scroll();
+        state.deferred_scroll_to_item = Some(DeferredScrollToItem {
             item_index: ix,
             strategy,
             offset: 0,
@@ -182,7 +188,9 @@ impl UniformListScrollHandle {
     /// - `ScrollStrategy::Center`: Shrinks from top, centers item in the reduced viewport
     /// - `ScrollStrategy::Bottom`: Shrinks from bottom, positions item at the new bottom
     pub fn scroll_to_item_with_offset(&self, ix: usize, strategy: ScrollStrategy, offset: usize) {
-        self.0.borrow_mut().deferred_scroll_to_item = Some(DeferredScrollToItem {
+        let mut state = self.0.borrow_mut();
+        state.base_handle.cancel_smooth_wheel_scroll();
+        state.deferred_scroll_to_item = Some(DeferredScrollToItem {
             item_index: ix,
             strategy,
             offset,
@@ -206,7 +214,9 @@ impl UniformListScrollHandle {
         strategy: ScrollStrategy,
         offset: usize,
     ) {
-        self.0.borrow_mut().deferred_scroll_to_item = Some(DeferredScrollToItem {
+        let mut state = self.0.borrow_mut();
+        state.base_handle.cancel_smooth_wheel_scroll();
+        state.deferred_scroll_to_item = Some(DeferredScrollToItem {
             item_index: ix,
             strategy,
             offset,
@@ -236,6 +246,27 @@ impl UniformListScrollHandle {
         } else {
             false
         }
+    }
+
+    #[allow(missing_docs)]
+    pub fn is_smooth_wheel_scrolling(&self) -> bool {
+        self.0
+            .borrow()
+            .base_handle
+            .is_smooth_wheel_scrolling()
+    }
+
+    #[allow(missing_docs)]
+    pub fn is_scroll_hover_suppressed(&self) -> bool {
+        self.0
+            .borrow()
+            .base_handle
+            .is_scroll_hover_suppressed()
+    }
+
+    #[allow(missing_docs)]
+    pub fn is_scroll_hover_active(&self) -> bool {
+        self.0.borrow().base_handle.is_scroll_hover_active()
     }
 
     /// Whether the list is scrolled to the end, or `None` if the list is
@@ -282,7 +313,9 @@ impl Element for UniformList {
         cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
         let max_items = self.item_count;
-        let item_size = self.measure_item(None, window, cx);
+        let item_size = self
+            .known_item_size
+            .unwrap_or_else(|| self.measure_item(None, window, cx));
         // mezon vendor edit: keep the measurement (see `measured_item_size`) — upstream
         // re-ran `measure_item` in `prepaint`, laying out a throwaway sample row a
         // second time on every frame of every uniform_list.
@@ -628,6 +661,24 @@ impl<T: UniformListDecoration + 'static> UniformListDecoration for Entity<T> {
 }
 
 impl UniformList {
+    #[allow(missing_docs)]
+    pub fn with_item_size(mut self, item_size: Size<Pixels>) -> Self {
+        self.known_item_size = Some(item_size);
+        self
+    }
+
+    #[allow(missing_docs)]
+    pub fn smooth_line_scroll(mut self) -> Self {
+        self.interactivity.smooth_line_scroll = true;
+        self
+    }
+
+    #[allow(missing_docs)]
+    pub fn suppress_hover_while_scrolling(mut self) -> Self {
+        self.interactivity.suppress_hover_while_scrolling = true;
+        self
+    }
+
     /// Selects a specific list item for measurement.
     pub fn with_width_from_item(mut self, item_index: Option<usize>) -> Self {
         self.item_to_measure_index = item_index.unwrap_or(0);

--- a/crates/vendor/ui/src/components/scrollbar.rs
+++ b/crates/vendor/ui/src/components/scrollbar.rs
@@ -792,6 +792,7 @@ impl<T: ScrollableHandle> ScrollbarState<T> {
     ) {
         self.set_thumb_state(ThumbState::Dragging(axis, drag_offset), window, cx);
         self.scroll_handle().drag_started();
+        self.notify_parent(cx);
     }
 
     fn update_hovered_thumb(
@@ -966,6 +967,14 @@ impl ScrollableHandle for UniformListScrollHandle {
     fn viewport(&self) -> Bounds<Pixels> {
         self.0.borrow().base_handle.bounds()
     }
+
+    fn drag_started(&self) {
+        self.0.borrow().base_handle.scrollbar_drag_started();
+    }
+
+    fn drag_ended(&self) {
+        self.0.borrow().base_handle.scrollbar_drag_ended();
+    }
 }
 
 impl ScrollableHandle for ListState {
@@ -1009,6 +1018,14 @@ impl ScrollableHandle for ScrollHandle {
 
     fn viewport(&self) -> Bounds<Pixels> {
         self.bounds()
+    }
+
+    fn drag_started(&self) {
+        self.scrollbar_drag_started();
+    }
+
+    fn drag_ended(&self) {
+        self.scrollbar_drag_ended();
     }
 }
 
@@ -1559,6 +1576,7 @@ impl<T: ScrollableHandle> Element for ScrollbarElement<T> {
                     state.update(cx, |state, cx| {
                         if state.is_dragging() {
                             state.scroll_handle().drag_ended();
+                            state.notify_parent(cx);
                         }
 
                         if !state.parent_hovered(window) {


### PR DESCRIPTION
## Summary
- Add smooth wheel scrolling and scroll-hover suppression to vendored `div`, `list`, and `uniform_list`
- Extend scrollbar helpers in vendored `ui`
- Wire clan/channel/DM sidebars and member list to the shared GPUI APIs (drop ad-hoc hover guards)
- Simplify channel message list scroll handling now covered by vendor list behavior

## Test plan
- [ ] Scroll member list and DM/clan/channel sidebars — smooth wheel, no row hover flicker mid-scroll
- [ ] Channel message list scroll unchanged vs PR #90 baseline
- [ ] `just lint` + `just test -p mezon-ui` green

Made with [Cursor](https://cursor.com)