### PR TITLE
Fix: active clan pill and macos window control tiling

### DIFF
--- a/crates/mezon-ui/src/app/root.rs
+++ b/crates/mezon-ui/src/app/root.rs
@@ -262,9 +262,6 @@ impl Render for RootView {
                 this.child(render_title_bar(self.title_bar.clone()))
             })
             .child(content)
-            .when(cfg!(target_os = "macos"), |this| {
-                this.child(window_controls::render_controls(theme, window))
-            })
             .when(window_controls::is_edge_resizable(), |this| {
                 this.child(window_controls::render_resize_edges(window))
             })

--- a/crates/mezon-ui/src/app/window_controls.rs
+++ b/crates/mezon-ui/src/app/window_controls.rs
@@ -27,14 +27,11 @@ use windows as platform;
 pub const HAS_CUSTOM_TITLE_BAR: bool = cfg!(any(target_os = "linux", target_os = "windows"));
 pub const APP_NAME: &str = "Mezon";
 
-/// React `SidebarMenu`: `mt-[21px]` on desktop + sticky `pt-3` (12px).
 pub const MACOS_TITLEBAR_INSET: f32 = 21.0;
 pub const CLAN_SIDEBAR_STICKY_TOP: f32 = 12.0;
 
-pub const MACOS_TRAFFIC_LIGHT_BUTTON_SIZE: f32 = 12.0;
-pub const MACOS_TRAFFIC_LIGHT_GAP: f32 = 8.0;
-pub const MACOS_TRAFFIC_LIGHT_PADDING_X: f32 = 12.0;
-pub const MACOS_TRAFFIC_LIGHT_PADDING_Y: f32 = 12.0;
+pub const MACOS_TRAFFIC_LIGHT_X: f32 = 10.0;
+pub const MACOS_TRAFFIC_LIGHT_Y: f32 = 9.0;
 
 pub const NAV_ARROW_ICON_SIZE: f32 = 20.0;
 pub const NAV_ARROW_BUTTON_PADDING: f32 = 4.0;
@@ -60,8 +57,10 @@ pub fn window_title_options() -> TitlebarOptions {
         TitlebarOptions {
             title: None,
             appears_transparent: true,
-            // Hide native traffic lights; we paint custom controls like the React app.
-            traffic_light_position: Some(point(px(-100.), px(-100.))),
+            traffic_light_position: Some(point(
+                px(MACOS_TRAFFIC_LIGHT_X),
+                px(MACOS_TRAFFIC_LIGHT_Y),
+            )),
         }
     }
     #[cfg(not(target_os = "macos"))]
@@ -75,20 +74,7 @@ pub fn window_title_options() -> TitlebarOptions {
 }
 
 pub fn viewer_title_options() -> TitlebarOptions {
-    #[cfg(target_os = "macos")]
-    {
-        use gpui::{point, px};
-
-        TitlebarOptions {
-            title: None,
-            appears_transparent: true,
-            traffic_light_position: Some(point(px(13.), px(9.))),
-        }
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        window_title_options()
-    }
+    window_title_options()
 }
 
 pub fn main_window_decorations() -> Option<WindowDecorations> {

--- a/crates/mezon-ui/src/app/window_controls.rs
+++ b/crates/mezon-ui/src/app/window_controls.rs
@@ -73,10 +73,6 @@ pub fn window_title_options() -> TitlebarOptions {
     }
 }
 
