### PR TITLE
feat(chat): voice message recording and streaming playback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5518,6 +5518,8 @@ name = "mezon-audio"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "flume",
+ "ogg",
  "parking_lot",
  "rodio",
  "symphonia",
@@ -6606,6 +6608,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ogg"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdab8dcd8d4052eaacaf8fb07a3ccd9a6e26efadb42878a413c68fc4af1dee2b"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,6 +271,7 @@ lsp-types            = { version = "0.97.0", features = ["proposed"] }
 profiling            = "1"
 chrono               = { version = "0.4", features = ["serde"] }
 cpal                 = "0.17.3"
+ogg                  = "0.9"
 rodio                = { git = "https://github.com/RustAudio/rodio", rev = "e50e726ddd0292f6ef9de0dda6b90af4ed1fb66a", default-features = false, features = ["playback"] }
 livekit              = { version = "0.7", features = ["rustls-tls-native-roots"] }
 flume                = "0.11"

--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -653,6 +653,23 @@ fn open_main_window(
         }),
         cx,
     );
+    mezon_store::AudioStore::set_mic_pcm_capture_factory(
+        &audio_store,
+        std::sync::Arc::new(|sender: flume::Sender<Vec<f32>>| {
+            mezon_native::audio::MicPcmCapture::start(sender)
+                .map(|(capture, format)| {
+                    (
+                        Box::new(capture) as Box<dyn Send>,
+                        mezon_store::MicPcmFormat {
+                            sample_rate: format.sample_rate,
+                            channels: format.channels,
+                        },
+                    )
+                })
+                .map_err(|e| e.to_string())
+        }),
+        cx,
+    );
 
     let root_auth_state = auth_state.clone();
     let window_handle = cx

--- a/crates/mezon-audio/Cargo.toml
+++ b/crates/mezon-audio/Cargo.toml
@@ -24,3 +24,5 @@ symphonia = { version = "0.5", default-features = false, features = [
     "wav",
 ] }
 unsafe-libopus = "0.2"
+ogg.workspace = true
+flume.workspace = true

--- a/crates/mezon-audio/src/decode.rs
+++ b/crates/mezon-audio/src/decode.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use symphonia::core::audio::{AudioBufferRef, SampleBuffer};
 use symphonia::core::codecs::{CODEC_TYPE_NULL, CODEC_TYPE_OPUS, DecoderOptions};
 use symphonia::core::errors::Error as SymphoniaError;
-use symphonia::core::formats::FormatOptions;
+use symphonia::core::formats::{FormatOptions, FormatReader};
 use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
