### PR TITLE
fix: PR #136 review follow-ups

### DIFF
--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -2484,6 +2484,7 @@ pub fn extract_canvas_ids_from_text(text: &str) -> Vec<String> {
     let mut search_from = 0usize;
     while let Some(rel) = text.get(search_from..).and_then(|hay| hay.find(marker)) {
         let base = search_from + rel + marker.len();
+        search_from = base;
         let Some(rest) = text.get(base..) else {
             break;
         };
@@ -2492,36 +2493,36 @@ pub fn extract_canvas_ids_from_text(text: &str) -> Vec<String> {
             break;
         };
         if clan_id.is_empty() || !clan_id.bytes().all(|b| b.is_ascii_digit()) {
-            search_from = base + 1;
             continue;
         }
         if parts.next() != Some("channels") {
-            search_from = base + 1;
             continue;
         }
         let Some(channel_id) = parts.next() else {
             break;
         };
         if channel_id.is_empty() || !channel_id.bytes().all(|b| b.is_ascii_digit()) {
-            search_from = base + 1;
             continue;
         }
         if parts.next() != Some("canvas") {
-            search_from = base + 1;
             continue;
         }
-        let Some(canvas_id) = parts.next() else {
+        let Some(canvas_segment) = parts.next() else {
             break;
         };
-        let canvas_id = canvas_id
-            .split(['?', '#'])
+        search_from = base
+            + clan_id.len()
+            + "/channels/".len()
+            + channel_id.len()
+            + "/canvas/".len()
+            + canvas_segment.len();
+        let canvas_id = canvas_segment
+            .split(|c: char| c.is_whitespace() || c == '?' || c == '#')
             .next()
-            .unwrap_or(canvas_id)
-            .trim();
+            .unwrap_or_default();
         if !canvas_id.is_empty() {
             ids.push(canvas_id.to_string());
         }
-        search_from = base + rest.len();
     }
     ids.sort();
     ids.dedup();
@@ -9497,6 +9498,23 @@ mod tests {
         let parsed = parse_search_attachment_field(raw);
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].url, "https://cdn/b.png");
+    }
+
+    #[test]
+    fn extract_canvas_ids_finds_every_link() {
+        let text = "a https://mezon.ai/chat/clans/1/channels/2/canvas/aaa and \
+                    https://mezon.ai/chat/clans/1/channels/2/canvas/bbb?x=1 end";
+        assert_eq!(
+            extract_canvas_ids_from_text(text),
+            vec!["aaa".to_string(), "bbb".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_canvas_ids_skips_non_canvas_links_and_keeps_scanning() {
+        let text = "/chat/clans/1/channels/2/threads/9 — chào bạn 👋 \
+                    https://mezon.ai/chat/clans/3/channels/4/canvas/zzz";
+        assert_eq!(extract_canvas_ids_from_text(text), vec!["zzz".to_string()]);
     }
 
     #[test]

--- a/crates/mezon-store/src/channel_media.rs
+++ b/crates/mezon-store/src/channel_media.rs
@@ -236,7 +236,7 @@ pub fn first_event_year(events: &[ChannelTimeline]) -> Option<String> {
 }
 
 pub fn timeline_card_position(index: usize) -> TimelineCardSide {
-    if index % 2 == 0 {
+    if index.is_multiple_of(2) {
         TimelineCardSide::Left
     } else {
         TimelineCardSide::Right
@@ -436,8 +436,10 @@ impl ChannelMediaStore {
             bucket.is_loading = true;
             bucket.error = None;
         } else {
-            let mut bucket = ChannelMediaBucket::default();
-            bucket.is_loading = true;
+            let bucket = ChannelMediaBucket {
+                is_loading: true,
+                ..Default::default()
+            };
             self.by_key
                 .insert(key.clone(), bucket, self.active_key.as_ref());
         }
@@ -739,10 +741,10 @@ impl ChannelMediaStore {
 
     fn update_event_in_lists(&mut self, channel_id: ChannelId, year: i32, event: &ChannelTimeline) {
         let key = CacheKey { channel_id, year };
-        if let Some(bucket) = self.by_key.get_mut(&key) {
-            if let Some(existing) = bucket.events.iter_mut().find(|e| e.id == event.id) {
-                *existing = merge_timeline_event(existing, event);
-            }
+        if let Some(bucket) = self.by_key.get_mut(&key)
+            && let Some(existing) = bucket.events.iter_mut().find(|e| e.id == event.id)
+        {
+            *existing = merge_timeline_event(existing, event);
         }
     }
 

--- a/crates/mezon-store/src/direct.rs
+++ b/crates/mezon-store/src/direct.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Task};
-use mezon_client::transport::{
-    ApiChannelDesc, ApiDirectChannel, ApiMessageContent, build_send_content,
-};
+use mezon_client::transport::{ApiChannelDesc, ApiDirectChannel, build_send_content};
 use mezon_client::{AppApi, ConnectionStatus, RealtimeEvent};
 
 use crate::Freshness;
@@ -392,7 +390,7 @@ impl DirectMessageStore {
         member_label: String,
         member_avatar: String,
         member_username: String,
-        content: String,
+        body: DirectMessageBody,
         cx: &mut Context<Self>,
     ) -> Task<anyhow::Result<()>> {
         let api = self.api.clone();
@@ -435,7 +433,7 @@ impl DirectMessageStore {
                 }
             };
 
-            let content_json = direct_message_content_json(&content);
+            let content_json = body.into_content_json();
             let sent = api
                 .send_channel_message_structured(channel_id.get(), &content_json, mode)
                 .await?;
@@ -452,7 +450,7 @@ impl DirectMessageStore {
         member_label: String,
         member_avatar: String,
         member_username: String,
-        content: String,
+        body: DirectMessageBody,
         cx: &mut Context<Self>,
     ) -> Task<anyhow::Result<(ChannelId, i32)>> {
         let api = self.api.clone();
@@ -507,7 +505,7 @@ impl DirectMessageStore {
                 tracing::warn!("join_chat after create DM failed: {e}");
             }
 
-            let content_json = direct_message_content_json(&content);
+            let content_json = body.into_content_json();
             let sent = api
                 .send_channel_message_structured(channel_id.get(), &content_json, send_mode)
                 .await?;
@@ -706,11 +704,17 @@ impl DirectMessageStore {
     }
 }
 
-fn direct_message_content_json(content: &str) -> String {
-    if serde_json::from_str::<ApiMessageContent>(content).is_ok() {
-        content.to_string()
-    } else {
-        build_send_content(content, &[], &[], &[]).json
+pub enum DirectMessageBody {
+    Text(String),
+    ContentJson(String),
+}
+
+impl DirectMessageBody {
+    fn into_content_json(self) -> String {
+        match self {
+            Self::Text(text) => build_send_content(&text, &[], &[], &[]).json,
+            Self::ContentJson(json) => json,
+        }
     }
 }
 
@@ -878,6 +882,7 @@ fn direct_from_api(c: ApiDirectChannel) -> DirectChannel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mezon_client::transport::ApiMessageContent;
 
     fn api_dm(id: i64, label: &str, ty: u32) -> ApiDirectChannel {
         ApiDirectChannel {
@@ -1311,14 +1316,25 @@ mod tests {
     }
 
     #[test]
-    fn direct_message_content_json_wraps_plain_text() {
-        let json = direct_message_content_json("hello");
-        assert!(serde_json::from_str::<ApiMessageContent>(&json).is_ok());
+    fn direct_body_text_is_wrapped_into_content_json() {
+        let json = DirectMessageBody::Text("hello".into()).into_content_json();
+        let parsed: ApiMessageContent = serde_json::from_str(&json).expect("json");
+        assert_eq!(parsed.t, "hello");
     }
 
     #[test]
-    fn direct_message_content_json_passes_through_structured() {
+    fn direct_body_text_that_looks_like_json_is_still_wrapped() {
+        let json = DirectMessageBody::Text(r#"{"t":"","foo":1}"#.into()).into_content_json();
+        let parsed: ApiMessageContent = serde_json::from_str(&json).expect("json");
+        assert_eq!(parsed.t, r#"{"t":"","foo":1}"#);
+    }
+
+    #[test]
+    fn direct_body_content_json_passes_through() {
         let structured = build_send_content("hello", &[], &[], &[]).json;
-        assert_eq!(direct_message_content_json(&structured), structured);
+        assert_eq!(
+            DirectMessageBody::ContentJson(structured.clone()).into_content_json(),
+            structured
+        );
     }
 }

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -88,7 +88,7 @@ pub use clan_members::{
 };
 pub use config::AppConfig;
 pub use connection::{ConnectionStore, resolve_initial_auth_state};
-pub use direct::{DirectChannel, DirectEvent, DirectKind, DirectMessageStore};
+pub use direct::{DirectChannel, DirectEvent, DirectKind, DirectMessageBody, DirectMessageStore};
 pub use emoji::{Emoji, EmojiEvent, EmojiStore};
 pub use files::{
     ChannelDocument, FILES_BROAD_QUERY, FILES_CACHE_TTL, FILES_PAGE_SIZE, FILES_TYPED_QUERY,

--- a/crates/mezon-store/src/message.rs
+++ b/crates/mezon-store/src/message.rs
@@ -8,7 +8,6 @@ use mezon_client::transport::{
 };
 
 use crate::album_layout::AlbumLayout;
-use crate::config::AppConfig;
 use crate::ids::{ChannelId, MessageId, UserId};
 use crate::message_time::{format_local_time_hhmm, local_datetime, local_day_key};
 
@@ -200,14 +199,11 @@ pub struct ReactionSender {
     pub count: u32,
 }
 
-const REACTION_EMOJI_PROXY_PX: u32 = 100;
-
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Reaction {
     pub key: String,
     pub emoji: SharedString,
     pub emoji_id: SharedString,
-    pub emoji_proxied: SharedString,
     pub count: u32,
     pub count_label: SharedString,
     pub senders: Vec<ReactionSender>,
@@ -224,13 +220,9 @@ impl Reaction {
             .any(|s| s.sender_id == sender_id && s.count > 0)
     }
 
-    fn refresh(&mut self, cfg: Option<&AppConfig>) {
+    fn refresh(&mut self) {
         self.count = self.senders.iter().map(|s| s.count).sum();
         self.count_label = format_reaction_count(self.count).into();
-        self.emoji_proxied = cfg
-            .map(|c| c.emoji_src_sized(&self.emoji_id, REACTION_EMOJI_PROXY_PX))
-            .unwrap_or_default()
-            .into();
     }
 }
 
@@ -744,7 +736,7 @@ fn mention_user_id_targets_viewer(uid: &str, viewer_id: UserId) -> bool {
             || uid.parse::<i64>().ok().map(UserId) == Some(viewer_id))
 }
 
-pub fn aggregate_reactions(raw: &[ApiMessageReaction], cfg: Option<&AppConfig>) -> Vec<Reaction> {
+pub fn aggregate_reactions(raw: &[ApiMessageReaction]) -> Vec<Reaction> {
     let mut out: Vec<Reaction> = Vec::new();
     for r in raw {
         if r.action {
@@ -770,7 +762,7 @@ pub fn aggregate_reactions(raw: &[ApiMessageReaction], cfg: Option<&AppConfig>) 
         upsert_sender(&mut out[idx].senders, &r.sender_id, count, true);
     }
     for r in out.iter_mut() {
-        r.refresh(cfg);
+        r.refresh();
     }
     out.retain(|r| r.count > 0);
     out
@@ -782,7 +774,6 @@ pub fn apply_reaction_event(
     emoji: &str,
     sender_id: &str,
     removed: bool,
-    cfg: Option<&AppConfig>,
 ) {
     let key = reaction_key(emoji_id, emoji);
     if key.is_empty() {
@@ -791,14 +782,14 @@ pub fn apply_reaction_event(
     if removed {
         if let Some(pos) = reactions.iter().position(|x| x.key == key) {
             reactions[pos].senders.retain(|s| s.sender_id != sender_id);
-            reactions[pos].refresh(cfg);
+            reactions[pos].refresh();
             if reactions[pos].count == 0 {
                 reactions.remove(pos);
             }
         }
     } else if let Some(rec) = reactions.iter_mut().find(|x| x.key == key) {
         upsert_sender(&mut rec.senders, sender_id, 1, false);
-        rec.refresh(cfg);
+        rec.refresh();
     } else {
         let mut rec = Reaction {
             key: key.to_string(),
@@ -810,7 +801,7 @@ pub fn apply_reaction_event(
             }],
             ..Default::default()
         };
-        rec.refresh(cfg);
+        rec.refresh();
         reactions.push(rec);
     }
 }
@@ -821,10 +812,9 @@ pub fn rollback_reaction(
     emoji: &str,
     sender_id: &str,
     was_remove: bool,
-    cfg: Option<&AppConfig>,
 ) {
     if was_remove {
-        apply_reaction_event(reactions, emoji_id, emoji, sender_id, false, cfg);
+        apply_reaction_event(reactions, emoji_id, emoji, sender_id, false);
         return;
     }
     let key = reaction_key(emoji_id, emoji);
@@ -839,7 +829,7 @@ pub fn rollback_reaction(
         s.count = s.count.saturating_sub(1);
     }
     reactions[pos].senders.retain(|s| s.count > 0);
-    reactions[pos].refresh(cfg);
+    reactions[pos].refresh();
     if reactions[pos].count == 0 {
         reactions.remove(pos);
     }
@@ -1844,7 +1834,7 @@ mod tests {
                 action: true,
             },
         ];
-        let agg = aggregate_reactions(&raw, None);
+        let agg = aggregate_reactions(&raw);
         assert_eq!(agg.len(), 1);
         assert_eq!(agg[0].key, "10");
         assert_eq!(agg[0].count(), 2);
@@ -1870,27 +1860,27 @@ mod tests {
             }],
             ..Default::default()
         }];
-        apply_reaction_event(&mut reactions, "10", ":a:", "u2", false, None);
+        apply_reaction_event(&mut reactions, "10", ":a:", "u2", false);
         assert_eq!(reactions[0].count(), 2);
-        apply_reaction_event(&mut reactions, "10", ":a:", "u1", false, None);
+        apply_reaction_event(&mut reactions, "10", ":a:", "u1", false);
         assert_eq!(reactions[0].count(), 3);
         assert!(reactions[0].has_sender("u1"));
-        apply_reaction_event(&mut reactions, "10", ":a:", "u1", true, None);
+        apply_reaction_event(&mut reactions, "10", ":a:", "u1", true);
         assert_eq!(reactions[0].count(), 1);
         assert!(!reactions[0].has_sender("u1"));
-        apply_reaction_event(&mut reactions, "10", ":a:", "u2", true, None);
+        apply_reaction_event(&mut reactions, "10", ":a:", "u2", true);
         assert!(reactions.is_empty());
     }
 
     #[test]
     fn rollback_reaction_undoes_optimistic_add() {
         let mut reactions = Vec::new();
-        apply_reaction_event(&mut reactions, "10", ":a:", "u1", false, None);
-        apply_reaction_event(&mut reactions, "10", ":a:", "u1", false, None);
+        apply_reaction_event(&mut reactions, "10", ":a:", "u1", false);
+        apply_reaction_event(&mut reactions, "10", ":a:", "u1", false);
         assert_eq!(reactions[0].count(), 2);
-        rollback_reaction(&mut reactions, "10", ":a:", "u1", false, None);
+        rollback_reaction(&mut reactions, "10", ":a:", "u1", false);
         assert_eq!(reactions[0].count(), 1);
-        rollback_reaction(&mut reactions, "10", ":a:", "u1", false, None);
+        rollback_reaction(&mut reactions, "10", ":a:", "u1", false);
         assert!(reactions.is_empty());
     }
 

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -148,6 +148,7 @@ pub enum MessagesEvent {
         sent: usize,
         failed: Vec<SharedString>,
     },
+    AnonymousModeChanged,
 }
 
 /// The message currently being replied to (composer state), mirroring React's
@@ -531,7 +532,8 @@ pub struct MessagesStore {
     pending_send_payloads: HashMap<MessageId, PendingSendPayload>,
     anonymous_clans: HashSet<ClanId>,
     topic_anonymous_mode: bool,
-    last_typing_sent: Option<Instant>,
+    last_anonymous_mode: bool,
+    last_typing_sent: Option<(ChannelId, Instant)>,
     buzz_player: Option<AudioPlayer>,
     buzz_sound_loading: bool,
 }
@@ -887,6 +889,7 @@ impl MessagesStore {
         self.pending_send_payloads.clear();
         self.anonymous_clans.clear();
         self.topic_anonymous_mode = false;
+        self.sync_anonymous_mode(cx);
         self.last_typing_sent = None;
         self.buzz_player = None;
         self.buzz_sound_loading = false;
@@ -944,6 +947,7 @@ impl MessagesStore {
             pending_send_payloads: HashMap::new(),
             anonymous_clans: HashSet::new(),
             topic_anonymous_mode: false,
+            last_anonymous_mode: false,
             last_typing_sent: None,
             buzz_player: None,
             buzz_sound_loading: false,
@@ -1899,9 +1903,19 @@ impl MessagesStore {
             .is_some_and(|id| self.anonymous_clans.contains(&id))
     }
 
+    pub(crate) fn sync_anonymous_mode(&mut self, cx: &mut Context<Self>) {
+        let next = self.is_anonymous_mode();
+        if self.last_anonymous_mode == next {
+            return;
+        }
+        self.last_anonymous_mode = next;
+        cx.emit(MessagesEvent::AnonymousModeChanged);
+    }
+
     pub fn toggle_anonymous_mode(&mut self, cx: &mut Context<Self>) {
         if self.active_topic_id.is_some() {
             self.topic_anonymous_mode = !self.topic_anonymous_mode;
+            self.sync_anonymous_mode(cx);
             cx.notify();
             return;
         }
@@ -1913,6 +1927,7 @@ impl MessagesStore {
         } else {
             self.anonymous_clans.insert(clan_id);
         }
+        self.sync_anonymous_mode(cx);
         cx.notify();
     }
 
@@ -1920,20 +1935,18 @@ impl MessagesStore {
         if self.is_anonymous_mode() {
             return;
         }
-        let now = Instant::now();
-        if self
-            .last_typing_sent
-            .is_some_and(|last| now.duration_since(last) < TYPING_THROTTLE)
-        {
-            return;
-        }
-        self.last_typing_sent = Some(now);
         let Some(clan_id) = self.active_clan_id else {
             return;
         };
         let Some(channel_id) = self.active_channel_id else {
             return;
         };
+        let now = Instant::now();
+        if self.last_typing_sent.is_some_and(|(last_channel, last)| {
+            last_channel == channel_id && now.duration_since(last) < TYPING_THROTTLE
+        }) {
+            return;
+        }
         let display_name = AccountStore::global(cx)
             .read(cx)
             .account
@@ -1949,6 +1962,7 @@ impl MessagesStore {
         if display_name.is_empty() {
             return;
         }
+        self.last_typing_sent = Some((channel_id, now));
         let mode = self.mode;
         let is_public = self.is_public;
         let topic_id = self.active_topic_id.map(|t| t.get()).unwrap_or(0);
@@ -2201,7 +2215,7 @@ impl MessagesStore {
     pub fn remove_failed_message(&mut self, message_id: MessageId, cx: &mut Context<Self>) {
         if self.active_channel_id.is_none() {
             return;
-        };
+        }
         let storage_id = self.reaction_storage_channel(message_id);
         let is_failed = self
             .cache
@@ -2636,6 +2650,7 @@ impl MessagesStore {
                 .retain(|(channel_id, _, _), _| *channel_id != prev);
         }
         self.active_topic_id = next;
+        self.sync_anonymous_mode(cx);
         cx.notify();
     }
 
@@ -3655,6 +3670,7 @@ impl MessagesStore {
             && self.poll_my_vote.is_empty()
             && self.select_ui.is_empty()
             && self.embed_form.is_empty()
+            && self.pending_send_payloads.is_empty()
         {
             return;
         }
@@ -3664,6 +3680,7 @@ impl MessagesStore {
             .chain(self.poll_my_vote.keys())
             .chain(self.select_ui.keys())
             .chain(self.embed_form.keys())
+            .chain(self.pending_send_payloads.keys())
             .copied()
             .filter(|id| !self.message_is_loaded(*id))
             .collect();
@@ -3672,6 +3689,7 @@ impl MessagesStore {
             self.poll_my_vote.remove(&id);
             self.select_ui.remove(&id);
             self.embed_form.remove(&id);
+            self.pending_send_payloads.remove(&id);
         }
     }
 
@@ -3688,6 +3706,7 @@ impl MessagesStore {
             if self.reply_target.take().is_some() {
                 cx.emit(MessagesEvent::ReplyTargetChanged);
             }
+            self.sync_anonymous_mode(cx);
             cx.emit(MessagesEvent::Reset { count: 0 });
             cx.notify();
             return;
@@ -3789,6 +3808,7 @@ impl MessagesStore {
         self.mode = mode;
         self.viewing_older_by_channel.insert(channel_id, false);
         self.loading_more = false;
+        self.sync_anonymous_mode(cx);
         if self.reply_target.take().is_some() {
             cx.emit(MessagesEvent::ReplyTargetChanged);
         }
@@ -4247,13 +4267,12 @@ impl MessagesStore {
         };
         let uid_str = current_uid.get().to_string();
         let key = reaction_key(&emoji_id, &emoji).to_string();
-        let cfg = AppConfig::try_global(cx);
         let applied = self
             .cache
             .get_mut(&storage_id)
             .and_then(|channel| channel.messages.get_mut_by_id(message_id))
             .map(|msg| {
-                apply_reaction_event(&mut msg.reactions, &emoji_id, &emoji, &uid_str, remove, cfg);
+                apply_reaction_event(&mut msg.reactions, &emoji_id, &emoji, &uid_str, remove);
             })
             .is_some();
         if applied {
@@ -4366,20 +4385,12 @@ impl MessagesStore {
         was_remove: bool,
         cx: &mut Context<Self>,
     ) {
-        let cfg = AppConfig::try_global(cx);
         if let Some(msg) = self
             .cache
             .get_mut(&channel_id)
             .and_then(|channel| channel.messages.get_mut_by_id(message_id))
         {
-            rollback_reaction(
-                &mut msg.reactions,
-                emoji_id,
-                emoji,
-                sender_id,
-                was_remove,
-                cfg,
-            );
+            rollback_reaction(&mut msg.reactions, emoji_id, emoji, sender_id, was_remove);
         }
         if !was_remove {
             let entry_key = (
@@ -4598,7 +4609,6 @@ impl MessagesStore {
             return;
         }
 
-        let cfg = AppConfig::try_global(cx);
         let Some(channel) = self.cache.get_mut(&storage_id) else {
             return;
         };
@@ -4611,7 +4621,6 @@ impl MessagesStore {
             &r.emoji,
             &sender_id,
             r.action,
-            cfg,
         );
         if is_active_topic {
             cx.emit(MessagesEvent::TopicUpdated {
@@ -5467,7 +5476,7 @@ fn message_from_api(m: ApiMessage, cfg: Option<&AppConfig>, viewer_id: Option<Us
         .iter()
         .map(|r| message_reference_from_api(r, cfg))
         .collect();
-    let reactions = aggregate_reactions(&m.reactions, cfg);
+    let reactions = aggregate_reactions(&m.reactions);
     let mut attachments: Vec<MessageAttachment> = m
         .attachments
         .into_iter()

--- a/crates/mezon-store/src/voice.rs
+++ b/crates/mezon-store/src/voice.rs
@@ -1318,7 +1318,8 @@ impl VoiceStore {
         let Some((identity, _)) = self.pending_kick.take() else {
             return;
         };
-        self.pending_removals.insert(identity.clone(), Instant::now());
+        self.pending_removals
+            .insert(identity.clone(), Instant::now());
         self.participants.retain(|p| p.identity != identity);
         cx.notify();
         self.moderate_participant(identity, ModerationAction::Kick, cx);

--- a/crates/mezon-ui/src/chat/inbox/panel.rs
+++ b/crates/mezon-ui/src/chat/inbox/panel.rs
@@ -60,7 +60,7 @@ impl InboxPopoverPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let list_state = ListState::new(0, ListAlignment::Top, px(LIST_OVERDRAW));
+        let list_state = ListState::new(0, ListAlignment::Top, px(LIST_OVERDRAW)).measure_all();
         let weak = cx.weak_entity();
         Self::attach_list_scroll_handler(&list_state, weak);
         let avatar_image_cache = crate::image_cache::shared_avatar_cache(cx);

--- a/crates/mezon-ui/src/chat/input_bar.rs
+++ b/crates/mezon-ui/src/chat/input_bar.rs
@@ -5,7 +5,7 @@ use gpui::{
     Context, Entity, FontWeight, ObjectFit, Render, SharedString, Subscription, Window, div, img,
     prelude::*, px, radians,
 };
-use mezon_store::{MessagesStore, OgpResult, Settings, TopicsStore};
+use mezon_store::{MessagesEvent, MessagesStore, OgpResult, Settings, TopicsStore};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ReplyClearSource {
@@ -21,7 +21,7 @@ pub struct InputBar {
     reply_clear: ReplyClearSource,
     _settings_observe: Subscription,
     _mention_observe: Subscription,
-    _messages_observe: Subscription,
+    _messages_sub: Subscription,
 }
 
 impl InputBar {
@@ -33,7 +33,14 @@ impl InputBar {
     ) -> Self {
         let settings_observe = cx.observe(settings, |_, _, cx| cx.notify());
         let mention_observe = cx.observe(&mention_input, |_, _, cx| cx.notify());
-        let messages_observe = cx.observe(&MessagesStore::global(cx), |_, _, cx| cx.notify());
+        let messages_sub = cx.subscribe(
+            &MessagesStore::global(cx),
+            |_, _, event: &MessagesEvent, cx| {
+                if matches!(event, MessagesEvent::AnonymousModeChanged) {
+                    cx.notify();
+                }
+            },
+        );
         Self {
             mention_input,
             locale,
@@ -41,7 +48,7 @@ impl InputBar {
             reply_clear: ReplyClearSource::Messages,
             _settings_observe: settings_observe,
             _mention_observe: mention_observe,
-            _messages_observe: messages_observe,
+            _messages_sub: messages_sub,
         }
     }
 

--- a/crates/mezon-ui/src/chat/layout.rs
+++ b/crates/mezon-ui/src/chat/layout.rs
@@ -793,9 +793,9 @@ impl ChatLayout {
     }
 
     pub(crate) fn toggle_member_list(&mut self, cx: &mut Context<Self>) {
-        let dm_group = self.is_dm_group_chat(cx);
+        let dm = self.is_dm_route(cx);
         self.show_member_list = !self.show_member_list;
-        if dm_group {
+        if dm {
             self.ui_state.show_member_list_dm = self.show_member_list;
         } else {
             self.ui_state.show_member_list = self.show_member_list;
@@ -824,16 +824,11 @@ impl ChatLayout {
     }
 
     fn sync_member_list_visibility(&mut self, cx: &Context<Self>) {
-        self.show_member_list = if self.is_dm_group_chat(cx) {
+        self.show_member_list = if self.is_dm_route(cx) {
             self.ui_state.show_member_list_dm
         } else {
             self.ui_state.show_member_list
         };
-    }
-
-    fn is_dm_group_chat(&self, cx: &Context<Self>) -> bool {
-        self.current_dm(cx)
-            .is_some_and(|dm| dm.kind == DirectKind::Group)
     }
 
     fn channel_supports_timeline_view(&self, cx: &Context<Self>) -> bool {

--- a/crates/mezon-ui/src/chat/media_channel/panel.rs
+++ b/crates/mezon-ui/src/chat/media_channel/panel.rs
@@ -95,8 +95,10 @@ impl MediaChannelPanel {
             detail_event_id: None,
             detail_start_time: 0,
             detail_view: None,
-            timeline_list_state: ListState::new(0, ListAlignment::Top, px(MEDIA_LIST_OVERDRAW)),
-            events_list_state: ListState::new(0, ListAlignment::Top, px(MEDIA_LIST_OVERDRAW)),
+            timeline_list_state: ListState::new(0, ListAlignment::Top, px(MEDIA_LIST_OVERDRAW))
+                .measure_all(),
+            events_list_state: ListState::new(0, ListAlignment::Top, px(MEDIA_LIST_OVERDRAW))
+                .measure_all(),
             _store_sub,
             _window_activation: None,
             last_fetch_error: None,

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -1535,7 +1535,8 @@ impl ChannelMessages {
                 MessagesEvent::ReplyTargetChanged
                 | MessagesEvent::ForwardProgress { .. }
                 | MessagesEvent::ForwardFinished { .. }
-                | MessagesEvent::ShareContactFinished { .. } => return,
+                | MessagesEvent::ShareContactFinished { .. }
+                | MessagesEvent::AnonymousModeChanged => return,
                 MessagesEvent::TopicUpdated { .. } => {}
             }
             if structural {

--- a/crates/mezon-ui/src/chat/message/message_buzz_modal.rs
+++ b/crates/mezon-ui/src/chat/message/message_buzz_modal.rs
@@ -25,6 +25,9 @@ impl Focusable for MessageBuzzModal {
 
 impl MessageBuzzModal {
     pub fn open(locale: SharedString, window: &mut Window, cx: &mut App) {
+        if Shell::global(cx).read(cx).has_modal() {
+            return;
+        }
         let view = cx.new(|cx| {
             let placeholder = mezon_i18n::t(&locale, "messageBuzz.enterMessage").to_string();
             let message = cx.new(|cx| {

--- a/crates/mezon-ui/src/chat/message_search.rs
+++ b/crates/mezon-ui/src/chat/message_search.rs
@@ -211,7 +211,8 @@ impl MessageSearchPanel {
             clan_id,
             is_direct,
             locale,
-            list_state: ListState::new(0, ListAlignment::Top, px(SEARCH_LIST_OVERDRAW)),
+            list_state: ListState::new(0, ListAlignment::Top, px(SEARCH_LIST_OVERDRAW))
+                .measure_all(),
             last_results_page: 0,
             cached_rows: Rc::new(Vec::new()),
             cached_highlights: Rc::new(Vec::new()),

--- a/crates/mezon-ui/src/chat/user_profile_popover.rs
+++ b/crates/mezon-ui/src/chat/user_profile_popover.rs
@@ -4,8 +4,8 @@ use gpui::{
     SharedString, Stateful, StyleRefinement, Styled, Window, div, prelude::*, px, svg,
 };
 use mezon_store::{
-    BadgeService, ChannelList, DirectMessageStore, FriendState, FriendStore, PresenceStore,
-    ProfileContext, RolesStore, Settings, UserId, resolve_user_profile,
+    BadgeService, ChannelList, DirectMessageBody, DirectMessageStore, FriendState, FriendStore,
+    PresenceStore, ProfileContext, RolesStore, Settings, UserId, resolve_user_profile,
 };
 use ui::{Clickable, PopoverMenu, Toggleable};
 
@@ -109,7 +109,14 @@ impl UserProfilePopover {
         let avatar = profile.avatar_url.clone();
         let username = profile.username.clone();
         let task = DirectMessageStore::global(cx).update(cx, |store, cx| {
-            store.create_dm_and_send_text(user_id, label, avatar, username.clone(), content, cx)
+            store.create_dm_and_send_text(
+                user_id,
+                label,
+                avatar,
+                username.clone(),
+                DirectMessageBody::Text(content),
+                cx,
+            )
         });
         cx.spawn(async move |this, cx| match task.await {
             Ok((channel_id, channel_type)) => {
@@ -117,7 +124,7 @@ impl UserProfilePopover {
                     this.sending_message = false;
                     cx.emit(DismissEvent);
                 });
-                let _ = cx.update(|cx| {
+                cx.update(|cx| {
                     navigate(
                         cx,
                         Route::DirectMessage {
@@ -296,17 +303,12 @@ impl Render for UserProfilePopover {
                     .p_2()
                     .children(
                         voice_info.map(|info| {
-                            render_voice_button(info.clan_id, info.channel_id, &theme, cx)
+                            render_voice_button(info.clan_id, info.channel_id, theme, cx)
                         }),
                     )
                     .children(banner_actions),
             )
-            .child(render_avatar_row(
-                avatar,
-                status_icon,
-                custom_status,
-                &theme,
-            ))
+            .child(render_avatar_row(avatar, status_icon, custom_status, theme))
             .child(
                 div().px(px(16.)).child(
                     div()

--- a/crates/mezon-ui/src/clan/invite_people_modal.rs
+++ b/crates/mezon-ui/src/clan/invite_people_modal.rs
@@ -11,8 +11,8 @@ use gpui::{
 };
 use mezon_store::{
     AppConfig, ChannelId, ClanId, ClanInviteLink, ClanList, ClanMembersEvent, ClanMembersStore,
-    DirectEvent, DirectKind, DirectMessageStore, Friend, FriendEvent, FriendState, FriendStore,
-    UserId,
+    DirectEvent, DirectKind, DirectMessageBody, DirectMessageStore, Friend, FriendEvent,
+    FriendState, FriendStore, UserId,
 };
 use std::collections::HashSet;
 use std::io::Cursor;
@@ -325,9 +325,9 @@ impl InvitePeopleModal {
         let username = row.username.to_string();
         let user_id = row.user_id;
         let channel = row.channel;
-        let content = self.invite_message_content(cx);
+        let body = self.invite_message_body(cx);
         let task = store.update(cx, |store, cx| {
-            store.send_direct_text_to_target(user_id, channel, label, avatar, username, content, cx)
+            store.send_direct_text_to_target(user_id, channel, label, avatar, username, body, cx)
         });
         let locale = self.locale.clone();
         cx.spawn(async move |this, cx| match task.await {
@@ -353,17 +353,17 @@ impl InvitePeopleModal {
         .detach();
     }
 
-    fn invite_message_content(&self, cx: &App) -> String {
+    fn invite_message_body(&self, cx: &App) -> DirectMessageBody {
         let Some(clan) = ClanList::global(cx)
             .read(cx)
             .clan_by_id(self.clan_id)
             .cloned()
         else {
-            return self.invite_link();
+            return DirectMessageBody::Text(self.invite_link());
         };
         let url = self.invite_link();
         let end = url.chars().count();
-        serde_json::json!({
+        let json = serde_json::json!({
             "t": url,
             "mk": [
                 { "s": 0, "e": end, "type": "lk" },
@@ -376,7 +376,8 @@ impl InvitePeopleModal {
                 }
             ]
         })
-        .to_string()
+        .to_string();
+        DirectMessageBody::ContentJson(json)
     }
 
     fn copy_invite_link(&mut self, cx: &mut Context<Self>) {


### PR DESCRIPTION
## Summary
- Fix canvas ID extraction to scan every link in a message and add regression tests
- Scope typing-event throttle per channel instead of globally
- Emit `AnonymousModeChanged` so composer UI stays in sync when anonymous mode toggles
- Introduce `DirectMessageBody` so plain DM text that looks like JSON is still wrapped as send content
- Clippy cleanups in channel media and minor UI wiring follow-ups from PR #136 review

## Test plan
- [ ] Message with multiple canvas links resolves all canvas IDs for cvtt
- [ ] Switching channels allows typing events without being throttled by the previous channel
- [ ] Anonymous mode toggle updates input bar label/state immediately
- [ ] DM send with plain text containing `{` characters still sends as normal text
- [ ] `just lint` and `just test` pass


Made with [Cursor](https://cursor.com)