### PR TITLE
feat(notifications): channel notification settings and push delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5771,9 +5771,10 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
+ "tokio-tungstenite",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5789,6 +5790,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "auto-launch",
+ "block",
  "cpal",
  "crossbeam-channel",
  "dirs 5.0.1",
@@ -10315,6 +10317,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -11358,6 +11361,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]

--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -56,6 +56,25 @@ fn main() -> Result<()> {
 
     tracing::info!("Starting Mezon desktop app v{}", env!("CARGO_PKG_VERSION"));
 
+    #[cfg(debug_assertions)]
+    if std::env::args().any(|a| a == "--notify-test") {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        mezon_native::notifications::init();
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        mezon_native::notifications::show(&mezon_native::notifications::Notification {
+            title: "Mezon".to_string(),
+            body: format!("Test notification #{nonce} — desktop notifications work."),
+            channel_id: Some(nonce.to_string()),
+            clan_id: Some("456".to_string()),
+            link: None,
+        });
+        std::thread::sleep(std::time::Duration::from_secs(3));
+        return Ok(());
+    }
+
     // Check if a mezonapp:// deep link URL was passed as argv[1].
     let deep_link_url: Option<String> = std::env::args()
         .nth(1)
@@ -342,6 +361,7 @@ fn run_app(lock: SingleInstance, initial_url: Option<String>) {
                 .spawn(async move {
                     mezon_native::autostart::sync_auto_start(auto_start);
                     mezon_native::deep_link::register_deep_link_scheme();
+                    mezon_native::notifications::init();
                 })
                 .detach();
         }
@@ -604,6 +624,8 @@ fn open_main_window(
     mezon_store::GalleryStore::init(api.clone(), cx);
     mezon_store::FilesStore::init(api.clone(), cx);
     mezon_store::PermissionStore::init(api.clone(), auth_state.clone(), cx);
+    mezon_store::NotificationSettingStore::init(api.clone(), cx);
+    mezon_store::NotificationPushStore::init(api.clone(), auth_state.clone(), cx);
     mezon_store::AccountStore::init(api, cx);
 
     let platform_store = mezon_store::PlatformStore::init(cx);
@@ -624,10 +646,38 @@ fn open_main_window(
                 title: n.title,
                 body: n.body,
                 channel_id: n.channel_id,
+                clan_id: n.clan_id,
+                link: n.link,
             });
         }),
         cx,
     );