@@ -35,8 +35,47 @@ impl DecodedPcm {
 }
 
 pub fn decode_audio(bytes: Vec<u8>) -> Result<DecodedPcm, AudioError> {
-    let source = Cursor::new(bytes);
-    let mss = MediaSourceStream::new(Box::new(source), Default::default());
+    let mss = MediaSourceStream::new(Box::new(Cursor::new(bytes)), Default::default());
+    let mut samples: Vec<f32> = Vec::new();
+    let mut channels = 1usize;
+    let mut sample_rate = OPUS_SAMPLE_RATE;
+
+    decode_packets(
+        mss,
+        |_| {},
+        |pcm, spec| {
+            samples.extend_from_slice(pcm);
+            channels = spec.channels;
+            sample_rate = spec.sample_rate;
+        },
+    )?;
+
+    if samples.is_empty() {
+        return Err(AudioError::Decode("no samples produced".into()));
+    }
+
+    Ok(DecodedPcm {
+        samples: samples.into(),
+        channels,
+        sample_rate,
+    })
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct PcmSpec {
+    pub channels: usize,
+    pub sample_rate: u32,
+}
+
+pub(crate) fn decode_packets<T, F>(
+    mss: MediaSourceStream,
+    mut on_track: T,
+    mut emit: F,
+) -> Result<(), AudioError>
+where
+    T: FnMut(Option<f64>),
+    F: FnMut(&[f32], PcmSpec),
+{
     let probed = symphonia::default::get_probe()
         .format(
             &Hint::new(),
@@ -61,22 +100,40 @@ pub fn decode_audio(bytes: Vec<u8>) -> Result<DecodedPcm, AudioError> {
         .map(|c| c.count())
         .unwrap_or(1)
         .clamp(1, 2);
+    on_track(track_duration_secs(&track.codec_params));
 
     if codec == CODEC_TYPE_OPUS {
-        decode_opus(format.as_mut(), track_id, channels)
+        decode_opus(format.as_mut(), track_id, channels, &mut emit)
     } else {
-        decode_symphonia(format.as_mut(), track_id)
+        decode_symphonia(format.as_mut(), track_id, &mut emit)
     }
 }
 
-fn decode_opus(
-    format: &mut dyn symphonia::core::formats::FormatReader,
+fn track_duration_secs(params: &symphonia::core::codecs::CodecParameters) -> Option<f64> {
+    let frames = params.n_frames?;
+    let time_base = params.time_base?;
+    let time = time_base.calc_time(frames);
+    let seconds = time.seconds as f64 + time.frac;
+    (seconds > 0.0).then_some(seconds)
+}
+
+fn decode_opus<F>(
+    format: &mut dyn FormatReader,
     track_id: u32,
     channels: usize,
-) -> Result<DecodedPcm, AudioError> {
+    emit: &mut F,
+) -> Result<(), AudioError>
+where
+    F: FnMut(&[f32], PcmSpec),
+{
     let mut decoder = OpusDecoder::new(OPUS_SAMPLE_RATE as i32, channels as i32)?;
     let mut scratch = vec![0.0f32; OPUS_MAX_FRAME * channels];
-    let mut samples: Vec<f32> = Vec::new();
+    let spec = PcmSpec {
+        channels,
+        sample_rate: OPUS_SAMPLE_RATE,
+    };
+    let mut emitted_frames = 0usize;
+    let mut produced = false;
 
     loop {
         let packet = match format.next_packet() {
@@ -85,6 +142,10 @@ fn decode_opus(
                 break;
             }
             Err(SymphoniaError::ResetRequired) => break,
+            Err(e) if produced => {
+                tracing::warn!("audio stream ended early: {e}");
+                break;
+            }
             Err(e) => return Err(AudioError::Demux(e.to_string())),
         };
         if packet.track_id() != track_id {
@@ -92,28 +153,30 @@ fn decode_opus(
         }
         let decoded = decoder.decode_float(&packet.data, &mut scratch, OPUS_MAX_FRAME as i32);
         if decoded > 0 {
-            samples.extend_from_slice(&scratch[..decoded as usize * channels]);
-            if samples.len() / channels >= MAX_DECODED_FRAMES {
+            let frames = decoded as usize;
+            emit(&scratch[..frames * channels], spec);
+            produced = true;
+            emitted_frames += frames;
+            if emitted_frames >= MAX_DECODED_FRAMES {
                 break;
             }
         }
     }
 
-    if samples.is_empty() {
+    if !produced {
         return Err(AudioError::Decode("opus produced no samples".into()));
     }
-
-    Ok(DecodedPcm {
-        samples: samples.into(),
-        channels,
-        sample_rate: OPUS_SAMPLE_RATE,
-    })
+    Ok(())
 }
 
-fn decode_symphonia(
-    format: &mut dyn symphonia::core::formats::FormatReader,
+fn decode_symphonia<F>(
+    format: &mut dyn FormatReader,
     track_id: u32,
-) -> Result<DecodedPcm, AudioError> {
+    emit: &mut F,
+) -> Result<(), AudioError>
+where
+    F: FnMut(&[f32], PcmSpec),
+{
     let params = format
         .tracks()
         .iter()
@@ -125,10 +188,9 @@ fn decode_symphonia(
         .make(&params, &DecoderOptions::default())
         .map_err(|e| AudioError::Decode(e.to_string()))?;
 
-    let mut samples: Vec<f32> = Vec::new();
-    let mut sample_rate = params.sample_rate.unwrap_or(48_000);
-    let mut channels = params.channels.map(|c| c.count()).unwrap_or(1).max(1);
     let mut buffer: Option<SampleBuffer<f32>> = None;
+    let mut emitted_frames = 0usize;
+    let mut produced = false;
 
     loop {
         let packet = match format.next_packet() {
@@ -137,6 +199,10 @@ fn decode_symphonia(
                 break;
             }
             Err(SymphoniaError::ResetRequired) => break,
+            Err(e) if produced => {
+                tracing::warn!("audio stream ended early: {e}");
+                break;
+            }
             Err(e) => return Err(AudioError::Demux(e.to_string())),
         };
         if packet.track_id() != track_id {
@@ -145,45 +211,50 @@ fn decode_symphonia(
         let decoded = match decoder.decode(&packet) {
             Ok(d) => d,
             Err(SymphoniaError::DecodeError(_)) => continue,
+            Err(e) if produced => {
+                tracing::warn!("audio stream ended early: {e}");
+                break;
+            }
             Err(e) => return Err(AudioError::Decode(e.to_string())),
         };
-        append_interleaved(
-            decoded,
-            &mut buffer,
-            &mut samples,
-            &mut sample_rate,
-            &mut channels,
-        );
-        if samples.len() / channels.max(1) >= MAX_DECODED_FRAMES {
-            break;
+        let frames = emit_interleaved(decoded, &mut buffer, emit);
+        if frames > 0 {
+            produced = true;
+            emitted_frames += frames;
+            if emitted_frames >= MAX_DECODED_FRAMES {
+                break;
+            }
         }
     }
 
-    if samples.is_empty() {
+    if !produced {
         return Err(AudioError::Decode("no samples produced".into()));
     }
-
-    Ok(DecodedPcm {
-        samples: samples.into(),
-        channels,
-        sample_rate,
-    })
+    Ok(())
 }
 
-fn append_interleaved(
+fn emit_interleaved<F>(
     decoded: AudioBufferRef<'_>,
     buffer: &mut Option<SampleBuffer<f32>>,
-    samples: &mut Vec<f32>,
-    sample_rate: &mut u32,
-    channels: &mut usize,
-) {
+    emit: &mut F,
+) -> usize
+where
+    F: FnMut(&[f32], PcmSpec),
+{
     let spec = *decoded.spec();
     let capacity = decoded.capacity() as u64;
-    *sample_rate = spec.rate;
-    *channels = spec.channels.count().max(1);
+    let channels = spec.channels.count().max(1);
     let buf = buffer.get_or_insert_with(|| SampleBuffer::new(capacity, spec));
     buf.copy_interleaved_ref(decoded);
-    samples.extend_from_slice(buf.samples());
+    let samples = buf.samples();
+    emit(
+        samples,
+        PcmSpec {
+            channels,
+            sample_rate: spec.rate,
+        },
+    );
+    samples.len() / channels
 }
 
 struct OpusDecoder {

--- a/crates/mezon-audio/src/encode.rs
+++ b/crates/mezon-audio/src/encode.rs
@@ -1,0 +1,311 @@
+use std::io::Cursor;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ogg::writing::{PacketWriteEndInfo, PacketWriter};
+
+use crate::AudioError;
+
+const TARGET_RATE: u32 = 48_000;
+const FRAME_SAMPLES: usize = 960;
+const MAX_PACKET_BYTES: usize = 4000;
+const VOICE_BITRATE: i32 = 32_000;
+const DEFAULT_LOOKAHEAD: i32 = 312;
+
+pub struct VoiceRecording {
+    pub bytes: Vec<u8>,
+    pub duration_secs: f64,
+}
+
+pub struct VoiceEncoder {
+    encoder: OpusEncoder,
+    writer: PacketWriter<'static, Cursor<Vec<u8>>>,
+    serial: u32,
+    source_rate: u32,
+    source_channels: usize,
+    source_pcm: Vec<f32>,
+    source_cursor: f64,
+    frame: Vec<f32>,
+    packet: Vec<u8>,
+    preskip: u64,
+    total_samples: u64,
+    encoded_samples: u64,
+}
+
+impl VoiceEncoder {
+    pub fn new(source_rate: u32, source_channels: u16) -> Result<Self, AudioError> {
+        let mut encoder = OpusEncoder::new(TARGET_RATE as i32, 1)?;
+        encoder.set_bitrate(VOICE_BITRATE)?;
+        let preskip = encoder.lookahead().max(0) as u64;
+
+        let serial = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.subsec_nanos() ^ d.as_secs() as u32)
+            .unwrap_or(1)
+            | 1;
+
+        let mut recorder = Self {
+            encoder,
+            writer: PacketWriter::new(Cursor::new(Vec::new())),
+            serial,
+            source_rate: source_rate.max(1),
+            source_channels: (source_channels as usize).max(1),
+            source_pcm: Vec::new(),
+            source_cursor: 0.0,
+            frame: Vec::with_capacity(FRAME_SAMPLES),
+            packet: vec![0u8; MAX_PACKET_BYTES],
+            preskip,
+            total_samples: 0,
+            encoded_samples: 0,
+        };
+        recorder.write_headers()?;
+        Ok(recorder)
+    }
+
+    fn write_headers(&mut self) -> Result<(), AudioError> {
+        let mut head = Vec::with_capacity(19);
+        head.extend_from_slice(b"OpusHead");
+        head.push(1);
+        head.push(1);
+        head.extend_from_slice(&(self.preskip as u16).to_le_bytes());
+        head.extend_from_slice(&self.source_rate.to_le_bytes());
+        head.extend_from_slice(&0i16.to_le_bytes());
+        head.push(0);
+        self.write_packet(head, PacketWriteEndInfo::EndPage, 0)?;
+
+        let vendor = b"mezon-desktop";
+        let mut tags = Vec::with_capacity(8 + 4 + vendor.len() + 4);
+        tags.extend_from_slice(b"OpusTags");
+        tags.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+        tags.extend_from_slice(vendor);
+        tags.extend_from_slice(&0u32.to_le_bytes());
+        self.write_packet(tags, PacketWriteEndInfo::EndPage, 0)
+    }
+
+    fn write_packet(
+        &mut self,
+        data: Vec<u8>,
+        end: PacketWriteEndInfo,
+        granule: u64,
+    ) -> Result<(), AudioError> {
+        self.writer
+            .write_packet(data, self.serial, end, granule)
+            .map_err(|e| AudioError::Encode(e.to_string()))
+    }
+
+    pub fn push(&mut self, interleaved: &[f32]) {
+        for frame in interleaved.chunks(self.source_channels) {
+            let sum: f32 = frame.iter().sum();
+            self.source_pcm.push(sum / frame.len() as f32);
+        }
+        self.resample();
+    }
+
+    fn resample(&mut self) {
+        if self.source_rate == TARGET_RATE {
+            self.frame.append(&mut self.source_pcm);
+            return;
+        }
+        let step = self.source_rate as f64 / TARGET_RATE as f64;
+        while self.source_cursor + 1.0 < self.source_pcm.len() as f64 {
+            let index = self.source_cursor as usize;
+            let fraction = (self.source_cursor - index as f64) as f32;
+            let sample =
+                self.source_pcm[index] * (1.0 - fraction) + self.source_pcm[index + 1] * fraction;
+            self.frame.push(sample);
+            self.source_cursor += step;
+        }
+        let consumed = self.source_cursor as usize;
+        if consumed > 0 {
+            self.source_pcm.drain(..consumed);
+            self.source_cursor -= consumed as f64;
+        }
+    }
+
+    pub fn encode_ready_frames(&mut self) -> Result<(), AudioError> {
+        while self.frame.len() >= FRAME_SAMPLES {
+            let rest = self.frame.split_off(FRAME_SAMPLES);
+            let frame = std::mem::replace(&mut self.frame, rest);
+            self.total_samples += FRAME_SAMPLES as u64;
+            self.encode_frame(&frame, false)?;
+        }
+        Ok(())
+    }
+
+    fn encode_frame(&mut self, samples: &[f32], last: bool) -> Result<(), AudioError> {
+        let written = self.encoder.encode_float(samples, &mut self.packet)?;
+        self.encoded_samples += FRAME_SAMPLES as u64;
+        let granule = if last {
+            self.preskip + self.total_samples
+        } else {
+            self.preskip + self.encoded_samples
+        };
+        let end = if last {
+            PacketWriteEndInfo::EndStream
+        } else {
+            PacketWriteEndInfo::NormalPacket
+        };
+        let packet = self.packet[..written].to_vec();
+        self.write_packet(packet, end, granule)
+    }
+
+    pub fn finish(mut self) -> Result<VoiceRecording, AudioError> {
+        self.encode_ready_frames()?;
+
+        let tail = self.frame.len();
+        if tail > 0 {
+            self.total_samples += tail as u64;
+        }
+        if self.total_samples == 0 {
+            return Err(AudioError::Encode("no audio was recorded".into()));
+        }
+        let mut last = std::mem::take(&mut self.frame);
+        last.resize(FRAME_SAMPLES, 0.0);
+        self.encode_frame(&last, true)?;
+
+        let duration_secs = self.total_samples as f64 / TARGET_RATE as f64;
+        let bytes = self.writer.into_inner().into_inner();
+        Ok(VoiceRecording {
+            bytes,
+            duration_secs,
+        })
+    }
+}
+
+struct OpusEncoder {
+    inner: *mut unsafe_libopus::OpusEncoder,
+}
+
+unsafe impl Send for OpusEncoder {}
+
+impl OpusEncoder {
+    fn new(sample_rate: i32, channels: i32) -> Result<Self, AudioError> {
+        let mut error = 0i32;
+        let inner = unsafe {
+            unsafe_libopus::opus_encoder_create(
+                sample_rate,
+                channels,
+                unsafe_libopus::OPUS_APPLICATION_VOIP,
+                &mut error,
+            )
+        };
+        if inner.is_null() || error != unsafe_libopus::OPUS_OK {
+            return Err(AudioError::Encode(format!(
+                "opus_encoder_create failed (error {error})"
+            )));
+        }
+        Ok(Self { inner })
+    }
+
+    fn set_bitrate(&mut self, bitrate: i32) -> Result<(), AudioError> {
+        let status = unsafe {
+            unsafe_libopus::opus_encoder_ctl!(
+                self.inner,
+                unsafe_libopus::OPUS_SET_BITRATE_REQUEST,
+                bitrate
+            )
+        };
+        if status != unsafe_libopus::OPUS_OK {
+            return Err(AudioError::Encode(format!(
+                "opus set bitrate failed (error {status})"
+            )));
+        }
+        Ok(())
+    }
+
+    fn lookahead(&mut self) -> i32 {
+        let mut lookahead = 0i32;
+        let status = unsafe {
+            unsafe_libopus::opus_encoder_ctl!(
+                self.inner,
+                unsafe_libopus::OPUS_GET_LOOKAHEAD_REQUEST,
+                &mut lookahead
+            )
+        };
+        if status == unsafe_libopus::OPUS_OK {
+            lookahead
+        } else {
+            DEFAULT_LOOKAHEAD
+        }
+    }
+
+    fn encode_float(&mut self, pcm: &[f32], out: &mut [u8]) -> Result<usize, AudioError> {
+        let written = unsafe {
+            unsafe_libopus::opus_encode_float(
+                self.inner,
+                pcm.as_ptr(),
+                pcm.len() as i32,
+                out.as_mut_ptr(),
+                out.len() as i32,
+            )
+        };
+        if written < 0 {
+            return Err(AudioError::Encode(format!(
+                "opus_encode_float failed (error {written})"
+            )));
+        }
+        Ok(written as usize)
+    }
+}
+
+impl Drop for OpusEncoder {
+    fn drop(&mut self) {
+        unsafe { unsafe_libopus::opus_encoder_destroy(self.inner) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sine(rate: u32, channels: u16, seconds: f64) -> Vec<f32> {
+        let frames = (rate as f64 * seconds) as usize;
+        let mut pcm = Vec::with_capacity(frames * channels as usize);
+        for frame in 0..frames {
+            let phase = frame as f64 / rate as f64 * 440.0 * std::f64::consts::TAU;
+            let sample = (phase.sin() * 0.5) as f32;
+            for _ in 0..channels {
+                pcm.push(sample);
+            }
+        }
+        pcm
+    }
+
+    fn record(rate: u32, channels: u16, seconds: f64) -> VoiceRecording {
+        let mut encoder = VoiceEncoder::new(rate, channels).expect("encoder");
+        for chunk in sine(rate, channels, seconds).chunks(1024) {
+            encoder.push(chunk);
+            encoder.encode_ready_frames().expect("encode");
+        }
+        encoder.finish().expect("finish")
+    }
+
+    #[test]
+    fn encodes_ogg_opus_the_player_can_decode() {
+        let recording = record(48_000, 1, 2.0);
+
+        assert_eq!(&recording.bytes[..4], b"OggS");
+        assert!((recording.duration_secs - 2.0).abs() < 0.05);
+
+        let decoded = crate::decode_audio(recording.bytes).expect("round-trip decode");
+        assert_eq!(decoded.sample_rate, TARGET_RATE);
+        assert_eq!(decoded.channels, 1);
+        assert!((decoded.duration_secs() - 2.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn resamples_and_downmixes_the_capture_device_format() {
+        let recording = record(44_100, 2, 1.5);
+
+        assert!((recording.duration_secs - 1.5).abs() < 0.05);
+        let decoded = crate::decode_audio(recording.bytes).expect("round-trip decode");
+        assert_eq!(decoded.channels, 1);
+        assert_eq!(decoded.sample_rate, TARGET_RATE);
+        assert!((decoded.duration_secs() - 1.5).abs() < 0.1);
+    }
+
+    #[test]
+    fn empty_recording_is_an_error() {
+        let encoder = VoiceEncoder::new(48_000, 1).expect("encoder");
+        assert!(encoder.finish().is_err());
+    }
+}

--- a/crates/mezon-audio/src/lib.rs
+++ b/crates/mezon-audio/src/lib.rs
@@ -1,8 +1,12 @@
 mod decode;
+mod encode;
 mod playback;
+mod stream;
 
 pub use decode::{DecodedPcm, decode_audio};
+pub use encode::{VoiceEncoder, VoiceRecording};
 pub use playback::AudioPlayer;
+pub use stream::{PcmStream, spawn_stream_decode};
 
 #[derive(Debug, thiserror::Error)]
 pub enum AudioError {
@@ -10,6 +14,8 @@ pub enum AudioError {
     Demux(String),
     #[error("failed to decode audio: {0}")]
     Decode(String),
+    #[error("failed to encode audio: {0}")]
+    Encode(String),
     #[error("no audio track in stream")]
     NoAudioTrack,
     #[error("no audio output device")]

--- a/crates/mezon-audio/src/playback.rs
+++ b/crates/mezon-audio/src/playback.rs
@@ -8,6 +8,9 @@ use std::time::Duration;
 
 use crate::AudioError;
 use crate::decode::DecodedPcm;
+use crate::stream::{ChunkState, PcmStream};
+
+const STREAM_SPAN: usize = 32_768;
 
 thread_local! {
     static SHARED_SINK: RefCell<Weak<MixerDeviceSink>> = const { RefCell::new(Weak::new()) };
@@ -104,10 +107,112 @@ impl Source for SharedSamplesSource {
     }
 }
 
+struct PcmStreamSource {
+    stream: Arc<PcmStream>,
+    chunk: Option<Arc<[f32]>>,
+    next_chunk: usize,
+    offset: usize,
+    silence_debt: usize,
+    exhausted: bool,
+    channels: NonZeroU16,
+    sample_rate: NonZeroU32,
+}
+
+impl PcmStreamSource {
+    fn new(stream: Arc<PcmStream>) -> Self {
+        let channels =
+            NonZeroU16::new(stream.channels().clamp(1, 2) as u16).unwrap_or(NonZeroU16::MIN);
+        let sample_rate =
+            NonZeroU32::new(stream.sample_rate()).unwrap_or(NonZeroU32::new(48_000).unwrap());
+        Self {
+            stream,
+            chunk: None,
+            next_chunk: 0,
+            offset: 0,
+            silence_debt: 0,
+            exhausted: false,
+            channels,
+            sample_rate,
+        }
+    }
+
+    fn silence(&mut self) -> Option<f32> {
+        self.silence_debt += 1;
+        Some(0.0)
+    }
+}
+
+impl Iterator for PcmStreamSource {
+    type Item = f32;
+
+    fn next(&mut self) -> Option<f32> {
+        loop {
+            if let Some(chunk) = &self.chunk
+                && let Some(sample) = chunk.get(self.offset).copied()
+            {
+                self.offset += 1;
+                return Some(sample);
+            }
+            if !self
+                .silence_debt
+                .is_multiple_of(self.channels.get() as usize)
+            {
+                return self.silence();
+            }
+            match self.stream.chunk_at(self.next_chunk) {
+                ChunkState::Ready(chunk) => {
+                    self.chunk = Some(chunk);
+                    self.next_chunk += 1;
+                    self.offset = 0;
+                    self.silence_debt = 0;
+                }
+                ChunkState::Pending => return self.silence(),
+                ChunkState::Complete => {
+                    self.exhausted = true;
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+impl Source for PcmStreamSource {
+    fn current_span_len(&self) -> Option<usize> {
+        if self.exhausted {
+            Some(0)
+        } else {
+            Some(STREAM_SPAN)
+        }
+    }
+
+    fn channels(&self) -> NonZeroU16 {
+        self.channels
+    }
+
+    fn sample_rate(&self) -> NonZeroU32 {
+        self.sample_rate
+    }
+
+    fn total_duration(&self) -> Option<Duration> {
+        None
+    }
+
+    fn try_seek(&mut self, _: Duration) -> Result<(), rodio::source::SeekError> {
+        Err(rodio::source::SeekError::NotSupported {
+            underlying_source: "PcmStreamSource",
+        })
+    }
+}
+
+enum Playable {
+    Pcm(PcmData),
+    Stream(Arc<PcmStream>),
+}
+
 pub struct AudioPlayer {
     _sink: Rc<MixerDeviceSink>,
     player: Player,
-    data: RefCell<Option<PcmData>>,
+    data: RefCell<Option<Playable>>,
     started: Cell<bool>,
 }
 
@@ -129,12 +234,16 @@ impl AudioPlayer {
         let duration = pcm.duration_secs();
         let (samples, channel_count) = downmix_to_playable(pcm.samples, pcm.channels);
         let channels = NonZeroU16::new(channel_count).unwrap_or(NonZeroU16::MIN);
-        *self.data.borrow_mut() = Some(PcmData {
+        *self.data.borrow_mut() = Some(Playable::Pcm(PcmData {
             samples,
             channels,
             sample_rate,
             duration,
-        });
+        }));
+    }
+
+    pub fn set_stream(&self, stream: Arc<PcmStream>) {
+        *self.data.borrow_mut() = Some(Playable::Stream(stream));
     }
 
     pub fn is_ready(&self) -> bool {
@@ -148,13 +257,18 @@ impl AudioPlayer {
     pub fn play(&self) {
         if let Some(data) = self.data.borrow().as_ref() {
             if self.player.empty() {
-                self.player.append(SharedSamplesSource {
-                    samples: Arc::clone(&data.samples),
-                    position: 0,
-                    channels: data.channels,
-                    sample_rate: data.sample_rate,
-                    duration: data.duration,
-                });
+                match data {
+                    Playable::Pcm(data) => self.player.append(SharedSamplesSource {
+                        samples: Arc::clone(&data.samples),
+                        position: 0,
+                        channels: data.channels,
+                        sample_rate: data.sample_rate,
+                        duration: data.duration,
+                    }),
+                    Playable::Stream(stream) => {
+                        self.player.append(PcmStreamSource::new(Arc::clone(stream)))
+                    }
+                }
             }
             self.started.set(true);
             self.player.play();
@@ -178,16 +292,58 @@ impl AudioPlayer {
     }
 
     pub fn duration_secs(&self) -> f64 {
-        self.data
-            .borrow()
-            .as_ref()
-            .map(|d| d.duration)
-            .unwrap_or(0.0)
+        match self.data.borrow().as_ref() {
+            Some(Playable::Pcm(data)) => data.duration,
+            Some(Playable::Stream(stream)) => stream.duration_secs(),
+            None => 0.0,
+        }
     }
 }
 
 impl Drop for AudioPlayer {
     fn drop(&mut self) {
         self.player.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_source_pads_underruns_to_whole_frames() {
+        let stream = Arc::new(PcmStream::new(2, 48_000, None));
+        stream.push(&[1.0, -1.0, 2.0, -2.0]);
+        let mut source = PcmStreamSource::new(Arc::clone(&stream));
+
+        assert_eq!(
+            (&mut source).take(4).collect::<Vec<_>>(),
+            vec![1.0, -1.0, 2.0, -2.0]
+        );
+
+        let starved: Vec<f32> = (&mut source).take(3).collect();
+        assert_eq!(starved, vec![0.0, 0.0, 0.0]);
+
+        stream.push(&[3.0, -3.0]);
+        let resumed: Vec<f32> = (&mut source).take(3).collect();
+        assert_eq!(resumed, vec![0.0, 3.0, -3.0]);
+
+        stream.finish();
+        assert_eq!(source.next(), None);
+        assert_eq!(source.current_span_len(), Some(0));
+    }
+
+    #[test]
+    fn stream_source_ends_only_when_the_stream_completes() {
+        let stream = Arc::new(PcmStream::new(1, 48_000, None));
+        stream.push(&[0.5]);
+        let mut source = PcmStreamSource::new(Arc::clone(&stream));
+
+        assert_eq!(source.next(), Some(0.5));
+        assert_eq!(source.next(), Some(0.0));
+        assert_eq!(source.current_span_len(), Some(STREAM_SPAN));
+
+        stream.finish();
+        assert_eq!(source.next(), None);
     }
 }

--- a/crates/mezon-audio/src/stream.rs
+++ b/crates/mezon-audio/src/stream.rs
@@ -1,0 +1,376 @@
+use std::io::{self, Read, Seek, SeekFrom};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use parking_lot::Mutex;
+use symphonia::core::io::{MediaSource, MediaSourceStream};
+
+use crate::AudioError;
+use crate::decode::{PcmSpec, decode_packets};
+
+const PREROLL_SECS: f64 = 0.5;
+const CHUNK_FRAMES: usize = 2048;
+
+pub(crate) enum ChunkState {
+    Ready(Arc<[f32]>),
+    Pending,
+    Complete,
+}
+
+struct StreamBuffer {
+    chunks: Vec<Arc<[f32]>>,
+    complete: bool,
+}
+
+pub struct PcmStream {
+    buffer: Mutex<StreamBuffer>,
+    ready_samples: AtomicUsize,
+    channels: usize,
+    sample_rate: u32,
+    duration_hint: Option<f64>,
+}
+
+impl PcmStream {
+    pub(crate) fn new(channels: usize, sample_rate: u32, duration_hint: Option<f64>) -> Self {
+        Self {
+            buffer: Mutex::new(StreamBuffer {
+                chunks: Vec::new(),
+                complete: false,
+            }),
+            ready_samples: AtomicUsize::new(0),
+            channels: channels.max(1),
+            sample_rate: sample_rate.max(1),
+            duration_hint,
+        }
+    }
+
+    pub fn channels(&self) -> usize {
+        self.channels
+    }
+
+    pub fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
+    pub fn duration_secs(&self) -> f64 {
+        if !self.buffer.lock().complete {
+            return self.duration_hint.unwrap_or(0.0);
+        }
+        let frames = self.ready_samples.load(Ordering::Acquire) / self.channels;
+        frames as f64 / self.sample_rate as f64
+    }
+
+    pub(crate) fn chunk_at(&self, index: usize) -> ChunkState {
+        let buffer = self.buffer.lock();
+        match buffer.chunks.get(index) {
+            Some(chunk) => ChunkState::Ready(Arc::clone(chunk)),
+            None if buffer.complete => ChunkState::Complete,
+            None => ChunkState::Pending,
+        }
+    }
+
+    pub(crate) fn push(&self, samples: &[f32]) {
+        self.buffer.lock().chunks.push(Arc::from(samples));
+        self.ready_samples
+            .fetch_add(samples.len(), Ordering::Release);
+    }
+
+    pub(crate) fn finish(&self) {
+        self.buffer.lock().complete = true;
+    }
+
+    fn ready_frames(&self) -> usize {
+        self.ready_samples.load(Ordering::Acquire) / self.channels
+    }
+
+    fn preroll_frames(&self) -> usize {
+        (PREROLL_SECS * self.sample_rate as f64) as usize
+    }
+}
+
+pub fn spawn_stream_decode(
+    bytes: flume::Receiver<Vec<u8>>,
+) -> flume::Receiver<Result<Arc<PcmStream>, AudioError>> {
+    let (ready_tx, ready_rx) = flume::bounded(1);
+    let spawned = std::thread::Builder::new()
+        .name("mezon-audio-decode".into())
+        .spawn(move || decode_thread(bytes, &ready_tx));
+    if let Err(err) = spawned {
+        return failed_receiver(AudioError::Decode(format!(
+            "failed to start audio decoder: {err}"
+        )));
+    }
+    ready_rx
+}
+
+fn failed_receiver(err: AudioError) -> flume::Receiver<Result<Arc<PcmStream>, AudioError>> {
+    let (tx, rx) = flume::bounded(1);
+    let _ = tx.send(Err(err));
+    rx
+}
+
+fn decode_thread(
+    bytes: flume::Receiver<Vec<u8>>,
+    ready_tx: &flume::Sender<Result<Arc<PcmStream>, AudioError>>,
+) {
+    let source = ChunkReader::new(bytes);
+    let mss = MediaSourceStream::new(Box::new(source), Default::default());
+
+    let mut stream: Option<Arc<PcmStream>> = None;
+    let mut pending: Vec<f32> = Vec::new();
+    let mut announced = false;
+    let duration_hint = std::cell::Cell::new(None);
+
+    let result = decode_packets(
+        mss,
+        |duration| duration_hint.set(duration),
+        |samples, spec| {
+            let stream = stream.get_or_insert_with(|| {
+                Arc::new(PcmStream::new(
+                    spec.channels.min(2),
+                    spec.sample_rate,
+                    duration_hint.get(),
+                ))
+            });
+            append_downmixed(&mut pending, samples, spec, stream.channels());
+            if pending.len() >= CHUNK_FRAMES * stream.channels() {
+                stream.push(&pending);
+                pending.clear();
+            }
+            if !announced && stream.ready_frames() >= stream.preroll_frames() {
+                announced = true;
+                let _ = ready_tx.send(Ok(Arc::clone(stream)));
+            }
+        },
+    );
+
+    let Some(stream) = stream else {
+        let err = result
+            .err()
+            .unwrap_or_else(|| AudioError::Decode("audio stream produced no samples".into()));
+        let _ = ready_tx.send(Err(err));
+        return;
+    };
+
+    if !pending.is_empty() {
+        stream.push(&pending);
+    }
+    stream.finish();
+
+    if let Err(err) = result {
+        tracing::warn!("audio stream decode ended with error: {err}");
+    }
+    if !announced {
+        let _ = ready_tx.send(Ok(stream));
+    }
+}
+
+fn append_downmixed(out: &mut Vec<f32>, samples: &[f32], spec: PcmSpec, out_channels: usize) {
+    if spec.channels == out_channels {
+        out.extend_from_slice(samples);
+        return;
+    }
+    for frame in samples.chunks_exact(spec.channels) {
+        out.push(frame.iter().sum::<f32>() / spec.channels as f32);
+    }
+}
+
+struct ChunkReader {
+    bytes: flume::Receiver<Vec<u8>>,
+    current: Vec<u8>,
+    offset: usize,
+    ended: bool,
+}
+
+impl ChunkReader {
+    fn new(bytes: flume::Receiver<Vec<u8>>) -> Self {
+        Self {
+            bytes,
+            current: Vec::new(),
+            offset: 0,
+            ended: false,
+        }
+    }
+}
+
+impl Read for ChunkReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let available = self.current.len() - self.offset;
+            if available > 0 {
+                let n = available.min(buf.len());
+                buf[..n].copy_from_slice(&self.current[self.offset..self.offset + n]);
+                self.offset += n;
+                return Ok(n);
+            }
+            if self.ended {
+                return Ok(0);
+            }
+            match self.bytes.recv() {
+                Ok(chunk) => {
+                    self.current = chunk;
+                    self.offset = 0;
+                }
+                Err(_) => {
+                    self.ended = true;
+                    return Ok(0);
+                }
+            }
+        }
+    }
+}
+
+impl Seek for ChunkReader {
+    fn seek(&mut self, _: SeekFrom) -> io::Result<u64> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "audio stream is not seekable",
+        ))
+    }
+}
+
+impl MediaSource for ChunkReader {
+    fn is_seekable(&self) -> bool {
+        false
+    }
+
+    fn byte_len(&self) -> Option<u64> {
+        None
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    const RATE: u32 = 48_000;
+
+    pub(crate) fn wav_sine(seconds: f64) -> Vec<u8> {
+        let frames = (RATE as f64 * seconds) as u32;
+        let data_len = frames * 2;
+        let mut wav = Vec::with_capacity(44 + data_len as usize);
+        wav.extend_from_slice(b"RIFF");
+        wav.extend_from_slice(&(36 + data_len).to_le_bytes());
+        wav.extend_from_slice(b"WAVEfmt ");
+        wav.extend_from_slice(&16u32.to_le_bytes());
+        wav.extend_from_slice(&1u16.to_le_bytes());
+        wav.extend_from_slice(&1u16.to_le_bytes());
+        wav.extend_from_slice(&RATE.to_le_bytes());
+        wav.extend_from_slice(&(RATE * 2).to_le_bytes());
+        wav.extend_from_slice(&2u16.to_le_bytes());
+        wav.extend_from_slice(&16u16.to_le_bytes());
+        wav.extend_from_slice(b"data");
+        wav.extend_from_slice(&data_len.to_le_bytes());
+        for frame in 0..frames {
+            let phase = frame as f64 / RATE as f64 * 440.0 * std::f64::consts::TAU;
+            let sample = (phase.sin() * 16_384.0) as i16;
+            wav.extend_from_slice(&sample.to_le_bytes());
+        }
+        wav
+    }
+
+    fn drain(stream: &Arc<PcmStream>) -> Vec<f32> {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut samples = Vec::new();
+        let mut index = 0;
+        loop {
+            match stream.chunk_at(index) {
+                ChunkState::Ready(chunk) => {
+                    samples.extend_from_slice(&chunk);
+                    index += 1;
+                }
+                ChunkState::Complete => return samples,
+                ChunkState::Pending => {
+                    assert!(Instant::now() < deadline, "stream never completed");
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn streamed_pcm_matches_buffered_decode() {
+        let bytes = wav_sine(2.0);
+        let (tx, rx) = flume::bounded(4);
+        let ready = spawn_stream_decode(rx);
+        for chunk in bytes.chunks(4096) {
+            tx.send(chunk.to_vec()).expect("decoder alive");
+        }
+        drop(tx);
+
+        let stream = ready
+            .recv_timeout(Duration::from_secs(10))
+            .expect("ready signal")
+            .expect("stream decodes");
+        let streamed = drain(&stream);
+        let buffered = crate::decode_audio(bytes).expect("buffered decode");
+
+        assert_eq!(stream.channels(), buffered.channels);
+        assert_eq!(stream.sample_rate(), buffered.sample_rate);
+        assert_eq!(streamed.len(), buffered.samples.len());
+        assert!(
+            streamed
+                .iter()
+                .zip(buffered.samples.iter())
+                .all(|(a, b)| (a - b).abs() < 1e-6)
+        );
+        assert!((stream.duration_secs() - 2.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn total_duration_is_known_before_the_stream_completes() {
+        let bytes = wav_sine(20.0);
+        let (tx, rx) = flume::bounded(4);
+        let ready = spawn_stream_decode(rx);
+
+        let preroll_bytes = 44 + RATE as usize * 2;
+        let mut sent = 0;
+        for chunk in bytes.chunks(8192) {
+            if sent >= preroll_bytes {
+                break;
+            }
+            tx.send(chunk.to_vec()).expect("decoder alive");
+            sent += chunk.len();
+        }
+
+        let stream = ready
+            .recv_timeout(Duration::from_secs(10))
+            .expect("ready")
+            .expect("stream decodes");
+
+        assert!(!matches!(stream.chunk_at(usize::MAX), ChunkState::Complete));
+        assert!(
+            (stream.duration_secs() - 20.0).abs() < 0.1,
+            "expected the container duration up front, got {}",
+            stream.duration_secs()
+        );
+        drop(tx);
+    }
+
+    #[test]
+    fn playback_starts_before_the_whole_file_arrives() {
+        let bytes = wav_sine(20.0);
+        let (tx, rx) = flume::bounded(4);
+        let ready = spawn_stream_decode(rx);
+
+        let preroll_bytes = 44 + RATE as usize * 2;
+        let mut sent = 0;
+        for chunk in bytes.chunks(8192) {
+            if sent >= preroll_bytes {
+                break;
+            }
+            tx.send(chunk.to_vec()).expect("decoder alive");
+            sent += chunk.len();
+        }
+
+        let stream = ready
+            .recv_timeout(Duration::from_secs(10))
+            .expect("ready before the download finished")
+            .expect("stream decodes");
+
+        assert!(sent * 10 < bytes.len(), "fed {sent} of {}", bytes.len());
+        assert!(matches!(stream.chunk_at(0), ChunkState::Ready(_)));
+        drop(tx);
+    }
+}

--- a/crates/mezon-client/src/app_api.rs
+++ b/crates/mezon-client/src/app_api.rs
@@ -96,6 +96,7 @@ pub struct UploadFile {
     pub filetype: String,
     pub width: i32,
     pub height: i32,
+    pub duration: i32,
     pub thumbnail: Option<UploadThumbnail>,
 }
 
@@ -1011,6 +1012,7 @@ impl AppApi {
             filetype,
             width,
             height,
+            duration,
             thumbnail,
         } = file;
         let filename = sanitize_filename(&filename);
@@ -1076,7 +1078,7 @@ impl AppApi {
                 width,
                 height,
                 thumbnail: thumbnail_url,
-                duration: 0,
+                duration,
             },
             plan,
         })

--- a/crates/mezon-native/src/audio.rs
+++ b/crates/mezon-native/src/audio.rs
@@ -1,3 +1,4 @@
+use cpal::Sample as _;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use flume::Sender;
 use std::sync::Mutex;
@@ -106,6 +107,111 @@ impl MicCapture {
             .map_err(|e: cpal::PlayStreamError| MicCaptureError::StreamError(e.to_string()))?;
 
         Ok(Self { _stream: stream })
+    }
+}
+
+/// Format of the PCM delivered by [`MicPcmCapture`].
+#[derive(Debug, Clone, Copy)]
+pub struct MicPcmFormat {
+    pub sample_rate: u32,
+    pub channels: u16,
+}
+
+/// A live microphone capture handle that delivers raw interleaved PCM.
+///
+/// Unlike [`MicCapture`], which reduces every buffer to a single RMS level,
+/// this hands the samples themselves to `sender` so they can be encoded.
+///
+/// Dropping this struct stops the stream and releases audio resources.
+pub struct MicPcmCapture {
+    _stream: cpal::Stream,
+}
+
+impl MicPcmCapture {
+    /// Start capturing raw PCM from the default input device.
+    ///
+    /// Returns the device format alongside the handle; the samples are
+    /// interleaved `f32` in that format, converted from whatever the device
+    /// natively provides.
+    ///
+    /// `sender` must be unbounded: the samples are handed over from the
+    /// high-priority audio thread with a non-blocking send, so a bounded
+    /// channel that fills up would silently drop captured audio.
+    pub fn start(sender: Sender<Vec<f32>>) -> Result<(Self, MicPcmFormat), MicCaptureError> {
+        let host = cpal::default_host();
+        let device = host
+            .default_input_device()
+            .ok_or_else(|| MicCaptureError::DeviceNotFound("default input".to_string()))?;
+
+        let supported =
+            device
+                .default_input_config()
+                .map_err(|e: cpal::DefaultStreamConfigError| {
+                    MicCaptureError::ConfigError(e.to_string())
+                })?;
+
+        let format = MicPcmFormat {
+            sample_rate: supported.sample_rate(),
+            channels: supported.channels(),
+        };
+        let sample_format = supported.sample_format();
+        let config: cpal::StreamConfig = supported.into();
+
+        let stream = match sample_format {
+            cpal::SampleFormat::I8 => build_pcm_stream::<i8>(&device, &config, sender),
+            cpal::SampleFormat::I16 => build_pcm_stream::<i16>(&device, &config, sender),
+            cpal::SampleFormat::I24 => build_pcm_stream::<cpal::I24>(&device, &config, sender),
+            cpal::SampleFormat::I32 => build_pcm_stream::<i32>(&device, &config, sender),
+            cpal::SampleFormat::I64 => build_pcm_stream::<i64>(&device, &config, sender),
+            cpal::SampleFormat::U8 => build_pcm_stream::<u8>(&device, &config, sender),
+            cpal::SampleFormat::U16 => build_pcm_stream::<u16>(&device, &config, sender),
+            cpal::SampleFormat::U32 => build_pcm_stream::<u32>(&device, &config, sender),
+            cpal::SampleFormat::U64 => build_pcm_stream::<u64>(&device, &config, sender),
+            cpal::SampleFormat::F32 => build_pcm_stream::<f32>(&device, &config, sender),
+            cpal::SampleFormat::F64 => build_pcm_stream::<f64>(&device, &config, sender),
+            other => {
+                return Err(MicCaptureError::ConfigError(format!(
+                    "unsupported input sample format {other:?}"
+                )));
+            }
+        }
+        .map_err(|e: cpal::BuildStreamError| MicCaptureError::StreamError(e.to_string()))?;
+
+        stream
+            .play()
+            .map_err(|e: cpal::PlayStreamError| MicCaptureError::StreamError(e.to_string()))?;
+
+        Ok((Self { _stream: stream }, format))
+    }
+}
+
+fn build_pcm_stream<T>(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    sender: Sender<Vec<f32>>,
+) -> Result<cpal::Stream, cpal::BuildStreamError>
+where
+    T: cpal::SizedSample,
+    f32: cpal::FromSample<T>,
+{
+    let sender = Mutex::new(sender);
+    device.build_input_stream(
+        config,
+        move |data: &[T], _: &cpal::InputCallbackInfo| {
+            let pcm = data
+                .iter()
+                .map(|sample| f32::from_sample(*sample))
+                .collect::<Vec<f32>>();
+            send_pcm(&sender, pcm);
+        },
+        |err| tracing::warn!("Mic capture stream error: {err}"),
+        None,
+    )
+}
+
+fn send_pcm(sender: &Mutex<Sender<Vec<f32>>>, pcm: Vec<f32>) {
+    if let Ok(sender) = sender.lock() {
+        let _ = sender.try_send(pcm);
     }
 }
 

--- a/crates/mezon-store/src/audio.rs
+++ b/crates/mezon-store/src/audio.rs
@@ -12,6 +12,18 @@ pub type MicCaptureHandle = Box<dyn Send>;
 pub type MicCaptureFactory =
     Arc<dyn Fn(&str, flume::Sender<f32>) -> Result<MicCaptureHandle, String> + Send + Sync>;
 
+#[derive(Debug, Clone, Copy)]
+pub struct MicPcmFormat {
+    pub sample_rate: u32,
+    pub channels: u16,
+}
+
+pub type MicPcmCaptureFactory = Arc<
+    dyn Fn(flume::Sender<Vec<f32>>) -> Result<(MicCaptureHandle, MicPcmFormat), String>
+        + Send
+        + Sync,
+>;
+
 pub type DeviceEnumerator =
     Arc<dyn Fn() -> (Vec<AudioDeviceInfo>, Vec<AudioDeviceInfo>) + Send + Sync>;
 
@@ -19,6 +31,7 @@ pub struct AudioStore {
     pub input_devices: Vec<AudioDeviceInfo>,
     pub output_devices: Vec<AudioDeviceInfo>,
     pub mic_capture_factory: Option<MicCaptureFactory>,
+    pub mic_pcm_capture_factory: Option<MicPcmCaptureFactory>,
     device_enumerator: Option<DeviceEnumerator>,
     devices_requested: bool,
 }
@@ -29,6 +42,7 @@ impl AudioStore {
             input_devices: Vec::new(),
             output_devices: Vec::new(),
             mic_capture_factory: None,
+            mic_pcm_capture_factory: None,
             device_enumerator: None,
             devices_requested: false,
         });
@@ -104,6 +118,16 @@ impl AudioStore {
         .detach();
     }
 
+    pub fn set_mic_pcm_capture_factory(
+        entity: &Entity<Self>,
+        factory: MicPcmCaptureFactory,
+        cx: &mut App,
+    ) {
+        entity.update(cx, |store, _| {
+            store.mic_pcm_capture_factory = Some(factory);
+        });
+    }
+
     pub fn start_mic_capture(
         &self,
         device_id: &str,
@@ -111,6 +135,16 @@ impl AudioStore {
     ) -> Result<MicCaptureHandle, String> {
         match &self.mic_capture_factory {
             Some(factory) => factory(device_id, sender),
+            None => Err("Mic capture not available on this platform".to_string()),
+        }
+    }
+
+    pub fn start_mic_pcm_capture(
+        &self,
+        sender: flume::Sender<Vec<f32>>,
+    ) -> Result<(MicCaptureHandle, MicPcmFormat), String> {
+        match &self.mic_pcm_capture_factory {
+            Some(factory) => factory(sender),
             None => Err("Mic capture not available on this platform".to_string()),
         }
     }

--- a/crates/mezon-store/src/gif.rs
+++ b/crates/mezon-store/src/gif.rs
@@ -160,10 +160,12 @@ pub struct GifStore {
     search_results: Vec<Gif>,
     loaded: bool,
     loading: bool,
+    featured_loading: bool,
     searching: bool,
     search_generation: u64,
     config: KlipyConfig,
     _base_task: Option<Task<()>>,
+    _featured_task: Option<Task<()>>,
     _search_task: Option<Task<()>>,
 }
 
@@ -194,10 +196,12 @@ impl GifStore {
             search_results: Vec::new(),
             loaded: false,
             loading: false,
+            featured_loading: false,
             searching: false,
             search_generation: 0,
             config: KlipyConfig::from_app(cx),
             _base_task: None,
+            _featured_task: None,
             _search_task: None,
         }
     }
@@ -206,6 +210,36 @@ impl GifStore {
         if !self.loaded && !self.loading {
             self.fetch_base(cx);
         }
+    }
+
+    pub fn ensure_featured(&mut self, cx: &mut Context<Self>) {
+        if !self.featured.is_empty() || self.loading || self.featured_loading {
+            return;
+        }
+        if self.config.key.is_empty() {
+            tracing::error!(
+                "klipy api key is empty: set NX_CHAT_APP_API_KLIPY_KEY at build time (.env or CI)"
+            );
+            return;
+        }
+        self.featured_loading = true;
+        cx.notify();
+        let featured_url = self.config.featured_url();
+        self._featured_task = Some(cx.spawn(async move |this, cx| {
+            let featured = fetch_gifs(&featured_url).await;
+            let _ = this.update(cx, |this, cx| {
+                this.featured_loading = false;
+                if let Some(featured) = featured {
+                    this.featured = featured;
+                }
+                cx.emit(GifEvent::Changed);
+                cx.notify();
+            });
+        }));
+    }
+
+    pub fn is_featured_loading(&self) -> bool {
+        self.loading || self.featured_loading
     }
 
     fn fetch_base(&mut self, cx: &mut Context<Self>) {
@@ -444,6 +478,49 @@ mod tests {
     fn encodes_reserved_query_characters() {
         assert_eq!(encode_query("a b&c"), "a%20b%26c");
         assert_eq!(encode_query("plain-text_1.0~"), "plain-text_1.0~");
+    }
+
+    #[test]
+    fn parses_a_klipy_trending_payload() {
+        let payload = br#"{
+            "result": true,
+            "data": {
+                "current_page": 1,
+                "per_page": 30,
+                "data": [
+                    {
+                        "id": 1,
+                        "slug": "naruto-sleep",
+                        "type": "gif",
+                        "file": {
+                            "xs": {"gif": {"url": "https://static.klipy.com/xs.gif", "width": 160, "height": 90}},
+                            "sm": {"gif": {"url": "https://static.klipy.com/sm.gif", "width": 220, "height": 124}}
+                        }
+                    },
+                    {
+                        "id": 2,
+                        "slug": "no-xs-variant",
+                        "type": "gif",
+                        "file": {
+                            "md": {"gif": {"url": "https://static.klipy.com/md.gif", "width": 320, "height": 180}}
+                        }
+                    },
+                    { "id": 3, "slug": "no-gif-at-all", "type": "gif", "file": {} }
+                ]
+            }
+        }"#;
+
+        let response: KlipyGifsResponse = serde_json::from_slice(payload).expect("klipy shape");
+        let gifs: Vec<Gif> = response
+            .data
+            .data
+            .into_iter()
+            .filter_map(gif_from_klipy)
+            .collect();
+
+        assert_eq!(gifs.len(), 2);
+        assert_eq!(gifs[0].url.as_ref(), "https://static.klipy.com/xs.gif");
+        assert_eq!(gifs[1].url.as_ref(), "https://static.klipy.com/md.gif");
     }
 
     #[test]

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -55,7 +55,10 @@ use tokio::fs;
 pub use account::*;
 pub use activity::{ActivityEvent, ActivityStore, UserActivity};
 pub use album_layout::{AlbumLayout, AlbumTile, calculate_album_layout};
-pub use audio::{AudioDeviceInfo, AudioStore, MicCaptureFactory, MicCaptureHandle};
+pub use audio::{
+    AudioDeviceInfo, AudioStore, MicCaptureFactory, MicCaptureHandle, MicPcmCaptureFactory,
+    MicPcmFormat,
+};
 pub use badge::BadgeService;
 pub use cache::{Freshness, KeyedCache};
 pub use channel::*;

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -217,6 +217,7 @@ pub struct OutgoingAttachment {
     pub filetype: String,
     pub width: i32,
     pub height: i32,
+    pub duration: i32,
     pub poster_jpeg: Option<Vec<u8>>,
 }
 
@@ -2546,6 +2547,7 @@ impl MessagesStore {
                             filetype: att.filetype,
                             width: att.width,
                             height: att.height,
+                            duration: att.duration,
                             thumbnail,
                         }
                     })
@@ -5347,7 +5349,7 @@ impl MessageAttachment {
             width,
             height,
             thumbnail: String::new(),
-            duration: 0,
+            duration: att.duration,
             size: 0,
             size_label: SharedString::default(),
             presign_pending: false,
@@ -6030,6 +6032,7 @@ mod tests {
             filetype: "image/png".to_string(),
             width: 100,
             height: 100,
+            duration: 0,
             poster_jpeg: None,
         };
         let atts = [outgoing("a.png"), outgoing("b.png")];

--- a/crates/mezon-store/src/topics.rs
+++ b/crates/mezon-store/src/topics.rs
@@ -832,6 +832,7 @@ impl TopicsStore {
                             filetype: att.filetype,
                             width: att.width,
                             height: att.height,
+                            duration: att.duration,
                             thumbnail,
                         }
                     })

--- a/crates/mezon-ui/src/chat/gif_sticker_emoji/gif_panel.rs
+++ b/crates/mezon-ui/src/chat/gif_sticker_emoji/gif_panel.rs
@@ -32,6 +32,7 @@ struct GifCell {
 enum CatCell {
     Trending {
         label: SharedString,
+        image: SharedString,
     },
     Category {
         name: SharedString,
@@ -161,7 +162,14 @@ impl GifPanel {
         } else {
             let trending =
                 SharedString::new_static(mezon_i18n::t(&self.locale, "chat.gifPicker.trending"));
-            let mut items: Vec<CatCell> = vec![CatCell::Trending { label: trending }];
+            let mut items: Vec<CatCell> = vec![CatCell::Trending {
+                label: trending,
+                image: store
+                    .featured()
+                    .first()
+                    .map(|gif| gif.preview_url.clone())
+                    .unwrap_or_default(),
+            }];
             items.extend(store.categories().iter().map(|category| CatCell::Category {
                 name: category.name.clone(),
                 searchterm: category.searchterm.clone(),
@@ -185,9 +193,11 @@ impl Render for GifPanel {
         let searching = self.searching();
         let is_searching =
             GifStore::try_global(cx).is_some_and(|store| store.read(cx).is_searching());
+        let is_loading_featured =
+            GifStore::try_global(cx).is_some_and(|store| store.read(cx).is_featured_loading());
 
         let empty_label: Option<SharedString> = self.rows.is_empty().then(|| {
-            if searching && is_searching {
+            if (searching && is_searching) || (self.show_featured && is_loading_featured) {
                 self.searching_label.clone()
             } else {
                 self.no_gifs_label.clone()
@@ -361,9 +371,14 @@ type CatTile = (
 fn render_category_tile(theme: &Theme, cell: &CatCell, entity: &Entity<GifPanel>) -> AnyElement {
     let ent = entity.clone();
     let (label, image, id, action): CatTile = match cell {
-        CatCell::Trending { label } => (
+        CatCell::Trending { label, image } => (
             label.clone(),
-            None,
+            (!image.is_empty()).then(|| {
+                (
+                    SharedString::new_static("gse-gif-cat-img-trending"),
+                    image.clone(),
+                )
+            }),
             SharedString::new_static("gse-gif-cat-trending"),
             CatAction::Trending,
         ),
@@ -429,7 +444,10 @@ fn render_category_tile(theme: &Theme, cell: &CatCell, entity: &Entity<GifPanel>
             CatAction::Trending => {
                 this.show_featured = true;
                 if let Some(store) = GifStore::try_global(cx) {
-                    store.update(cx, |store, cx| store.ensure_loaded(cx));
+                    store.update(cx, |store, cx| {
+                        store.ensure_loaded(cx);
+                        store.ensure_featured(cx);
+                    });
                 }
                 this.rebuild(cx);
                 cx.notify();

--- a/crates/mezon-ui/src/chat/mention_input/attachments.rs
+++ b/crates/mezon-ui/src/chat/mention_input/attachments.rs
@@ -16,6 +16,7 @@ pub struct PendingAttachment {
     pub is_video: bool,
     pub width: u32,
     pub height: u32,
+    pub duration: i32,
     pub poster_jpeg: Option<Vec<u8>>,
 }
 
@@ -81,6 +82,7 @@ pub fn build_pending(path: PathBuf) -> Option<PendingAttachment> {
         is_video,
         width,
         height,
+        duration: 0,
         poster_jpeg,
     })
 }
@@ -142,6 +144,7 @@ mod tests {
             is_video: false,
             width: 0,
             height: 0,
+            duration: 0,
             poster_jpeg: None,
         };
         assert!(validate_batch(0, std::slice::from_ref(&img)).is_ok());

--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -1,4 +1,5 @@
 mod attachments;
+mod recorder;
 mod text_field;
 
 use std::cell::Cell;
@@ -7,22 +8,23 @@ use std::rc::Rc;
 
 use gpui::{
     AnyElement, App, Bounds, Context, DismissEvent, Div, Entity, EventEmitter, Focusable,
-    FontWeight, Image, ImageFormat, IntoElement, KeyBinding, PathPromptOptions, Pixels, Rgba,
-    ScrollStrategy, SharedString, Stateful, Subscription, UniformListScrollHandle, Window, actions,
-    canvas, deferred, div, img, prelude::*, px, uniform_list,
+    FontWeight, Image, ImageFormat, IntoElement, KeyBinding, MouseButton, PathPromptOptions,
+    Pixels, Rgba, ScrollStrategy, SharedString, Stateful, Subscription, UniformListScrollHandle,
+    Window, actions, canvas, deferred, div, img, prelude::*, px, uniform_list,
 };
 use mezon_store::{
-    AccountEvent, AccountStore, Channel, ChannelEvent, ChannelId, ChannelList, ChannelMembersEvent,
-    ChannelMembersStore, ClanList, ClanMembersEvent, ClanMembersStore, DirectEvent,
-    DirectMessageStore, Emoji, EmojiEvent, EmojiStore, GroupMembersEvent, GroupMembersStore,
-    MENTION_HERE_ID, MessageSpan, OutgoingAttachment, OutgoingContent, OutgoingEmoji,
-    OutgoingHashtag, OutgoingMention, RolesEvent, RolesStore, Settings,
+    AccountEvent, AccountStore, AudioStore, Channel, ChannelEvent, ChannelId, ChannelList,
+    ChannelMembersEvent, ChannelMembersStore, ClanList, ClanMembersEvent, ClanMembersStore,
+    DirectEvent, DirectMessageStore, Emoji, EmojiEvent, EmojiStore, GroupMembersEvent,
+    GroupMembersStore, MENTION_HERE_ID, MessageSpan, OutgoingAttachment, OutgoingContent,
+    OutgoingEmoji, OutgoingHashtag, OutgoingMention, RolesEvent, RolesStore, Settings,
 };
 
 use attachments::{
     AttachmentLimit, MAX_FILE_ATTACHMENTS, PendingAttachment, build_pending, mime_from_extension,
     validate_batch,
 };
+use recorder::{ActiveRecording, MIN_RECORDING_MILLIS, RecordTask, encode_recording};
 
 use crate::app::shell::Shell;
 use crate::chat::gif_sticker_emoji::{GifStickerEmojiEvent, GifStickerEmojiPopup, SubPanel};
@@ -30,7 +32,7 @@ use crate::chat::member_list::{
     MentionMemberRaw, MentionScope, ensure_mention_members_loaded, mention_direct_id,
     mention_member_pool, mention_private_channel, mention_role_clan, mention_scope,
 };
-use crate::components::primitives::{Avatar, Icon, IconName};
+use crate::components::primitives::{Avatar, Icon, IconName, ToastKind};
 use crate::image_cache::{
     AVATAR_ENTRY_MAX_BYTES, AVATAR_IMAGE_CACHE_BYTES, AVATAR_IMAGE_CACHE_CAPACITY, LruImageCache,
 };
@@ -42,6 +44,12 @@ use text_field::{
 };
 
 const KEY_CONTEXT: &str = "MezonMention";
+const RECORDING_COLOR: Rgba = Rgba {
+    r: 0xdc as f32 / 255.,
+    g: 0x26 as f32 / 255.,
+    b: 0x26 as f32 / 255.,
+    a: 1.0,
+};
 const MAX_SUGGESTIONS: usize = 10;
 const MAX_EMOJI_CANDIDATES: usize = 20;
 const MENTION_HERE_DISPLAY: &str = "@here";
@@ -255,6 +263,10 @@ pub struct MentionInput {
     preview_cache: Entity<LruImageCache>,
     settings: Entity<Settings>,
     pending_attachments: Vec<PendingAttachment>,
+    recording: Option<ActiveRecording>,
+    record_generation: u64,
+    encoding_recording: bool,
+    _record_task: Option<RecordTask>,
     compact: bool,
     overflow_to_file: bool,
     overflow_counter: Option<isize>,
@@ -428,6 +440,10 @@ impl MentionInput {
             preview_cache,
             settings,
             pending_attachments: Vec::new(),
+            recording: None,
+            record_generation: 0,
+            encoding_recording: false,
+            _record_task: None,
             compact,
             overflow_to_file: false,
             overflow_counter: None,
@@ -517,6 +533,7 @@ impl MentionInput {
                 filetype: p.filetype,
                 width: i32::try_from(p.width).unwrap_or(0),
                 height: i32::try_from(p.height).unwrap_or(0),
+                duration: p.duration,
                 poster_jpeg: p.poster_jpeg,
             })
             .collect();
@@ -658,6 +675,92 @@ impl MentionInput {
             .filter(|path| mime_from_extension(path).starts_with("image/"))
             .collect();
         self.add_dropped_paths(images, window, cx);
+    }
+
+    fn start_recording(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.recording.is_some() || self.encoding_recording {
+            return;
+        }
+        let Some(store) = AudioStore::try_global(cx) else {
+            return;
+        };
+        let Some(factory) = store.read(cx).mic_pcm_capture_factory.clone() else {
+            Self::show_recording_error(cx);
+            return;
+        };
+
+        self.record_generation = self.record_generation.wrapping_add(1);
+        let generation = self.record_generation;
+        let (sender, receiver) = flume::unbounded();
+
+        self._record_task = Some(cx.spawn_in(window, async move |this, cx| {
+            let opened = cx
+                .background_executor()
+                .spawn(async move { factory(sender) })
+                .await;
+            let (capture, format) = match opened {
+                Ok(opened) => opened,
+                Err(err) => {
+                    tracing::warn!("voice recording unavailable: {err}");
+                    let _ = this.update(cx, |this, cx| {
+                        this.recording = None;
+                        Self::show_recording_error(cx);
+                        cx.notify();
+                    });
+                    return;
+                }
+            };
+
+            let live = this
+                .update(cx, |this, cx| {
+                    let attached = this
+                        .recording
+                        .as_mut()
+                        .is_some_and(|recording| recording.attach(generation, capture));
+                    cx.notify();
+                    attached
+                })
+                .unwrap_or(false);
+            if !live {
+                return;
+            }
+
+            let built = cx
+                .background_executor()
+                .spawn(encode_recording(receiver, format))
+                .await;
+            let _ = this.update_in(cx, |this, window, cx| {
+                this.encoding_recording = false;
+                match built {
+                    Ok(attachment) => this.add_pending(vec![attachment], window, cx),
+                    Err(err) => tracing::warn!("voice recording failed: {err}"),
+                }
+                cx.notify();
+            });
+        }));
+        self.recording = Some(ActiveRecording::opening(generation));
+        cx.notify();
+    }
+
+    fn stop_recording(&mut self, cx: &mut Context<Self>) {
+        let Some(recording) = self.recording.take() else {
+            return;
+        };
+        let keep = recording.is_live() && recording.elapsed_millis() >= MIN_RECORDING_MILLIS;
+        drop(recording);
+
+        if keep {
+            self.encoding_recording = true;
+        } else {
+            self._record_task = None;
+        }
+        cx.notify();
+    }
+
+    fn show_recording_error(cx: &mut Context<Self>) {
+        Shell::global(cx).update(cx, |shell, cx| {
+            shell.toast(ToastKind::Error, "Microphone unavailable", cx)
+        });
     }
 
     fn add_pending(
@@ -1222,7 +1325,14 @@ impl MentionInput {
         cx.notify();
     }
 
-    fn picker_toggle(&self, id: &'static str, icon: IconName, color: Rgba) -> Stateful<Div> {
+    fn picker_toggle(
+        &self,
+        id: &'static str,
+        icon: IconName,
+        color: Rgba,
+        hover_bg: Rgba,
+        hover_color: Rgba,
+    ) -> Stateful<Div> {
         div()
             .id(id)
             .flex()
@@ -1231,7 +1341,13 @@ impl MentionInput {
             .size(px(20.))
             .rounded(px(4.))
             .cursor_pointer()
-            .child(Icon::new(icon).size_5().text_color(color))
+            .hover(|s| s.bg(hover_bg))
+            .child(
+                Icon::new(icon)
+                    .size_5()
+                    .text_color(color)
+                    .hover(|s| s.text_color(hover_color)),
+            )
     }
 
     fn toggle_tab(&mut self, tab: SubPanel, window: &mut Window, cx: &mut Context<Self>) {
@@ -1849,12 +1965,28 @@ impl Render for MentionInput {
                     .rounded(px(4.))
                     .cursor_pointer()
                     .hover(|s| s.bg(icon_bg_hover))
-                    .child(
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this, _event, window, cx| this.start_recording(window, cx)),
+                    )
+                    .on_mouse_up(
+                        MouseButton::Left,
+                        cx.listener(|this, _event, _window, cx| this.stop_recording(cx)),
+                    )
+                    .on_mouse_up_out(
+                        MouseButton::Left,
+                        cx.listener(|this, _event, _window, cx| this.stop_recording(cx)),
+                    )
+                    .child(if self.recording.is_some() {
+                        Icon::new(IconName::MicEnable)
+                            .size_5()
+                            .text_color(RECORDING_COLOR)
+                    } else {
                         Icon::new(IconName::MicEnable)
                             .size_5()
                             .text_color(theme.text_muted)
-                            .hover(|s| s.text_color(icon_hover)),
-                    ),
+                            .hover(|s| s.text_color(icon_hover))
+                    }),
             )
             .child(
                 div()
@@ -1876,22 +2008,40 @@ impl Render for MentionInput {
                         .size_full(),
                     )
                     .child(
-                        self.picker_toggle("gif-toggle", IconName::Gif, gif_color)
-                            .on_click(cx.listener(|this, _, window, cx| {
-                                this.toggle_tab(SubPanel::Gifs, window, cx)
-                            })),
+                        self.picker_toggle(
+                            "gif-toggle",
+                            IconName::Gif,
+                            gif_color,
+                            icon_bg_hover,
+                            icon_hover,
+                        )
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.toggle_tab(SubPanel::Gifs, window, cx)
+                        })),
                     )
                     .child(
-                        self.picker_toggle("sticker-toggle", IconName::Sticker, sticker_color)
-                            .on_click(cx.listener(|this, _, window, cx| {
-                                this.toggle_tab(SubPanel::Stickers, window, cx)
-                            })),
+                        self.picker_toggle(
+                            "sticker-toggle",
+                            IconName::Sticker,
+                            sticker_color,
+                            icon_bg_hover,
+                            icon_hover,
+                        )
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.toggle_tab(SubPanel::Stickers, window, cx)
+                        })),
                     )
                     .child(
-                        self.picker_toggle("emoji-toggle", IconName::Smile, toggle_color)
-                            .on_click(cx.listener(|this, _, window, cx| {
-                                this.toggle_tab(SubPanel::Emoji, window, cx)
-                            })),
+                        self.picker_toggle(
+                            "emoji-toggle",
+                            IconName::Smile,
+                            toggle_color,
+                            icon_bg_hover,
+                            icon_hover,
+                        )
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.toggle_tab(SubPanel::Emoji, window, cx)
+                        })),
                     ),
             )
             .when_some(popup, |this, popup| this.child(popup))

--- a/crates/mezon-ui/src/chat/mention_input/recorder.rs
+++ b/crates/mezon-ui/src/chat/mention_input/recorder.rs
@@ -1,0 +1,141 @@
+use std::path::PathBuf;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use gpui::Task;
+use mezon_audio::VoiceEncoder;
+use mezon_store::{MicCaptureHandle, MicPcmFormat};
+
+use super::attachments::PendingAttachment;
+
+pub(super) const MIN_RECORDING_MILLIS: u128 = 500;
+const VOICE_FILETYPE: &str = "audio/ogg";
+
+pub(super) struct ActiveRecording {
+    capture: Option<MicCaptureHandle>,
+    generation: u64,
+    started_at: Instant,
+}
+
+impl ActiveRecording {
+    pub(super) fn opening(generation: u64) -> Self {
+        Self {
+            capture: None,
+            generation,
+            started_at: Instant::now(),
+        }
+    }
+
+    pub(super) fn attach(&mut self, generation: u64, capture: MicCaptureHandle) -> bool {
+        if self.generation != generation {
+            return false;
+        }
+        self.capture = Some(capture);
+        true
+    }
+
+    pub(super) fn is_live(&self) -> bool {
+        self.capture.is_some()
+    }
+
+    pub(super) fn elapsed_millis(&self) -> u128 {
+        self.started_at.elapsed().as_millis()
+    }
+}
+
+pub(super) type RecordTask = Task<()>;
+
+pub(super) async fn encode_recording(
+    pcm: flume::Receiver<Vec<f32>>,
+    format: MicPcmFormat,
+) -> anyhow::Result<PendingAttachment> {
+    let mut encoder = VoiceEncoder::new(format.sample_rate, format.channels)?;
+    while let Ok(chunk) = pcm.recv_async().await {
+        encoder.push(&chunk);
+        encoder.encode_ready_frames()?;
+    }
+    let recording = encoder.finish()?;
+
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis())
+        .unwrap_or_default();
+    let filename = format!("audio-{stamp}.ogg");
+    let path: PathBuf = std::env::temp_dir().join(&filename);
+    let size = recording.bytes.len() as u64;
+    std::fs::write(&path, recording.bytes)?;
+
+    Ok(PendingAttachment {
+        path,
+        filename,
+        filetype: VOICE_FILETYPE.to_string(),
+        size,
+        is_image: false,
+        is_video: false,
+        width: 0,
+        height: 0,
+        duration: recording.duration_secs.round() as i32,
+        poster_jpeg: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn capture(rate: u32, channels: u16, seconds: f64) -> flume::Receiver<Vec<f32>> {
+        let (sender, receiver) = flume::unbounded();
+        let frames = (rate as f64 * seconds) as usize;
+        let mut chunk = Vec::new();
+        for frame in 0..frames {
+            let phase = frame as f64 / rate as f64 * 440.0 * std::f64::consts::TAU;
+            let sample = (phase.sin() * 0.5) as f32;
+            for _ in 0..channels {
+                chunk.push(sample);
+            }
+            if chunk.len() >= 1024 {
+                sender.send(std::mem::take(&mut chunk)).expect("send");
+            }
+        }
+        if !chunk.is_empty() {
+            sender.send(chunk).expect("send");
+        }
+        receiver
+    }
+
+    #[test]
+    fn encodes_captured_pcm_into_a_playable_attachment() {
+        let format = MicPcmFormat {
+            sample_rate: 44_100,
+            channels: 2,
+        };
+        let attachment =
+            futures::executor::block_on(encode_recording(capture(44_100, 2, 1.6), format))
+                .expect("recording");
+
+        assert_eq!(attachment.filetype, "audio/ogg");
+        assert!(attachment.filename.ends_with(".ogg"));
+        assert_eq!(attachment.duration, 2);
+        assert!(!attachment.is_image && !attachment.is_video);
+        assert!(attachment.size > 0);
+
+        let bytes = std::fs::read(&attachment.path).expect("recorded file exists");
+        assert_eq!(attachment.size, bytes.len() as u64);
+        let decoded = mezon_audio::decode_audio(bytes).expect("the player can decode it");
+        assert_eq!(decoded.sample_rate, 48_000);
+        assert_eq!(decoded.channels, 1);
+        assert!((decoded.duration_secs() - 1.6).abs() < 0.1);
+
+        std::fs::remove_file(&attachment.path).ok();
+    }
+
+    #[test]
+    fn a_capture_with_no_samples_is_an_error() {
+        let format = MicPcmFormat {
+            sample_rate: 48_000,
+            channels: 1,
+        };
+        let (sender, receiver) = flume::unbounded::<Vec<f32>>();
+        drop(sender);
+        assert!(futures::executor::block_on(encode_recording(receiver, format)).is_err());
+    }
+}

--- a/crates/mezon-ui/src/chat/message/audio_player.rs
+++ b/crates/mezon-ui/src/chat/message/audio_player.rs
@@ -1,15 +1,20 @@
+use std::sync::Arc;
 use std::time::Duration;
 
+use futures::AsyncReadExt;
 use gpui::{
-    App, ClickEvent, Context, ElementId, Rgba, SharedString, Task, Window, div, prelude::*, px,
+    App, ClickEvent, Context, ElementId, Rgba, SharedString, Task, Window, div,
+    http_client::HttpClient, prelude::*, px,
 };
-use mezon_audio::AudioPlayer;
+use mezon_audio::{AudioPlayer, DecodedPcm, PcmStream};
 use mezon_store::PlatformStore;
 
 use crate::components::primitives::{Icon, IconName, Sizable, Size, Spinner};
 
 const AUDIO_FETCH_MAX_BYTES: usize = 64 * 1024 * 1024;
 const AUDIO_TICK_INTERVAL: Duration = Duration::from_millis(250);
+const AUDIO_FETCH_CHUNK: usize = 64 * 1024;
+const AUDIO_FETCH_QUEUE: usize = 8;
 
 const PILL_BG: Rgba = Rgba {
     r: 0x50 as f32 / 255.,
@@ -87,24 +92,25 @@ impl AudioPlayerView {
         }
         let client = cx.http_client();
         self._load_task = Some(cx.spawn(async move |this, cx| {
-            let fetch = async {
-                let mut response = client.get(url.as_ref(), ().into(), true).await?;
-                if !response.status().is_success() {
-                    anyhow::bail!("audio fetch status {}", response.status());
+            let (byte_tx, byte_rx) = flume::bounded(AUDIO_FETCH_QUEUE);
+            let ready = mezon_audio::spawn_stream_decode(byte_rx);
+            let fetch = cx
+                .background_executor()
+                .spawn(async move { fetch_audio(client, url, byte_tx).await });
+
+            if let Ok(Ok(stream)) = ready.recv_async().await {
+                let _ = this.update(cx, |view, cx| view.on_stream_ready(stream, cx));
+                if let Err(err) = fetch.await {
+                    tracing::warn!("audio download failed: {err}");
                 }
-                let body =
-                    crate::image_cache::read_body_limited(&mut response, AUDIO_FETCH_MAX_BYTES)
-                        .await?;
-                anyhow::Ok(body)
-            };
+                return;
+            }
+
             let bytes = match fetch.await {
                 Ok(bytes) => bytes,
                 Err(err) => {
                     tracing::warn!("audio download failed: {err}");
-                    let _ = this.update(cx, |view, cx| {
-                        view.state = LoadState::Failed;
-                        cx.notify();
-                    });
+                    let _ = this.update(cx, |view, cx| view.on_load_failed(cx));
                     return;
                 }
             };
@@ -112,26 +118,43 @@ impl AudioPlayerView {
                 .background_executor()
                 .spawn(async move { mezon_audio::decode_audio(bytes) })
                 .await;
-            let _ = this.update(cx, |view, cx| {
-                match decoded {
-                    Ok(pcm) => {
-                        view.state = LoadState::Ready;
-                        if let Some(player) = &view.player {
-                            player.set_data(pcm);
-                            if view.want_play {
-                                player.play();
-                                view.restart_tick(cx);
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        tracing::warn!("audio decode failed: {err}");
-                        view.state = LoadState::Failed;
-                    }
+            let _ = this.update(cx, |view, cx| match decoded {
+                Ok(pcm) => view.on_pcm_ready(pcm, cx),
+                Err(err) => {
+                    tracing::warn!("audio decode failed: {err}");
+                    view.on_load_failed(cx);
                 }
-                cx.notify();
             });
         }));
+    }
+
+    fn on_stream_ready(&mut self, stream: Arc<PcmStream>, cx: &mut Context<Self>) {
+        self.state = LoadState::Ready;
+        if let Some(player) = &self.player {
+            player.set_stream(stream);
+            if self.want_play {
+                player.play();
+                self.restart_tick(cx);
+            }
+        }
+        cx.notify();
+    }
+
+    fn on_pcm_ready(&mut self, pcm: DecodedPcm, cx: &mut Context<Self>) {
+        self.state = LoadState::Ready;
+        if let Some(player) = &self.player {
+            player.set_data(pcm);
+            if self.want_play {
+                player.play();
+                self.restart_tick(cx);
+            }
+        }
+        cx.notify();
+    }
+
+    fn on_load_failed(&mut self, cx: &mut Context<Self>) {
+        self.state = LoadState::Failed;
+        cx.notify();
     }
 
     fn is_ready(&self) -> bool {
@@ -381,6 +404,43 @@ pub(crate) fn audio_failed_pill(duration: f64) -> gpui::AnyElement {
         .into_any_element()
 }
 
+async fn fetch_audio(
+    client: Arc<dyn HttpClient>,
+    url: SharedString,
+    byte_tx: flume::Sender<Vec<u8>>,
+) -> anyhow::Result<Vec<u8>> {
+    let mut response = client.get(url.as_ref(), ().into(), true).await?;
+    if !response.status().is_success() {
+        anyhow::bail!("audio fetch status {}", response.status());
+    }
+    if let Some(length) = response
+        .headers()
+        .get("content-length")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        && length > AUDIO_FETCH_MAX_BYTES as u64
+    {
+        anyhow::bail!(
+            "response body of {length} bytes exceeds the {AUDIO_FETCH_MAX_BYTES} byte transfer limit"
+        );
+    }
+
+    let mut body = Vec::new();
+    let mut buffer = vec![0u8; AUDIO_FETCH_CHUNK];
+    loop {
+        let read = response.body_mut().read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        if body.len() + read > AUDIO_FETCH_MAX_BYTES {
+            anyhow::bail!("response body exceeds the {AUDIO_FETCH_MAX_BYTES} byte transfer limit");
+        }
+        body.extend_from_slice(&buffer[..read]);
+        let _ = byte_tx.send_async(buffer[..read].to_vec()).await;
+    }
+    Ok(body)
+}
+
 fn open_audio_external(url: &str, cx: &mut App) {
     if let Some(store) = PlatformStore::try_global(cx) {
         let _ = store.read(cx).open_url_external(url);
@@ -401,9 +461,24 @@ fn format_mmss(total: f64) -> String {
 }
 
 fn time_label(current: f64, duration: f64) -> String {
+    if whole_seconds(duration) == 0 {
+        return format_mmss(current);
+    }
     format!("{} / {}", format_mmss(current), format_mmss(duration))
 }
 
 pub(crate) fn audio_time_label(current: f64, duration: f64) -> SharedString {
     SharedString::from(time_label(current, duration))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::time_label;
+
+    #[test]
+    fn the_total_is_hidden_until_it_is_known() {
+        assert_eq!(time_label(0.0, 0.0), "0:00");
+        assert_eq!(time_label(5.0, 0.0), "0:05");
+        assert_eq!(time_label(5.0, 222.0), "0:05 / 3:42");
+    }
 }

--- a/crates/vendor/gpui/src/elements/div.rs
+++ b/crates/vendor/gpui/src/elements/div.rs
@@ -2211,7 +2211,7 @@ impl Interactivity {
                             let result = f(&style, scroll_offset, hitbox, window, cx);
                             if self.suppress_hover_while_scrolling
                                 && self.tracked_scroll_handle.as_ref().is_some_and(|handle| {
-                                    handle.0.borrow().is_scroll_hover_suppressed()
+                                    handle.0.borrow().is_scroll_hover_active()
                                 })
                             {
                                 window.insert_hitbox(


### PR DESCRIPTION
## Summary
- Add mic PCM capture via `mezon-native`/`AudioStore`, with composer hold-to-record in `MentionInput`
- Encode voice clips in `mezon-audio` and send as attachments with duration metadata
- Stream-decode voice attachments during download for faster playback start

## Test plan
- [ ] Hold mic button in composer → recording UI shows, release → voice attachment appears
- [ ] Send voice message in channel/DM → uploads and renders with correct duration
- [ ] Play incoming voice message while still downloading → audio starts without waiting for full file
- [ ] Cancel recording before minimum duration → no attachment added
- [ ] `cargo check -p mezon-app` passes on macOS


Made with [Cursor](https://cursor.com)