### PR TITLE
fix(ci): unblock Linux and Windows builds after notification merge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,7 @@ windows              = { version = "0.61.3", features = [
     "Win32_Security",
     "Win32_Security_Credentials",
     "Win32_Security_Cryptography",
+    "Win32_Storage_EnhancedStorage",
     "Win32_Storage_FileSystem",
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",

--- a/crates/mezon-native/src/notifications.rs
+++ b/crates/mezon-native/src/notifications.rs
@@ -174,7 +174,6 @@ extern "C" fn did_receive_notification_response(
     use objc::runtime::Object;
     use objc::{msg_send, sel, sel_impl};
 
-    tracing::debug!("native: notification response delegate fired");
     unsafe {
         if !response.is_null() {
             let notification: *mut Object = msg_send![response, notification];
@@ -182,9 +181,7 @@ extern "C" fn did_receive_notification_response(
                 let request: *mut Object = msg_send![notification, request];
                 if !request.is_null() {
                     let identifier: *mut Object = msg_send![request, identifier];
-                    let decoded = nsstring_to_string(identifier);
-                    tracing::debug!(identifier = ?decoded, "native: notification response identifier");
-                    if let Some(identifier) = decoded
+                    if let Some(identifier) = nsstring_to_string(identifier)
                         && let Some(target) = build_target(&identifier)
                     {
                         dispatch_click(target);
@@ -249,7 +246,6 @@ fn install_notification_delegate(center: *mut objc::runtime::Object) {
     unsafe {
         let _: () = msg_send![center, setDelegate: delegate as *mut Object];
     }
-    tracing::debug!("native: notification delegate installed");
 }
 
 #[cfg(target_os = "macos")]
@@ -379,15 +375,15 @@ fn init_windows() {
 
 #[cfg(target_os = "windows")]
 fn ensure_start_menu_shortcut() -> anyhow::Result<()> {
-    use windows::Win32::System::Com::StructuredStorage::PROPVARIANT;
+    use windows::Win32::Storage::EnhancedStorage::PKEY_AppUserModel_ID;
+    use windows::Win32::System::Com::StructuredStorage::InitPropVariantFromStringAsVector;
     use windows::Win32::System::Com::{
         CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx,
         IPersistFile,
     };
-    use windows::Win32::UI::Shell::PropertiesSystem::{
-        IPropertyStore, InitPropVariantFromStringAsVector, PKEY_AppUserModel_ID,
-    };
+    use windows::Win32::UI::Shell::PropertiesSystem::IPropertyStore;
     use windows::Win32::UI::Shell::{IShellLinkW, ShellLink};
+    use windows::core::PROPVARIANT;
     use windows::core::{HSTRING, Interface};
 
     let Some(appdata) = dirs::data_dir() else {
@@ -435,7 +431,7 @@ fn ensure_start_menu_shortcut() -> anyhow::Result<()> {
 fn show_windows(n: &Notification) {
     let title = n.title.clone();
     let body = n.body.clone();
-    let tag = replacement_key(n.channel_id.as_ref());
+    let tag = replacement_key(n);
 
     std::thread::spawn(move || {
         if let Err(e) = try_show_toast(&title, &body, tag.as_deref()) {

--- a/crates/mezon-ui/src/channel_app/mod.rs
+++ b/crates/mezon-ui/src/channel_app/mod.rs
@@ -195,7 +195,7 @@ fn request_channel_app_from_store(
         let Some(url) = task.await else {
             return;
         };
-        let _ = cx.update(|cx| {
+        cx.update(|cx| {
             present_channel_app_window(
                 OpenChannelAppRequest {
                     app_id,
@@ -308,7 +308,6 @@ fn spawn_channel_app_window(request: OpenChannelAppRequest, cx: &mut App) {
         Ok(handle) => {
             #[cfg(target_os = "macos")]
             {
-                let handle = handle.clone();
                 cx.defer(move |cx| {
                     let _ = handle.update(cx, |_, window, _| {
                         window_controls::macos::disable_window_fullscreen(window);

--- a/scripts/linux-deps
+++ b/scripts/linux-deps
@@ -17,6 +17,7 @@ install_apt() {
     cmake
     clang
     libglib2.0-dev
+    libsoup-3.0-dev
     libgtk-3-dev
     libatk1.0-dev
     libpango1.0-dev
@@ -79,6 +80,7 @@ install_dnf() {
     cmake
     clang
     glib2-devel
+    libsoup3-devel
     gtk3-devel
     atk-devel
     pango-devel


### PR DESCRIPTION
## Summary
- Fix Windows compile errors in `mezon-native` toast setup: import `PKEY_AppUserModel_ID` and `InitPropVariantFromStringAsVector` from the correct `windows-rs` modules, and pass `&Notification` to `replacement_key`
- Add `libsoup-3.0-dev` / `libsoup3-devel` to `scripts/linux-deps` so Linux build/test can link `soup3-sys` (channel app webview)
- Fix two clippy errors in `channel_app/mod.rs` that block the macOS lint job

## Root cause
PR #124 introduced Windows notification code using APIs from the wrong module path; Linux CI was missing libsoup 3 for the webview stack.

## Test plan
- [ ] Windows Check passes (`cargo check -p mezon-app` on windows-latest)
- [ ] Linux Build passes (`cargo build --release -p mezon-app`)
- [ ] Lint + Test jobs green on CI