+
+    {
+        let (click_tx, mut click_rx) =
+            futures::channel::mpsc::unbounded::<mezon_native::notifications::NotificationTarget>();
+        mezon_native::notifications::set_click_handler(Box::new(move |target| {
+            let _ = click_tx.unbounded_send(target);
+        }));
+        let task = cx.spawn(async move |cx: &mut AsyncApp| {
+            while let Some(target) = click_rx.next().await {
+                let _ = cx.update(|cx| {
+                    activate_main_window(cx);
+                    tracing::debug!(
+                        clan_id = ?target.clan_id,
+                        channel_id = %target.channel_id,
+                        link = ?target.link,
+                        "notification clicked"
+                    );
+                    match notification_route(&target) {
+                        Some(route) => mezon_ui::router::navigate(cx, route),
+                        None => tracing::warn!("notification click with unroutable target"),
+                    }
+                });
+            }
+        });
+        cx.set_global(NotificationClickGlobal(task));
+    }
 
     let audio_store = mezon_store::AudioStore::init(cx);
     mezon_store::AudioStore::set_device_enumerator(
@@ -700,21 +750,25 @@ impl gpui::Global for SingleInstanceGlobal {}
 struct BadgeBridgeGlobal {
     _clan: gpui::Subscription,
     _dm: gpui::Subscription,
+    _friends: gpui::Subscription,
 }
 impl gpui::Global for BadgeBridgeGlobal {}
 
 fn install_badge_bridge(cx: &mut App) {
     let clan_list = mezon_store::ClanList::global(cx);
     let dm_store = mezon_store::DirectMessageStore::global(cx);
+    let friend_store = mezon_store::FriendStore::global(cx);
 
     update_native_badge(cx);
 
     let clan_sub = cx.observe(&clan_list, |_, cx| update_native_badge(cx));
     let dm_sub = cx.observe(&dm_store, |_, cx| update_native_badge(cx));
+    let friends_sub = cx.observe(&friend_store, |_, cx| update_native_badge(cx));
 
     cx.set_global(BadgeBridgeGlobal {
         _clan: clan_sub,
         _dm: dm_sub,
+        _friends: friends_sub,
     });
 }
 
@@ -734,7 +788,12 @@ fn update_native_badge(cx: &App) {
         .iter()
         .map(|channel| channel.unread_count)
         .sum();
-    let total = clan_total.saturating_add(dm_total);
+    let pending_friend_requests = mezon_store::FriendStore::try_global(cx)
+        .map(|store| store.read(cx).pending_incoming_count() as u32)
+        .unwrap_or(0);
+    let total = clan_total
+        .saturating_add(dm_total)
+        .saturating_add(pending_friend_requests);
 
     if LAST_BADGE.swap(total, Ordering::Relaxed) != total {
         mezon_native::badge::set_badge_count(total);
@@ -743,6 +802,41 @@ fn update_native_badge(cx: &App) {
 
 fn show_main_window(cx: &mut App) {
     activate_main_window(cx);
+}
+
+struct NotificationClickGlobal(#[allow(dead_code)] gpui::Task<()>);
+impl gpui::Global for NotificationClickGlobal {}
+
+fn notification_route(
+    target: &mezon_native::notifications::NotificationTarget,
+) -> Option<mezon_ui::Route> {
+    // Prefer the server-rendered path (React `extras.link`), which routes correctly
+    // regardless of whether the clan is cached locally. The link is an absolute URL
+    // (`https://mezon.ai/chat/...`), so route on its path component.
+    if let Some(link) = target.link.as_deref().filter(|l| !l.is_empty()) {
+        let path = link
+            .split_once("://")
+            .map(|(_, rest)| rest.find('/').map_or("/", |i| &rest[i..]))
+            .unwrap_or(link);
+        let route = mezon_ui::Route::from_path(path);
+        if !matches!(route, mezon_ui::Route::NotFound { .. }) {
+            return Some(route);
+        }
+    }
+    let channel_id = target.channel_id.parse::<mezon_store::ChannelId>().ok()?;
+    match target.clan_id.as_deref() {
+        Some(clan) => {
+            let clan_id = clan.parse::<mezon_store::ClanId>().ok()?;
+            Some(mezon_ui::Route::Channel {
+                clan_id,
+                channel_id,
+            })
+        }
+        None => Some(mezon_ui::Route::DirectMessage {
+            direct_id: channel_id,
+            message_type: "3".into(),
+        }),
+    }
 }
 
 struct TrayGlobal(#[allow(dead_code)] mezon_native::tray::MezonTray);

--- a/crates/mezon-client/Cargo.toml
+++ b/crates/mezon-client/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 mezon-proto.workspace = true
 tokio.workspace = true
 tokio-rustls = { version = "0.26", features = ["ring"] }
+tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 webpki-roots = "1.0.7"
 http_client.workspace = true
 reqwest_client.workspace = true

--- a/crates/mezon-client/src/app_api.rs
+++ b/crates/mezon-client/src/app_api.rs
@@ -1738,6 +1738,68 @@ impl AppApi {
         self.transport.get_notification_clan(clan_id).await
     }
 
+    pub async fn get_notification_channel(
+        &self,
+        channel_id: i64,
+    ) -> Result<crate::ChannelNotificationSetting> {
+        let dto = self.transport.get_notification_channel(channel_id).await?;
+        Ok(crate::ChannelNotificationSetting::from_api(&dto))
+    }
+
+    pub async fn set_notification_channel_setting(
+        &self,
+        channel_id: i64,
+        notification_type: i32,
+        clan_id: i64,
+    ) -> Result<()> {
+        self.transport
+            .set_notification_channel_setting(channel_id, notification_type, clan_id)
+            .await
+    }
+
+    pub async fn delete_notification_channel(&self, channel_id: i64) -> Result<()> {
+        self.transport.delete_notification_channel(channel_id).await
+    }
+
+    pub async fn set_mute_channel(
+        &self,
+        channel_id: i64,
+        mute_seconds: i32,
+        clan_id: i64,
+    ) -> Result<()> {
+        self.transport
+            .set_mute_channel(channel_id, mute_seconds, clan_id)
+            .await
+    }
+
+    pub async fn list_muted_channels(&self, clan_id: i64) -> Result<Vec<String>> {
+        self.transport.list_muted_channels(clan_id).await
+    }
+
+    pub fn spawn_gotify_stream(
+        &self,
+        ws_base: String,
+        token: String,
+    ) -> tokio::sync::mpsc::UnboundedReceiver<crate::gotify::GotifyNotification> {
+        self.transport.spawn_gotify_stream(ws_base, token)
+    }
+
+    /// Register a device token and return the Gotify notification-stream token.
+    pub async fn regist_fcm_device_token(
+        &self,
+        token: &str,
+        device_id: &str,
+        platform: &str,
+    ) -> Result<String> {
+        self.transport
+            .regist_fcm_device_token(
+                token.to_string(),
+                device_id.to_string(),
+                platform.to_string(),
+            )
+            .await
+    }
+
     pub async fn list_notifications(
         &self,
         clan_id: &str,

--- a/crates/mezon-client/src/gotify.rs
+++ b/crates/mezon-client/src/gotify.rs
@@ -1,0 +1,166 @@
+use std::time::Duration;
+
+use futures::{SinkExt, StreamExt};
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message;
+
+const BACKOFF_BASE: Duration = Duration::from_secs(1);
+const BACKOFF_MAX: Duration = Duration::from_secs(32);
+const MAX_RECONNECT_ATTEMPTS: u32 = 10;
+const PING_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Server-rendered notification payload from the Gotify `/stream` endpoint,
+/// mirroring the React `NotificationData` shape. Snowflake ids arrive on the wire
+/// as JSON integers, so id fields are decoded from either a number or a string.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GotifyNotification {
+    #[serde(default, deserialize_with = "de_id")]
+    pub channel_id: String,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub image: String,
+    #[serde(default, deserialize_with = "de_id")]
+    pub sender_id: String,
+    #[serde(default)]
+    pub extras: GotifyExtras,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct GotifyExtras {
+    #[serde(default)]
+    pub link: String,
+    #[serde(default)]
+    pub e2eemess: String,
+    #[serde(default, rename = "topicId", deserialize_with = "de_id")]
+    pub topic_id: String,
+    #[serde(default, rename = "messageId", deserialize_with = "de_id")]
+    pub message_id: String,
+}
+
+/// Decode a snowflake id that may arrive as a JSON number, string, or null.
+fn de_id<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize as _;
+    match serde_json::Value::deserialize(deserializer)? {
+        serde_json::Value::String(s) => Ok(s),
+        serde_json::Value::Number(n) => Ok(n.to_string()),
+        serde_json::Value::Null => Ok(String::new()),
+        other => Ok(other.to_string()),
+    }
+}
+
+/// Run the Gotify notification stream until `tx` is closed. Reconnects with
+/// exponential backoff (1s→32s, ×2, cap 10 attempts, reset on a clean open) and
+/// replies `pong` to each `ping`, treating a 60s ping gap as a dead connection.
+/// Parsed notifications are forwarded to `tx`; suppression is the caller's job.
+pub async fn run_stream(
+    ws_base: String,
+    token: String,
+    tx: mpsc::UnboundedSender<GotifyNotification>,
+) {
+    let url = format!("{}/stream?token={token}", ws_base.trim_end_matches('/'));
+    let mut attempts: u32 = 0;
+    let mut backoff = BACKOFF_BASE;
+
+    loop {
+        if tx.is_closed() {
+            return;
+        }
+        match connect_once(&url, &tx).await {
+            ConnectOutcome::StopClean => return,
+            ConnectOutcome::Opened => {
+                attempts = 0;
+                backoff = BACKOFF_BASE;
+            }
+            ConnectOutcome::FailedBeforeOpen => {}
+        }
+
+        attempts += 1;
+        if attempts >= MAX_RECONNECT_ATTEMPTS {
+            tracing::warn!("gotify: giving up after {MAX_RECONNECT_ATTEMPTS} reconnect attempts");
+            return;
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(BACKOFF_MAX);
+    }
+}
+
+enum ConnectOutcome {
+    /// Opened and later dropped by ping-timeout or read error — reconnect.
+    Opened,
+    /// Never opened (connect error) — reconnect after backoff.
+    FailedBeforeOpen,
+    /// Clean close (server Close frame / receiver dropped) — do not reconnect,
+    /// matching React's `onclose` which only marks the socket inactive.
+    StopClean,
+}
+
+async fn connect_once(url: &str, tx: &mpsc::UnboundedSender<GotifyNotification>) -> ConnectOutcome {
+    let stream = match tokio_tungstenite::connect_async(url).await {
+        Ok((stream, _)) => stream,
+        Err(e) => {
+            tracing::warn!("gotify: connect failed: {e}");
+            return ConnectOutcome::FailedBeforeOpen;
+        }
+    };
+    tracing::debug!("gotify: stream connected");
+    let (mut write, mut read) = stream.split();
+
+    // The 60s watchdog advances only on a received `ping`, mirroring React's
+    // `startPingMonitoring`; a lapse means the connection is dead → reconnect.
+    let mut deadline = tokio::time::Instant::now() + PING_TIMEOUT;
+
+    loop {
+        let frame = tokio::select! {
+            () = tokio::time::sleep_until(deadline) => {
+                tracing::debug!("gotify: ping timeout, reconnecting");
+                return ConnectOutcome::Opened;
+            }
+            frame = read.next() => match frame {
+                None => return ConnectOutcome::StopClean,
+                Some(Err(e)) => {
+                    tracing::warn!("gotify: read error: {e}");
+                    return ConnectOutcome::Opened;
+                }
+                Some(Ok(frame)) => frame,
+            },
+        };
+
+        let text = match frame {
+            Message::Text(t) => t.to_string(),
+            Message::Binary(b) => match String::from_utf8(b.to_vec()) {
+                Ok(t) => t,
+                Err(_) => continue,
+            },
+            Message::Ping(p) => {
+                let _ = write.send(Message::Pong(p)).await;
+                continue;
+            }
+            Message::Close(_) => return ConnectOutcome::StopClean,
+            _ => continue,
+        };
+
+        let trimmed = text.trim();
+        if trimmed == "ping" || trimmed == "\"ping\"" {
+            let _ = write.send(Message::Text("pong".into())).await;
+            deadline = tokio::time::Instant::now() + PING_TIMEOUT;
+            continue;
+        }
+        tracing::debug!("gotify: raw frame: {trimmed}");
+
+        match serde_json::from_str::<GotifyNotification>(trimmed) {
+            Ok(notification) => {
+                if tx.send(notification).is_err() {
+                    return ConnectOutcome::StopClean;
+                }
+            }
+            Err(e) => tracing::debug!("gotify: unparseable frame: {e}"),
+        }
+    }
+}

--- a/crates/mezon-client/src/lib.rs
+++ b/crates/mezon-client/src/lib.rs
@@ -6,11 +6,13 @@ pub mod app_api;
 pub mod attachment_download;
 pub mod auth;
 pub mod channel_app_launch;
+pub mod gotify;
 pub mod image_disk_cache;
 pub mod inbox;
 pub mod keychain;
 pub mod network_monitor;
 pub mod network_probe;
+pub mod notification_setting;
 pub mod ogp;
 pub mod search_message;
 pub mod session;
@@ -31,6 +33,7 @@ pub use auth::MezonClient;
 pub use auth::QrLoginId;
 pub use auth::{DEFAULT_API_HOST, DEFAULT_API_PORT, DEFAULT_API_SECURE, DEFAULT_SERVER_KEY};
 pub use channel_app_launch::{ChannelAppLaunchParams, build_channel_app_url};
+pub use gotify::{GotifyExtras, GotifyNotification};
 pub use inbox::{
     DIRECTION_AROUND_TIMESTAMP, DIRECTION_BEFORE_TIMESTAMP, INBOX_PAGE_LIMIT, InboxCategory,
     InboxMentionSpan, InboxMessagePreview, InboxNotification, TopicDiscussion,
@@ -42,6 +45,7 @@ pub use network_monitor::NetworkMonitor;
 pub use network_probe::{
     RECONNECT_NETWORK_PROBE_TIMEOUT, favicon_probe_url, probe_network_reachability,
 };
+pub use notification_setting::ChannelNotificationSetting;
 pub use ogp::{OgpResult, fetch_ogp};
 pub use search_message::{
     SEARCH_PAGE_SIZE, SearchDropdownMode, SearchPageToken, active_search_trigger,

--- a/crates/mezon-client/src/notification_setting.rs
+++ b/crates/mezon-client/src/notification_setting.rs
@@ -1,0 +1,162 @@
+use mezon_proto::api;
+
+pub const NOTIFICATION_DEFAULT: i32 = 0;
+pub const NOTIFICATION_ALL_MESSAGE: i32 = 1;
+pub const NOTIFICATION_MENTION_MESSAGE: i32 = 2;
+pub const NOTIFICATION_NOTHING_MESSAGE: i32 = 3;
+
+pub const MUTE_UNMUTE: i32 = 0;
+pub const MUTE_INFINITY: i32 = -1;
+
+pub const MUTE_FOR_15_MINUTES_SEC: i32 = 15 * 60;
+pub const MUTE_FOR_1_HOUR_SEC: i32 = 60 * 60;
+pub const MUTE_FOR_3_HOURS_SEC: i32 = 3 * 60 * 60;
+pub const MUTE_FOR_8_HOURS_SEC: i32 = 8 * 60 * 60;
+pub const MUTE_FOR_24_HOURS_SEC: i32 = 24 * 60 * 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ChannelNotificationSetting {
+    pub id: i64,
+    pub level: i32,
+    pub mute_until_ms: i64,
+}
+
+impl ChannelNotificationSetting {
+    pub fn from_api(dto: &api::NotificationUserChannel) -> Self {
+        Self {
+            id: dto.id,
+            level: dto.notification_setting_type,
+            mute_until_ms: i64::from(dto.time_mute_seconds),
+        }
+    }
+
+    /// React stores `Date.now() + duration*1000` on write, so this field is an epoch
+    /// in milliseconds despite the wire name. `MUTE_INFINITY` never yields a date.
+    pub fn muted_until_ms(&self, now_ms: i64) -> Option<i64> {
+        (self.mute_until_ms > now_ms).then_some(self.mute_until_ms)
+    }
+
+    pub fn expiry_from_duration(now_ms: i64, mute_seconds: i32) -> i64 {
+        match mute_seconds {
+            MUTE_UNMUTE => 0,
+            MUTE_INFINITY => i64::from(MUTE_INFINITY),
+            seconds => now_ms + i64::from(seconds) * 1000,
+        }
+    }
+
+    /// Mirrors React `MuteButton`: an explicit per-channel override wins, otherwise
+    /// the category default is consulted, then the clan default.
+    pub fn is_muted(&self, category_default: Option<i32>, clan_default: Option<i32>) -> bool {
+        if self.mute_until_ms == 0 {
+            if self.level == NOTIFICATION_NOTHING_MESSAGE {
+                return true;
+            }
+        } else if self.id != 0 {
+            return true;
+        }
+        if self.id != 0 {
+            return false;
+        }
+        match category_default {
+            Some(level) => level == NOTIFICATION_NOTHING_MESSAGE,
+            None => clan_default == Some(NOTIFICATION_NOTHING_MESSAGE),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setting(id: i64, level: i32, mute_until_ms: i64) -> ChannelNotificationSetting {
+        ChannelNotificationSetting {
+            id,
+            level,
+            mute_until_ms,
+        }
+    }
+
+    #[test]
+    fn expiry_from_duration_matches_react_write_semantics() {
+        let now = 1_700_000_000_000;
+        assert_eq!(
+            ChannelNotificationSetting::expiry_from_duration(now, MUTE_FOR_15_MINUTES_SEC),
+            now + 900_000
+        );
+        assert_eq!(
+            ChannelNotificationSetting::expiry_from_duration(now, MUTE_UNMUTE),
+            0
+        );
+        assert_eq!(
+            ChannelNotificationSetting::expiry_from_duration(now, MUTE_INFINITY),
+            -1
+        );
+    }
+
+    #[test]
+    fn muted_until_is_hidden_when_expired_or_infinite() {
+        let now = 1_700_000_000_000;
+        assert_eq!(
+            setting(5, NOTIFICATION_DEFAULT, now + 60_000).muted_until_ms(now),
+            Some(now + 60_000)
+        );
+        assert_eq!(
+            setting(5, NOTIFICATION_DEFAULT, now - 60_000).muted_until_ms(now),
+            None
+        );
+        assert_eq!(
+            setting(5, NOTIFICATION_DEFAULT, -1).muted_until_ms(now),
+            None
+        );
+        assert_eq!(
+            setting(0, NOTIFICATION_DEFAULT, 0).muted_until_ms(now),
+            None
+        );
+    }
+
+    #[test]
+    fn nothing_message_without_mute_timer_is_muted() {
+        assert!(setting(5, NOTIFICATION_NOTHING_MESSAGE, 0).is_muted(None, None));
+    }
+
+    #[test]
+    fn override_with_mute_timer_is_muted() {
+        assert!(setting(5, NOTIFICATION_ALL_MESSAGE, 900).is_muted(None, None));
+    }
+
+    #[test]
+    fn explicit_override_ignores_category_and_clan_defaults() {
+        let s = setting(5, NOTIFICATION_ALL_MESSAGE, 0);
+        assert!(!s.is_muted(Some(NOTIFICATION_NOTHING_MESSAGE), None));
+        assert!(!s.is_muted(None, Some(NOTIFICATION_NOTHING_MESSAGE)));
+    }
+
+    #[test]
+    fn without_override_category_default_decides() {
+        let s = setting(0, NOTIFICATION_DEFAULT, 0);
+        assert!(s.is_muted(Some(NOTIFICATION_NOTHING_MESSAGE), None));
+        assert!(!s.is_muted(Some(NOTIFICATION_ALL_MESSAGE), None));
+    }
+
+    #[test]
+    fn without_override_or_category_clan_default_decides() {
+        let s = setting(0, NOTIFICATION_DEFAULT, 0);
+        assert!(s.is_muted(None, Some(NOTIFICATION_NOTHING_MESSAGE)));
+        assert!(!s.is_muted(None, Some(NOTIFICATION_ALL_MESSAGE)));
+        assert!(!s.is_muted(None, None));
+    }
+
+    #[test]
+    fn from_api_maps_every_field() {
+        let dto = api::NotificationUserChannel {
+            id: 7,
+            notification_setting_type: NOTIFICATION_MENTION_MESSAGE,
+            time_mute_seconds: 3600,
+            ..Default::default()
+        };
+        assert_eq!(
+            ChannelNotificationSetting::from_api(&dto),
+            setting(7, NOTIFICATION_MENTION_MESSAGE, 3600)
+        );
+    }
+}

--- a/crates/mezon-client/src/transport_runtime.rs
+++ b/crates/mezon-client/src/transport_runtime.rs
@@ -625,6 +625,95 @@ impl TransportClient {
             .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
     }
 
+    pub async fn get_notification_channel(
+        &self,
+        channel_id: i64,
+    ) -> Result<mezon_proto::api::NotificationUserChannel> {
+        let transport = self.inner.clone();
+        runtime()
+            .spawn(async move { transport.get_notification_channel(channel_id).await })
+            .await
+            .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
+    }
+
+    pub async fn set_notification_channel_setting(
+        &self,
+        channel_id: i64,
+        notification_type: i32,
+        clan_id: i64,
+    ) -> Result<()> {
+        let transport = self.inner.clone();
+        runtime()
+            .spawn(async move {
+                transport
+                    .set_notification_channel_setting(channel_id, notification_type, clan_id)
+                    .await
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
+    }
+
+    pub async fn delete_notification_channel(&self, channel_id: i64) -> Result<()> {
+        let transport = self.inner.clone();
+        runtime()
+            .spawn(async move { transport.delete_notification_channel(channel_id).await })
+            .await
+            .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
+    }
+
+    pub async fn set_mute_channel(
+        &self,
+        channel_id: i64,
+        mute_seconds: i32,
+        clan_id: i64,
+    ) -> Result<()> {
+        let transport = self.inner.clone();
+        runtime()
+            .spawn(async move {
+                transport
+                    .set_mute_channel(channel_id, mute_seconds, clan_id)
+                    .await
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
+    }
+
+    pub fn spawn_gotify_stream(
+        &self,
+        ws_base: String,
+        token: String,
+    ) -> tokio::sync::mpsc::UnboundedReceiver<crate::gotify::GotifyNotification> {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        runtime().spawn(crate::gotify::run_stream(ws_base, token, tx));
+        rx
+    }
+
+    pub async fn regist_fcm_device_token(
+        &self,
+        token: String,
+        device_id: String,
+        platform: String,
+    ) -> Result<String> {
+        let transport = self.inner.clone();
+        runtime()
+            .spawn(async move {
+                transport
+                    .regist_fcm_device_token(&token, &device_id, &platform)
+                    .await
+                    .map(|resp| resp.token)
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
+    }
+
+    pub async fn list_muted_channels(&self, clan_id: i64) -> Result<Vec<String>> {
+        let transport = self.inner.clone();
+        runtime()
+            .spawn(async move { transport.list_muted_channels(clan_id).await })
+            .await
+            .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
+    }
+
     pub async fn list_clan_descs(&self) -> Result<Vec<crate::transport::ApiClanDesc>> {
         tracing::debug!("TransportClient::list_clan_descs() called");
 

--- a/crates/mezon-native/Cargo.toml
+++ b/crates/mezon-native/Cargo.toml
@@ -25,6 +25,7 @@ auto-launch = "0.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc.workspace = true
+block = "0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows.workspace = true

--- a/crates/mezon-native/src/notifications.rs
+++ b/crates/mezon-native/src/notifications.rs
@@ -1,16 +1,107 @@
 /// Desktop notification support.
 ///
 /// macOS  : `UNUserNotificationCenter` via raw `objc` runtime calls.
-///          Requests authorisation on first call, then delivers the notification.
+///          Authorisation is requested once from `init`, not per notification.
 /// Windows: Windows Runtime `ToastNotification` via the `windows` crate.
+///          `init` registers the process AUMID and a Start Menu shortcut carrying
+///          the same AUMID — without that shortcut the OS drops every toast.
 /// Linux  : `notify-rust` (wraps `libnotify` / D-Bus `org.freedesktop.Notifications`).
 
 #[derive(Debug, Clone)]
 pub struct Notification {
     pub title: String,
     pub body: String,
-    /// Optional channel ID — used as the notification category/thread identifier.
+    /// Optional channel ID — used as the per-channel replacement key.
     pub channel_id: Option<String>,
+    pub clan_id: Option<String>,
+    /// Server-rendered navigation path (React `extras.link`); the click target.
+    pub link: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NotificationTarget {
+    pub clan_id: Option<String>,
+    pub channel_id: String,
+    pub link: Option<String>,
+}
+
+type ClickHandler = Box<dyn Fn(NotificationTarget) + Send + Sync + 'static>;
+
+static CLICK_HANDLER: std::sync::OnceLock<ClickHandler> = std::sync::OnceLock::new();
+
+/// Maps a notification's replacement identifier to its server-rendered link, so a
+/// click can navigate exactly where React would (`extras.link`) instead of
+/// reconstructing a route from ids.
+static LINK_BY_ID: std::sync::Mutex<Option<std::collections::HashMap<String, String>>> =
+    std::sync::Mutex::new(None);
+
+fn remember_link(identifier: &str, link: &str) {
+    if link.is_empty() {
+        return;
+    }
+    if let Ok(mut guard) = LINK_BY_ID.lock() {
+        guard
+            .get_or_insert_with(std::collections::HashMap::new)
+            .insert(identifier.to_owned(), link.to_owned());
+    }
+}
+
+fn build_target(identifier: &str) -> Option<NotificationTarget> {
+    let mut target = decode_identifier(identifier)?;
+    target.link = LINK_BY_ID
+        .lock()
+        .ok()
+        .and_then(|g| g.as_ref().and_then(|m| m.get(identifier).cloned()));
+    Some(target)
+}
+
+pub fn set_click_handler(handler: ClickHandler) {
+    if CLICK_HANDLER.set(handler).is_err() {
+        tracing::warn!("notification click handler already registered");
+    }
+}
+
+fn dispatch_click(target: NotificationTarget) {
+    match CLICK_HANDLER.get() {
+        Some(handler) => handler(target),
+        None => tracing::debug!("notification clicked but no handler registered"),
+    }
+}
+
+const IDENTIFIER_PREFIX: &str = "mezon-notify";
+
+fn encode_identifier(clan_id: Option<&String>, channel_id: &str) -> String {
+    let clan = clan_id
+        .map(String::as_str)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("0");
+    format!("{IDENTIFIER_PREFIX}-{clan}-{channel_id}")
+}
+
+fn decode_identifier(identifier: &str) -> Option<NotificationTarget> {
+    let rest = identifier
+        .strip_prefix(IDENTIFIER_PREFIX)?
+        .strip_prefix('-')?;
+    let (clan, channel) = rest.split_once('-')?;
+    if channel.is_empty() {
+        return None;
+    }
+    Some(NotificationTarget {
+        clan_id: Some(clan.to_owned()).filter(|c| c != "0" && !c.is_empty()),
+        link: None,
+        channel_id: channel.to_owned(),
+    })
+}
+
+#[cfg(target_os = "windows")]
+const APP_USER_MODEL_ID: &str = "ai.mezon.Mezon";
+
+pub fn init() {
+    #[cfg(target_os = "macos")]
+    init_macos();
+
+    #[cfg(target_os = "windows")]
+    init_windows();
 }
 
 /// Show a desktop notification.  Fire-and-forget; errors are logged but not propagated.
@@ -19,6 +110,10 @@ pub fn show(notification: &Notification) {
         channel_id = ?notification.channel_id,
         "Showing desktop notification"
     );
+
+    if let (Some(key), Some(link)) = (replacement_key(notification), notification.link.as_deref()) {
+        remember_link(&key, link);
+    }
 
     #[cfg(target_os = "macos")]
     show_macos(notification);
@@ -30,6 +125,15 @@ pub fn show(notification: &Notification) {
     show_linux(notification);
 }
 
+fn replacement_key(n: &Notification) -> Option<String> {
+    let channel = n
+        .channel_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty() && *id != "0")?;
+    Some(encode_identifier(n.clan_id.as_ref(), channel))
+}
+
 // ─── macOS ────────────────────────────────────────────────────────────────────
 //
 // UNUserNotificationCenter is available on macOS 10.14+.
@@ -37,64 +141,198 @@ pub fn show(notification: &Notification) {
 // UserNotifications framework header directly.
 
 #[cfg(target_os = "macos")]
-fn show_macos(n: &Notification) {
+static NOTIFICATION_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(target_os = "macos")]
+fn leak_for_async_objc_callback<T>(block: T) {
+    std::mem::forget(block);
+}
+
+#[cfg(target_os = "macos")]
+fn has_bundle_identifier() -> bool {
     use objc::runtime::Object;
     use objc::{class, msg_send, sel, sel_impl};
-
-    let title = n.title.clone();
-    let body = n.body.clone();
-    let category = n.channel_id.clone().unwrap_or_default();
 
     unsafe {
         let bundle: *mut Object = msg_send![class!(NSBundle), mainBundle];
         if bundle.is_null() {
-            tracing::debug!("skipping notification: not running from an app bundle");
-            return;
+            return false;
         }
         let bundle_id: *mut Object = msg_send![bundle, bundleIdentifier];
-        if bundle_id.is_null() {
-            tracing::debug!("skipping notification: not running from an app bundle");
-            return;
-        }
+        !bundle_id.is_null()
+    }
+}
 
+#[cfg(target_os = "macos")]
+extern "C" fn did_receive_notification_response(
+    _this: &objc::runtime::Object,
+    _sel: objc::runtime::Sel,
+    _center: *mut objc::runtime::Object,
+    response: *mut objc::runtime::Object,
+    completion: *mut objc::runtime::Object,
+) {
+    use objc::runtime::Object;
+    use objc::{msg_send, sel, sel_impl};
+
+    tracing::debug!("native: notification response delegate fired");
+    unsafe {
+        if !response.is_null() {
+            let notification: *mut Object = msg_send![response, notification];
+            if !notification.is_null() {
+                let request: *mut Object = msg_send![notification, request];
+                if !request.is_null() {
+                    let identifier: *mut Object = msg_send![request, identifier];
+                    let decoded = nsstring_to_string(identifier);
+                    tracing::debug!(identifier = ?decoded, "native: notification response identifier");
+                    if let Some(identifier) = decoded
+                        && let Some(target) = build_target(&identifier)
+                    {
+                        dispatch_click(target);
+                    }
+                }
+            }
+        }
+        if !completion.is_null() {
+            let block = completion as *mut block::Block<(), ()>;
+            (*block).call(());
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn nsstring_to_string(s: *mut objc::runtime::Object) -> Option<String> {
+    use objc::{msg_send, sel, sel_impl};
+
+    if s.is_null() {
+        return None;
+    }
+    unsafe {
+        let bytes: *const std::os::raw::c_char = msg_send![s, UTF8String];
+        if bytes.is_null() {
+            return None;
+        }
+        std::ffi::CStr::from_ptr(bytes)
+            .to_str()
+            .ok()
+            .map(str::to_owned)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn install_notification_delegate(center: *mut objc::runtime::Object) {
+    use objc::declare::ClassDecl;
+    use objc::runtime::{Class, Object, Sel};
+    use objc::{class, msg_send, sel, sel_impl};
+
+    static DELEGATE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+    let delegate = *DELEGATE.get_or_init(|| unsafe {
+        let superclass = class!(NSObject);
+        let Some(mut decl) = ClassDecl::new("MezonNotificationDelegate", superclass) else {
+            return 0;
+        };
+        let callback: extern "C" fn(&Object, Sel, *mut Object, *mut Object, *mut Object) =
+            did_receive_notification_response;
+        decl.add_method(
+            sel!(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:),
+            callback,
+        );
+        let cls: &Class = decl.register();
+        let instance: *mut Object = msg_send![cls, new];
+        instance as usize
+    });
+
+    if delegate == 0 {
+        tracing::warn!("could not register notification delegate class");
+        return;
+    }
+    unsafe {
+        let _: () = msg_send![center, setDelegate: delegate as *mut Object];
+    }
+    tracing::debug!("native: notification delegate installed");
+}
+
+#[cfg(target_os = "macos")]
+fn init_macos() {
+    use block::ConcreteBlock;
+    use objc::runtime::{BOOL, Object, YES};
+    use objc::{class, msg_send, sel, sel_impl};
+
+    if !has_bundle_identifier() {
+        tracing::debug!("skipping notification setup: not running from an app bundle");
+        return;
+    }
+
+    unsafe {
         let center_cls = class!(UNUserNotificationCenter);
         let center: *mut Object = msg_send![center_cls, currentNotificationCenter];
 
-        let options: usize = 0b111;
+        install_notification_delegate(center);
+
+        const AUTH_OPTIONS_BADGE_SOUND_ALERT: usize = 0b111;
+        let options: usize = AUTH_OPTIONS_BADGE_SOUND_ALERT;
+        let handler = ConcreteBlock::new(move |granted: BOOL, _error: *mut Object| {
+            if granted == YES {
+                tracing::info!("notification authorisation granted");
+            } else {
+                tracing::warn!("notification authorisation denied; notifications will not appear");
+            }
+        });
+        let handler = handler.copy();
         let _: () = msg_send![
             center,
             requestAuthorizationWithOptions: options
-            completionHandler: objc_block_noop()
+            completionHandler: &*handler
         ];
+        leak_for_async_objc_callback(handler);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn show_macos(n: &Notification) {
+    use objc::runtime::Object;
+    use objc::{class, msg_send, sel, sel_impl};
+
+    if !has_bundle_identifier() {
+        tracing::debug!("skipping notification: not running from an app bundle");
+        return;
+    }
+
+    unsafe {
+        let center_cls = class!(UNUserNotificationCenter);
+        let center: *mut Object = msg_send![center_cls, currentNotificationCenter];
 
         let content_cls = class!(UNMutableNotificationContent);
         let content: *mut Object = msg_send![content_cls, new];
 
-        let ns_title = nsstring(&title);
+        let ns_title = nsstring(&n.title);
         let _: () = msg_send![content, setTitle: ns_title];
         let _: () = msg_send![ns_title, release];
 
-        let ns_body = nsstring(&body);
+        let ns_body = nsstring(&n.body);
         let _: () = msg_send![content, setBody: ns_body];
         let _: () = msg_send![ns_body, release];
 
-        if !category.is_empty() {
-            let ns_cat = nsstring(&category);
-            let _: () = msg_send![content, setThreadIdentifier: ns_cat];
-            let _: () = msg_send![ns_cat, release];
+        let key = replacement_key(n);
+        if let Some(key) = key.as_deref() {
+            let ns_thread = nsstring(key);
+            let _: () = msg_send![content, setThreadIdentifier: ns_thread];
+            let _: () = msg_send![ns_thread, release];
         }
 
-        let counter = NOTIFICATION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let uuid_str = format!("mezon-{}-{counter}", std::process::id());
-        let ns_uuid = nsstring(&uuid_str);
+        let identifier = key.unwrap_or_else(|| {
+            let counter = NOTIFICATION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            format!("mezon-{}-{counter}", std::process::id())
+        });
+        let ns_identifier = nsstring(&identifier);
         let request_cls = class!(UNNotificationRequest);
         let request: *mut Object = msg_send![
             request_cls,
-            requestWithIdentifier: ns_uuid
+            requestWithIdentifier: ns_identifier
             content: content
             trigger: std::ptr::null::<Object>()
         ];
-        let _: () = msg_send![ns_uuid, release];
+        let _: () = msg_send![ns_identifier, release];
         let _: () = msg_send![content, release];
 
         let _: () = msg_send![
@@ -104,9 +342,6 @@ fn show_macos(n: &Notification) {
         ];
     }
 }
-
-#[cfg(target_os = "macos")]
-static NOTIFICATION_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Create an Objective-C NSString from a Rust &str.
 #[cfg(target_os = "macos")]
@@ -124,38 +359,97 @@ unsafe fn nsstring(s: &str) -> *mut objc::runtime::Object {
     ]
 }
 
-/// A no-op Objective-C block used for the authorisation completion handler.
-/// The block takes (BOOL granted, NSError *error) and does nothing.
-#[cfg(target_os = "macos")]
-unsafe fn objc_block_noop() -> *mut objc::runtime::Object {
-    // We pass nil — UNUserNotificationCenter accepts a nil completion handler.
-    std::ptr::null_mut()
+// ─── Windows ──────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "windows")]
+fn init_windows() {
+    use windows::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID;
+    use windows::core::HSTRING;
+
+    unsafe {
+        if let Err(e) = SetCurrentProcessExplicitAppUserModelID(&HSTRING::from(APP_USER_MODEL_ID)) {
+            tracing::warn!("failed to set AppUserModelID: {e}");
+        }
+    }
+
+    if let Err(e) = ensure_start_menu_shortcut() {
+        tracing::warn!("failed to create Start Menu shortcut; toasts may not appear: {e}");
+    }
 }
 
-// ─── Windows ──────────────────────────────────────────────────────────────────
-//
-// Windows Runtime ToastNotification.  Requires the app to have an AUMID
-// (Application User Model ID) registered; we use a sensible default.
+#[cfg(target_os = "windows")]
+fn ensure_start_menu_shortcut() -> anyhow::Result<()> {
+    use windows::Win32::System::Com::StructuredStorage::PROPVARIANT;
+    use windows::Win32::System::Com::{
+        CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx,
+        IPersistFile,
+    };
+    use windows::Win32::UI::Shell::PropertiesSystem::{
+        IPropertyStore, InitPropVariantFromStringAsVector, PKEY_AppUserModel_ID,
+    };
+    use windows::Win32::UI::Shell::{IShellLinkW, ShellLink};
+    use windows::core::{HSTRING, Interface};
+
+    let Some(appdata) = dirs::data_dir() else {
+        anyhow::bail!("no APPDATA directory");
+    };
+    let shortcut = appdata
+        .join("Microsoft")
+        .join("Windows")
+        .join("Start Menu")
+        .join("Programs")
+        .join("Mezon.lnk");
+    if shortcut.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = shortcut.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let exe = std::env::current_exe()?;
+
+    unsafe {
+        let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+
+        let link: IShellLinkW = CoCreateInstance(&ShellLink, None, CLSCTX_INPROC_SERVER)?;
+        link.SetPath(&HSTRING::from(exe.as_os_str()))?;
+        if let Some(dir) = exe.parent() {
+            link.SetWorkingDirectory(&HSTRING::from(dir.as_os_str()))?;
+        }
+
+        let store: IPropertyStore = link.cast()?;
+        let value: PROPVARIANT =
+            InitPropVariantFromStringAsVector(&HSTRING::from(APP_USER_MODEL_ID))?;
+        store.SetValue(&PKEY_AppUserModel_ID, &value)?;
+        store.Commit()?;
+
+        let file: IPersistFile = link.cast()?;
+        file.Save(&HSTRING::from(shortcut.as_os_str()), true)?;
+    }
+
+    tracing::info!("created Start Menu shortcut for toast notifications");
+    Ok(())
+}
 
 #[cfg(target_os = "windows")]
 fn show_windows(n: &Notification) {
     let title = n.title.clone();
     let body = n.body.clone();
+    let tag = replacement_key(n.channel_id.as_ref());
 
     std::thread::spawn(move || {
-        if let Err(e) = try_show_toast(&title, &body) {
+        if let Err(e) = try_show_toast(&title, &body, tag.as_deref()) {
             tracing::warn!("Windows toast notification failed: {e}");
         }
     });
 }
 
 #[cfg(target_os = "windows")]
-fn try_show_toast(title: &str, body: &str) -> windows::core::Result<()> {
+fn try_show_toast(title: &str, body: &str, tag: Option<&str>) -> windows::core::Result<()> {
     use windows::Data::Xml::Dom::XmlDocument;
     use windows::UI::Notifications::{ToastNotification, ToastNotificationManager};
     use windows::core::HSTRING;
 
-    // The XML template for a simple text toast.
     let xml_str = format!(
         r#"<toast>
   <visual>
@@ -172,11 +466,26 @@ fn try_show_toast(title: &str, body: &str) -> windows::core::Result<()> {
     let doc = XmlDocument::new()?;
     doc.LoadXml(&HSTRING::from(xml_str))?;
 
-    // AUMID — must match the registered shortcut / installer entry.
-    // Falls back gracefully if not registered (notification is silently dropped by the OS).
-    let aumid = HSTRING::from("ai.mezon.Mezon");
-    let notifier = ToastNotificationManager::CreateToastNotifierWithId(&aumid)?;
+    let notifier =
+        ToastNotificationManager::CreateToastNotifierWithId(&HSTRING::from(APP_USER_MODEL_ID))?;
     let toast = ToastNotification::CreateToastNotification(&doc)?;
+    if let Some(tag) = tag {
+        let tag: String = tag.chars().take(64).collect();
+        toast.SetTag(&HSTRING::from(tag.as_str()))?;
+        toast.SetGroup(&HSTRING::from("mezon"))?;
+    }
+
+    let activation_target = tag.and_then(|t| build_target(&t));
+    toast.Activated(&windows::Foundation::TypedEventHandler::<
+        ToastNotification,
+        windows::core::IInspectable,
+    >::new(move |_, _| {
+        if let Some(target) = activation_target.clone() {
+            dispatch_click(target);
+        }
+        Ok(())
+    }))?;
+
     notifier.Show(&toast)?;
     Ok(())
 }
@@ -195,18 +504,135 @@ fn escape_xml(s: &str) -> String {
 // Uses the `notify-rust` crate which wraps D-Bus `org.freedesktop.Notifications`.
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+const LINUX_DESKTOP_ENTRY: &str = "mezon";
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn linux_replace_id(key: &str) -> u32 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut hasher);
+    (hasher.finish() as u32).max(1)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn show_linux(n: &Notification) {
     let title = n.title.clone();
     let body = n.body.clone();
+    let key = replacement_key(n);
+    let replace_id = key.as_deref().map(linux_replace_id);
+    let activation_target = key.as_deref().and_then(build_target);
+
     std::thread::spawn(move || {
-        if let Err(e) = notify_rust::Notification::new()
+        let mut notification = notify_rust::Notification::new();
+        notification
             .appname("Mezon")
             .summary(&title)
             .body(&body)
-            .icon("dialog-information")
-            .show()
-        {
-            tracing::warn!("Linux notification failed: {e}");
+            .icon(LINUX_DESKTOP_ENTRY)
+            .hint(notify_rust::Hint::DesktopEntry(
+                LINUX_DESKTOP_ENTRY.to_owned(),
+            ));
+        if let Some(id) = replace_id {
+            notification.id(id);
+        }
+        if activation_target.is_some() {
+            notification.action("default", "Open");
+        }
+        match notification.show() {
+            Ok(handle) => {
+                if let Some(target) = activation_target {
+                    handle.wait_for_action(|action| {
+                        if action == "default" {
+                            dispatch_click(target);
+                        }
+                    });
+                }
+            }
+            Err(e) => tracing::warn!("Linux notification failed: {e}"),
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn notification(channel_id: Option<&str>, clan_id: Option<&str>) -> Notification {
+        Notification {
+            title: "t".into(),
+            body: "b".into(),
+            channel_id: channel_id.map(str::to_owned),
+            clan_id: clan_id.map(str::to_owned),
+            link: None,
+        }
+    }
+
+    #[test]
+    fn replacement_key_is_stable_per_channel() {
+        let a = replacement_key(&notification(Some("12345"), Some("77")));
+        assert_eq!(a.as_deref(), Some("mezon-notify-77-12345"));
+        assert_eq!(a, replacement_key(&notification(Some("12345"), Some("77"))));
+        assert_ne!(a, replacement_key(&notification(Some("12346"), Some("77"))));
+    }
+
+    #[test]
+    fn replacement_key_rejects_absent_blank_and_zero_channel_ids() {
+        assert_eq!(replacement_key(&notification(None, Some("77"))), None);
+        assert_eq!(replacement_key(&notification(Some(""), Some("77"))), None);
+        assert_eq!(
+            replacement_key(&notification(Some("   "), Some("77"))),
+            None
+        );
+        assert_eq!(replacement_key(&notification(Some("0"), Some("77"))), None);
+    }
+
+    #[test]
+    fn identifier_round_trips_clan_and_channel() {
+        let key = replacement_key(&notification(Some("12345"), Some("77"))).unwrap();
+        assert_eq!(
+            decode_identifier(&key),
+            Some(NotificationTarget {
+                clan_id: Some("77".into()),
+                channel_id: "12345".into(),
+                link: None,
+            })
+        );
+    }
+
+    #[test]
+    fn identifier_round_trips_dm_without_clan() {
+        let key = replacement_key(&notification(Some("12345"), None)).unwrap();
+        assert_eq!(key, "mezon-notify-0-12345");
+        assert_eq!(
+            decode_identifier(&key),
+            Some(NotificationTarget {
+                clan_id: None,
+                channel_id: "12345".into(),
+                link: None,
+            })
+        );
+    }
+
+    #[test]
+    fn decode_identifier_rejects_foreign_and_malformed_ids() {
+        assert_eq!(decode_identifier("some-other-app-1-2"), None);
+        assert_eq!(decode_identifier("mezon-notify"), None);
+        assert_eq!(decode_identifier("mezon-notify-77"), None);
+        assert_eq!(decode_identifier("mezon-notify-77-"), None);
+        assert_eq!(decode_identifier(""), None);
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[test]
+    fn linux_replace_id_is_stable_and_never_zero() {
+        assert_eq!(
+            linux_replace_id("mezon-channel-1"),
+            linux_replace_id("mezon-channel-1")
+        );
+        assert_ne!(
+            linux_replace_id("mezon-channel-1"),
+            linux_replace_id("mezon-channel-2")
+        );
+        assert!(linux_replace_id("mezon-channel-1") > 0);
+    }
 }

--- a/crates/mezon-store/src/badge.rs
+++ b/crates/mezon-store/src/badge.rs
@@ -5,7 +5,6 @@ use mezon_client::RealtimeEvent;
 use mezon_proto::api::{ChannelMessage, Notification};
 
 use crate::AuthState;
-use crate::Settings;
 use crate::channel::ChannelList;
 use crate::clan::ClanList;
 use crate::clan_members::ClanMembersStore;
@@ -13,7 +12,6 @@ use crate::direct::DirectMessageStore;
 use crate::ids::{ChannelId, ClanId, MessageId, UserId};
 use crate::message::MessageCode;
 use crate::messages::MessagesStore;
-use crate::platform::{DesktopNotification, PlatformStore};
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
 
 const STREAM_MODE_GROUP: i32 = 3;
@@ -121,53 +119,6 @@ fn is_viewing_channel(cx: &App, channel_id: ChannelId) -> bool {
         return false;
     }
     messages.active_channel_id() == Some(channel_id)
-}
-
-fn maybe_show_desktop_notification(cx: &App, notif: &Notification, channel_id: ChannelId) {
-    if cx.active_window().is_some() {
-        return;
-    }
-    let Some(settings) = Settings::try_global(cx) else {
-        return;
-    };
-    let (enabled, hide_content) = {
-        let s = settings.read(cx);
-        (s.notifications_enabled, s.notifications_hide_content)
-    };
-    if !enabled {
-        return;
-    }
-    let Some(platform) = PlatformStore::try_global(cx) else {
-        return;
-    };
-    let title = notif
-        .channel
-        .as_ref()
-        .map(|c| c.channel_label.clone())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "Mezon".to_string());
-    let body = if hide_content || notif.subject.is_empty() {
-        "New message".to_string()
-    } else {
-        notif.subject.clone()
-    };
-    platform.read(cx).show_notification(DesktopNotification {
-        title,
-        body,
-        channel_id: Some(channel_id.to_string()),
-    });
-}
-
-fn dm_message_preview(m: &ChannelMessage) -> String {
-    let text = serde_json::from_str::<mezon_client::transport::ApiMessageContent>(&m.content)
-        .map(|c| c.t)
-        .unwrap_or_default();
-    let trimmed = text.trim();
-    if trimmed.is_empty() {
-        "New message".to_string()
-    } else {
-        trimmed.chars().take(140).collect()
-    }
 }
 
 fn is_message_already_seen(
@@ -280,57 +231,6 @@ impl BadgeService {
         )
     }
 
-    fn maybe_show_dm_notification(
-        &mut self,
-        cx: &App,
-        m: &ChannelMessage,
-        channel_id: ChannelId,
-        message_id: MessageId,
-    ) {
-        if cx.active_window().is_some() {
-            return;
-        }
-        let Some(settings) = Settings::try_global(cx) else {
-            return;
-        };
-        let (enabled, hide_content) = {
-            let s = settings.read(cx);
-            (s.notifications_enabled, s.notifications_hide_content)
-        };
-        if !enabled {
-            return;
-        }
-        if !mark_badge_processed(
-            &mut self.processed_badge_messages,
-            &mut self.processed_badge_order,
-            (channel_id, message_id),
-        ) {
-            return;
-        }
-        let Some(platform) = PlatformStore::try_global(cx) else {
-            return;
-        };
-        let title = if !m.display_name.is_empty() {
-            m.display_name.clone()
-        } else if !m.username.is_empty() {
-            m.username.clone()
-        } else if !m.channel_label.is_empty() {
-            m.channel_label.clone()
-        } else {
-            "Mezon".to_string()
-        };
-        let body = if hide_content {
-            "New message".to_string()
-        } else {
-            dm_message_preview(m)
-        };
-        platform.read(cx).show_notification(DesktopNotification {
-            title,
-            body,
-            channel_id: Some(channel_id.to_string()),
-        });
-    }
-
     fn handle_event(&mut self, event: &RealtimeEvent, cx: &mut Context<Self>) {
         match event {
             RealtimeEvent::ChannelMessage(m) => {
@@ -360,9 +260,6 @@ impl BadgeService {
                                 cx,
                             );
                         });
-                        if !from_me && increment_unread {
-                            self.maybe_show_dm_notification(cx, m, channel_id, message_id);
-                        }
                     }
                 } else {
                     let clan_id = ClanId(m.clan_id);
@@ -604,7 +501,6 @@ impl BadgeService {
             message_id = message_id.get(),
             "badge: apply notification increment"
         );
-        maybe_show_desktop_notification(cx, notif, badge_channel);
         ChannelList::global(cx).update(cx, |cl, cx| {
             cl.note_channel_message(
                 clan_id,

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -26,6 +26,8 @@ pub mod message;
 pub mod message_search;
 pub mod message_time;
 pub mod messages;
+pub mod notification_push;
+pub mod notification_setting;
 pub mod ogp;
 pub mod permissions;
 pub mod pinned;
@@ -115,6 +117,8 @@ pub use mezon_client::{
     search_content_highlight_terms, search_dropdown_mode, search_filter_chip_ranges,
     search_page_count, search_page_numbers, should_show_search_dropdown,
 };
+pub use notification_push::NotificationPushStore;
+pub use notification_setting::{NotificationSettingEvent, NotificationSettingStore};
 pub use ogp::{OgpResult, OutgoingOgp, fetch_ogp, first_previewable_url};
 pub use permissions::{
     ClanSettingsPermissions, PERMISSION_ADMINISTRATOR, PERMISSION_CLAN_OWNER,

--- a/crates/mezon-store/src/notification_push.rs
+++ b/crates/mezon-store/src/notification_push.rs
@@ -1,0 +1,209 @@
+use std::sync::Arc;
+
+use gpui::{App, AppContext, Context, Entity, Global, Subscription, Task};
+use mezon_client::{AppApi, GotifyNotification};
+
+use crate::channel::ChannelList;
+use crate::clan::ClanList;
+use crate::config::AppConfig;
+use crate::ids::ChannelId;
+use crate::messages::MessagesStore;
+use crate::platform::{DesktopNotification, PlatformStore};
+use crate::presence::PresenceStore;
+use crate::{AuthState, Settings};
+
+const USER_STATUS_DO_NOT_DISTURB: &str = "Do Not Disturb";
+const DEVICE_PLATFORM: &str = "desktop";
+
+/// Consumes the server-rendered Gotify notification stream (React `MezonNotificationService`)
+/// and raises OS notifications through [`PlatformStore`]. This is the source of channel
+/// notifications for non-mention messages: the server pushes whatever the channel's
+/// notification level allows, and the client only suppresses DND / own-message /
+/// currently-viewing-while-focused.
+pub struct NotificationPushStore {
+    auth_state: Entity<AuthState>,
+    api: Arc<AppApi>,
+    connection: Option<Task<()>>,
+    connected_user: Option<String>,
+    _auth_sub: Subscription,
+}
+
+struct GlobalNotificationPushStore(Entity<NotificationPushStore>);
+impl Global for GlobalNotificationPushStore {}
+
+impl NotificationPushStore {
+    pub fn init(api: Arc<AppApi>, auth_state: Entity<AuthState>, cx: &mut App) -> Entity<Self> {
+        let entity = cx.new(|cx| {
+            let auth_sub = cx.observe(&auth_state, Self::on_auth_changed);
+            let mut this = Self {
+                auth_state: auth_state.clone(),
+                api,
+                connection: None,
+                connected_user: None,
+                _auth_sub: auth_sub,
+            };
+            this.sync_connection(cx);
+            this
+        });
+        cx.set_global(GlobalNotificationPushStore(entity.clone()));
+        entity
+    }
+
+    pub fn try_global(cx: &App) -> Option<Entity<Self>> {
+        cx.try_global::<GlobalNotificationPushStore>()
+            .map(|g| g.0.clone())
+    }
+
+    fn on_auth_changed(this: &mut Self, _auth: Entity<AuthState>, cx: &mut Context<Self>) {
+        this.sync_connection(cx);
+    }
+
+    fn authenticated_user(&self, cx: &App) -> Option<String> {
+        match self.auth_state.read(cx) {
+            AuthState::Authenticated(session) => Some(session.user_id.clone()),
+            _ => None,
+        }
+    }
+
+    fn sync_connection(&mut self, cx: &mut Context<Self>) {
+        let user = self.authenticated_user(cx);
+        match user {
+            Some(user_id) if self.connected_user.as_deref() != Some(user_id.as_str()) => {
+                self.start(user_id, cx);
+            }
+            None if self.connection.is_some() => {
+                self.connection = None;
+                self.connected_user = None;
+            }
+            _ => {}
+        }
+    }
+
+    fn start(&mut self, user_id: String, cx: &mut Context<Self>) {
+        let Some(ws_base) = AppConfig::try_global(cx)
+            .map(|c| c.notification_ws_url.clone())
+            .filter(|u| !u.is_empty())
+        else {
+            return;
+        };
+        let api = self.api.clone();
+        self.connected_user = Some(user_id.clone());
+        self.connection = Some(cx.spawn(async move |this, cx| {
+            let token = match api.regist_fcm_device_token("", "", DEVICE_PLATFORM).await {
+                Ok(token) if !token.trim().is_empty() => token.trim().to_string(),
+                Ok(_) => {
+                    tracing::warn!("gotify: empty notification token; not connecting");
+                    return;
+                }
+                Err(e) => {
+                    tracing::warn!("gotify: failed to register device token: {e}");
+                    return;
+                }
+            };
+            tracing::debug!("gotify: token acquired, opening stream");
+            let mut rx = api.spawn_gotify_stream(ws_base, token);
+            while let Some(notification) = rx.recv().await {
+                let delivered = this.update(cx, |_, cx| {
+                    deliver(cx, &user_id, &notification);
+                });
+                if delivered.is_err() {
+                    break;
+                }
+            }
+        }));
+    }
+}
+
+fn deliver(cx: &App, user_id: &str, n: &GotifyNotification) {
+    tracing::debug!(
+        channel_id = %n.channel_id,
+        sender_id = %n.sender_id,
+        title = %n.title,
+        link = %n.extras.link,
+        "gotify: received notification"
+    );
+    if n.sender_id == user_id {
+        tracing::debug!("gotify: suppressed — own message");
+        return;
+    }
+    if is_do_not_disturb(cx, user_id) {
+        tracing::debug!("gotify: suppressed — do not disturb");
+        return;
+    }
+    if is_viewing_while_focused(cx, &n.channel_id) {
+        tracing::debug!("gotify: suppressed — viewing this channel while focused");
+        return;
+    }
+    let hide_content = Settings::try_global(cx)
+        .map(|s| s.read(cx).notifications_hide_content)
+        .unwrap_or(false);
+    let Some(platform) = PlatformStore::try_global(cx) else {
+        tracing::warn!("gotify: no PlatformStore; cannot show notification");
+        return;
+    };
+
+    let title = n.title.clone();
+    let body = if hide_content {
+        String::new()
+    } else {
+        n.message.clone()
+    };
+    let (channel_id, clan_id) = route_ids(cx, &n.channel_id);
+    let link = Some(n.extras.link.clone()).filter(|l| !l.is_empty());
+    tracing::debug!("gotify: delivering desktop notification");
+    platform.read(cx).show_notification(DesktopNotification {
+        title,
+        body,
+        channel_id,
+        clan_id,
+        link,
+    });
+}
+
+fn is_do_not_disturb(cx: &App, user_id: &str) -> bool {
+    let Ok(uid) = user_id.parse::<i64>() else {
+        return false;
+    };
+    PresenceStore::try_global(cx)
+        .and_then(|p| {
+            p.read(cx)
+                .user_status(crate::ids::UserId(uid))
+                .map(str::to_owned)
+        })
+        .as_deref()
+        == Some(USER_STATUS_DO_NOT_DISTURB)
+}
+
+fn is_viewing_while_focused(cx: &App, channel_id: &str) -> bool {
+    if cx.active_window().is_none() {
+        return false;
+    }
+    let Ok(raw) = channel_id.parse::<i64>() else {
+        return false;
+    };
+    MessagesStore::global(cx).read(cx).active_channel_id() == Some(ChannelId(raw))
+}
+
+/// Resolve the clan that owns a channel so a notification click can route to it;
+/// a channel absent from the clan cache (e.g. a DM) yields `clan_id = None`.
+fn route_ids(cx: &App, channel_id: &str) -> (Option<String>, Option<String>) {
+    let Ok(raw) = channel_id.parse::<i64>() else {
+        return (None, None);
+    };
+    let cid = ChannelId(raw);
+    let clan_id = ClanList::global(cx)
+        .read(cx)
+        .clans
+        .iter()
+        .map(|clan| clan.id)
+        .find(|clan_id| {
+            ChannelList::global(cx)
+                .read(cx)
+                .channel(*clan_id, cid)
+                .is_some()
+        });
+    (
+        Some(channel_id.to_string()),
+        clan_id.filter(|c| !c.is_zero()).map(|c| c.to_string()),
+    )
+}

--- a/crates/mezon-store/src/notification_setting.rs
+++ b/crates/mezon-store/src/notification_setting.rs
@@ -1,0 +1,310 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Subscription, Task};
+use mezon_client::AppApi;
+use mezon_client::notification_setting::{ChannelNotificationSetting, MUTE_UNMUTE};
+
+use crate::ids::{ChannelId, ClanId};
+
+pub use mezon_client::notification_setting::{
+    MUTE_FOR_1_HOUR_SEC, MUTE_FOR_3_HOURS_SEC, MUTE_FOR_8_HOURS_SEC, MUTE_FOR_15_MINUTES_SEC,
+    MUTE_FOR_24_HOURS_SEC, NOTIFICATION_ALL_MESSAGE, NOTIFICATION_MENTION_MESSAGE,
+    NOTIFICATION_NOTHING_MESSAGE,
+};
+pub use mezon_client::notification_setting::{
+    MUTE_INFINITY, MUTE_INFINITY as MUTE_FOREVER, NOTIFICATION_DEFAULT,
+};
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum NotificationSettingEvent {
+    Changed(ChannelId),
+}
+
+struct GlobalNotificationSettingStore(Entity<NotificationSettingStore>);
+impl Global for GlobalNotificationSettingStore {}
+
+/// Per-channel notification overrides, mirroring React `notificationSettingChannel.slice`.
+/// Clan and category defaults are cached alongside so [`ChannelNotificationSetting::is_muted`]
+/// can resolve the same three-level fallback the React `MuteButton` uses.
+pub struct NotificationSettingStore {
+    settings: HashMap<ChannelId, ChannelNotificationSetting>,
+    clan_defaults: HashMap<ClanId, i32>,
+    in_flight: HashMap<ChannelId, Task<()>>,
+    clan_prefetch: HashMap<ClanId, Task<()>>,
+    api: Arc<AppApi>,
+    _channel_sub: Subscription,
+    _clan_sub: Subscription,
+}
+
+impl EventEmitter<NotificationSettingEvent> for NotificationSettingStore {}
+
+impl NotificationSettingStore {
+    pub fn init(api: Arc<AppApi>, cx: &mut App) -> Entity<Self> {
+        let entity = cx.new(|cx| {
+            let channel_sub = cx.subscribe(
+                &crate::channel::ChannelList::global(cx),
+                |this: &mut Self, _, event: &crate::channel::ChannelEvent, cx| {
+                    if let crate::channel::ChannelEvent::ActiveChannelChanged(Some(channel_id)) =
+                        event
+                    {
+                        this.ensure_loaded(*channel_id, cx);
+                    }
+                },
+            );
+            let clan_sub = cx.subscribe(
+                &crate::clan::ClanList::global(cx),
+                |this: &mut Self, _, event: &crate::clan::ClanEvent, cx| {
+                    if let crate::clan::ClanEvent::ActiveClanChanged(Some(clan_id)) = event {
+                        this.prefetch_clan(*clan_id, cx);
+                    }
+                },
+            );
+            Self {
+                settings: HashMap::new(),
+                clan_defaults: HashMap::new(),
+                in_flight: HashMap::new(),
+                clan_prefetch: HashMap::new(),
+                api,
+                _channel_sub: channel_sub,
+                _clan_sub: clan_sub,
+            }
+        });
+        cx.set_global(GlobalNotificationSettingStore(entity.clone()));
+        entity
+    }
+
+    pub fn global(cx: &App) -> Entity<Self> {
+        cx.global::<GlobalNotificationSettingStore>().0.clone()
+    }
+
+    pub fn try_global(cx: &App) -> Option<Entity<Self>> {
+        cx.try_global::<GlobalNotificationSettingStore>()
+            .map(|g| g.0.clone())
+    }
+
+    pub fn reset(&mut self, cx: &mut Context<Self>) {
+        self.settings.clear();
+        self.clan_defaults.clear();
+        self.in_flight.clear();
+        self.clan_prefetch.clear();
+        cx.notify();
+    }
+
+    pub fn setting(&self, channel_id: ChannelId) -> Option<ChannelNotificationSetting> {
+        self.settings.get(&channel_id).copied()
+    }
+
+    pub fn level(&self, channel_id: ChannelId) -> i32 {
+        self.setting(channel_id)
+            .map(|s| s.level)
+            .unwrap_or(NOTIFICATION_DEFAULT)
+    }
+
+    pub fn is_muted(&self, channel_id: ChannelId, clan_id: ClanId) -> bool {
+        self.setting(channel_id).is_some_and(|setting| {
+            setting.is_muted(None, self.clan_defaults.get(&clan_id).copied())
+        })
+    }
+
+    pub fn muted_until_ms(&self, channel_id: ChannelId) -> Option<i64> {
+        self.setting(channel_id)
+            .and_then(|s| s.muted_until_ms(now_ms()))
+    }
+
+    pub fn clan_default(&self, clan_id: ClanId) -> Option<i32> {
+        self.clan_defaults.get(&clan_id).copied()
+    }
+
+    pub fn set_clan_default(&mut self, clan_id: ClanId, level: i32) {
+        self.clan_defaults.insert(clan_id, level);
+    }
+
+    /// Mirrors React `changeCurrentClan`, which batches `fetchMutedChannels` and
+    /// `getDefaultNotificationClan` so the bell icon is correct before it is opened.
+    pub fn prefetch_clan(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+        if clan_id.is_zero() || self.clan_prefetch.contains_key(&clan_id) {
+            return;
+        }
+        let api = self.api.clone();
+        let task = cx.spawn(async move |this, cx| {
+            let muted = api.list_muted_channels(clan_id.get()).await;
+            let clan_default = api.get_notification_clan(clan_id.get()).await;
+            let _ = this.update(cx, |store, cx| {
+                store.clan_prefetch.remove(&clan_id);
+                match muted {
+                    Ok(ids) => store.seed_muted_channels(&ids),
+                    Err(e) => tracing::warn!(
+                        clan_id = clan_id.get(),
+                        "failed to list muted channels: {e}"
+                    ),
+                }
+                match clan_default {
+                    Ok(level) => store.set_clan_default(clan_id, level),
+                    Err(e) => tracing::warn!(
+                        clan_id = clan_id.get(),
+                        "failed to load clan notification default: {e}"
+                    ),
+                }
+                cx.notify();
+            });
+        });
+        self.clan_prefetch.insert(clan_id, task);
+    }
+
+    /// `list_muted_channels` returns ids only, so it can establish that a channel is
+    /// muted but not when the mute expires; the exact expiry arrives with
+    /// [`Self::ensure_loaded`] for the channel actually being opened.
+    fn seed_muted_channels(&mut self, muted_ids: &[String]) {
+        for id in muted_ids {
+            let Ok(raw) = id.parse::<i64>() else {
+                continue;
+            };
+            let channel_id = ChannelId(raw);
+            if channel_id.is_zero() {
+                continue;
+            }
+            let entry = self.settings.entry(channel_id).or_default();
+            entry.id = raw;
+            if entry.mute_until_ms == 0 {
+                entry.mute_until_ms = i64::from(MUTE_INFINITY);
+            }
+        }
+    }
+
+    /// Load the override for a channel unless a request is already in flight.
+    pub fn ensure_loaded(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
+        if channel_id.is_zero()
+            || self.settings.contains_key(&channel_id)
+            || self.in_flight.contains_key(&channel_id)
+        {
+            return;
+        }
+        let api = self.api.clone();
+        let task = cx.spawn(async move |this, cx| {
+            let fetched = api.get_notification_channel(channel_id.get()).await;
+            let _ = this.update(cx, |store, cx| {
+                store.in_flight.remove(&channel_id);
+                match fetched {
+                    Ok(setting) => {
+                        store.settings.insert(channel_id, setting);
+                        cx.emit(NotificationSettingEvent::Changed(channel_id));
+                        cx.notify();
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            channel_id = channel_id.get(),
+                            "failed to load channel notification setting: {e}"
+                        );
+                    }
+                }
+            });
+        });
+        self.in_flight.insert(channel_id, task);
+    }
+
+    pub fn set_level(
+        &mut self,
+        channel_id: ChannelId,
+        clan_id: ClanId,
+        level: i32,
+        cx: &mut Context<Self>,
+    ) {
+        let previous = self.setting(channel_id);
+        let entry = self.settings.entry(channel_id).or_default();
+        entry.level = level;
+        if level != NOTIFICATION_DEFAULT {
+            entry.id = channel_id.get();
+        }
+        cx.emit(NotificationSettingEvent::Changed(channel_id));
+        cx.notify();
+
+        let api = self.api.clone();
+        let reset_to_default = level == NOTIFICATION_DEFAULT;
+        cx.spawn(async move |this, cx| {
+            let result = if reset_to_default {
+                api.delete_notification_channel(channel_id.get()).await
+            } else {
+                api.set_notification_channel_setting(channel_id.get(), level, clan_id.get())
+                    .await
+            };
+            if let Err(e) = result {
+                tracing::warn!(
+                    channel_id = channel_id.get(),
+                    "failed to save notification level, rolling back: {e}"
+                );
+                let _ = this.update(cx, |store, cx| {
+                    store.restore(channel_id, previous);
+                    cx.emit(NotificationSettingEvent::Changed(channel_id));
+                    cx.notify();
+                });
+            }
+        })
+        .detach();
+    }
+
+    pub fn set_mute(
+        &mut self,
+        channel_id: ChannelId,
+        clan_id: ClanId,
+        mute_seconds: i32,
+        cx: &mut Context<Self>,
+    ) {
+        let previous = self.setting(channel_id);
+        let expiry = ChannelNotificationSetting::expiry_from_duration(now_ms(), mute_seconds);
+        let entry = self.settings.entry(channel_id).or_default();
+        entry.mute_until_ms = expiry;
+        if mute_seconds == MUTE_UNMUTE {
+            entry.id = 0;
+        } else {
+            entry.id = channel_id.get();
+        }
+        cx.emit(NotificationSettingEvent::Changed(channel_id));
+        cx.notify();
+
+        let api = self.api.clone();
+        cx.spawn(async move |this, cx| {
+            if let Err(e) = api
+                .set_mute_channel(channel_id.get(), mute_seconds, clan_id.get())
+                .await
+            {
+                tracing::warn!(
+                    channel_id = channel_id.get(),
+                    "failed to save channel mute, rolling back: {e}"
+                );
+                let _ = this.update(cx, |store, cx| {
+                    store.restore(channel_id, previous);
+                    cx.emit(NotificationSettingEvent::Changed(channel_id));
+                    cx.notify();
+                });
+            }
+        })
+        .detach();
+    }
+
+    pub fn mute_forever(&mut self, channel_id: ChannelId, clan_id: ClanId, cx: &mut Context<Self>) {
+        self.set_mute(channel_id, clan_id, MUTE_INFINITY, cx);
+    }
+
+    pub fn unmute(&mut self, channel_id: ChannelId, clan_id: ClanId, cx: &mut Context<Self>) {
+        self.set_mute(channel_id, clan_id, MUTE_UNMUTE, cx);
+    }
+
+    fn restore(&mut self, channel_id: ChannelId, previous: Option<ChannelNotificationSetting>) {
+        match previous {
+            Some(setting) => {
+                self.settings.insert(channel_id, setting);
+            }
+            None => {
+                self.settings.remove(&channel_id);
+            }
+        }
+    }
+}

--- a/crates/mezon-store/src/platform.rs
+++ b/crates/mezon-store/src/platform.rs
@@ -108,6 +108,8 @@ pub struct DesktopNotification {
     pub title: String,
     pub body: String,
     pub channel_id: Option<String>,
+    pub clan_id: Option<String>,
+    pub link: Option<String>,
 }
 
 pub struct PlatformStore {

--- a/crates/mezon-ui/src/chat/channel_header.rs
+++ b/crates/mezon-ui/src/chat/channel_header.rs
@@ -26,6 +26,7 @@ const HEADER_POPOVER_Y_OFFSET: f32 = 4.;
 pub struct ChannelHeader {
     name: String,
     dm: bool,
+    muted: bool,
     in_voice: Option<(SharedString, InVoiceInfo)>,
     members_action: bool,
     members_active: bool,
@@ -41,6 +42,7 @@ pub struct ChannelHeader {
     settings: Option<Entity<Settings>>,
     gallery_trigger: Option<AnyElement>,
     files_trigger: Option<AnyElement>,
+    notification_trigger: Option<AnyElement>,
     search_bar: Option<AnyElement>,
 }
 
@@ -49,6 +51,7 @@ impl ChannelHeader {
         Self {
             name: name.into(),
             dm: false,
+            muted: false,
             in_voice: None,
             members_action: true,
             members_active: false,
@@ -64,6 +67,7 @@ impl ChannelHeader {
             settings: None,
             gallery_trigger: None,
             files_trigger: None,
+            notification_trigger: None,
             search_bar: None,
         }
     }
@@ -144,6 +148,11 @@ impl ChannelHeader {
         self
     }
 
+    pub fn notification_trigger(mut self, trigger: Option<AnyElement>) -> Self {
+        self.notification_trigger = trigger;
+        self
+    }
+
     pub fn files_trigger(mut self, trigger: AnyElement) -> Self {
         self.files_trigger = Some(trigger);
         self
@@ -154,19 +163,34 @@ impl ChannelHeader {
         let bg_active = theme.bg_tertiary;
         let icon_color = theme.text_muted;
         let icon_active = theme.text_primary;
-        let actions = [
+        let bell_icon = if self.muted {
+            IconName::MuteBell
+        } else {
+            IconName::Bell
+        };
+        let channel_only_actions: &[(&str, IconName)] = &[
             ("hdr-canvas", IconName::CanvasIcon),
             ("hdr-timeline", IconName::History),
             ("hdr-thread", IconName::ThreadIcon),
             ("hdr-members", IconName::MemberList),
             ("hdr-pin", IconName::PinRight),
-            ("hdr-bell", IconName::Bell),
+            ("hdr-bell", bell_icon),
             ("hdr-gallery", IconName::ImageThumbnail),
             ("hdr-files", IconName::FileIcon),
         ];
+        let dm_actions: &[(&str, IconName)] = &[
+            ("hdr-members", IconName::MemberList),
+            ("hdr-pin", IconName::PinRight),
+        ];
+        let actions: Vec<(&str, IconName)> = if self.dm {
+            dm_actions.to_vec()
+        } else {
+            channel_only_actions.to_vec()
+        };
         let ChannelHeader {
             name,
             dm,
+            muted: _,
             in_voice,
             members_action,
             members_active,
@@ -182,6 +206,7 @@ impl ChannelHeader {
             settings,
             gallery_trigger,
             files_trigger,
+            notification_trigger,
             search_bar,
         } = self;
         let inbox_el = if show_inbox && !dm {
@@ -212,6 +237,7 @@ impl ChannelHeader {
             settings,
             gallery_trigger,
             files_trigger,
+            notification_trigger,
             cx,
         );
 
@@ -318,6 +344,8 @@ impl ChannelHeader {
         locale: Option<String>,
     ) -> gpui::AnyElement {
         let header = ChannelHeader {
+            muted: false,
+            notification_trigger: None,
             name: String::new(),
             dm: false,
             in_voice: None,
@@ -341,7 +369,7 @@ impl ChannelHeader {
     }
 
     fn build_action_buttons(
-        actions: [(&'static str, IconName); 8],
+        actions: Vec<(&'static str, IconName)>,
         theme: &Theme,
         icon_color: gpui::Rgba,
         icon_active: gpui::Rgba,
@@ -357,9 +385,12 @@ impl ChannelHeader {
         settings: Option<Entity<Settings>>,
         gallery_trigger: Option<AnyElement>,
         files_trigger: Option<AnyElement>,
+        notification_trigger: Option<AnyElement>,
         cx: &App,
     ) -> Vec<AnyElement> {
         let header = ChannelHeader {
+            muted: false,
+            notification_trigger,
             name: String::new(),
             dm: false,
             in_voice: None,
@@ -392,7 +423,7 @@ impl ChannelHeader {
 
     fn action_buttons(
         self,
-        actions: [(&'static str, IconName); 8],
+        actions: Vec<(&'static str, IconName)>,
         theme: &Theme,
         icon_color: gpui::Rgba,
         icon_active: gpui::Rgba,
@@ -410,6 +441,7 @@ impl ChannelHeader {
         let settings = self.settings;
         let mut gallery_trigger = self.gallery_trigger;
         let mut files_trigger = self.files_trigger;
+        let mut notification_trigger = self.notification_trigger;
         let mut buttons: Vec<AnyElement> = Vec::new();
         for (id, icon) in actions {
             if id == "hdr-members" && !members_action {
@@ -486,6 +518,12 @@ impl ChannelHeader {
                 && let Some(trigger) = gallery_trigger.take()
             {
                 buttons.push(trigger);
+                continue;
+            }
+            if id == "hdr-bell" {
+                if let Some(trigger) = notification_trigger.take() {
+                    buttons.push(trigger);
+                }
                 continue;
             }
             if id == "hdr-files" {
@@ -709,6 +747,41 @@ impl Render for ChatHeader {
             .clone()
             .unwrap_or_else(|| SharedString::from("en"));
 
+        let muted = crate::chat::files_popover::active_files_channel(cx)
+            .map(|(clan_id, channel_id)| {
+                mezon_store::NotificationSettingStore::global(cx)
+                    .read(cx)
+                    .is_muted(channel_id, clan_id)
+            })
+            .unwrap_or(false);
+        let notification_trigger = if self.dm {
+            None
+        } else {
+            Some(
+                PopoverMenu::new("hdr-bell-popover")
+                    .anchor(Anchor::TopRight)
+                    .attach(Anchor::BottomRight)
+                    .offset(point(px(0.), px(HEADER_POPOVER_Y_OFFSET)))
+                    .trigger(NotificationSettingTrigger::new(&theme, muted))
+                    .menu({
+                        let settings = settings.clone();
+                        move |_window, cx| {
+                            let (clan_id, channel_id) =
+                                crate::chat::files_popover::active_files_channel(cx)?;
+                            Some(cx.new(|cx| {
+                                crate::chat::notification_setting_popover::NotificationSettingPanel::new(
+                                    clan_id,
+                                    channel_id,
+                                    settings.clone(),
+                                    cx,
+                                )
+                            }))
+                        }
+                    })
+                    .into_any_element(),
+            )
+        };
+
         let gallery_trigger = PopoverMenu::new("hdr-gallery-popover")
             .anchor(Anchor::TopRight)
             .attach(Anchor::BottomRight)
@@ -759,6 +832,7 @@ impl Render for ChatHeader {
             .members_action(self.members_action)
             .members_active(self.members_active)
             .gallery_trigger(gallery_trigger)
+            .notification_trigger(notification_trigger)
             .show_inbox(self.show_inbox)
             .on_toggle_members(members_toggle)
             .show_threads(show_threads);
@@ -1226,6 +1300,90 @@ impl IntoElement for FilesPopoverTrigger {
             .hover(move |s| s.bg(bg_hover))
             .occlude()
             .child(Icon::new(IconName::FileIcon).size(px(20.)).text_color(tint));
+        if self.selected {
+            button = button.bg(self.bg_active);
+        }
+        if let Some(cursor) = self.cursor {
+            button = button.cursor(cursor);
+        }
+        if let Some(handler) = self.on_click {
+            button = button.on_click(handler);
+        }
+        button
+    }
+}
+
+pub struct NotificationSettingTrigger {
+    icon: IconName,
+    icon_idle: gpui::Rgba,
+    icon_active: gpui::Rgba,
+    bg_hover: gpui::Rgba,
+    bg_active: gpui::Rgba,
+    selected: bool,
+    on_click: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
+    cursor: Option<CursorStyle>,
+}
+
+impl NotificationSettingTrigger {
+    fn new(theme: &Theme, muted: bool) -> Self {
+        Self {
+            icon: if muted {
+                IconName::MuteBell
+            } else {
+                IconName::Bell
+            },
+            icon_idle: theme.text_muted,
+            icon_active: theme.text_primary,
+            bg_hover: theme.bg_hover,
+            bg_active: theme.bg_tertiary,
+            selected: false,
+            on_click: None,
+            cursor: None,
+        }
+    }
+}
+
+impl Clickable for NotificationSettingTrigger {
+    fn on_click(mut self, handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static) -> Self {
+        self.on_click = Some(Box::new(handler));
+        self
+    }
+
+    fn cursor_style(mut self, cursor_style: CursorStyle) -> Self {
+        self.cursor = Some(cursor_style);
+        self
+    }
+}
+
+impl Toggleable for NotificationSettingTrigger {
+    fn toggle_state(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+}
+
+impl IntoElement for NotificationSettingTrigger {
+    type Element = Stateful<Div>;
+
+    fn into_element(self) -> Self::Element {
+        let bg_hover = self.bg_hover;
+        let tint = if self.selected {
+            self.icon_active
+        } else {
+            self.icon_idle
+        };
+        let mut button = div()
+            .id("hdr-bell")
+            .flex()
+            .items_center()
+            .justify_center()
+            .w(px(32.))
+            .h(px(32.))
+            .rounded_md()
+            .cursor_pointer()
+            .hover(move |s| s.bg(bg_hover))
+            .occlude()
+            .child(Icon::new(self.icon).size(px(20.)).text_color(tint));
         if self.selected {
             button = button.bg(self.bg_active);
         }

--- a/crates/mezon-ui/src/chat/mod.rs
+++ b/crates/mezon-ui/src/chat/mod.rs
@@ -21,6 +21,7 @@ pub mod member_row_element;
 pub mod mention_input;
 pub mod message;
 pub mod message_search;
+pub mod notification_setting_popover;
 pub mod pinned_popover;
 pub mod screen_share_modal;
 pub mod screen_share_pip;

--- a/crates/mezon-ui/src/chat/notification_setting_popover.rs
+++ b/crates/mezon-ui/src/chat/notification_setting_popover.rs
@@ -1,0 +1,292 @@
+use gpui::{
+    Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, IntoElement,
+    MouseDownEvent, ParentElement, Render, Styled, Window, div, prelude::*, px, relative,
+};
+use mezon_store::notification_setting::{
+    MUTE_FOR_1_HOUR_SEC, MUTE_FOR_3_HOURS_SEC, MUTE_FOR_8_HOURS_SEC, MUTE_FOR_15_MINUTES_SEC,
+    MUTE_FOR_24_HOURS_SEC, MUTE_FOREVER, NOTIFICATION_ALL_MESSAGE, NOTIFICATION_DEFAULT,
+    NOTIFICATION_MENTION_MESSAGE, NOTIFICATION_NOTHING_MESSAGE,
+};
+use mezon_store::{ChannelId, ClanId, NotificationSettingStore, Settings};
+
+use crate::components::primitives::{Icon, IconName, Label, h_flex, v_flex};
+use crate::theme::ActiveTheme;
+
+const MUTE_OPTIONS: &[(i32, &str)] = &[
+    (
+        MUTE_FOR_15_MINUTES_SEC,
+        "channelTopbar.notificationSetting.muteOptions.for15Minutes",
+    ),
+    (
+        MUTE_FOR_1_HOUR_SEC,
+        "channelTopbar.notificationSetting.muteOptions.for1Hour",
+    ),
+    (
+        MUTE_FOR_3_HOURS_SEC,
+        "channelTopbar.notificationSetting.muteOptions.for3Hours",
+    ),
+    (
+        MUTE_FOR_8_HOURS_SEC,
+        "channelTopbar.notificationSetting.muteOptions.for8Hours",
+    ),
+    (
+        MUTE_FOR_24_HOURS_SEC,
+        "channelTopbar.notificationSetting.muteOptions.for24Hours",
+    ),
+    (
+        MUTE_FOREVER,
+        "channelTopbar.notificationSetting.muteOptions.untilTurnedBackOn",
+    ),
+];
+
+const LEVEL_OPTIONS: &[(i32, &str)] = &[
+    (
+        NOTIFICATION_DEFAULT,
+        "notificationSetting.bottomSheet.labelOptions.categoryDefault",
+    ),
+    (
+        NOTIFICATION_ALL_MESSAGE,
+        "notificationSetting.bottomSheet.labelOptions.allMessage",
+    ),
+    (
+        NOTIFICATION_MENTION_MESSAGE,
+        "notificationSetting.bottomSheet.labelOptions.mentionMessage",
+    ),
+    (
+        NOTIFICATION_NOTHING_MESSAGE,
+        "notificationSetting.bottomSheet.labelOptions.notThingMessage",
+    ),
+];
+
+pub struct NotificationSettingPanel {
+    clan_id: ClanId,
+    channel_id: ChannelId,
+    settings: Entity<Settings>,
+    focus_handle: FocusHandle,
+    mute_submenu_open: bool,
+}
+
+impl EventEmitter<DismissEvent> for NotificationSettingPanel {}
+
+impl Focusable for NotificationSettingPanel {
+    fn focus_handle(&self, _cx: &gpui::App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl NotificationSettingPanel {
+    pub fn new(
+        clan_id: ClanId,
+        channel_id: ChannelId,
+        settings: Entity<Settings>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let store = NotificationSettingStore::global(cx);
+        store.update(cx, |store, cx| store.ensure_loaded(channel_id, cx));
+        cx.observe(&store, |_, _, cx| cx.notify()).detach();
+        Self {
+            clan_id,
+            channel_id,
+            settings,
+            focus_handle: cx.focus_handle(),
+            mute_submenu_open: false,
+        }
+    }
+}
+
+impl Render for NotificationSettingPanel {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme().clone();
+        let tokens = &theme.tokens;
+        let locale = self.settings.read(cx).language.clone();
+        let store = NotificationSettingStore::global(cx);
+        let (muted, level, muted_until) = {
+            let store = store.read(cx);
+            (
+                store.is_muted(self.channel_id, self.clan_id),
+                store.level(self.channel_id),
+                store.muted_until_ms(self.channel_id),
+            )
+        };
+        let t = |key: &'static str| mezon_i18n::t(&locale, key);
+
+        let channel_id = self.channel_id;
+        let clan_id = self.clan_id;
+
+        let mute_header = if muted {
+            t("channelTopbar.notificationSetting.unmuteChannel")
+        } else {
+            t("channelTopbar.notificationSetting.muteChannel")
+        };
+
+        let mut mute_row = v_flex().w_full().child(
+            h_flex()
+                .w_full()
+                .items_center()
+                .justify_between()
+                .child(Label::new(mute_header).text_color(tokens.text_theme_primary))
+                .when(!muted, |row| {
+                    row.child(
+                        Icon::new(IconName::ChevronRight)
+                            .size(px(14.))
+                            .text_color(tokens.text_secondary),
+                    )
+                }),
+        );
+        if let Some(until_ms) = muted_until {
+            mute_row = mute_row.child(
+                div().ml(px(8.)).mb(px(4.)).child(
+                    Label::new(
+                        t("channelTopbar.notificationSetting.mutedUntil")
+                            .replace("{{date}}", &format_muted_until(until_ms)),
+                    )
+                    .text_xs()
+                    .text_color(tokens.text_theme_primary),
+                ),
+            );
+        }
+
+        let submenu_open = self.mute_submenu_open && !muted;
+        let mut mute_entry = div()
+            .id("noti-mute-toggle")
+            .relative()
+            .px(px(8.))
+            .py(px(6.))
+            .rounded(px(2.))
+            .cursor_pointer()
+            .hover(|s| s.bg(tokens.bg_item_hover))
+            .child(mute_row)
+            .on_hover(cx.listener(|this, hovered: &bool, _, cx| {
+                if *hovered {
+                    this.mute_submenu_open = true;
+                    cx.notify();
+                }
+            }))
+            .on_click(cx.listener(move |_, _, _, cx| {
+                NotificationSettingStore::global(cx).update(cx, |store, cx| {
+                    if store.is_muted(channel_id, clan_id) {
+                        store.unmute(channel_id, clan_id, cx);
+                    } else {
+                        store.mute_forever(channel_id, clan_id, cx);
+                    }
+                });
+            }));
+
+        if submenu_open {
+            let mut submenu = v_flex()
+                .id("noti-mute-submenu")
+                .absolute()
+                .top(px(-6.))
+                .left(relative(1.))
+                .ml(px(4.))
+                .w(px(200.))
+                .p(px(6.))
+                .rounded_md()
+                .border_1()
+                .border_color(tokens.border_primary)
+                .bg(tokens.theme_setting_primary)
+                .shadow_lg()
+                .occlude();
+            for (seconds, key) in MUTE_OPTIONS {
+                let seconds = *seconds;
+                submenu = submenu.child(
+                    div()
+                        .id(*key)
+                        .px(px(8.))
+                        .py(px(6.))
+                        .rounded(px(2.))
+                        .cursor_pointer()
+                        .hover(|s| s.bg(tokens.bg_item_hover))
+                        .child(
+                            Label::new(t(key))
+                                .text_sm()
+                                .text_color(tokens.text_theme_primary),
+                        )
+                        .on_click(cx.listener(move |_, _, _, cx| {
+                            NotificationSettingStore::global(cx).update(cx, |store, cx| {
+                                store.set_mute(channel_id, clan_id, seconds, cx);
+                            });
+                        })),
+                );
+            }
+            mute_entry = mute_entry.child(submenu);
+        }
+
+        let mut root = v_flex()
+            .key_context("menu")
+            .track_focus(&self.focus_handle)
+            .on_action(cx.listener(|_, _: &::menu::Cancel, _window, cx| {
+                cx.emit(DismissEvent);
+            }))
+            .on_mouse_down_out(cx.listener(|this, _: &MouseDownEvent, _window, cx| {
+                if this.mute_submenu_open {
+                    this.mute_submenu_open = false;
+                    cx.notify();
+                    return;
+                }
+                cx.emit(DismissEvent);
+            }))
+            .w(px(202.))
+            .py(px(6.))
+            .px(px(8.))
+            .rounded_md()
+            .border_1()
+            .border_color(tokens.border_primary)
+            .bg(tokens.theme_setting_primary)
+            .text_color(tokens.text_theme_message)
+            .child(
+                div()
+                    .w_full()
+                    .pb(px(4.))
+                    .mb(px(4.))
+                    .border_b_1()
+                    .border_color(tokens.border_primary)
+                    .child(mute_entry),
+            );
+
+        for (option_level, key) in LEVEL_OPTIONS {
+            let option_level = *option_level;
+            let selected = level == option_level;
+            root = root.child(
+                h_flex()
+                    .id(*key)
+                    .items_center()
+                    .gap(px(8.))
+                    .px(px(8.))
+                    .py(px(6.))
+                    .rounded(px(4.))
+                    .cursor_pointer()
+                    .hover(|s| s.bg(tokens.bg_item_hover))
+                    .child(
+                        div()
+                            .w(px(12.))
+                            .h(px(12.))
+                            .rounded(px(6.))
+                            .border_1()
+                            .border_color(tokens.border_primary)
+                            .when(selected, |d| d.bg(tokens.text_theme_primary)),
+                    )
+                    .child(
+                        Label::new(t(key))
+                            .text_sm()
+                            .text_color(tokens.text_theme_primary),
+                    )
+                    .on_click(cx.listener(move |_, _, _, cx| {
+                        NotificationSettingStore::global(cx).update(cx, |store, cx| {
+                            store.set_level(channel_id, clan_id, option_level, cx);
+                        });
+                    })),
+            );
+        }
+
+        root
+    }
+}
+
+pub fn format_muted_until(epoch_ms: i64) -> String {
+    use chrono::{Local, TimeZone};
+    match Local.timestamp_millis_opt(epoch_ms).single() {
+        Some(dt) => dt.format("%d/%m, %H:%M").to_string(),
+        None => String::new(),
+    }
+}

--- a/crates/mezon-ui/src/components/primitives/context_menu.rs
+++ b/crates/mezon-ui/src/components/primitives/context_menu.rs
@@ -36,8 +36,25 @@ enum Item {
         on_react: QuickReactionHandler,
         on_view_more: MenuHandler,
     },
+    Submenu {
+        label: SharedString,
+        sub_text: Option<SharedString>,
+        options: Vec<SubmenuOption>,
+        open: bool,
+        on_open: MenuHandler,
+        on_select: SubmenuHandler,
+    },
     Separator,
 }
+
+#[derive(Clone)]
+pub struct SubmenuOption {
+    pub value: i32,
+    pub label: SharedString,
+    pub selected: bool,
+}
+
+type SubmenuHandler = Rc<dyn Fn(i32, &mut Window, &mut App)>;
 
 #[derive(IntoElement, Default)]
 pub struct ContextMenu {
@@ -228,6 +245,26 @@ impl ContextMenu {
         });
         self
     }
+
+    pub fn submenu(
+        mut self,
+        label: impl Into<SharedString>,
+        sub_text: Option<SharedString>,
+        options: Vec<SubmenuOption>,
+        open: bool,
+        on_open: impl Fn(&mut Window, &mut App) + 'static,
+        on_select: impl Fn(i32, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.items.push(Item::Submenu {
+            label: label.into(),
+            sub_text,
+            options,
+            open,
+            on_open: Rc::new(on_open),
+            on_select: Rc::new(on_select),
+        });
+        self
+    }
 }
 
 impl RenderOnce for ContextMenu {
@@ -362,6 +399,103 @@ impl RenderOnce for ContextMenu {
                                     dismiss(window, cx);
                                 }
                             }),
+                    );
+                }
+                Item::Submenu {
+                    label,
+                    sub_text,
+                    options,
+                    open,
+                    on_open,
+                    on_select,
+                } => {
+                    let dismiss = dismiss.clone();
+                    let submenu = if open {
+                        let mut sub = v_flex()
+                            .absolute()
+                            .top(px(-6.))
+                            .when(submenu_open_left, |el| el.right(relative(1.)).mr(px(4.)))
+                            .when(!submenu_open_left, |el| el.left(relative(1.)).ml(px(4.)))
+                            .w(px(SUBMENU_WIDTH))
+                            .p(px(6.))
+                            .rounded_md()
+                            .border_1()
+                            .border_color(border)
+                            .bg(bg)
+                            .shadow_lg()
+                            .occlude();
+                        for (oi, option) in options.iter().enumerate() {
+                            let value = option.value;
+                            let on_select = on_select.clone();
+                            let dismiss_o = dismiss.clone();
+                            sub = sub.child(
+                                h_flex()
+                                    .id(("submenu-option", oi))
+                                    .w_full()
+                                    .items_center()
+                                    .gap_2()
+                                    .px(px(8.))
+                                    .py(px(6.))
+                                    .rounded(px(4.))
+                                    .cursor_pointer()
+                                    .hover(|s| s.bg(hover))
+                                    .child(
+                                        div()
+                                            .flex_1()
+                                            .text_sm()
+                                            .text_color(text)
+                                            .truncate()
+                                            .child(option.label.clone()),
+                                    )
+                                    .when(option.selected, |el| {
+                                        el.child(
+                                            Icon::new(IconName::Check).size_4().text_color(text),
+                                        )
+                                    })
+                                    .on_click(move |_: &ClickEvent, window, cx| {
+                                        on_select(value, window, cx);
+                                        if let Some(dismiss) = &dismiss_o {
+                                            dismiss(window, cx);
+                                        }
+                                    }),
+                            );
+                        }
+                        Some(sub)
+                    } else {
+                        None
+                    };
+                    let mut label_col = v_flex().flex_1().child(div().child(label));
+                    if let Some(sub_text) = sub_text {
+                        label_col = label_col.child(
+                            div()
+                                .ml(px(8.))
+                                .mb(px(4.))
+                                .text_xs()
+                                .text_color(text)
+                                .child(sub_text),
+                        );
+                    }
+                    panel = panel.child(
+                        h_flex()
+                            .id(("context-menu-item", index))
+                            .relative()
+                            .w_full()
+                            .items_center()
+                            .px(px(10.))
+                            .py(px(8.))
+                            .rounded(px(4.))
+                            .text_sm()
+                            .text_color(text)
+                            .cursor_pointer()
+                            .hover(|s| s.bg(hover))
+                            .on_hover(move |hovered, window, cx| {
+                                if *hovered {
+                                    on_open(window, cx);
+                                }
+                            })
+                            .child(label_col)
+                            .child(Icon::new(IconName::ChevronRight).size_4().text_color(muted))
+                            .children(submenu),
                     );
                 }
                 Item::ReactionSubmenu {

--- a/crates/mezon-ui/src/components/primitives/mod.rs
+++ b/crates/mezon-ui/src/components/primitives/mod.rs
@@ -29,7 +29,7 @@ pub(crate) use avatar::{avatar_color, name_initials};
 pub use badge::Badge;
 pub use button::{Button, ButtonVariant, ButtonVariants};
 pub use checkbox::{Checkbox, Radio};
-pub use context_menu::{ContextMenu, context_menu_at};
+pub use context_menu::{ContextMenu, SubmenuOption, context_menu_at};
 pub use date_picker::{DatePicker, DatePickerEvent};
 pub use divider::Divider;
 pub use dropdown::{Dropdown, DropdownTriggerStyle};

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/menu.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/menu.rs
@@ -1,9 +1,9 @@
 use gpui::{App, ClickEvent, Entity, Pixels, Point, WeakEntity, Window};
-use mezon_store::{ChannelList, ChannelType, ClanId};
+use mezon_store::{ChannelId, ChannelList, ChannelType, ClanId};
 
 use super::ChannelSidebar;
 use crate::app::shell::Shell;
-use crate::components::primitives::ContextMenu;
+use crate::components::primitives::{ContextMenu, SubmenuOption};
 
 pub(super) fn on_channel_click(
     channel_id: String,
@@ -39,6 +39,10 @@ pub(super) struct OpenMenu {
     pub(super) channel_type: ChannelType,
     pub(super) is_thread: bool,
     pub(super) position: Point<Pixels>,
+    pub(super) channel_id: ChannelId,
+    pub(super) clan_id: ClanId,
+    pub(super) mute_sub_open: bool,
+    pub(super) noti_sub_open: bool,
 }
 
 fn coming_soon_toast(message: String) -> impl Fn(&mut Window, &mut App) + 'static {
@@ -58,18 +62,160 @@ fn coming_soon_modal(title: String, locale: String) -> impl Fn(&mut Window, &mut
     }
 }
 
+const MUTE_DURATIONS: &[(i32, &str)] = &[
+    (
+        mezon_store::notification_setting::MUTE_FOR_15_MINUTES_SEC,
+        "channelMenu.menu.notification.for15Minutes",
+    ),
+    (
+        mezon_store::notification_setting::MUTE_FOR_1_HOUR_SEC,
+        "channelMenu.menu.notification.for1Hour",
+    ),
+    (
+        mezon_store::notification_setting::MUTE_FOR_3_HOURS_SEC,
+        "channelMenu.menu.notification.for3Hours",
+    ),
+    (
+        mezon_store::notification_setting::MUTE_FOR_8_HOURS_SEC,
+        "channelMenu.menu.notification.for8Hours",
+    ),
+    (
+        mezon_store::notification_setting::MUTE_FOR_24_HOURS_SEC,
+        "channelMenu.menu.notification.for24Hours",
+    ),
+    (
+        mezon_store::notification_setting::MUTE_FOREVER,
+        "channelMenu.menu.notification.untilTurnedBackOn",
+    ),
+];
+
+const NOTI_LEVELS: &[(i32, &str)] = &[
+    (
+        mezon_store::notification_setting::NOTIFICATION_DEFAULT,
+        "channelMenu.menu.notification.useCategoryDefault",
+    ),
+    (
+        mezon_store::notification_setting::NOTIFICATION_ALL_MESSAGE,
+        "channelMenu.menu.notification.all",
+    ),
+    (
+        mezon_store::notification_setting::NOTIFICATION_MENTION_MESSAGE,
+        "channelMenu.menu.notification.onlyMention",
+    ),
+    (
+        mezon_store::notification_setting::NOTIFICATION_NOTHING_MESSAGE,
+        "channelMenu.menu.notification.nothing",
+    ),
+];
+
+/// Mirrors React `PanelChannel`: the row's subText shows the level actually in
+/// effect, resolving `DEFAULT` through the clan default.
+fn effective_level_label(locale: &str, level: i32, clan_default: Option<i32>) -> String {
+    use mezon_store::notification_setting as ns;
+    let effective = if level == ns::NOTIFICATION_DEFAULT {
+        clan_default.unwrap_or(ns::NOTIFICATION_DEFAULT)
+    } else {
+        level
+    };
+    let key = match effective {
+        v if v == ns::NOTIFICATION_ALL_MESSAGE => "channelMenu.menu.notification.all",
+        v if v == ns::NOTIFICATION_MENTION_MESSAGE => "channelMenu.menu.notification.onlyMention",
+        v if v == ns::NOTIFICATION_NOTHING_MESSAGE => "channelMenu.menu.notification.nothing",
+        _ => "channelMenu.menu.notification.useCategoryDefault",
+    };
+    mezon_i18n::t(locale, key).to_string()
+}
+
+fn submenu_options(
+    locale: &str,
+    source: &[(i32, &'static str)],
+    selected: i32,
+) -> Vec<SubmenuOption> {
+    source
+        .iter()
+        .map(|(value, key)| SubmenuOption {
+            value: *value,
+            label: mezon_i18n::t(locale, key).into(),
+            selected: *value == selected,
+        })
+        .collect()
+}
+
+fn set_submenu_open(
+    sidebar: WeakEntity<ChannelSidebar>,
+    mute: bool,
+) -> impl Fn(&mut Window, &mut App) + 'static {
+    move |_window: &mut Window, cx: &mut App| {
+        let _ = sidebar.update(cx, |this, cx| {
+            if let Some(menu) = this.open_menu.as_mut() {
+                let (m, n) = if mute { (true, false) } else { (false, true) };
+                if menu.mute_sub_open != m || menu.noti_sub_open != n {
+                    menu.mute_sub_open = m;
+                    menu.noti_sub_open = n;
+                    cx.notify();
+                }
+            }
+        });
+    }
+}
+
+fn apply_mute(
+    channel_id: ChannelId,
+    clan_id: ClanId,
+) -> impl Fn(i32, &mut Window, &mut App) + 'static {
+    move |seconds: i32, _window: &mut Window, cx: &mut App| {
+        if let Some(store) = mezon_store::NotificationSettingStore::try_global(cx) {
+            store.update(cx, |store, cx| {
+                store.set_mute(channel_id, clan_id, seconds, cx)
+            });
+        }
+    }
+}
+
+fn apply_level(
+    channel_id: ChannelId,
+    clan_id: ClanId,
+) -> impl Fn(i32, &mut Window, &mut App) + 'static {
+    move |level: i32, _window: &mut Window, cx: &mut App| {
+        if let Some(store) = mezon_store::NotificationSettingStore::try_global(cx) {
+            store.update(cx, |store, cx| {
+                store.set_level(channel_id, clan_id, level, cx)
+            });
+        }
+    }
+}
+
+fn mute_label(locale: &str, is_thread: bool, muted: bool) -> String {
+    let key = match (is_thread, muted) {
+        (true, true) => "channelMenu.menu.notification.unmuteThreadStatus",
+        (true, false) => "channelMenu.menu.notification.muteThreadStatus",
+        (false, true) => "channelMenu.menu.notification.unmuteChannelStatus",
+        (false, false) => "channelMenu.menu.notification.muteChannelStatus",
+    };
+    mezon_i18n::t(locale, key).to_string()
+}
+
 pub(super) fn build_channel_menu(
     sidebar: WeakEntity<ChannelSidebar>,
     locale: &str,
     channel_type: ChannelType,
     is_thread: bool,
+    channel_id: ChannelId,
+    clan_id: ClanId,
+    muted: bool,
+    muted_until: Option<String>,
+    level: i32,
+    mute_sub_open: bool,
+    noti_sub_open: bool,
+    clan_default: Option<i32>,
 ) -> ContextMenu {
     let t = |key: &'static str| mezon_i18n::t(locale, key).to_string();
     let coming_soon = t("common.comingSoon");
     let locale_owned = locale.to_string();
+    let sidebar_dismiss = sidebar.clone();
 
     let mut menu = ContextMenu::new().on_dismiss(move |_window, cx| {
-        if let Some(view) = sidebar.upgrade() {
+        if let Some(view) = sidebar_dismiss.upgrade() {
             view.update(cx, |this, cx| {
                 this.open_menu = None;
                 cx.notify();
@@ -101,13 +247,21 @@ pub(super) fn build_channel_menu(
                     locale_owned.clone(),
                 ),
             )
-            .item(
-                t("channelMenu.menu.notification.muteThread"),
-                coming_soon_toast(coming_soon.clone()),
+            .submenu(
+                mute_label(locale, true, muted),
+                muted_until.clone().map(Into::into),
+                submenu_options(locale, MUTE_DURATIONS, -2),
+                mute_sub_open,
+                set_submenu_open(sidebar.clone(), true),
+                apply_mute(channel_id, clan_id),
             )
-            .item(
+            .submenu(
                 t("channelMenu.menu.notification.notification"),
-                coming_soon_toast(coming_soon.clone()),
+                Some(effective_level_label(locale, level, clan_default).into()),
+                submenu_options(locale, NOTI_LEVELS, level),
+                noti_sub_open,
+                set_submenu_open(sidebar.clone(), false),
+                apply_level(channel_id, clan_id),
             )
             .danger_item(
                 leave_label.clone(),
@@ -133,13 +287,21 @@ pub(super) fn build_channel_menu(
                     locale_owned.clone(),
                 ),
             )
-            .item(
-                t("channelMenu.menu.notification.muteChannel"),
-                coming_soon_toast(coming_soon.clone()),
+            .submenu(
+                mute_label(locale, false, muted),
+                muted_until.clone().map(Into::into),
+                submenu_options(locale, MUTE_DURATIONS, -2),
+                mute_sub_open,
+                set_submenu_open(sidebar.clone(), true),
+                apply_mute(channel_id, clan_id),
             )
-            .item(
+            .submenu(
                 t("channelMenu.menu.notification.notification"),
-                coming_soon_toast(coming_soon.clone()),
+                Some(effective_level_label(locale, level, clan_default).into()),
+                submenu_options(locale, NOTI_LEVELS, level),
+                noti_sub_open,
+                set_submenu_open(sidebar.clone(), false),
+                apply_level(channel_id, clan_id),
             )
             .item(
                 t("channelMenu.menu.inviteMenu.markFavorite"),

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
@@ -84,6 +84,7 @@ pub struct ChannelSidebar {
     _router_observe: Subscription,
     _members_observe: Subscription,
     _permissions_observe: Subscription,
+    _notification_setting_observe: Subscription,
 }
 
 impl ChannelSidebar {
@@ -134,6 +135,14 @@ impl ChannelSidebar {
                 cx.notify();
             }
         });
+        let notification_setting_observe = cx.observe(
+            &mezon_store::NotificationSettingStore::global(cx),
+            |this, _, cx| {
+                if this.open_menu.is_some() {
+                    cx.notify();
+                }
+            },
+        );
         let members_observe = cx.observe(&ClanMembersStore::global(cx), |this, _, cx| {
             let resolves_members = this.items.iter().any(|item| {
                 matches!(item, SidebarItem::Channel { voice_members, .. } if !voice_members.is_empty())
@@ -178,6 +187,7 @@ impl ChannelSidebar {
             _router_observe: router_observe,
             _members_observe: members_observe,
             _permissions_observe: permissions_observe,
+            _notification_setting_observe: notification_setting_observe,
         };
         this.rebuild_items(cx);
         this
@@ -524,6 +534,26 @@ impl Render for ChannelSidebar {
                 menu.channel_type,
                 menu.is_thread,
                 locale.clone(),
+                menu.channel_id,
+                menu.clan_id,
+                mezon_store::NotificationSettingStore::try_global(cx)
+                    .is_some_and(|store| store.read(cx).is_muted(menu.channel_id, menu.clan_id)),
+                mezon_store::NotificationSettingStore::try_global(cx)
+                    .and_then(|store| store.read(cx).muted_until_ms(menu.channel_id))
+                    .map(|ms| {
+                        format!(
+                            "{} {}",
+                            mezon_i18n::t(&locale, "channelMenu.menu.notification.mutedUntil"),
+                            crate::chat::notification_setting_popover::format_muted_until(ms)
+                        )
+                    }),
+                mezon_store::NotificationSettingStore::try_global(cx)
+                    .map(|store| store.read(cx).level(menu.channel_id))
+                    .unwrap_or(0),
+                menu.mute_sub_open,
+                menu.noti_sub_open,
+                mezon_store::NotificationSettingStore::try_global(cx)
+                    .and_then(|store| store.read(cx).clan_default(menu.clan_id)),
             )
         });
         let clan_menu_data = self.clan_menu_open.then(|| {
@@ -752,7 +782,21 @@ impl Render for ChannelSidebar {
             )
             .when_some(
                 menu_overlay,
-                move |el, (position, channel_type, is_thread, locale)| {
+                move |el,
+                      (
+                    position,
+                    channel_type,
+                    is_thread,
+                    locale,
+                    channel_id,
+                    clan_id,
+                    muted,
+                    muted_until,
+                    level,
+                    mute_sub_open,
+                    noti_sub_open,
+                    clan_default,
+                )| {
                     el.child(context_menu_at(
                         position,
                         build_channel_menu(
@@ -760,6 +804,14 @@ impl Render for ChannelSidebar {
                             &locale,
                             channel_type,
                             is_thread,
+                            channel_id,
+                            clan_id,
+                            muted,
+                            muted_until,
+                            level,
+                            mute_sub_open,
+                            noti_sub_open,
+                            clan_default,
                         ),
                     ))
                 },
@@ -929,7 +981,7 @@ fn render_banner_and_events(
     sidebar: WeakEntity<ChannelSidebar>,
     cx: &App,
     suppress_hover: bool,
-    locale: &str,
+    _locale: &str,
 ) -> AnyElement {
     let theme = cx.theme();
     let divider_color = theme.border;
@@ -1063,7 +1115,7 @@ fn render_banner_and_events(
             let all_apps: Vec<AppChannelSlot> = app_channels.to_vec();
             let sidebar_more = sidebar.clone();
             let channel_apps_label =
-                SharedString::from(mezon_i18n::t(locale, "channelList.channelApps").to_string());
+                SharedString::from(mezon_i18n::t(&locale, "channelList.channelApps").to_string());
             app_row = app_row.child(
                 div()
                     .id("app-channels-more")
@@ -1194,6 +1246,8 @@ fn render_sidebar_item(
         } => {
             let ch_id = id.clone();
             let clan_id_inner = active_clan_id_for_nav;
+            let menu_channel_id: ChannelId = ch_id.parse().unwrap_or_default();
+            let menu_clan_id: ClanId = clan_id_inner.unwrap_or_default();
 
             let make_channel_element = || {
                 let icon = channel_type_icon(*channel_type, *private);
@@ -1340,6 +1394,10 @@ fn render_sidebar_item(
                                     channel_type: menu_channel_type,
                                     is_thread: menu_is_thread,
                                     position,
+                                    channel_id: menu_channel_id,
+                                    clan_id: menu_clan_id,
+                                    mute_sub_open: false,
+                                    noti_sub_open: false,
                                 });
                                 cx.notify();
                             });
@@ -1406,6 +1464,10 @@ fn render_sidebar_item(
                                 channel_type,
                                 is_thread,
                                 position,
+                                channel_id: menu_channel_id,
+                                clan_id: menu_clan_id,
+                                mute_sub_open: false,
+                                noti_sub_open: false,
                             });
                             cx.notify();
                         });


### PR DESCRIPTION
## Summary
- Add per-channel notification settings store and AppApi transport for mute/unmute and notification level changes
- Wire Gotify push delivery and improve native OS notification handling (badges, suppress when focused/muted)
- Add notification settings popover in channel header and sidebar context menu, matching React parity

## Test plan
- [ ] Open a channel and change notification settings from the header popover; verify selection persists after reload
- [ ] Right-click a channel in the sidebar and change notification settings from the context menu
- [ ] Receive a message in a muted vs unmuted channel and confirm native notifications respect the setting
- [ ] Confirm dock/tray badge counts update correctly when notifications are suppressed
- [ ] `just lint` and `just test` pass locally