-pub fn viewer_title_options() -> TitlebarOptions {
-    window_title_options()
-}
-
 pub fn main_window_decorations() -> Option<WindowDecorations> {
     #[cfg(target_os = "linux")]
     {

--- a/crates/mezon-ui/src/app/window_controls/macos.rs
+++ b/crates/mezon-ui/src/app/window_controls/macos.rs
@@ -1,17 +1,11 @@
 use block::ConcreteBlock;
-use gpui::{App, Window, WindowHandle, div, prelude::*, px, rgb};
+use gpui::{App, Window, WindowHandle, div, prelude::*};
 use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use std::sync::{Once, OnceLock};
 
-use crate::components::primitives::{Icon, IconName};
 use crate::theme::Theme;
-
-use super::{
-    MACOS_TRAFFIC_LIGHT_BUTTON_SIZE, MACOS_TRAFFIC_LIGHT_GAP, MACOS_TRAFFIC_LIGHT_PADDING_X,
-    MACOS_TRAFFIC_LIGHT_PADDING_Y,
-};
 
 const NS_KEY_DOWN_MASK: u64 = 1 << 10;
 const NS_COMMAND_KEY_MASK: u64 = 1 << 20;
@@ -27,67 +21,7 @@ unsafe impl Sync for EventMonitor {}
 static EVENT_MONITOR: OnceLock<EventMonitor> = OnceLock::new();
 
 pub fn render_controls(_theme: &Theme, _window: &Window) -> impl IntoElement {
-    let zoom_icon = IconName::MacOSMaximizeIcon;
-
     div()
-        .id("macos-window-controls")
-        .absolute()
-        .top_0()
-        .left_0()
-        .flex()
-        .flex_row()
-        .items_center()
-        .gap(px(MACOS_TRAFFIC_LIGHT_GAP))
-        .pl(px(MACOS_TRAFFIC_LIGHT_PADDING_X))
-        .pr(px(8.))
-        .py(px(MACOS_TRAFFIC_LIGHT_PADDING_Y))
-        .child(macos_traffic_button(
-            "macos-close",
-            rgb(0xff5f57),
-            IconName::MacOSCloseIcon,
-            |window, _| hide_window(window),
-        ))
-        .child(macos_traffic_button(
-            "macos-minimize",
-            rgb(0xffbd2e),
-            IconName::MacOSMinimizeIcon,
-            |window, _| window.minimize_window(),
-        ))
-        .child(macos_traffic_button(
-            "macos-zoom",
-            rgb(0x28ca42),
-            zoom_icon,
-            |window, _| window.zoom_window(),
-        ))
-}
-
-fn macos_traffic_button(
-    id: &'static str,
-    background: gpui::Rgba,
-    icon: IconName,
-    on_click: impl Fn(&mut Window, &mut App) + 'static,
-) -> impl IntoElement {
-    div()
-        .id(id)
-        .group("macos-traffic")
-        .flex()
-        .items_center()
-        .justify_center()
-        .size(px(MACOS_TRAFFIC_LIGHT_BUTTON_SIZE))
-        .rounded_full()
-        .bg(background)
-        .cursor_pointer()
-        .on_click(move |_, window, cx| on_click(window, cx))
-        .child(
-            div()
-                .opacity(0.)
-                .group_hover("macos-traffic", |s| s.opacity(100.))
-                .flex()
-                .items_center()
-                .justify_center()
-                .size_full()
-                .child(Icon::new(icon).size(px(8.)).text_color(gpui::black())),
-        )
 }
 
 pub fn hide_window(window: &Window) {

--- a/crates/mezon-ui/src/app/window_controls/macos.rs
+++ b/crates/mezon-ui/src/app/window_controls/macos.rs
@@ -36,6 +36,12 @@ pub fn minimize_active_window(cx: &mut App) {
     update_active_window(cx, |window| window.minimize_window());
 }
 
+pub fn disable_window_fullscreen(window: &Window) {
+    if let Some(view) = appkit_view(window) {
+        disable_fullscreen(view);
+    }
+}
+
 pub fn configure_window<V: 'static>(cx: &mut App, handle: WindowHandle<V>) {
     if let Err(error) = cx.update_window(handle.into(), |_, window, cx| {
         window.on_window_should_close(cx, |window, _| {
@@ -43,9 +49,7 @@ pub fn configure_window<V: 'static>(cx: &mut App, handle: WindowHandle<V>) {
             false
         });
 
-        if let Some(view) = appkit_view(window) {
-            disable_fullscreen(view);
-        }
+        disable_window_fullscreen(window);
     }) {
         tracing::warn!("Failed to configure window: {error}");
     }

--- a/crates/mezon-ui/src/image_viewer/mod.rs
+++ b/crates/mezon-ui/src/image_viewer/mod.rs
@@ -152,7 +152,15 @@ fn spawn_image_viewer_window(
     match cx.open_window(options, |window, cx| {
         cx.new(|cx| ImageViewer::new(request, window, cx))
     }) {
-        Ok(handle) => cx.set_global(GlobalImageViewer(handle)),
+        Ok(handle) => {
+            #[cfg(target_os = "macos")]
+            if let Err(error) = handle.update(cx, |_, window, _| {
+                window_controls::macos::disable_window_fullscreen(window);
+            }) {
+                tracing::warn!("Failed to configure image viewer window: {error}");
+            }
+            cx.set_global(GlobalImageViewer(handle));
+        }
         Err(e) => tracing::error!("failed to open image viewer window: {e}"),
     }
 }
@@ -914,6 +922,7 @@ impl Render for ImageViewer {
             .when_some(self.context_menu, |el, pos| {
                 el.child(context_menu_at(pos, self.build_context_menu(&locale, cx)))
             })
+            .child(window_controls::render_app_drag_header())
             .when(window_controls::is_edge_resizable(), |el| {
                 el.child(window_controls::render_resize_edges(window))
             })
@@ -922,7 +931,9 @@ impl Render for ImageViewer {
 
 impl ImageViewer {
     fn render_app_title_strip(&self, theme: &Theme) -> impl IntoElement {
-        div().flex_shrink_0().h_8().w_full().bg(theme.title_bar_bg)
+        window_controls::window_drag_handle(
+            div().flex_shrink_0().h_8().w_full().bg(theme.title_bar_bg),
+        )
     }
 
     fn render_channel_header(&self, theme: &Theme) -> impl IntoElement {

--- a/crates/mezon-ui/src/image_viewer/mod.rs
+++ b/crates/mezon-ui/src/image_viewer/mod.rs
@@ -144,7 +144,7 @@ fn spawn_image_viewer_window(
         kind: WindowKind::Normal,
         focus: true,
         show: true,
-        titlebar: Some(window_controls::viewer_title_options()),
+        titlebar: Some(window_controls::window_title_options()),
         window_decorations: window_controls::main_window_decorations(),
         ..Default::default()
     };

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
@@ -55,7 +55,7 @@ pub(super) fn render_pill(
     let anim_id = SharedString::from(format!("pill-{group_name}"));
     div()
         .absolute()
-        .left_0()
+        .left(px(8.))
         .top_0()
         .bottom_0()
         .flex()
@@ -63,7 +63,7 @@ pub(super) fn render_pill(
         .child(
             div()
                 .w(px(4.))
-                .rounded_r(px(4.))
+                .rounded_full()
                 .bg(pill_color)
                 .with_animation(
                     anim_id,


### PR DESCRIPTION
- Change macOS window control from custom gpui to native component to support window tiling
- Fix active clan pill bar space from app window

**BEFORE CHANGE:**
<img width="256" height="241" alt="Screenshot 2026-07-14 at 23 57 30" src="https://github.com/user-attachments/assets/6999b142-fb83-49cd-8d9b-60f2919cc069" />

**AFTER CHANGE:**
<img width="243" height="204" alt="Screenshot 2026-07-14 at 23 29 37" src="https://github.com/user-attachments/assets/463c47a6-46ec-49df-8955-6365f13425c3" />
