### PR TITLE
fix(ci): Windows PROPVARIANT import and Linux webkit deps

### DIFF
--- a/crates/mezon-native/src/notifications.rs
+++ b/crates/mezon-native/src/notifications.rs
@@ -376,14 +376,15 @@ fn init_windows() {
 #[cfg(target_os = "windows")]
 fn ensure_start_menu_shortcut() -> anyhow::Result<()> {
     use windows::Win32::Storage::EnhancedStorage::PKEY_AppUserModel_ID;
-    use windows::Win32::System::Com::StructuredStorage::InitPropVariantFromStringAsVector;
+    use windows::Win32::System::Com::StructuredStorage::{
+        InitPropVariantFromStringAsVector, PROPVARIANT,
+    };
     use windows::Win32::System::Com::{
         CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx,
         IPersistFile,
     };
     use windows::Win32::UI::Shell::PropertiesSystem::IPropertyStore;
     use windows::Win32::UI::Shell::{IShellLinkW, ShellLink};
-    use windows::core::PROPVARIANT;
     use windows::core::{HSTRING, Interface};
 
     let Some(appdata) = dirs::data_dir() else {

--- a/scripts/linux-deps
+++ b/scripts/linux-deps
@@ -18,6 +18,8 @@ install_apt() {
     clang
     libglib2.0-dev
     libsoup-3.0-dev
+    libjavascriptcoregtk-4.1-dev
+    libwebkit2gtk-4.1-dev
     libgtk-3-dev
     libatk1.0-dev
     libpango1.0-dev
@@ -81,6 +83,8 @@ install_dnf() {
     clang
     glib2-devel
     libsoup3-devel
+    javascriptcoregtk4.1-devel
+    webkit2gtk4.1-devel
     gtk3-devel
     atk-devel
     pango-devel


### PR DESCRIPTION
## Summary
- Fix Windows build: import `PROPVARIANT` and `InitPropVariantFromStringAsVector` from `Win32::System::Com::StructuredStorage` (PR #125 incorrectly used `windows::core::PROPVARIANT`).
- Fix Linux build: add `libjavascriptcoregtk-4.1-dev` and `libwebkit2gtk-4.1-dev` to `scripts/linux-deps` for `wry` / `mezon-webview`.

## Test plan
- [ ] CI Build — Linux, Windows, macOS
- [ ] CI Windows Check
- [ ] CI Lint + Test

