### PR TITLE
feat: add clan load scheduler and shared text edit primitives

### DIFF
--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -587,7 +587,6 @@ fn open_main_window(
     mezon_store::RealtimeDispatch::init(api.clone(), cx);
     mezon_store::ConnectionStore::init(transport, api.clone(), auth_state.clone(), cx);
     mezon_store::ClanList::init(api.clone(), cx);
-    mezon_store::ClanMembersStore::init(api.clone(), cx);
     mezon_store::ChannelList::init(api.clone(), cx);
     mezon_store::ChannelSettingsStore::init(api.clone(), cx);
     mezon_store::DirectMessageStore::init(api.clone(), cx);
@@ -619,6 +618,7 @@ fn open_main_window(
     mezon_store::PermissionStore::init(api.clone(), auth_state.clone(), cx);
     mezon_store::NotificationSettingStore::init(api.clone(), auth_state.clone(), cx);
     mezon_store::NotificationPushStore::init(api.clone(), auth_state.clone(), cx);
+    mezon_store::ClanLoadScheduler::init(cx);
     mezon_store::QuickMenuStore::init(api.clone(), cx);
     mezon_store::WalletStore::init(auth_state.clone(), cx);
     mezon_ui::WalletToastBridge::init(cx);

--- a/crates/mezon-client/src/abridged_tcp_adapter.rs
+++ b/crates/mezon-client/src/abridged_tcp_adapter.rs
@@ -131,6 +131,7 @@ const PREFIX_RAW: u8 = 0xff;
 const PREFIX_EXTENDED: u8 = 0x7f;
 const RAW_HEADER_LENGTH: usize = 11;
 const MAX_REALTIME_FRAME_LEN: usize = 1 << 20;
+const MAX_API_RESPONSE_LEN: usize = 16 << 20;
 const RESPONSE_CODE_TOO_LARGE: u32 = u16::MAX as u32;
 const ENVELOPE_CID_TAG: u8 = 0x08;
 
@@ -375,7 +376,7 @@ fn decode_frame(buf: &[u8]) -> FrameStep {
             let cid = u16::from_be_bytes([buf[1], buf[2]]);
             let code = u32::from_be_bytes([buf[3], buf[4], buf[5], buf[6]]);
             let len = u32::from_be_bytes([buf[7], buf[8], buf[9], buf[10]]) as usize;
-            if len > MAX_REALTIME_FRAME_LEN {
+            if len > MAX_API_RESPONSE_LEN {
                 return FrameStep::Reset("raw frame length too large");
             }
             let total = RAW_HEADER_LENGTH + len;
@@ -488,10 +489,15 @@ impl IoLoopState {
                         return Ok(());
                     }
                     FrameStep::Reset(reason) => {
-                        tracing::warn!("frame desync ({reason}), resetting read buffer");
+                        let abandoned: Vec<u16> = self.streams.keys().copied().collect();
+                        tracing::error!(
+                            "frame desync ({reason}); dropping {} buffered bytes and {} partial response(s) {abandoned:?} — forcing reconnect",
+                            self.read_buffer.len(),
+                            abandoned.len(),
+                        );
                         self.read_buffer.clear();
                         self.streams.clear();
-                        return Ok(());
+                        return Err(anyhow::anyhow!("frame desync: {reason}"));
                     }
                     FrameStep::Frame { consumed, frame } => {
                         start += consumed;
@@ -529,10 +535,10 @@ impl IoLoopState {
                         let chunks = self.streams.entry(cid).or_default();
                         chunks.push(payload);
                         let buffered: usize = chunks.iter().map(Vec::len).sum();
-                        if buffered > MAX_REALTIME_FRAME_LEN {
+                        if buffered > MAX_API_RESPONSE_LEN {
                             self.streams.remove(&cid);
                             tracing::warn!(
-                                "cid={cid} response exceeds {MAX_REALTIME_FRAME_LEN}-byte cap, failing request"
+                                "cid={cid} response exceeds {MAX_API_RESPONSE_LEN}-byte cap, failing request"
                             );
                             handlers.trigger_message(cid, RESPONSE_CODE_TOO_LARGE, vec![]);
                         }
@@ -619,6 +625,7 @@ impl AbridgedTcpAdapter {
 
                             if let Err(e) = state.handle_data(&handlers, &read_buf[..n]) {
                                 tracing::error!("handle_data error: {}", e);
+                                break LoopExit::Error(e.to_string());
                             }
                         }
                         Err(e) => {

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -202,6 +202,7 @@ pub fn build_location_content_json(latitude: f64, longitude: f64) -> String {
 }
 pub const QUICK_MENU_TYPE_FLASH: i32 = 1;
 pub const QUICK_MENU_TYPE_QUICK: i32 = 2;
+const CHANNEL_TYPE_MEZON_VOICE: i32 = 10;
 
 #[derive(Clone, Copy, Default)]
 pub struct OutgoingMessageFlags {
@@ -5172,6 +5173,7 @@ impl MezonTransport {
         let cid = self.generate_cid();
         let body = api::ListChannelUsersRequest {
             clan_id,
+            channel_type: CHANNEL_TYPE_MEZON_VOICE,
             limit: 100,
             state: 1,
             ..Default::default()

--- a/crates/mezon-native/src/badge.rs
+++ b/crates/mezon-native/src/badge.rs
@@ -161,70 +161,105 @@ fn try_set_overlay_icon(count: u32) -> windows::core::Result<()> {
     Ok(())
 }
 
-/// Generate a 16×16 `HICON` containing the badge count text.
+/// Generate a 16×16 `HICON` with the badge count centred on a red circle
+/// (matching the in-app `#DA373C` unread badges). A monochrome AND-mask makes
+/// the pixels outside the circle transparent so the overlay reads as a dot, not
+/// a square.
 #[cfg(target_os = "windows")]
 fn build_count_icon(
     count: u32,
 ) -> windows::core::Result<windows::Win32::UI::WindowsAndMessaging::HICON> {
     use windows::Win32::Foundation::{COLORREF, RECT};
     use windows::Win32::Graphics::Gdi::{
-        CreateCompatibleBitmap, CreateCompatibleDC, CreateSolidBrush, DeleteDC, DeleteObject,
-        FillRect, GetDC, ReleaseDC, SelectObject, SetBkMode, SetTextColor, TRANSPARENT, TextOutW,
+        CreateBitmap, CreateCompatibleBitmap, CreateCompatibleDC, CreateSolidBrush,
+        DEFAULT_GUI_FONT, DeleteDC, DeleteObject, Ellipse, FillRect, GetDC, GetStockObject,
+        NULL_PEN, ReleaseDC, SelectObject, SetBkMode, SetTextColor, TRANSPARENT, TextOutW,
     };
     use windows::Win32::UI::WindowsAndMessaging::{CreateIconIndirect, ICONINFO};
 
     const SIZE: i32 = 16;
-    // #5865F2 brand blue, white text
-    const BG_COLOR: u32 = 0x00F26558; // COLORREF is BGR
-    const TEXT_COLOR: u32 = 0x00FFFFFF;
+    // #DA373C danger red (matches every in-app badge); white text. COLORREF is 0x00BBGGRR.
+    const BG_COLOR: u32 = 0x003C_37DA;
+    const TEXT_COLOR: u32 = 0x00FF_FFFF;
+    const WHITE: u32 = 0x00FF_FFFF;
+    const BLACK: u32 = 0x0000_0000;
+
+    let label = if count > 99 {
+        "99+".to_owned()
+    } else {
+        count.to_string()
+    };
+    let text: Vec<u16> = label.encode_utf16().collect();
+    let text_x = match text.len() {
+        1 => 5,
+        2 => 2,
+        _ => 0,
+    };
+
+    let full = RECT {
+        left: 0,
+        top: 0,
+        right: SIZE,
+        bottom: SIZE,
+    };
 
     let hdc_screen = unsafe { GetDC(None) };
     let hdc = unsafe { CreateCompatibleDC(Some(hdc_screen)) };
     let hbmp_color = unsafe { CreateCompatibleBitmap(hdc_screen, SIZE, SIZE) };
-    let hbmp_mask = unsafe { CreateCompatibleBitmap(hdc_screen, SIZE, SIZE) };
+    // The AND-mask must be a 1bpp monochrome bitmap: white = transparent, black = opaque.
+    let hbmp_mask = unsafe { CreateBitmap(SIZE, SIZE, 1, 1, None) };
     unsafe { ReleaseDC(None, hdc_screen) };
 
     unsafe {
-        SelectObject(hdc, hbmp_color.into());
+        let old_bmp = SelectObject(hdc, hbmp_color.into());
+        let old_pen = SelectObject(hdc, GetStockObject(NULL_PEN));
 
-        // Fill background circle.
-        let brush = CreateSolidBrush(COLORREF(BG_COLOR));
-        let rc = RECT {
-            left: 0,
-            top: 0,
-            right: SIZE,
-            bottom: SIZE,
-        };
-        FillRect(hdc, &rc, brush);
-        let _ = DeleteObject(brush.into());
+        // ── Colour bitmap: transparent (black) background + red filled circle + text ──
+        let black_brush = CreateSolidBrush(COLORREF(BLACK));
+        FillRect(hdc, &full, black_brush);
+        let _ = DeleteObject(black_brush.into());
 
-        // Draw count text.
-        let label = if count > 99 {
-            "99+".to_owned()
-        } else {
-            count.to_string()
-        };
-        let text: Vec<u16> = label.encode_utf16().collect();
+        let red_brush = CreateSolidBrush(COLORREF(BG_COLOR));
+        let old_brush = SelectObject(hdc, red_brush.into());
+        let _ = Ellipse(hdc, 0, 0, SIZE, SIZE);
+        SelectObject(hdc, old_brush);
+        let _ = DeleteObject(red_brush.into());
+
+        let old_font = SelectObject(hdc, GetStockObject(DEFAULT_GUI_FONT));
         SetBkMode(hdc, TRANSPARENT);
         SetTextColor(hdc, COLORREF(TEXT_COLOR));
-        TextOutW(hdc, 1, 2, &text);
+        let _ = TextOutW(hdc, text_x, 2, &text);
+        SelectObject(hdc, old_font);
 
-        DeleteDC(hdc);
+        // ── Monochrome mask: white (transparent) everywhere, black (opaque) circle ──
+        SelectObject(hdc, hbmp_mask.into());
+        let white_brush = CreateSolidBrush(COLORREF(WHITE));
+        FillRect(hdc, &full, white_brush);
+        let _ = DeleteObject(white_brush.into());
+        let mask_black = CreateSolidBrush(COLORREF(BLACK));
+        let mask_old_brush = SelectObject(hdc, mask_black.into());
+        let _ = Ellipse(hdc, 0, 0, SIZE, SIZE);
+        SelectObject(hdc, mask_old_brush);
+        let _ = DeleteObject(mask_black.into());
+
+        SelectObject(hdc, old_pen);
+        SelectObject(hdc, old_bmp);
+        let _ = DeleteDC(hdc);
     }
 
     let icon_info = ICONINFO {
         fIcon: true.into(),
         xHotspot: 0,
         yHotspot: 0,
-        hbmMask: hbmp_mask.into(),
-        hbmColor: hbmp_color.into(),
+        hbmMask: hbmp_mask,
+        hbmColor: hbmp_color,
     };
 
     let hicon = unsafe { CreateIconIndirect(&icon_info)? };
 
     unsafe {
-        DeleteObject(hbmp_color.into());
-        DeleteObject(hbmp_mask.into());
+        let _ = DeleteObject(hbmp_color.into());
+        let _ = DeleteObject(hbmp_mask.into());
     }
 
     Ok(hicon)

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -23,6 +23,8 @@ const CATEGORY_EVENT_CREATED: i32 = 1;
 const CATEGORY_EVENT_UPDATED: i32 = 2;
 
 const PREVIOUS_CHANNELS_PERSIST_DEBOUNCE: Duration = Duration::from_millis(500);
+const BADGE_SEED_MAX_ATTEMPTS: u32 = 3;
+const BADGE_SEED_RETRY_BACKOFF: Duration = Duration::from_millis(400);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ChannelType {
@@ -201,11 +203,32 @@ struct TopicParentBadge {
     count: u32,
 }
 
+struct ClanExtras {
+    voice_map: HashMap<ChannelId, Vec<UserId>>,
+    favorite_ids: HashSet<ChannelId>,
+    app_channels: Vec<AppChannel>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ChannelUnreadSeed {
+    badge_count: u32,
+    last_seen_timestamp: i64,
+    last_seen_message_id: MessageId,
+    last_sent_timestamp: i64,
+    last_sent_message_id: MessageId,
+}
+
 pub struct ChannelList {
     cache: KeyedCache<ClanId, Vec<Category>>,
     app_channels_cache: HashMap<ClanId, Vec<AppChannel>>,
     topic_parent_badges: HashMap<ChannelId, TopicParentBadge>,
     pending_channel_badges: HashMap<ChannelId, u32>,
+    pending_badge_seed: HashMap<ClanId, HashMap<ChannelId, ChannelUnreadSeed>>,
+    want_extras: HashSet<ClanId>,
+    extras_loaded: HashSet<ClanId>,
+    extras_loading: HashSet<ClanId>,
+    badge_seeding: HashSet<ClanId>,
+    badge_seeded: HashSet<ClanId>,
     user_channels: HashMap<ChannelId, Channel>,
     user_channels_order: Vec<ChannelId>,
     user_channels_loading: bool,
@@ -351,6 +374,12 @@ impl ChannelList {
         self.app_channels_cache.clear();
         self.topic_parent_badges.clear();
         self.pending_channel_badges.clear();
+        self.pending_badge_seed.clear();
+        self.want_extras.clear();
+        self.extras_loaded.clear();
+        self.extras_loading.clear();
+        self.badge_seeding.clear();
+        self.badge_seeded.clear();
         self.user_channels.clear();
         self.user_channels_order.clear();
         self.user_channels_loading = false;
@@ -377,7 +406,6 @@ impl ChannelList {
                 match active {
                     Some(clan_id) => {
                         this.active_clan_id = Some(*clan_id);
-                        this.load_for_clan(*clan_id, cx);
                         cx.notify();
                     }
                     None => {
@@ -421,6 +449,12 @@ impl ChannelList {
             app_channels_cache: HashMap::new(),
             topic_parent_badges: HashMap::new(),
             pending_channel_badges: HashMap::new(),
+            pending_badge_seed: HashMap::new(),
+            want_extras: HashSet::new(),
+            extras_loaded: HashSet::new(),
+            extras_loading: HashSet::new(),
+            badge_seeding: HashSet::new(),
+            badge_seeded: HashSet::new(),
             user_channels: HashMap::new(),
             user_channels_order: Vec::new(),
             user_channels_loading: false,
@@ -459,6 +493,125 @@ impl ChannelList {
 
     fn merge_pending_badges(&mut self, categories: &mut [Category]) {
         merge_pending_badges_into(&mut self.pending_channel_badges, categories);
+    }
+
+    fn consume_badge_seed(&mut self, clan_id: ClanId, categories: &mut [Category]) {
+        if let Some(seed) = self.pending_badge_seed.remove(&clan_id) {
+            let applied = apply_unread_seed_into(&seed, categories);
+            tracing::info!(
+                target: "unread_seed",
+                clan_id = clan_id.get(),
+                seeded = seed.len(),
+                applied,
+                "CONSUME parked badge seed on structure insert"
+            );
+        }
+    }
+
+    fn drop_seeded_badge(&mut self, clan_id: ClanId, channel_id: ChannelId) {
+        if let Some(seed) = self.pending_badge_seed.get_mut(&clan_id) {
+            seed.remove(&channel_id);
+        }
+    }
+
+    pub fn seed_badges(&mut self, clan_id: ClanId, cx: &mut Context<Self>) -> Task<()> {
+        if self.badge_seeded.contains(&clan_id) || !self.badge_seeding.insert(clan_id) {
+            return Task::ready(());
+        }
+        let api = self.api.clone();
+        let generation = self.reset_generation;
+        cx.spawn(async move |this, cx| {
+            if let Err(e) = api.join_clan_chat(clan_id.get()).await {
+                tracing::error!(target: "unread_seed", "join_clan_chat failed for clan {clan_id}: {e}");
+            }
+            let mut attempt = 0u32;
+            let descs = loop {
+                match api.list_channel_badge_counts(clan_id.get()).await {
+                    Ok(descs) => break Some(descs),
+                    Err(e) => {
+                        attempt += 1;
+                        if attempt >= BADGE_SEED_MAX_ATTEMPTS {
+                            tracing::warn!(
+                                "list_channel_badge_counts failed for clan {clan_id} after {attempt} attempts: {e}"
+                            );
+                            break None;
+                        }
+                        tracing::warn!(
+                            "list_channel_badge_counts failed for clan {clan_id} (attempt {attempt}): {e}, retrying"
+                        );
+                        cx.background_executor()
+                            .timer(BADGE_SEED_RETRY_BACKOFF * attempt)
+                            .await;
+                    }
+                }
+            };
+            let _ = this.update(cx, |this, cx| {
+                this.badge_seeding.remove(&clan_id);
+                if this.reset_generation != generation {
+                    return;
+                }
+                let Some(descs) = descs else {
+                    return;
+                };
+                this.badge_seeded.insert(clan_id);
+                let desc_count = descs.len();
+                let seed = unread_seed_from_descs(descs);
+                let last_messages: Vec<(ChannelId, MessageId)> = seed
+                    .iter()
+                    .filter(|(_, s)| !s.last_sent_message_id.is_zero())
+                    .map(|(id, s)| (*id, s.last_sent_message_id))
+                    .collect();
+                let badged: Vec<ChannelId> = seed
+                    .iter()
+                    .filter(|(_, s)| s.badge_count > 0)
+                    .map(|(id, _)| *id)
+                    .collect();
+                let with_badge = badged.len();
+                let applied = match this.cache.get_mut(&clan_id) {
+                    Some(categories) => apply_unread_seed_into(&seed, categories),
+                    None => false,
+                };
+                let badged_rows: Vec<String> = badged
+                    .iter()
+                    .map(|id| match this.channel(clan_id, *id) {
+                        Some(ch) => format!(
+                            "{}#{} type={:?} badge={} muted={} thread={}",
+                            ch.name,
+                            id.get(),
+                            ch.channel_type,
+                            ch.badge_count,
+                            ch.muted,
+                            ch.parent_id.is_some()
+                        ),
+                        None => format!("MISSING#{}", id.get()),
+                    })
+                    .collect();
+                tracing::info!(
+                    target: "unread_seed",
+                    clan_id = clan_id.get(),
+                    desc_count,
+                    seeded = seed.len(),
+                    with_badge,
+                    cached = this.cache.contains(&clan_id),
+                    applied,
+                    active = this.active_clan_id == Some(clan_id),
+                    rows = ?badged_rows,
+                    "SEED badge counts"
+                );
+                this.pending_badge_seed.insert(clan_id, seed);
+                if applied {
+                    this.notify_channel_list(clan_id, cx);
+                }
+                if !last_messages.is_empty()
+                    && let Some(store) = MessagesStore::try_global(cx)
+                {
+                    store.update(cx, |store, cx| {
+                        store.set_many_last_messages(last_messages);
+                        cx.notify();
+                    });
+                }
+            });
+        })
     }
 
     fn register_realtime(cx: &mut Context<Self>) {
@@ -504,13 +657,44 @@ impl ChannelList {
     }
 
     pub fn load_for_clan(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+        self.want_extras.insert(clan_id);
+        if self.cache.is_fresh(&clan_id, crate::CACHE_TTL) {
+            self.ensure_extras(clan_id, cx);
+            return;
+        }
+        self.fetch_clan(clan_id, cx);
+    }
+
+    pub fn load_structure_for_clan(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
         if self.cache.is_fresh(&clan_id, crate::CACHE_TTL) {
             return;
         }
         self.fetch_clan(clan_id, cx);
     }
 
+    fn ensure_extras(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+        if self.extras_loaded.contains(&clan_id) || !self.extras_loading.insert(clan_id) {
+            return;
+        }
+        let api = self.api.clone();
+        let generation = self.reset_generation;
+        cx.spawn(async move |this, cx| {
+            let extras = Self::fetch_clan_extras(&api, clan_id).await;
+            let _ = this.update(cx, |this, cx| {
+                this.extras_loading.remove(&clan_id);
+                if this.reset_generation != generation {
+                    return;
+                }
+                this.extras_loaded.insert(clan_id);
+                this.apply_clan_extras(clan_id, extras, cx);
+            });
+        })
+        .detach();
+    }
+
     pub fn refresh_clan(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+        self.want_extras.insert(clan_id);
+        self.extras_loaded.remove(&clan_id);
         self.fetch_clan(clan_id, cx);
     }
 
@@ -522,15 +706,15 @@ impl ChannelList {
         let api = self.api.clone();
         let generation = self.reset_generation;
         cx.spawn(async move |this, cx| {
-            let result = Self::fetch_clan_data(&api, clan_id).await;
+            let result = Self::fetch_clan_structure(&api, clan_id).await;
             match result {
-                Ok((mut categories, app_channels, last_messages)) => {
+                Ok(mut categories) => {
                     let _ = this.update(cx, |this, cx| {
+                        this.loading.remove(&clan_id);
                         if this.reset_generation != generation {
                             return;
                         }
-                        this.loading.remove(&clan_id);
-                        this.app_channels_cache.insert(clan_id, app_channels);
+                        this.consume_badge_seed(clan_id, &mut categories);
                         this.merge_pending_badges(&mut categories);
                         let previous_voice = collect_voice_members(&this.cache, clan_id);
                         merge_previous_voice_members(&mut categories, &previous_voice);
@@ -539,14 +723,11 @@ impl ChannelList {
                         }
                         this.cache.insert(clan_id, categories, None);
                         this.invalidate_channel_index(clan_id);
-                        if let Some(store) = MessagesStore::try_global(cx) {
-                            store.update(cx, |store, cx| {
-                                store.set_many_last_messages(last_messages);
-                                cx.notify();
-                            });
-                        }
                         cx.emit(ChannelEvent::ClanChannelsLoaded(clan_id));
                         cx.notify();
+                        if this.want_extras.contains(&clan_id) {
+                            this.ensure_extras(clan_id, cx);
+                        }
                     });
                 }
                 Err(e) => {
@@ -619,25 +800,34 @@ impl ChannelList {
         }
     }
 
-    async fn fetch_clan_data(
-        api: &AppApi,
-        clan_id: ClanId,
-    ) -> anyhow::Result<(Vec<Category>, Vec<AppChannel>, Vec<(ChannelId, MessageId)>)> {
-        let (channels_res, categories_res, badges_res, voice_res, favorites_res, apps_res) = tokio::join!(
+    async fn fetch_clan_structure(api: &AppApi, clan_id: ClanId) -> anyhow::Result<Vec<Category>> {
+        let (channels_res, categories_res) = tokio::join!(
             api.list_channel_descs(clan_id.get(), 1),
             api.list_categories_typed(clan_id.get()),
-            api.list_channel_badge_counts(clan_id.get()),
+        );
+
+        let api_channels = channels_res?;
+        let api_categories = categories_res?;
+
+        let mut channels: Vec<Channel> = api_channels
+            .into_iter()
+            .map(|c| {
+                let badge = c.badge_count.max(0) as u32;
+                channel_from_desc(c, badge, Vec::new(), false)
+            })
+            .collect();
+
+        let categories = build_categories(api_categories, &mut channels);
+        Ok(assemble_with_favorites(categories, clan_id))
+    }
+
+    async fn fetch_clan_extras(api: &AppApi, clan_id: ClanId) -> ClanExtras {
+        let (voice_res, favorites_res, apps_res) = tokio::join!(
             api.list_voice_channel_users(clan_id.get()),
             api.list_favorite_channels(clan_id.get()),
             api.list_channel_apps(clan_id.get()),
         );
 
-        let api_channels = channels_res?;
-        let api_categories = categories_res?;
-        let badge_descs = badges_res.unwrap_or_else(|e| {
-            tracing::warn!("list_channel_badge_counts failed: {e}");
-            Vec::new()
-        });
         let voice_users = voice_res.unwrap_or_else(|e| {
             tracing::warn!("list_voice_channel_users failed: {e}");
             Vec::new()
@@ -659,17 +849,6 @@ impl ChannelList {
             .map(AppChannel::from)
             .collect();
 
-        let badge_map: HashMap<ChannelId, ApiChannelDesc> = badge_descs
-            .into_iter()
-            .filter(|d| {
-                !matches!(
-                    ChannelType::from_raw(d.channel_type),
-                    ChannelType::App | ChannelType::Voice
-                )
-            })
-            .map(|d| (ChannelId(d.channel_id), d))
-            .collect();
-
         let voice_map: HashMap<ChannelId, Vec<UserId>> = voice_users
             .into_iter()
             .map(|v| {
@@ -680,42 +859,72 @@ impl ChannelList {
             })
             .collect();
 
-        let mut channels: Vec<Channel> = api_channels
-            .into_iter()
-            .map(|mut c| {
-                let cid = ChannelId(c.channel_id);
-                let badge = if let Some(b) = badge_map.get(&cid) {
-                    if b.last_seen_timestamp > 0 {
-                        c.last_seen_timestamp = b.last_seen_timestamp;
-                        c.last_seen_message_id = b.last_seen_message_id;
-                    }
-                    if b.last_sent_timestamp > 0 {
-                        c.last_sent_timestamp = b.last_sent_timestamp;
-                        c.last_sent_message_id = b.last_sent_message_id;
-                    }
-                    b.badge_count
-                } else {
-                    c.badge_count
-                };
-                let badge = badge.max(0) as u32;
-                let voice_ids = voice_map.get(&cid).cloned().unwrap_or_default();
-                let is_favorite = favorite_ids.contains(&cid);
-                channel_from_desc(c, badge, voice_ids, is_favorite)
-            })
-            .collect();
-
-        let last_messages: Vec<(ChannelId, MessageId)> = channels
-            .iter()
-            .filter(|ch| !ch.last_sent_message_id.is_zero())
-            .map(|ch| (ch.id, ch.last_sent_message_id))
-            .collect();
-
-        let categories = build_categories(api_categories, &mut channels);
-        Ok((
-            assemble_with_favorites(categories, clan_id),
+        ClanExtras {
+            voice_map,
+            favorite_ids,
             app_channels,
-            last_messages,
-        ))
+        }
+    }
+
+    fn apply_clan_extras(&mut self, clan_id: ClanId, extras: ClanExtras, cx: &mut Context<Self>) {
+        self.app_channels_cache.insert(clan_id, extras.app_channels);
+
+        let Some(slot) = self.cache.get_mut(&clan_id) else {
+            cx.notify();
+            return;
+        };
+
+        let mut owned = std::mem::take(slot);
+        owned.retain(|category| category.id != FAVOR_CATE_ID);
+
+        let mut changed = false;
+        for ch in owned
+            .iter_mut()
+            .flat_map(|category| category.channels.iter_mut())
+        {
+            let is_favorite = extras.favorite_ids.contains(&ch.id);
+            if ch.is_favorite != is_favorite {
+                ch.is_favorite = is_favorite;
+                changed = true;
+            }
+            let members: Vec<VoiceMember> = extras
+                .voice_map
+                .get(&ch.id)
+                .map(|ids| {
+                    ids.iter()
+                        .map(|uid| VoiceMember {
+                            display_name: uid.to_string(),
+                            avatar_url: String::new(),
+                            user_id: *uid,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            if ch.voice_members != members {
+                ch.voice_members = members;
+                changed = true;
+            }
+        }
+
+        let rebuilt = assemble_with_favorites(owned, clan_id);
+        let in_voice_changed = seed_in_voice_from_categories(&mut self.in_voice, clan_id, &rebuilt);
+        if let Some(slot) = self.cache.get_mut(&clan_id) {
+            *slot = rebuilt;
+        }
+        self.invalidate_channel_index(clan_id);
+
+        if in_voice_changed {
+            cx.emit(ChannelEvent::InVoiceChanged);
+        }
+        tracing::info!(
+            target: "unread_seed",
+            clan_id = clan_id.get(),
+            favorites = extras.favorite_ids.len(),
+            voice_channels = extras.voice_map.len(),
+            changed,
+            "EXTRAS patched into cached clan structure"
+        );
+        cx.notify();
     }
 
     fn notify_channel_list(&self, clan_id: ClanId, cx: &mut Context<Self>) {
@@ -1070,6 +1279,7 @@ impl ChannelList {
             }
         }
         let overlaid = self.pending_channel_badges.remove(&channel_id);
+        self.drop_seeded_badge(clan_id, channel_id);
         if !found {
             cleared_badge = overlaid.unwrap_or(0);
         }
@@ -1088,6 +1298,7 @@ impl ChannelList {
 
     pub fn apply_clan_read(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
         let mut changed = false;
+        self.pending_badge_seed.remove(&clan_id);
         if let Some(categories) = self.cache.get_mut(&clan_id) {
             for category in categories.iter_mut() {
                 for ch in &category.channels {
@@ -1567,9 +1778,12 @@ impl ChannelList {
         tracing::info!("ChannelList resync — invalidating channel cache");
         self.cache.mark_all_stale();
         self.invalidate_channel_index_all();
+        self.badge_seeded.clear();
+        self.extras_loaded.clear();
         self.fetch_user_channels(cx);
         if let Some(clan_id) = self.active_clan_id {
             self.load_for_clan(clan_id, cx);
+            self.seed_badges(clan_id, cx).detach();
         }
     }
 
@@ -2329,6 +2543,58 @@ fn copy_channel_unread_fields(target: &mut Channel, source: &Channel) {
     target.last_seen_timestamp = source.last_seen_timestamp;
     target.last_sent_message_id = source.last_sent_message_id;
     target.last_seen_message_id = source.last_seen_message_id;
+}
+
+fn unread_seed_from_descs(descs: Vec<ApiChannelDesc>) -> HashMap<ChannelId, ChannelUnreadSeed> {
+    descs
+        .into_iter()
+        .filter(|d| {
+            !matches!(
+                ChannelType::from_raw(d.channel_type),
+                ChannelType::App | ChannelType::Voice
+            )
+        })
+        .map(|d| {
+            (
+                ChannelId(d.channel_id),
+                ChannelUnreadSeed {
+                    badge_count: d.badge_count.max(0) as u32,
+                    last_seen_timestamp: d.last_seen_timestamp,
+                    last_seen_message_id: MessageId(d.last_seen_message_id),
+                    last_sent_timestamp: d.last_sent_timestamp,
+                    last_sent_message_id: MessageId(d.last_sent_message_id),
+                },
+            )
+        })
+        .collect()
+}
+
+fn apply_unread_seed_into(
+    seed: &HashMap<ChannelId, ChannelUnreadSeed>,
+    categories: &mut [Category],
+) -> bool {
+    let mut changed = false;
+    for ch in categories
+        .iter_mut()
+        .flat_map(|category| category.channels.iter_mut())
+    {
+        let Some(s) = seed.get(&ch.id) else {
+            continue;
+        };
+        let was_unread = ch.is_unread();
+        let was_badge = ch.badge_count;
+        ch.badge_count = s.badge_count;
+        if s.last_seen_timestamp > 0 {
+            ch.last_seen_timestamp = s.last_seen_timestamp;
+            ch.last_seen_message_id = s.last_seen_message_id;
+        }
+        if s.last_sent_timestamp > 0 {
+            ch.last_sent_timestamp = s.last_sent_timestamp;
+            ch.last_sent_message_id = s.last_sent_message_id;
+        }
+        changed = changed || was_badge != ch.badge_count || was_unread != ch.is_unread();
+    }
+    changed
 }
 
 fn merge_pending_badges_into(pending: &mut HashMap<ChannelId, u32>, categories: &mut [Category]) {
@@ -3210,6 +3476,112 @@ mod tests {
         categories[0].channels[0].badge_count = 0;
         merge_pending_badges_into(&mut pending, &mut categories);
         assert_eq!(categories[0].channels[0].badge_count, 0);
+    }
+
+    fn seed_entry(badge: u32, last_seen: i64, last_sent: i64) -> ChannelUnreadSeed {
+        ChannelUnreadSeed {
+            badge_count: badge,
+            last_seen_timestamp: last_seen,
+            last_seen_message_id: MessageId(if last_seen > 0 { 100 } else { 0 }),
+            last_sent_timestamp: last_sent,
+            last_sent_message_id: MessageId(if last_sent > 0 { 200 } else { 0 }),
+        }
+    }
+
+    #[test]
+    fn favorites_rebuild_survives_a_later_extras_patch() {
+        let mut categories = assemble_with_favorites(categories(), ClanId(1));
+        assert_eq!(categories[0].id, FAVOR_CATE_ID);
+        assert!(categories[0].channels.is_empty());
+
+        let seed = HashMap::from([(ChannelId(10), seed_entry(4, 0, 0))]);
+        apply_unread_seed_into(&seed, &mut categories);
+
+        categories.retain(|category| category.id != FAVOR_CATE_ID);
+        for ch in categories
+            .iter_mut()
+            .flat_map(|category| category.channels.iter_mut())
+        {
+            ch.is_favorite = ch.id == ChannelId(10);
+        }
+        let rebuilt = assemble_with_favorites(categories, ClanId(1));
+
+        assert_eq!(rebuilt[0].id, FAVOR_CATE_ID);
+        assert_eq!(rebuilt[0].channels.len(), 1);
+        assert_eq!(rebuilt[0].channels[0].id, ChannelId(10));
+        assert_eq!(rebuilt[0].channels[0].badge_count, 4);
+        let original = rebuilt[1].channels.iter().find(|c| c.id == ChannelId(10));
+        assert_eq!(original.map(|c| c.badge_count), Some(4));
+    }
+
+    #[test]
+    fn unread_seed_applies_badge_and_timestamps() {
+        let mut categories = categories();
+        let seed = HashMap::from([(ChannelId(10), seed_entry(3, 50, 90))]);
+        assert!(apply_unread_seed_into(&seed, &mut categories));
+
+        let ch = &categories[0].channels[0];
+        assert_eq!(ch.badge_count, 3);
+        assert_eq!(ch.last_seen_timestamp, 50);
+        assert_eq!(ch.last_seen_message_id, MessageId(100));
+        assert_eq!(ch.last_sent_timestamp, 90);
+        assert_eq!(ch.last_sent_message_id, MessageId(200));
+        assert!(ch.is_unread());
+    }
+
+    #[test]
+    fn unread_seed_marks_white_unread_without_mention() {
+        let mut categories = categories();
+        let seed = HashMap::from([(ChannelId(10), seed_entry(0, 50, 90))]);
+        apply_unread_seed_into(&seed, &mut categories);
+
+        let ch = &categories[0].channels[0];
+        assert_eq!(ch.badge_count, 0);
+        assert!(ch.is_unread());
+    }
+
+    #[test]
+    fn unread_seed_ignores_zero_timestamps() {
+        let mut categories = categories();
+        categories[0].channels[0].last_seen_timestamp = 42;
+        categories[0].channels[0].last_sent_timestamp = 77;
+        let seed = HashMap::from([(ChannelId(10), seed_entry(1, 0, 0))]);
+        apply_unread_seed_into(&seed, &mut categories);
+
+        let ch = &categories[0].channels[0];
+        assert_eq!(ch.badge_count, 1);
+        assert_eq!(ch.last_seen_timestamp, 42);
+        assert_eq!(ch.last_sent_timestamp, 77);
+    }
+
+    #[test]
+    fn unread_seed_from_descs_drops_app_and_voice_channels() {
+        let desc = |id: i64, channel_type: u32| ApiChannelDesc {
+            channel_id: id,
+            channel_label: String::new(),
+            channel_type,
+            clan_id: 1,
+            category_name: String::new(),
+            category_id: 0,
+            channel_private: 0,
+            count_mess_unread: 2,
+            member_count: 0,
+            parent_id: 0,
+            is_mute: false,
+            last_seen_message_id: 0,
+            last_seen_timestamp: 0,
+            last_sent_message_id: 0,
+            last_sent_timestamp: 0,
+            badge_count: 2,
+            creator_id: 0,
+            clan_name: String::new(),
+        };
+        let seed = unread_seed_from_descs(vec![desc(10, 1), desc(11, 8), desc(12, 10)]);
+
+        assert_eq!(seed.len(), 1);
+        assert_eq!(seed[&ChannelId(10)].badge_count, 2);
+        assert!(!seed.contains_key(&ChannelId(11)));
+        assert!(!seed.contains_key(&ChannelId(12)));
     }
 
     #[test]

--- a/crates/mezon-store/src/clan.rs
+++ b/crates/mezon-store/src/clan.rs
@@ -556,7 +556,6 @@ impl ClanList {
             return;
         }
         self.active_clan_id = Some(id);
-        self.fire_join_clan_chat(id, cx);
         cx.emit(ClanEvent::ActiveClanChanged(self.active_clan_id));
         cx.notify();
     }

--- a/crates/mezon-store/src/clan_load.rs
+++ b/crates/mezon-store/src/clan_load.rs
@@ -1,0 +1,114 @@
+use gpui::{App, AppContext, AsyncApp, Context, Entity, Global, Subscription, WeakEntity};
+
+use crate::channel::ChannelList;
+use crate::clan::{ClanEvent, ClanList};
+use crate::clan_members::ClanMembersStore;
+use crate::emoji::EmojiStore;
+use crate::ids::ClanId;
+use crate::notification_setting::NotificationSettingStore;
+use crate::permissions::PermissionStore;
+use crate::roles::RolesStore;
+use crate::sticker::StickerStore;
+
+pub struct ClanLoadScheduler {
+    generation: u64,
+    _clan_sub: Subscription,
+}
+
+struct GlobalClanLoadScheduler(Entity<ClanLoadScheduler>);
+impl Global for GlobalClanLoadScheduler {}
+
+impl ClanLoadScheduler {
+    pub fn init(cx: &mut App) -> Entity<Self> {
+        let entity = cx.new(Self::new);
+        cx.set_global(GlobalClanLoadScheduler(entity.clone()));
+        entity
+    }
+
+    pub fn global(cx: &App) -> Entity<Self> {
+        cx.global::<GlobalClanLoadScheduler>().0.clone()
+    }
+
+    pub fn try_global(cx: &App) -> Option<Entity<Self>> {
+        cx.try_global::<GlobalClanLoadScheduler>()
+            .map(|g| g.0.clone())
+    }
+
+    pub fn reset(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+    }
+
+    fn new(cx: &mut Context<Self>) -> Self {
+        let clan_sub = cx.subscribe(&ClanList::global(cx), |this, _clan, event, cx| {
+            if let ClanEvent::ActiveClanChanged(active) = event {
+                match active {
+                    Some(clan_id) => this.start(*clan_id, cx),
+                    None => this.reset(),
+                }
+            }
+        });
+
+        Self {
+            generation: 0,
+            _clan_sub: clan_sub,
+        }
+    }
+
+    fn start(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+        self.generation = self.generation.wrapping_add(1);
+        let generation = self.generation;
+
+        cx.spawn(async move |this, cx| {
+            cx.update(|cx| {
+                ChannelList::global(cx)
+                    .update(cx, |channels, cx| channels.load_for_clan(clan_id, cx));
+            });
+
+            cx.update(|cx| {
+                ChannelList::global(cx).update(cx, |channels, cx| channels.seed_badges(clan_id, cx))
+            })
+            .await;
+            if !is_current(&this, cx, generation) {
+                return;
+            }
+
+            cx.update(|cx| {
+                ClanMembersStore::global(cx)
+                    .update(cx, |store, cx| store.ensure_loaded_task(clan_id, cx))
+            })
+            .await;
+            if !is_current(&this, cx, generation) {
+                return;
+            }
+
+            let deferred = cx.update(|cx| {
+                [
+                    RolesStore::global(cx)
+                        .update(cx, |store, cx| store.ensure_loaded_task(clan_id, cx)),
+                    PermissionStore::global(cx).update(cx, |store, cx| {
+                        store.load_clan_permissions_task(clan_id, cx)
+                    }),
+                    EmojiStore::global(cx).update(cx, |store, cx| store.ensure_loaded_task(cx)),
+                    StickerStore::global(cx).update(cx, |store, cx| store.ensure_loaded_task(cx)),
+                ]
+            });
+            for task in deferred {
+                task.await;
+            }
+            if !is_current(&this, cx, generation) {
+                return;
+            }
+
+            cx.update(|cx| {
+                NotificationSettingStore::global(cx)
+                    .update(cx, |store, cx| store.prefetch_clan(clan_id, cx));
+            });
+        })
+        .detach();
+    }
+}
+
+fn is_current(this: &WeakEntity<ClanLoadScheduler>, cx: &mut AsyncApp, generation: u64) -> bool {
+    this.update(cx, |this, _| this.generation == generation)
+        .unwrap_or(false)
+}

--- a/crates/mezon-store/src/clan_members.rs
+++ b/crates/mezon-store/src/clan_members.rs
@@ -2,13 +2,13 @@ use crate::ids::{ClanId, RoleId, UserId};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Subscription, Task};
+use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Task};
 use mezon_client::{AppApi, ConnectionStatus, RealtimeEvent};
 use mezon_proto::{api, realtime};
 
 use crate::KeyedCache;
 use crate::badge::BadgeService;
-use crate::clan::{ClanEvent, ClanList};
+use crate::clan::ClanList;
 use crate::presence::PresenceStore;
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
 
@@ -91,7 +91,6 @@ pub struct ClanMembersStore {
     self_role_ids: HashMap<ClanId, Vec<i64>>,
     loading: HashSet<ClanId>,
     api: Arc<AppApi>,
-    _clan_sub: Subscription,
     _conn_watch: Task<()>,
 }
 
@@ -130,12 +129,6 @@ impl ClanMembersStore {
     fn new(api: Arc<AppApi>, cx: &mut Context<Self>) -> Self {
         Self::register_realtime(cx);
 
-        let clan_sub = cx.subscribe(&ClanList::global(cx), |this, _clan, event, cx| {
-            if let ClanEvent::ActiveClanChanged(Some(clan_id)) = event {
-                this.ensure_loaded(*clan_id, cx);
-            }
-        });
-
         let conn_watch = Self::spawn_connection_watch(api.clone(), cx);
 
         Self {
@@ -143,7 +136,6 @@ impl ClanMembersStore {
             self_role_ids: HashMap::new(),
             loading: HashSet::new(),
             api,
-            _clan_sub: clan_sub,
             _conn_watch: conn_watch,
         }
     }
@@ -210,24 +202,29 @@ impl ClanMembersStore {
 
     fn refresh_active(&mut self, cx: &mut Context<Self>) {
         if let Some(clan_id) = ClanList::global(cx).read(cx).active_clan_id {
-            self.fetch(clan_id, cx);
+            self.fetch(clan_id, cx).detach();
         }
     }
 
     pub fn ensure_loaded(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+        self.ensure_loaded_task(clan_id, cx).detach();
+    }
+
+    pub fn ensure_loaded_task(&mut self, clan_id: ClanId, cx: &mut Context<Self>) -> Task<()> {
         self.cache.touch(&clan_id);
-        if !self.cache.is_fresh(&clan_id, crate::CACHE_TTL) {
-            self.fetch(clan_id, cx);
+        if self.cache.is_fresh(&clan_id, crate::CACHE_TTL) {
+            return Task::ready(());
         }
+        self.fetch(clan_id, cx)
     }
 
     pub fn refresh(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
-        self.fetch(clan_id, cx);
+        self.fetch(clan_id, cx).detach();
     }
 
-    fn fetch(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+    fn fetch(&mut self, clan_id: ClanId, cx: &mut Context<Self>) -> Task<()> {
         if !self.loading.insert(clan_id) {
-            return;
+            return Task::ready(());
         }
         let api = self.api.clone();
         cx.spawn(async move |this, cx| {
@@ -284,7 +281,6 @@ impl ClanMembersStore {
                 }
             });
         })
-        .detach();
     }
 
     fn handle_event(&mut self, event: &RealtimeEvent, cx: &mut Context<Self>) {

--- a/crates/mezon-store/src/connection.rs
+++ b/crates/mezon-store/src/connection.rs
@@ -24,7 +24,6 @@ const CONNECT_CONFIRM_GRACE: std::time::Duration = std::time::Duration::from_sec
 const MAX_CONSECUTIVE_FAILURES: u32 = 5;
 const RECONNECT_BACKOFF_CAP_SECS: u64 = 60;
 const DEFAULT_TLS_PORT: u16 = 443;
-
 /// Result of a single reconnect attempt. Only a rejected credential (the server accepted the TCP
 /// connection but refused the handshake) is treated as a dead session; an unreachable server must
 /// never discard the persisted session.

--- a/crates/mezon-store/src/emoji.rs
+++ b/crates/mezon-store/src/emoji.rs
@@ -4,14 +4,13 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Subscription, Task};
+use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Task};
 use image::ImageEncoder as _;
 use mezon_client::{AppApi, ConnectionStatus, RealtimeEvent};
 use mezon_proto::{api, realtime};
 
 use crate::Freshness;
 use crate::badge::BadgeService;
-use crate::clan::{ClanEvent, ClanList};
 use crate::ids::ClanId;
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
 
@@ -52,7 +51,6 @@ pub struct EmojiStore {
     freshness: Freshness,
     loading: bool,
     api: Arc<AppApi>,
-    _clan_sub: Subscription,
     _conn_watch: Task<()>,
 }
 
@@ -88,12 +86,6 @@ impl EmojiStore {
     fn new(api: Arc<AppApi>, cx: &mut Context<Self>) -> Self {
         Self::register_realtime(cx);
 
-        let clan_sub = cx.subscribe(&ClanList::global(cx), |this, _clan, event, cx| {
-            if let ClanEvent::ActiveClanChanged(Some(_)) = event {
-                this.ensure_loaded(cx);
-            }
-        });
-
         let conn_watch = Self::spawn_connection_watch(api.clone(), cx);
 
         let mut store = Self {
@@ -103,7 +95,6 @@ impl EmojiStore {
             freshness: Freshness::new(),
             loading: false,
             api,
-            _clan_sub: clan_sub,
             _conn_watch: conn_watch,
         };
         store.fetch_recent(cx);
@@ -145,18 +136,23 @@ impl EmojiStore {
     }
 
     pub fn ensure_loaded(&mut self, cx: &mut Context<Self>) {
-        if !self.freshness.is_fresh(crate::CACHE_TTL) {
-            self.fetch(cx);
+        self.ensure_loaded_task(cx).detach();
+    }
+
+    pub fn ensure_loaded_task(&mut self, cx: &mut Context<Self>) -> Task<()> {
+        if self.freshness.is_fresh(crate::CACHE_TTL) {
+            return Task::ready(());
         }
+        self.fetch(cx)
     }
 
     pub fn refresh(&mut self, cx: &mut Context<Self>) {
-        self.fetch(cx);
+        self.fetch(cx).detach();
     }
 
-    fn fetch(&mut self, cx: &mut Context<Self>) {
+    fn fetch(&mut self, cx: &mut Context<Self>) -> Task<()> {
         if self.loading {
-            return;
+            return Task::ready(());
         }
         self.loading = true;
         let api = self.api.clone();
@@ -185,7 +181,6 @@ impl EmojiStore {
                 }
             });
         })
-        .detach();
     }
 
     fn fetch_recent(&mut self, cx: &mut Context<Self>) {

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -10,6 +10,7 @@ pub mod channel_members;
 pub mod channel_permissions;
 pub mod channel_settings;
 pub mod clan;
+pub mod clan_load;
 pub mod clan_members;
 pub mod config;
 pub mod connection;
@@ -84,6 +85,7 @@ pub use channel_permissions::{
 };
 pub use channel_settings::{ChannelSetting, ChannelSettingsEvent, ChannelSettingsStore};
 pub use clan::*;
+pub use clan_load::ClanLoadScheduler;
 pub use clan_members::{
     ClanMember, ClanMembersEvent, ClanMembersStore, User, split_members_by_status,
 };

--- a/crates/mezon-store/src/login.rs
+++ b/crates/mezon-store/src/login.rs
@@ -105,6 +105,9 @@ impl LoginStore {
     }
 
     pub fn reset_all_user_stores(cx: &mut App) {
+        if let Some(e) = crate::clan_load::ClanLoadScheduler::try_global(cx) {
+            e.update(cx, |s, _| s.reset());
+        }
         if let Some(e) = crate::account::AccountStore::try_global(cx) {
             e.update(cx, |s, cx| s.reset(cx));
         }

--- a/crates/mezon-store/src/notification_setting.rs
+++ b/crates/mezon-store/src/notification_setting.rs
@@ -49,7 +49,6 @@ pub struct NotificationSettingStore {
     api: Arc<AppApi>,
     auth_state: Entity<AuthState>,
     _channel_sub: Subscription,
-    _clan_sub: Subscription,
     _auth_sub: Subscription,
 }
 
@@ -76,14 +75,6 @@ impl NotificationSettingStore {
                     }
                 },
             );
-            let clan_sub = cx.subscribe(
-                &crate::clan::ClanList::global(cx),
-                |this: &mut Self, _, event: &crate::clan::ClanEvent, cx| {
-                    if let crate::clan::ClanEvent::ActiveClanChanged(Some(clan_id)) = event {
-                        this.prefetch_clan(*clan_id, cx);
-                    }
-                },
-            );
             let this = Self {
                 settings: HashMap::new(),
                 clan_defaults: HashMap::new(),
@@ -97,7 +88,6 @@ impl NotificationSettingStore {
                 api,
                 auth_state: auth_state.clone(),
                 _channel_sub: channel_sub,
-                _clan_sub: clan_sub,
                 _auth_sub: auth_sub,
             };
             let entity = cx.entity();
@@ -225,8 +215,10 @@ impl NotificationSettingStore {
         }
         let api = self.api.clone();
         let task = cx.spawn(async move |this, cx| {
-            let muted = api.list_muted_channels(clan_id.get()).await;
-            let clan_default = api.get_notification_clan(clan_id.get()).await;
+            let (muted, clan_default) = tokio::join!(
+                api.list_muted_channels(clan_id.get()),
+                api.get_notification_clan(clan_id.get()),
+            );
             let _ = this.update(cx, |store, cx| {
                 store.clan_prefetch.remove(&clan_id);
                 match muted {

--- a/crates/mezon-store/src/permissions.rs
+++ b/crates/mezon-store/src/permissions.rs
@@ -1,11 +1,11 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Subscription, Task};
+use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Task};
 use mezon_client::{AppApi, ConnectionStatus};
 
 use crate::AuthState;
-use crate::clan::{ClanEvent, ClanList};
+use crate::clan::ClanList;
 use crate::ids::{ClanId, UserId};
 
 pub const PERMISSION_CLAN_OWNER: &str = "clan-owner";
@@ -54,7 +54,6 @@ pub struct PermissionStore {
     loading_clans: HashSet<ClanId>,
     api: Arc<AppApi>,
     auth_state: Entity<AuthState>,
-    _clan_sub: Subscription,
     _conn_watch: Task<()>,
 }
 
@@ -80,13 +79,6 @@ impl PermissionStore {
     }
 
     fn new(api: Arc<AppApi>, auth_state: Entity<AuthState>, cx: &mut Context<Self>) -> Self {
-        let clan_sub = cx.subscribe(&ClanList::global(cx), |this, _clan, event, cx| {
-            if let ClanEvent::ActiveClanChanged(Some(clan_id)) = event {
-                this.load_permission_catalog(cx);
-                this.load_clan_permissions(*clan_id, cx);
-            }
-        });
-
         let conn_watch = Self::spawn_connection_watch(api.clone(), cx);
 
         Self {
@@ -98,7 +90,6 @@ impl PermissionStore {
             loading_clans: HashSet::new(),
             api,
             auth_state,
-            _clan_sub: clan_sub,
             _conn_watch: conn_watch,
         }
     }
@@ -209,9 +200,17 @@ impl PermissionStore {
     }
 
     pub fn load_clan_permissions(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+        self.load_clan_permissions_task(clan_id, cx).detach();
+    }
+
+    pub fn load_clan_permissions_task(
+        &mut self,
+        clan_id: ClanId,
+        cx: &mut Context<Self>,
+    ) -> Task<()> {
         self.load_permission_catalog(cx);
         if self.max_level_by_clan.contains_key(&clan_id) || !self.loading_clans.insert(clan_id) {
-            return;
+            return Task::ready(());
         }
         let api = self.api.clone();
         cx.spawn(async move |this, cx| {
@@ -236,7 +235,6 @@ impl PermissionStore {
                 }
             });
         })
-        .detach();
     }
 
     fn load_permission_catalog(&mut self, cx: &mut Context<Self>) {

--- a/crates/mezon-store/src/roles.rs
+++ b/crates/mezon-store/src/roles.rs
@@ -1,12 +1,12 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Subscription, Task};
+use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Task};
 use mezon_client::{AppApi, ConnectionStatus};
 use mezon_proto::api;
 
 use crate::KeyedCache;
-use crate::clan::{ClanEvent, ClanList};
+use crate::clan::ClanList;
 use crate::clan_members::ClanMembersStore;
 use crate::ids::{ClanId, RoleId, UserId};
 use crate::permissions::PERMISSION_ADMINISTRATOR;
@@ -100,7 +100,6 @@ pub struct RolesStore {
     saving: HashSet<ClanId>,
     reset_generation: u64,
     api: Arc<AppApi>,
-    _clan_sub: Subscription,
     _conn_watch: Task<()>,
 }
 
@@ -151,12 +150,6 @@ impl RolesStore {
     fn new(api: Arc<AppApi>, cx: &mut Context<Self>) -> Self {
         Self::register_realtime(cx);
 
-        let clan_sub = cx.subscribe(&ClanList::global(cx), |this, _clan, event, cx| {
-            if let ClanEvent::ActiveClanChanged(Some(clan_id)) = event {
-                this.ensure_loaded(*clan_id, cx);
-            }
-        });
-
         let conn_watch = Self::spawn_connection_watch(api.clone(), cx);
 
         Self {
@@ -167,7 +160,6 @@ impl RolesStore {
             saving: HashSet::new(),
             reset_generation: 0,
             api,
-            _clan_sub: clan_sub,
             _conn_watch: conn_watch,
         }
     }
@@ -195,13 +187,13 @@ impl RolesStore {
 
     fn refresh_active(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
         if ClanList::global(cx).read(cx).active_clan_id == Some(clan_id) {
-            self.fetch(clan_id, true, cx);
+            self.fetch(clan_id, true, cx).detach();
         }
     }
 
     fn refresh_active_from_event(&mut self, cx: &mut Context<Self>) {
         if let Some(clan_id) = ClanList::global(cx).read(cx).active_clan_id {
-            self.fetch(clan_id, true, cx);
+            self.fetch(clan_id, true, cx).detach();
         }
     }
 
@@ -395,19 +387,24 @@ impl RolesStore {
     }
 
     pub fn ensure_loaded(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+        self.ensure_loaded_task(clan_id, cx).detach();
+    }
+
+    pub fn ensure_loaded_task(&mut self, clan_id: ClanId, cx: &mut Context<Self>) -> Task<()> {
         self.cache.touch(&clan_id);
-        if !self.cache.is_fresh(&clan_id, crate::CACHE_TTL) {
-            self.fetch(clan_id, false, cx);
+        if self.cache.is_fresh(&clan_id, crate::CACHE_TTL) {
+            return Task::ready(());
         }
+        self.fetch(clan_id, false, cx)
     }
 
     pub fn reload(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
-        self.fetch(clan_id, true, cx);
+        self.fetch(clan_id, true, cx).detach();
     }
 
-    fn fetch(&mut self, clan_id: ClanId, force: bool, cx: &mut Context<Self>) {
+    fn fetch(&mut self, clan_id: ClanId, force: bool, cx: &mut Context<Self>) -> Task<()> {
         if !force && !self.loading.insert(clan_id) {
-            return;
+            return Task::ready(());
         }
         if force {
             self.loading.insert(clan_id);
@@ -433,7 +430,6 @@ impl RolesStore {
                 }
             });
         })
-        .detach();
     }
 
     pub fn roles_for(&self, clan_id: ClanId, role_ids: &[RoleId]) -> Vec<Role> {

--- a/crates/mezon-store/src/sticker.rs
+++ b/crates/mezon-store/src/sticker.rs
@@ -2,12 +2,11 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Subscription, Task};
+use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Task};
 use mezon_client::{AppApi, ConnectionStatus};
 use mezon_proto::api;
 
 use crate::Freshness;
-use crate::clan::{ClanEvent, ClanList};
 use crate::emoji::{MAX_STICKER_BYTES, is_valid_emoticon_shortname, upload_emoticon_file};
 use crate::ids::ClanId;
 use crate::voice::{MAX_SOUND_BYTES, upload_sound_file};
@@ -51,7 +50,6 @@ pub struct StickerStore {
     freshness: Freshness,
     loading: bool,
     api: Arc<AppApi>,
-    _clan_sub: Subscription,
     _conn_watch: Task<()>,
 }
 
@@ -85,12 +83,6 @@ impl StickerStore {
     }
 
     fn new(api: Arc<AppApi>, cx: &mut Context<Self>) -> Self {
-        let clan_sub = cx.subscribe(&ClanList::global(cx), |this, _clan, event, cx| {
-            if let ClanEvent::ActiveClanChanged(Some(_)) = event {
-                this.ensure_loaded(cx);
-            }
-        });
-
         let conn_watch = Self::spawn_connection_watch(api.clone(), cx);
 
         Self {
@@ -100,7 +92,6 @@ impl StickerStore {
             freshness: Freshness::new(),
             loading: false,
             api,
-            _clan_sub: clan_sub,
             _conn_watch: conn_watch,
         }
     }
@@ -127,18 +118,23 @@ impl StickerStore {
     }
 
     pub fn ensure_loaded(&mut self, cx: &mut Context<Self>) {
-        if !self.freshness.is_fresh(crate::CACHE_TTL) {
-            self.fetch(cx);
+        self.ensure_loaded_task(cx).detach();
+    }
+
+    pub fn ensure_loaded_task(&mut self, cx: &mut Context<Self>) -> Task<()> {
+        if self.freshness.is_fresh(crate::CACHE_TTL) {
+            return Task::ready(());
         }
+        self.fetch(cx)
     }
 
     pub fn refresh(&mut self, cx: &mut Context<Self>) {
-        self.fetch(cx);
+        self.fetch(cx).detach();
     }
 
-    fn fetch(&mut self, cx: &mut Context<Self>) {
+    fn fetch(&mut self, cx: &mut Context<Self>) -> Task<()> {
         if self.loading {
-            return;
+            return Task::ready(());
         }
         self.loading = true;
         let api = self.api.clone();
@@ -180,7 +176,6 @@ impl StickerStore {
                 }
             });
         })
-        .detach();
     }
 
     fn insert(&mut self, sticker: Sticker) {

--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -2,6 +2,7 @@ mod attachments;
 mod recorder;
 mod text_field;
 
+use std::any::Any;
 use std::cell::Cell;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -493,6 +494,7 @@ impl MentionInput {
             window,
             |this, _input, event: &MentionFieldEvent, window, cx| match event {
                 MentionFieldEvent::Change => this.on_change(cx),
+                MentionFieldEvent::HistoryRestored => this.on_history_restored(cx),
                 MentionFieldEvent::PressEnter => this.on_enter(window, cx),
                 MentionFieldEvent::NavUp => this.on_nav_up(cx),
                 MentionFieldEvent::NavDown => this.on_nav_down(cx),
@@ -571,6 +573,7 @@ impl MentionInput {
             input.set_value(content, window, cx);
         });
         self.sync_ranges(cx);
+        self.sync_history_payload(cx);
     }
 
     pub fn focus_input(&self, window: &mut Window, cx: &mut App) {
@@ -1199,6 +1202,10 @@ impl MentionInput {
     fn on_change(&mut self, cx: &mut Context<Self>) {
         let content = self.input.read(cx).value_shared();
         self.revalidate(&content, cx);
+        self.after_content_change(content, cx);
+    }
+
+    fn after_content_change(&mut self, content: SharedString, cx: &mut Context<Self>) {
         self.check_trigger(&content, cx);
         self.overflow_counter = {
             let threshold = CONVERT_TO_FILE_THRESHOLD - CONVERT_PREFIX_LEN;
@@ -1212,6 +1219,28 @@ impl MentionInput {
         self.update_ogp_preview(&content, cx);
         self.last_content = content;
         MessagesStore::global(cx).update(cx, |store, cx| store.notify_typing(cx));
+    }
+
+    fn on_history_restored(&mut self, cx: &mut Context<Self>) {
+        let payload = self.input.read(cx).history_payload();
+        self.committed = payload
+            .as_deref()
+            .and_then(|p| p.downcast_ref::<Vec<CommittedToken>>())
+            .cloned()
+            .unwrap_or_default();
+        self.sync_ranges(cx);
+        let content = self.input.read(cx).value_shared();
+        self.after_content_change(content, cx);
+    }
+
+    fn sync_history_payload(&self, cx: &mut Context<Self>) {
+        let payload: Option<Rc<dyn Any>> = if self.committed.is_empty() {
+            None
+        } else {
+            Some(Rc::new(self.committed.clone()))
+        };
+        self.input
+            .update(cx, |input, _| input.set_history_payload(payload));
     }
 
     fn update_ogp_preview(&mut self, content: &str, cx: &mut Context<Self>) {
@@ -1345,6 +1374,7 @@ impl MentionInput {
         });
         if reanchored || self.committed.len() != before {
             self.sync_ranges(cx);
+            self.sync_history_payload(cx);
         }
     }
 
@@ -1752,6 +1782,7 @@ impl MentionInput {
         });
         self.reset_popup();
         self.sync_ranges(cx);
+        self.sync_history_payload(cx);
         cx.notify();
     }
 

--- a/crates/mezon-ui/src/chat/mention_input/text_field.rs
+++ b/crates/mezon-ui/src/chat/mention_input/text_field.rs
@@ -1,8 +1,10 @@
 #[path = "blink_manager.rs"]
 mod blink_manager;
 
+use std::any::Any;
 use std::ops::Range;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 use blink_manager::CaretBlink;
 
@@ -18,6 +20,10 @@ use gpui::{
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::theme::ActiveTheme;
+use crate::util::text_edit::{
+    EditKind, HistoryEntry, MAX_UNDO_HISTORY, home_target, line_end, line_start,
+    next_word_boundary, previous_word_boundary,
+};
 
 const MASK: char = '\u{2022}';
 const KEY_CONTEXT: &str = "MezonMentionInput";
@@ -167,6 +173,22 @@ actions!(
         SelectAll,
         Home,
         End,
+        MoveToPreviousWordStart,
+        MoveToNextWordEnd,
+        SelectToPreviousWordStart,
+        SelectToNextWordEnd,
+        DeleteToPreviousWordStart,
+        DeleteToNextWordEnd,
+        SelectToLineStart,
+        SelectToLineEnd,
+        MoveToDocStart,
+        MoveToDocEnd,
+        SelectToDocStart,
+        SelectToDocEnd,
+        DeleteToLineStart,
+        DeleteToLineEnd,
+        Undo,
+        Redo,
         ShowCharacterPalette,
         Paste,
         Cut,
@@ -175,7 +197,7 @@ actions!(
 );
 
 pub(crate) fn init(cx: &mut App) {
-    cx.bind_keys([
+    let mut bindings = vec![
         KeyBinding::new("backspace", Backspace, Some(KEY_CONTEXT)),
         KeyBinding::new("delete", Delete, Some(KEY_CONTEXT)),
         KeyBinding::new("enter", Enter, Some(KEY_CONTEXT)),
@@ -186,19 +208,77 @@ pub(crate) fn init(cx: &mut App) {
         KeyBinding::new("right", Right, Some(KEY_CONTEXT)),
         KeyBinding::new("shift-left", SelectLeft, Some(KEY_CONTEXT)),
         KeyBinding::new("shift-right", SelectRight, Some(KEY_CONTEXT)),
+        KeyBinding::new("home", Home, Some(KEY_CONTEXT)),
+        KeyBinding::new("end", End, Some(KEY_CONTEXT)),
+        KeyBinding::new("shift-home", SelectToLineStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("shift-end", SelectToLineEnd, Some(KEY_CONTEXT)),
         KeyBinding::new("secondary-a", SelectAll, Some(KEY_CONTEXT)),
         KeyBinding::new("secondary-v", Paste, Some(KEY_CONTEXT)),
         KeyBinding::new("secondary-c", Copy, Some(KEY_CONTEXT)),
         KeyBinding::new("secondary-x", Cut, Some(KEY_CONTEXT)),
-        KeyBinding::new("home", Home, Some(KEY_CONTEXT)),
-        KeyBinding::new("end", End, Some(KEY_CONTEXT)),
+        KeyBinding::new("secondary-z", Undo, Some(KEY_CONTEXT)),
+        KeyBinding::new("secondary-shift-z", Redo, Some(KEY_CONTEXT)),
         KeyBinding::new("ctrl-cmd-space", ShowCharacterPalette, Some(KEY_CONTEXT)),
+    ];
+
+    #[cfg(target_os = "macos")]
+    bindings.extend([
+        KeyBinding::new("alt-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("alt-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "alt-shift-left",
+            SelectToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("alt-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "alt-backspace",
+            DeleteToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("alt-delete", DeleteToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-left", Home, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-right", End, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-left", SelectToLineStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-right", SelectToLineEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-up", MoveToDocStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-down", MoveToDocEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-up", SelectToDocStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-down", SelectToDocEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-backspace", DeleteToLineStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-delete", DeleteToLineEnd, Some(KEY_CONTEXT)),
     ]);
+
+    #[cfg(not(target_os = "macos"))]
+    bindings.extend([
+        KeyBinding::new("ctrl-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "ctrl-shift-left",
+            SelectToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("ctrl-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "ctrl-backspace",
+            DeleteToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("ctrl-delete", DeleteToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-home", MoveToDocStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-end", MoveToDocEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-shift-home", SelectToDocStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-shift-end", SelectToDocEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-y", Redo, Some(KEY_CONTEXT)),
+    ]);
+
+    cx.bind_keys(bindings);
 }
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) enum MentionFieldEvent {
     Change,
+    HistoryRestored,
     PressEnter,
     NavUp,
     NavDown,
@@ -227,6 +307,10 @@ pub(crate) struct MentionInputState {
     compact: bool,
     mention_spans: Vec<MentionSpan>,
     caret_blink: CaretBlink,
+    undo_stack: Vec<HistoryEntry>,
+    redo_stack: Vec<HistoryEntry>,
+    last_edit_kind: Option<EditKind>,
+    history_payload: Option<Rc<dyn Any>>,
     _window_activation_sub: Subscription,
 }
 
@@ -259,6 +343,10 @@ impl MentionInputState {
             compact: false,
             mention_spans: Vec::new(),
             caret_blink: CaretBlink::new(window.is_window_active()),
+            undo_stack: Vec::new(),
+            redo_stack: Vec::new(),
+            last_edit_kind: None,
+            history_payload: None,
             _window_activation_sub: window_activation_sub,
         };
 
@@ -325,6 +413,7 @@ impl MentionInputState {
     ) {
         let start = range.start.min(self.content.len());
         let end = range.end.min(self.content.len()).max(start);
+        self.record_history(EditKind::Other);
         let mut next = String::with_capacity(self.content.len() - (end - start) + text.len());
         next.push_str(&self.content[..start]);
         next.push_str(text);
@@ -349,6 +438,8 @@ impl MentionInputState {
         let end = self.content.len();
         self.selected_range = end..end;
         self.marked_range = None;
+        self.clear_history();
+        self.history_payload = None;
         cx.notify();
         cx.emit(MentionFieldEvent::Change);
     }
@@ -383,11 +474,220 @@ impl MentionInputState {
     }
 
     fn home(&mut self, _: &Home, _: &mut Window, cx: &mut Context<Self>) {
-        self.move_to(0, cx);
+        self.move_to(home_target(&self.content, self.cursor_offset()), cx);
     }
 
     fn end(&mut self, _: &End, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(line_end(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn select_to_line_start(
+        &mut self,
+        _: &SelectToLineStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(home_target(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn select_to_line_end(&mut self, _: &SelectToLineEnd, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(line_end(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn move_to_doc_start(&mut self, _: &MoveToDocStart, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(0, cx);
+    }
+
+    fn move_to_doc_end(&mut self, _: &MoveToDocEnd, _: &mut Window, cx: &mut Context<Self>) {
         self.move_to(self.content.len(), cx);
+    }
+
+    fn select_to_doc_start(
+        &mut self,
+        _: &SelectToDocStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(0, cx);
+    }
+
+    fn select_to_doc_end(&mut self, _: &SelectToDocEnd, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(self.content.len(), cx);
+    }
+
+    fn move_to_previous_word_start(
+        &mut self,
+        _: &MoveToPreviousWordStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.move_to(
+            previous_word_boundary(&self.content, self.cursor_offset()),
+            cx,
+        );
+    }
+
+    fn move_to_next_word_end(
+        &mut self,
+        _: &MoveToNextWordEnd,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.move_to(next_word_boundary(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn select_to_previous_word_start(
+        &mut self,
+        _: &SelectToPreviousWordStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(
+            previous_word_boundary(&self.content, self.cursor_offset()),
+            cx,
+        );
+    }
+
+    fn select_to_next_word_end(
+        &mut self,
+        _: &SelectToNextWordEnd,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(next_word_boundary(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn delete_to_previous_word_start(
+        &mut self,
+        _: &DeleteToPreviousWordStart,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let prev = previous_word_boundary(&self.content, self.cursor_offset());
+            if prev == self.cursor_offset() {
+                window.play_system_bell();
+                return;
+            }
+            self.extend_selection(prev, cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    fn delete_to_next_word_end(
+        &mut self,
+        _: &DeleteToNextWordEnd,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let next = next_word_boundary(&self.content, self.cursor_offset());
+            if next == self.cursor_offset() {
+                window.play_system_bell();
+                return;
+            }
+            self.extend_selection(next, cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    fn delete_to_line_start(
+        &mut self,
+        _: &DeleteToLineStart,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let target = line_start(&self.content, self.cursor_offset());
+            if target == self.cursor_offset() {
+                window.play_system_bell();
+                return;
+            }
+            self.extend_selection(target, cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    fn delete_to_line_end(
+        &mut self,
+        _: &DeleteToLineEnd,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let target = line_end(&self.content, self.cursor_offset());
+            if target == self.cursor_offset() {
+                window.play_system_bell();
+                return;
+            }
+            self.extend_selection(target, cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    fn undo(&mut self, _: &Undo, _: &mut Window, cx: &mut Context<Self>) {
+        if let Some(entry) = self.undo_stack.pop() {
+            self.redo_stack.push(self.history_snapshot());
+            self.restore_history(entry, cx);
+        }
+    }
+
+    fn redo(&mut self, _: &Redo, _: &mut Window, cx: &mut Context<Self>) {
+        if let Some(entry) = self.redo_stack.pop() {
+            self.undo_stack.push(self.history_snapshot());
+            self.restore_history(entry, cx);
+        }
+    }
+
+    fn history_snapshot(&self) -> HistoryEntry {
+        HistoryEntry {
+            content: self.content.clone(),
+            selected_range: self.selected_range.clone(),
+            selection_reversed: self.selection_reversed,
+            payload: self.history_payload.clone(),
+        }
+    }
+
+    pub(crate) fn set_history_payload(&mut self, payload: Option<Rc<dyn Any>>) {
+        self.history_payload = payload;
+    }
+
+    pub(crate) fn history_payload(&self) -> Option<Rc<dyn Any>> {
+        self.history_payload.clone()
+    }
+
+    fn record_history(&mut self, kind: EditKind) {
+        let coalesce = matches!(kind, EditKind::Insert | EditKind::Delete)
+            && self.last_edit_kind == Some(kind);
+        self.redo_stack.clear();
+        if !coalesce {
+            self.undo_stack.push(self.history_snapshot());
+            if self.undo_stack.len() > MAX_UNDO_HISTORY {
+                let overflow = self.undo_stack.len() - MAX_UNDO_HISTORY;
+                self.undo_stack.drain(..overflow);
+            }
+        }
+        self.last_edit_kind = Some(kind);
+    }
+
+    fn restore_history(&mut self, entry: HistoryEntry, cx: &mut Context<Self>) {
+        self.content = entry.content;
+        self.line_count = self.content.split('\n').count().max(1);
+        self.selected_range = entry.selected_range;
+        self.selection_reversed = entry.selection_reversed;
+        self.marked_range = None;
+        self.last_edit_kind = None;
+        self.history_payload = entry.payload;
+        self.pending_caret_reveal = true;
+        self.pause_caret_blink(cx);
+        cx.notify();
+        cx.emit(MentionFieldEvent::HistoryRestored);
+    }
+
+    fn clear_history(&mut self) {
+        self.undo_stack.clear();
+        self.redo_stack.clear();
+        self.last_edit_kind = None;
     }
 
     fn backspace(&mut self, _: &Backspace, window: &mut Window, cx: &mut Context<Self>) {
@@ -397,7 +697,7 @@ impl MentionInputState {
                 window.play_system_bell();
                 return;
             }
-            self.select_to(prev, cx)
+            self.extend_selection(prev, cx)
         }
         self.replace_text_in_range(None, "", window, cx)
     }
@@ -461,7 +761,7 @@ impl MentionInputState {
                 window.play_system_bell();
                 return;
             }
-            self.select_to(next, cx)
+            self.extend_selection(next, cx)
         }
         self.replace_text_in_range(None, "", window, cx)
     }
@@ -560,6 +860,7 @@ impl MentionInputState {
 
     fn move_to(&mut self, offset: usize, cx: &mut Context<Self>) {
         self.selected_range = offset..offset;
+        self.last_edit_kind = None;
         self.pending_caret_reveal = true;
         self.pause_caret_blink(cx);
         cx.notify()
@@ -692,6 +993,11 @@ impl MentionInputState {
     }
 
     fn select_to(&mut self, offset: usize, cx: &mut Context<Self>) {
+        self.last_edit_kind = None;
+        self.extend_selection(offset, cx);
+    }
+
+    fn extend_selection(&mut self, offset: usize, cx: &mut Context<Self>) {
         if self.selection_reversed {
             self.selected_range.start = offset
         } else {
@@ -800,6 +1106,17 @@ impl EntityInputHandler for MentionInputState {
             .unwrap_or(self.selected_range.clone());
         let range = self.clamp_range(range);
 
+        let kind = if self.marked_range.is_some() {
+            EditKind::Insert
+        } else if new_text.is_empty() {
+            EditKind::Delete
+        } else if range.is_empty() && !new_text.contains('\n') {
+            EditKind::Insert
+        } else {
+            EditKind::Other
+        };
+        self.record_history(kind);
+
         let next = self.content[0..range.start].to_owned() + new_text + &self.content[range.end..];
         self.set_content(next);
         self.selected_range = range.start + new_text.len()..range.start + new_text.len();
@@ -823,6 +1140,10 @@ impl EntityInputHandler for MentionInputState {
             .or(self.marked_range.clone())
             .unwrap_or(self.selected_range.clone());
         let range = self.clamp_range(range);
+
+        if self.marked_range.is_none() {
+            self.record_history(EditKind::Insert);
+        }
 
         let next = self.content[0..range.start].to_owned() + new_text + &self.content[range.end..];
         self.set_content(next);
@@ -966,6 +1287,22 @@ impl Render for MentionInputState {
             .on_action(cx.listener(Self::select_all))
             .on_action(cx.listener(Self::home))
             .on_action(cx.listener(Self::end))
+            .on_action(cx.listener(Self::select_to_line_start))
+            .on_action(cx.listener(Self::select_to_line_end))
+            .on_action(cx.listener(Self::move_to_doc_start))
+            .on_action(cx.listener(Self::move_to_doc_end))
+            .on_action(cx.listener(Self::select_to_doc_start))
+            .on_action(cx.listener(Self::select_to_doc_end))
+            .on_action(cx.listener(Self::move_to_previous_word_start))
+            .on_action(cx.listener(Self::move_to_next_word_end))
+            .on_action(cx.listener(Self::select_to_previous_word_start))
+            .on_action(cx.listener(Self::select_to_next_word_end))
+            .on_action(cx.listener(Self::delete_to_previous_word_start))
+            .on_action(cx.listener(Self::delete_to_next_word_end))
+            .on_action(cx.listener(Self::delete_to_line_start))
+            .on_action(cx.listener(Self::delete_to_line_end))
+            .on_action(cx.listener(Self::undo))
+            .on_action(cx.listener(Self::redo))
             .on_action(cx.listener(Self::show_character_palette))
             .on_action(cx.listener(Self::paste))
             .on_action(cx.listener(Self::cut))

--- a/crates/mezon-ui/src/command_palette/items.rs
+++ b/crates/mezon-ui/src/command_palette/items.rs
@@ -132,7 +132,8 @@ pub(crate) fn ensure_palette_clans_loaded(store: &mut ChannelList, cx: &mut Cont
         .filter(|clan_id| !clan_id.is_zero())
         .collect();
     for clan_id in clan_ids {
-        store.load_for_clan(clan_id, cx);
+        store.load_structure_for_clan(clan_id, cx);
+        store.seed_badges(clan_id, cx).detach();
     }
 }
 

--- a/crates/mezon-ui/src/components/primitives/input.rs
+++ b/crates/mezon-ui/src/components/primitives/input.rs
@@ -13,6 +13,10 @@ use gpui::{
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::theme::ActiveTheme;
+use crate::util::text_edit::{
+    EditKind, HistoryEntry, MAX_UNDO_HISTORY, home_target, line_end, line_start,
+    next_word_boundary, previous_word_boundary,
+};
 
 const MASK: char = '\u{2022}';
 const KEY_CONTEXT: &str = "MezonInput";
@@ -30,6 +34,22 @@ actions!(
         SelectAll,
         Home,
         End,
+        MoveToPreviousWordStart,
+        MoveToNextWordEnd,
+        SelectToPreviousWordStart,
+        SelectToNextWordEnd,
+        DeleteToPreviousWordStart,
+        DeleteToNextWordEnd,
+        SelectToLineStart,
+        SelectToLineEnd,
+        MoveToDocStart,
+        MoveToDocEnd,
+        SelectToDocStart,
+        SelectToDocEnd,
+        DeleteToLineStart,
+        DeleteToLineEnd,
+        Undo,
+        Redo,
         ShowCharacterPalette,
         Paste,
         Cut,
@@ -38,7 +58,7 @@ actions!(
 );
 
 pub fn init(cx: &mut App) {
-    cx.bind_keys([
+    let mut bindings = vec![
         KeyBinding::new("backspace", Backspace, Some(KEY_CONTEXT)),
         KeyBinding::new("delete", Delete, Some(KEY_CONTEXT)),
         KeyBinding::new("enter", Enter, Some(KEY_CONTEXT)),
@@ -46,14 +66,71 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("right", Right, Some(KEY_CONTEXT)),
         KeyBinding::new("shift-left", SelectLeft, Some(KEY_CONTEXT)),
         KeyBinding::new("shift-right", SelectRight, Some(KEY_CONTEXT)),
+        KeyBinding::new("home", Home, Some(KEY_CONTEXT)),
+        KeyBinding::new("end", End, Some(KEY_CONTEXT)),
+        KeyBinding::new("shift-home", SelectToLineStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("shift-end", SelectToLineEnd, Some(KEY_CONTEXT)),
         KeyBinding::new("secondary-a", SelectAll, Some(KEY_CONTEXT)),
         KeyBinding::new("secondary-v", Paste, Some(KEY_CONTEXT)),
         KeyBinding::new("secondary-c", Copy, Some(KEY_CONTEXT)),
         KeyBinding::new("secondary-x", Cut, Some(KEY_CONTEXT)),
-        KeyBinding::new("home", Home, Some(KEY_CONTEXT)),
-        KeyBinding::new("end", End, Some(KEY_CONTEXT)),
+        KeyBinding::new("secondary-z", Undo, Some(KEY_CONTEXT)),
+        KeyBinding::new("secondary-shift-z", Redo, Some(KEY_CONTEXT)),
         KeyBinding::new("ctrl-cmd-space", ShowCharacterPalette, Some(KEY_CONTEXT)),
+    ];
+
+    #[cfg(target_os = "macos")]
+    bindings.extend([
+        KeyBinding::new("alt-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("alt-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "alt-shift-left",
+            SelectToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("alt-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "alt-backspace",
+            DeleteToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("alt-delete", DeleteToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-left", Home, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-right", End, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-left", SelectToLineStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-right", SelectToLineEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-up", MoveToDocStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-down", MoveToDocEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-up", SelectToDocStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-down", SelectToDocEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-backspace", DeleteToLineStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-delete", DeleteToLineEnd, Some(KEY_CONTEXT)),
     ]);
+
+    #[cfg(not(target_os = "macos"))]
+    bindings.extend([
+        KeyBinding::new("ctrl-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "ctrl-shift-left",
+            SelectToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("ctrl-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "ctrl-backspace",
+            DeleteToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("ctrl-delete", DeleteToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-home", MoveToDocStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-end", MoveToDocEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-shift-home", SelectToDocStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-shift-end", SelectToDocEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-y", Redo, Some(KEY_CONTEXT)),
+    ]);
+
+    cx.bind_keys(bindings);
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -92,6 +169,9 @@ pub struct InputState {
     filter_token_chips: bool,
     token_bg_ranges: Vec<Range<usize>>,
     token_bg_color: Option<Hsla>,
+    undo_stack: Vec<HistoryEntry>,
+    redo_stack: Vec<HistoryEntry>,
+    last_edit_kind: Option<EditKind>,
     pub(crate) caret_blink: CaretBlink,
 }
 
@@ -134,6 +214,9 @@ impl InputState {
             filter_token_chips: false,
             token_bg_ranges: Vec::new(),
             token_bg_color: None,
+            undo_stack: Vec::new(),
+            redo_stack: Vec::new(),
+            last_edit_kind: None,
             caret_blink: CaretBlink::new(),
         };
 
@@ -243,6 +326,7 @@ impl InputState {
         let end = self.content.len();
         self.selected_range = end..end;
         self.marked_range = None;
+        self.clear_history();
         self.refresh_filter_token_chips(cx);
         cx.notify();
         cx.emit(InputEvent::Change);
@@ -291,6 +375,7 @@ impl InputState {
         self.marked_range = None;
         self.token_bg_ranges.clear();
         self.token_bg_color = None;
+        self.clear_history();
         cx.notify();
     }
 
@@ -334,11 +419,210 @@ impl InputState {
     }
 
     fn home(&mut self, _: &Home, _: &mut Window, cx: &mut Context<Self>) {
-        self.move_to(0, cx);
+        self.move_to(home_target(&self.content, self.cursor_offset()), cx);
     }
 
     fn end(&mut self, _: &End, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(line_end(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn select_to_line_start(
+        &mut self,
+        _: &SelectToLineStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(home_target(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn select_to_line_end(&mut self, _: &SelectToLineEnd, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(line_end(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn move_to_doc_start(&mut self, _: &MoveToDocStart, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(0, cx);
+    }
+
+    fn move_to_doc_end(&mut self, _: &MoveToDocEnd, _: &mut Window, cx: &mut Context<Self>) {
         self.move_to(self.content.len(), cx);
+    }
+
+    fn select_to_doc_start(
+        &mut self,
+        _: &SelectToDocStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(0, cx);
+    }
+
+    fn select_to_doc_end(&mut self, _: &SelectToDocEnd, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(self.content.len(), cx);
+    }
+
+    fn move_to_previous_word_start(
+        &mut self,
+        _: &MoveToPreviousWordStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.move_to(
+            previous_word_boundary(&self.content, self.cursor_offset()),
+            cx,
+        );
+    }
+
+    fn move_to_next_word_end(
+        &mut self,
+        _: &MoveToNextWordEnd,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.move_to(next_word_boundary(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn select_to_previous_word_start(
+        &mut self,
+        _: &SelectToPreviousWordStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(
+            previous_word_boundary(&self.content, self.cursor_offset()),
+            cx,
+        );
+    }
+
+    fn select_to_next_word_end(
+        &mut self,
+        _: &SelectToNextWordEnd,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(next_word_boundary(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn delete_to_previous_word_start(
+        &mut self,
+        _: &DeleteToPreviousWordStart,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let prev = previous_word_boundary(&self.content, self.cursor_offset());
+            if prev == self.cursor_offset() {
+                window.play_system_bell();
+                return;
+            }
+            self.extend_selection(prev, cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    fn delete_to_next_word_end(
+        &mut self,
+        _: &DeleteToNextWordEnd,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let next = next_word_boundary(&self.content, self.cursor_offset());
+            if next == self.cursor_offset() {
+                window.play_system_bell();
+                return;
+            }
+            self.extend_selection(next, cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    fn delete_to_line_start(
+        &mut self,
+        _: &DeleteToLineStart,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let target = line_start(&self.content, self.cursor_offset());
+            if target == self.cursor_offset() {
+                window.play_system_bell();
+                return;
+            }
+            self.extend_selection(target, cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    fn delete_to_line_end(
+        &mut self,
+        _: &DeleteToLineEnd,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let target = line_end(&self.content, self.cursor_offset());
+            if target == self.cursor_offset() {
+                window.play_system_bell();
+                return;
+            }
+            self.extend_selection(target, cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    fn undo(&mut self, _: &Undo, _: &mut Window, cx: &mut Context<Self>) {
+        if let Some(entry) = self.undo_stack.pop() {
+            self.redo_stack.push(self.history_snapshot());
+            self.restore_history(entry, cx);
+        }
+    }
+
+    fn redo(&mut self, _: &Redo, _: &mut Window, cx: &mut Context<Self>) {
+        if let Some(entry) = self.redo_stack.pop() {
+            self.undo_stack.push(self.history_snapshot());
+            self.restore_history(entry, cx);
+        }
+    }
+
+    fn history_snapshot(&self) -> HistoryEntry {
+        HistoryEntry {
+            content: self.content.clone(),
+            selected_range: self.selected_range.clone(),
+            selection_reversed: self.selection_reversed,
+            payload: None,
+        }
+    }
+
+    fn record_history(&mut self, kind: EditKind) {
+        let coalesce = matches!(kind, EditKind::Insert | EditKind::Delete)
+            && self.last_edit_kind == Some(kind);
+        self.redo_stack.clear();
+        if !coalesce {
+            self.undo_stack.push(self.history_snapshot());
+            if self.undo_stack.len() > MAX_UNDO_HISTORY {
+                let overflow = self.undo_stack.len() - MAX_UNDO_HISTORY;
+                self.undo_stack.drain(..overflow);
+            }
+        }
+        self.last_edit_kind = Some(kind);
+    }
+
+    fn restore_history(&mut self, entry: HistoryEntry, cx: &mut Context<Self>) {
+        self.content = entry.content;
+        self.selected_range = entry.selected_range;
+        self.selection_reversed = entry.selection_reversed;
+        self.marked_range = None;
+        self.last_edit_kind = None;
+        self.refresh_filter_token_chips(cx);
+        self.pause_caret_blink(cx);
+        cx.notify();
+        cx.emit(InputEvent::Change);
+    }
+
+    fn clear_history(&mut self) {
+        self.undo_stack.clear();
+        self.redo_stack.clear();
+        self.last_edit_kind = None;
     }
 
     fn backspace(&mut self, _: &Backspace, window: &mut Window, cx: &mut Context<Self>) {
@@ -348,7 +632,7 @@ impl InputState {
                 window.play_system_bell();
                 return;
             }
-            self.select_to(prev, cx)
+            self.extend_selection(prev, cx)
         }
         self.replace_text_in_range(None, "", window, cx)
     }
@@ -368,7 +652,7 @@ impl InputState {
                 window.play_system_bell();
                 return;
             }
-            self.select_to(next, cx)
+            self.extend_selection(next, cx)
         }
         self.replace_text_in_range(None, "", window, cx)
     }
@@ -440,6 +724,7 @@ impl InputState {
 
     fn move_to(&mut self, offset: usize, cx: &mut Context<Self>) {
         self.selected_range = offset..offset;
+        self.last_edit_kind = None;
         self.pause_caret_blink(cx);
         cx.notify()
     }
@@ -509,6 +794,11 @@ impl InputState {
     }
 
     fn select_to(&mut self, offset: usize, cx: &mut Context<Self>) {
+        self.last_edit_kind = None;
+        self.extend_selection(offset, cx);
+    }
+
+    fn extend_selection(&mut self, offset: usize, cx: &mut Context<Self>) {
         if self.selection_reversed {
             self.selected_range.start = offset
         } else {
@@ -635,6 +925,17 @@ impl EntityInputHandler for InputState {
             return;
         }
 
+        let kind = if self.marked_range.is_some() {
+            EditKind::Insert
+        } else if new_text.is_empty() {
+            EditKind::Delete
+        } else if range.is_empty() && !new_text.contains('\n') {
+            EditKind::Insert
+        } else {
+            EditKind::Other
+        };
+        self.record_history(kind);
+
         self.content = candidate.into();
         self.selected_range = range.start + new_text.len()..range.start + new_text.len();
         self.marked_range.take();
@@ -657,6 +958,10 @@ impl EntityInputHandler for InputState {
             .map(|range_utf16| self.range_from_utf16(range_utf16))
             .or(self.marked_range.clone())
             .unwrap_or(self.selected_range.clone());
+
+        if self.marked_range.is_none() {
+            self.record_history(EditKind::Insert);
+        }
 
         self.content =
             (self.content[0..range.start].to_owned() + new_text + &self.content[range.end..])
@@ -765,6 +1070,22 @@ impl Render for InputState {
             .on_action(cx.listener(Self::select_all))
             .on_action(cx.listener(Self::home))
             .on_action(cx.listener(Self::end))
+            .on_action(cx.listener(Self::select_to_line_start))
+            .on_action(cx.listener(Self::select_to_line_end))
+            .on_action(cx.listener(Self::move_to_doc_start))
+            .on_action(cx.listener(Self::move_to_doc_end))
+            .on_action(cx.listener(Self::select_to_doc_start))
+            .on_action(cx.listener(Self::select_to_doc_end))
+            .on_action(cx.listener(Self::move_to_previous_word_start))
+            .on_action(cx.listener(Self::move_to_next_word_end))
+            .on_action(cx.listener(Self::select_to_previous_word_start))
+            .on_action(cx.listener(Self::select_to_next_word_end))
+            .on_action(cx.listener(Self::delete_to_previous_word_start))
+            .on_action(cx.listener(Self::delete_to_next_word_end))
+            .on_action(cx.listener(Self::delete_to_line_start))
+            .on_action(cx.listener(Self::delete_to_line_end))
+            .on_action(cx.listener(Self::undo))
+            .on_action(cx.listener(Self::redo))
             .on_action(cx.listener(Self::show_character_palette))
             .on_action(cx.listener(Self::paste))
             .on_action(cx.listener(Self::cut))

--- a/crates/mezon-ui/src/components/primitives/textarea.rs
+++ b/crates/mezon-ui/src/components/primitives/textarea.rs
@@ -12,6 +12,10 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use super::blink_manager::{CaretBlink, HasCaretBlink};
 use crate::theme::ActiveTheme;
+use crate::util::text_edit::{
+    EditKind, HistoryEntry, MAX_UNDO_HISTORY, home_target, line_end, line_start,
+    next_word_boundary, previous_word_boundary,
+};
 
 const KEY_CONTEXT: &str = "MezonTextArea";
 const DEFAULT_MAX_VISIBLE_LINES: usize = 8;
@@ -31,6 +35,22 @@ actions!(
         SelectAll,
         Home,
         End,
+        MoveToPreviousWordStart,
+        MoveToNextWordEnd,
+        SelectToPreviousWordStart,
+        SelectToNextWordEnd,
+        DeleteToPreviousWordStart,
+        DeleteToNextWordEnd,
+        SelectToLineStart,
+        SelectToLineEnd,
+        MoveToDocStart,
+        MoveToDocEnd,
+        SelectToDocStart,
+        SelectToDocEnd,
+        DeleteToLineStart,
+        DeleteToLineEnd,
+        Undo,
+        Redo,
         ShowCharacterPalette,
         Paste,
         Cut,
@@ -39,7 +59,7 @@ actions!(
 );
 
 pub fn init(cx: &mut App) {
-    cx.bind_keys([
+    let mut bindings = vec![
         KeyBinding::new("backspace", Backspace, Some(KEY_CONTEXT)),
         KeyBinding::new("delete", Delete, Some(KEY_CONTEXT)),
         KeyBinding::new("enter", Enter, Some(KEY_CONTEXT)),
@@ -49,14 +69,71 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("right", Right, Some(KEY_CONTEXT)),
         KeyBinding::new("shift-left", SelectLeft, Some(KEY_CONTEXT)),
         KeyBinding::new("shift-right", SelectRight, Some(KEY_CONTEXT)),
+        KeyBinding::new("home", Home, Some(KEY_CONTEXT)),
+        KeyBinding::new("end", End, Some(KEY_CONTEXT)),
+        KeyBinding::new("shift-home", SelectToLineStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("shift-end", SelectToLineEnd, Some(KEY_CONTEXT)),
         KeyBinding::new("secondary-a", SelectAll, Some(KEY_CONTEXT)),
         KeyBinding::new("secondary-v", Paste, Some(KEY_CONTEXT)),
         KeyBinding::new("secondary-c", Copy, Some(KEY_CONTEXT)),
         KeyBinding::new("secondary-x", Cut, Some(KEY_CONTEXT)),
-        KeyBinding::new("home", Home, Some(KEY_CONTEXT)),
-        KeyBinding::new("end", End, Some(KEY_CONTEXT)),
+        KeyBinding::new("secondary-z", Undo, Some(KEY_CONTEXT)),
+        KeyBinding::new("secondary-shift-z", Redo, Some(KEY_CONTEXT)),
         KeyBinding::new("ctrl-cmd-space", ShowCharacterPalette, Some(KEY_CONTEXT)),
+    ];
+
+    #[cfg(target_os = "macos")]
+    bindings.extend([
+        KeyBinding::new("alt-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("alt-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "alt-shift-left",
+            SelectToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("alt-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "alt-backspace",
+            DeleteToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("alt-delete", DeleteToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-left", Home, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-right", End, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-left", SelectToLineStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-right", SelectToLineEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-up", MoveToDocStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-down", MoveToDocEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-up", SelectToDocStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-shift-down", SelectToDocEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-backspace", DeleteToLineStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("cmd-delete", DeleteToLineEnd, Some(KEY_CONTEXT)),
     ]);
+
+    #[cfg(not(target_os = "macos"))]
+    bindings.extend([
+        KeyBinding::new("ctrl-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "ctrl-shift-left",
+            SelectToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("ctrl-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new(
+            "ctrl-backspace",
+            DeleteToPreviousWordStart,
+            Some(KEY_CONTEXT),
+        ),
+        KeyBinding::new("ctrl-delete", DeleteToNextWordEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-home", MoveToDocStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-end", MoveToDocEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-shift-home", SelectToDocStart, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-shift-end", SelectToDocEnd, Some(KEY_CONTEXT)),
+        KeyBinding::new("ctrl-y", Redo, Some(KEY_CONTEXT)),
+    ]);
+
+    cx.bind_keys(bindings);
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -142,6 +219,9 @@ pub struct TextArea {
     min_height: Pixels,
     max_visible_lines: usize,
     caret_blink: CaretBlink,
+    undo_stack: Vec<HistoryEntry>,
+    redo_stack: Vec<HistoryEntry>,
+    last_edit_kind: Option<EditKind>,
 }
 
 impl EventEmitter<TextAreaEvent> for TextArea {}
@@ -186,6 +266,9 @@ impl TextArea {
             min_height: px(36.),
             max_visible_lines: DEFAULT_MAX_VISIBLE_LINES,
             caret_blink: CaretBlink::new(),
+            undo_stack: Vec::new(),
+            redo_stack: Vec::new(),
+            last_edit_kind: None,
         };
 
         cx.on_focus(&focus_handle, window, |this, _window, cx| {
@@ -259,6 +342,7 @@ impl TextArea {
         let end = self.content.len();
         self.selected_range = end..end;
         self.marked_range = None;
+        self.clear_history();
         cx.notify();
         cx.emit(TextAreaEvent::Change);
     }
@@ -305,12 +389,18 @@ impl TextArea {
 
     fn move_to(&mut self, offset: usize, cx: &mut Context<Self>) {
         self.selected_range = offset..offset;
+        self.last_edit_kind = None;
         self.pending_caret_reveal = true;
         self.caret_blink.pause_blinking(cx);
         cx.notify();
     }
 
     fn select_to(&mut self, offset: usize, cx: &mut Context<Self>) {
+        self.last_edit_kind = None;
+        self.extend_selection(offset, cx);
+    }
+
+    fn extend_selection(&mut self, offset: usize, cx: &mut Context<Self>) {
         if self.selection_reversed {
             self.selected_range.start = offset;
         } else {
@@ -438,11 +528,207 @@ impl TextArea {
     }
 
     fn home(&mut self, _: &Home, _: &mut Window, cx: &mut Context<Self>) {
-        self.move_to(0, cx);
+        self.move_to(home_target(&self.content, self.cursor_offset()), cx);
     }
 
     fn end(&mut self, _: &End, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(line_end(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn select_to_line_start(
+        &mut self,
+        _: &SelectToLineStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(home_target(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn select_to_line_end(&mut self, _: &SelectToLineEnd, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(line_end(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn move_to_doc_start(&mut self, _: &MoveToDocStart, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(0, cx);
+    }
+
+    fn move_to_doc_end(&mut self, _: &MoveToDocEnd, _: &mut Window, cx: &mut Context<Self>) {
         self.move_to(self.content.len(), cx);
+    }
+
+    fn select_to_doc_start(
+        &mut self,
+        _: &SelectToDocStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(0, cx);
+    }
+
+    fn select_to_doc_end(&mut self, _: &SelectToDocEnd, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(self.content.len(), cx);
+    }
+
+    fn move_to_previous_word_start(
+        &mut self,
+        _: &MoveToPreviousWordStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.move_to(
+            previous_word_boundary(&self.content, self.cursor_offset()),
+            cx,
+        );
+    }
+
+    fn move_to_next_word_end(
+        &mut self,
+        _: &MoveToNextWordEnd,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.move_to(next_word_boundary(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn select_to_previous_word_start(
+        &mut self,
+        _: &SelectToPreviousWordStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(
+            previous_word_boundary(&self.content, self.cursor_offset()),
+            cx,
+        );
+    }
+
+    fn select_to_next_word_end(
+        &mut self,
+        _: &SelectToNextWordEnd,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(next_word_boundary(&self.content, self.cursor_offset()), cx);
+    }
+
+    fn delete_to_previous_word_start(
+        &mut self,
+        _: &DeleteToPreviousWordStart,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let prev = previous_word_boundary(&self.content, self.cursor_offset());
+            if prev == self.cursor_offset() {
+                return;
+            }
+            self.extend_selection(prev, cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    fn delete_to_next_word_end(
+        &mut self,
+        _: &DeleteToNextWordEnd,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let next = next_word_boundary(&self.content, self.cursor_offset());
+            if next == self.cursor_offset() {
+                return;
+            }
+            self.extend_selection(next, cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    fn delete_to_line_start(
+        &mut self,
+        _: &DeleteToLineStart,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let target = line_start(&self.content, self.cursor_offset());
+            if target == self.cursor_offset() {
+                return;
+            }
+            self.extend_selection(target, cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    fn delete_to_line_end(
+        &mut self,
+        _: &DeleteToLineEnd,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_range.is_empty() {
+            let target = line_end(&self.content, self.cursor_offset());
+            if target == self.cursor_offset() {
+                return;
+            }
+            self.extend_selection(target, cx);
+        }
+        self.replace_text_in_range(None, "", window, cx);
+    }
+
+    fn undo(&mut self, _: &Undo, _: &mut Window, cx: &mut Context<Self>) {
+        if let Some(entry) = self.undo_stack.pop() {
+            self.redo_stack.push(self.history_snapshot());
+            self.restore_history(entry, cx);
+        }
+    }
+
+    fn redo(&mut self, _: &Redo, _: &mut Window, cx: &mut Context<Self>) {
+        if let Some(entry) = self.redo_stack.pop() {
+            self.undo_stack.push(self.history_snapshot());
+            self.restore_history(entry, cx);
+        }
+    }
+
+    fn history_snapshot(&self) -> HistoryEntry {
+        HistoryEntry {
+            content: self.content.clone(),
+            selected_range: self.selected_range.clone(),
+            selection_reversed: self.selection_reversed,
+            payload: None,
+        }
+    }
+
+    fn record_history(&mut self, kind: EditKind) {
+        let coalesce = matches!(kind, EditKind::Insert | EditKind::Delete)
+            && self.last_edit_kind == Some(kind);
+        self.redo_stack.clear();
+        if !coalesce {
+            self.undo_stack.push(self.history_snapshot());
+            if self.undo_stack.len() > MAX_UNDO_HISTORY {
+                let overflow = self.undo_stack.len() - MAX_UNDO_HISTORY;
+                self.undo_stack.drain(..overflow);
+            }
+        }
+        self.last_edit_kind = Some(kind);
+    }
+
+    fn restore_history(&mut self, entry: HistoryEntry, cx: &mut Context<Self>) {
+        self.content = entry.content;
+        self.line_count = self.content.split('\n').count().max(1);
+        self.selected_range = entry.selected_range;
+        self.selection_reversed = entry.selection_reversed;
+        self.marked_range = None;
+        self.last_edit_kind = None;
+        self.pending_caret_reveal = true;
+        self.caret_blink.pause_blinking(cx);
+        cx.notify();
+        cx.emit(TextAreaEvent::Change);
+    }
+
+    fn clear_history(&mut self) {
+        self.undo_stack.clear();
+        self.redo_stack.clear();
+        self.last_edit_kind = None;
     }
 
     fn backspace(&mut self, _: &Backspace, window: &mut Window, cx: &mut Context<Self>) {
@@ -451,7 +737,7 @@ impl TextArea {
             if self.cursor_offset() == prev {
                 return;
             }
-            self.select_to(prev, cx);
+            self.extend_selection(prev, cx);
         }
         self.replace_text_in_range(None, "", window, cx);
     }
@@ -462,7 +748,7 @@ impl TextArea {
             if self.cursor_offset() == next {
                 return;
             }
-            self.select_to(next, cx);
+            self.extend_selection(next, cx);
         }
         self.replace_text_in_range(None, "", window, cx);
     }
@@ -618,6 +904,16 @@ impl EntityInputHandler for TextArea {
             .or(self.marked_range.clone())
             .unwrap_or(self.selected_range.clone());
         let range = self.clamp_range(range);
+        let kind = if self.marked_range.is_some() {
+            EditKind::Insert
+        } else if new_text.is_empty() {
+            EditKind::Delete
+        } else if range.is_empty() && !new_text.contains('\n') {
+            EditKind::Insert
+        } else {
+            EditKind::Other
+        };
+        self.record_history(kind);
         let next = self.content[0..range.start].to_owned() + new_text + &self.content[range.end..];
         self.set_content(next);
         self.selected_range = range.start + new_text.len()..range.start + new_text.len();
@@ -641,6 +937,9 @@ impl EntityInputHandler for TextArea {
             .or(self.marked_range.clone())
             .unwrap_or(self.selected_range.clone());
         let range = self.clamp_range(range);
+        if self.marked_range.is_none() {
+            self.record_history(EditKind::Insert);
+        }
         let next = self.content[0..range.start].to_owned() + new_text + &self.content[range.end..];
         self.set_content(next);
         if new_text.is_empty() {
@@ -739,6 +1038,22 @@ impl Render for TextArea {
             .on_action(cx.listener(Self::select_all))
             .on_action(cx.listener(Self::home))
             .on_action(cx.listener(Self::end))
+            .on_action(cx.listener(Self::select_to_line_start))
+            .on_action(cx.listener(Self::select_to_line_end))
+            .on_action(cx.listener(Self::move_to_doc_start))
+            .on_action(cx.listener(Self::move_to_doc_end))
+            .on_action(cx.listener(Self::select_to_doc_start))
+            .on_action(cx.listener(Self::select_to_doc_end))
+            .on_action(cx.listener(Self::move_to_previous_word_start))
+            .on_action(cx.listener(Self::move_to_next_word_end))
+            .on_action(cx.listener(Self::select_to_previous_word_start))
+            .on_action(cx.listener(Self::select_to_next_word_end))
+            .on_action(cx.listener(Self::delete_to_previous_word_start))
+            .on_action(cx.listener(Self::delete_to_next_word_end))
+            .on_action(cx.listener(Self::delete_to_line_start))
+            .on_action(cx.listener(Self::delete_to_line_end))
+            .on_action(cx.listener(Self::undo))
+            .on_action(cx.listener(Self::redo))
             .on_action(cx.listener(Self::show_character_palette))
             .on_action(cx.listener(Self::paste))
             .on_action(cx.listener(Self::cut))

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
@@ -8,7 +8,7 @@ use gpui::{
     prelude::*, px,
 };
 use mezon_store::{
-    ChannelId, ChannelList, ClanId, ClanList, ClanMembersStore, FAVOR_CATE_ID,
+    ChannelId, ChannelList, ChannelType, ClanId, ClanList, ClanMembersStore, FAVOR_CATE_ID,
     PERMISSION_ADMINISTRATOR, PERMISSION_MANAGE_CLAN, PermissionStore, Settings, VoiceMember,
 };
 
@@ -322,8 +322,25 @@ impl ChannelSidebar {
                             });
                         }
                     } else {
+                        let active_parent_id = active_channel_id.and_then(|id| {
+                            category
+                                .channels
+                                .iter()
+                                .find(|ch| ch.id == id)
+                                .and_then(|ch| ch.parent_id)
+                        });
                         for ch in &category.channels {
-                            if ch.voice_members.is_empty() {
+                            let is_voice_or_streaming = matches!(
+                                ch.channel_type,
+                                ChannelType::Voice | ChannelType::Stream | ChannelType::App
+                            );
+                            let has_members_in_voice =
+                                is_voice_or_streaming && !ch.voice_members.is_empty();
+                            let should_show = (ch.is_unread() && !is_voice_or_streaming)
+                                || active_channel_id == Some(ch.id)
+                                || active_parent_id == Some(ch.id)
+                                || has_members_in_voice;
+                            if !should_show {
                                 continue;
                             }
                             let badge_count = ch.badge_count;

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
@@ -285,15 +285,6 @@ pub(super) fn render_clan_row(
                     ),
             )
         })
-        .when(!suppress_hover, |row| {
-            row.on_hover(move |hovered, _window, cx| {
-                if *hovered {
-                    ChannelList::global(cx).update(cx, |channels, cx| {
-                        channels.load_for_clan(prefetch_clan_id, cx)
-                    });
-                }
-            })
-        })
         .on_click(on_clan_click(clan_list_handle, clan_id))
         .on_mouse_down(MouseButton::Right, {
             let clan_num = prefetch_clan_id;

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/direct_unread_list.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/direct_unread_list.rs
@@ -6,7 +6,7 @@ use gpui::{
     Animation, AnimationExt as _, AnyElement, App, ClickEvent, Context, SharedString, Task, Window,
     div, img, prelude::*, px, rgb,
 };
-use mezon_store::{ChannelId, DirectKind, DirectMessageStore};
+use mezon_store::{ChannelId, DirectKind, DirectMessageStore, NotificationSettingStore};
 
 use crate::components::primitives::Avatar;
 use crate::router::{Route, navigate};
@@ -119,7 +119,7 @@ impl DirectUnreadListState {
     }
 }
 
-pub(super) fn direct_unread_fingerprint(store: &DirectMessageStore) -> u64 {
+pub(super) fn direct_unread_fingerprint(store: &DirectMessageStore, cx: &App) -> u64 {
     const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
     const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
     fn fold(hash: u64, bytes: &[u8]) -> u64 {
@@ -127,10 +127,12 @@ pub(super) fn direct_unread_fingerprint(store: &DirectMessageStore) -> u64 {
             .iter()
             .fold(hash, |h, b| (h ^ u64::from(*b)).wrapping_mul(FNV_PRIME))
     }
+    let noti = NotificationSettingStore::try_global(cx);
+    let muted = noti.as_ref().map(|s| s.read(cx));
     store
         .channels()
         .iter()
-        .filter(|ch| ch.unread_count > 0)
+        .filter(|ch| ch.counts_toward_unread_badge(muted.is_some_and(|s| s.is_time_muted(ch.id))))
         .fold(FNV_OFFSET, |h, ch| {
             let h = fold(h, &ch.id.0.to_le_bytes());
             let h = fold(h, &ch.unread_count.to_le_bytes());
@@ -144,10 +146,12 @@ pub(super) fn build_direct_unread_items(
     store: &DirectMessageStore,
     cx: &App,
 ) -> Vec<DirectUnreadItem> {
+    let noti = NotificationSettingStore::try_global(cx);
+    let muted = noti.as_ref().map(|s| s.read(cx));
     store
         .channels()
         .iter()
-        .filter(|ch| ch.unread_count > 0)
+        .filter(|ch| ch.counts_toward_unread_badge(muted.is_some_and(|s| s.is_time_muted(ch.id))))
         .map(|ch| DirectUnreadItem {
             channel_id: ch.id,
             label: SharedString::from(ch.label.clone()),

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/mod.rs
@@ -65,14 +65,8 @@ impl ClanSidebar {
         let list_state = ListState::new(0, gpui::ListAlignment::Top, px(48.))
             .smooth_line_scroll()
             .suppress_hover_while_scrolling();
-        let direct_sub = cx.observe(&direct_store, |this, store, cx| {
-            let fingerprint = direct_unread_fingerprint(store.read(cx));
-            if this.direct_unread_fingerprint == Some(fingerprint) {
-                return;
-            }
-            this.direct_unread_fingerprint = Some(fingerprint);
-            let live = build_direct_unread_items(store.read(cx), cx);
-            this.direct_unread.sync(live, cx);
+        let direct_sub = cx.observe(&direct_store, |this, _store, cx| {
+            this.refresh_direct_unread(cx);
         });
 
         let clan_sub = cx.observe(&clan_list, |this, clan_list, cx| {
@@ -90,6 +84,7 @@ impl ClanSidebar {
         });
         let friend_sub = cx.observe(&FriendStore::global(cx), |_, _, cx| cx.notify());
         let notification_sub = cx.observe(&NotificationSettingStore::global(cx), |this, _, cx| {
+            this.refresh_direct_unread(cx);
             if this.clan_menu.is_some() {
                 cx.notify();
             }
@@ -129,7 +124,7 @@ impl ClanSidebar {
                 direct_store.read(cx),
                 cx,
             )),
-            direct_unread_fingerprint: Some(direct_unread_fingerprint(direct_store.read(cx))),
+            direct_unread_fingerprint: Some(direct_unread_fingerprint(direct_store.read(cx), cx)),
             list_state,
             dm_active: initial_dm_active,
             can_go_back: initial_can_go_back,
@@ -255,6 +250,17 @@ impl ClanSidebar {
             self.list_state.reset(item_count);
         }
         true
+    }
+
+    fn refresh_direct_unread(&mut self, cx: &mut Context<Self>) {
+        let store = DirectMessageStore::global(cx);
+        let fingerprint = direct_unread_fingerprint(store.read(cx), cx);
+        if self.direct_unread_fingerprint == Some(fingerprint) {
+            return;
+        }
+        self.direct_unread_fingerprint = Some(fingerprint);
+        let live = build_direct_unread_items(store.read(cx), cx);
+        self.direct_unread.sync(live, cx);
     }
 }
 

--- a/crates/mezon-ui/src/sidebar/direct_sidebar.rs
+++ b/crates/mezon-ui/src/sidebar/direct_sidebar.rs
@@ -10,7 +10,6 @@ use mezon_store::{
 };
 
 use super::channel_sidebar::menu::{MUTE_DURATIONS, apply_mute, mute_label, submenu_options};
-use super::friend_request_badge;
 use ui::{ScrollAxes, Scrollbars, WithScrollbar};
 
 use crate::components::compositions::{DM_ROW_HEIGHT, DmRow};
@@ -84,17 +83,12 @@ fn dm_items_fingerprint(store: &DirectMessageStore, cx: &App) -> u64 {
                 u8::from(ch.is_unread()),
                 u8::from(ch.online),
                 u8::from(dm_in_voice(ch, channels)),
-                u8::from(dm_muted(ch.id, cx)),
+                u8::from(super::dm_muted(ch.id, cx)),
             ],
         );
         let h = fold(h, ch.label.as_bytes());
         fold(h, ch.avatar.as_bytes())
     })
-}
-
-fn dm_muted(channel_id: ChannelId, cx: &App) -> bool {
-    NotificationSettingStore::try_global(cx)
-        .is_some_and(|store| store.read(cx).is_time_muted(channel_id))
 }
 
 fn build_dm_items(store: &DirectMessageStore, cx: &App) -> Rc<Vec<DmItem>> {
@@ -115,7 +109,7 @@ fn build_dm_items(store: &DirectMessageStore, cx: &App) -> Rc<Vec<DmItem>> {
                 unread: ch.is_unread(),
                 online: ch.online,
                 in_voice: dm_in_voice(ch, channels),
-                muted: dm_muted(ch.id, cx),
+                muted: super::dm_muted(ch.id, cx),
                 avatar_src: SharedString::from(crate::util::imgproxy::avatar_url(cx, &ch.avatar)),
                 avatar_raw: SharedString::from(ch.avatar.clone()),
             })
@@ -295,6 +289,7 @@ impl DirectSidebar {
         let bg_hover = theme.bg_hover;
         div()
             .id("dm-friends")
+            .relative()
             .w_full()
             .flex()
             .flex_row()
@@ -316,7 +311,22 @@ impl DirectSidebar {
                     .child(mezon_i18n::t(locale, "directMessage.friends")),
             )
             .when(pending > 0, |el| {
-                el.child(friend_request_badge(pending, px(11.)).ml_auto())
+                el.child(
+                    div()
+                        .absolute()
+                        .right(px(25.))
+                        .size(px(16.))
+                        .rounded_full()
+                        .bg(gpui::rgb(0xda_37_3c))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .text_size(px(9.))
+                        .line_height(px(9.))
+                        .font_weight(FontWeight::BOLD)
+                        .text_color(gpui::white())
+                        .child(SharedString::from(pending.to_string())),
+                )
             })
     }
 

--- a/crates/mezon-ui/src/sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/mod.rs
@@ -2,7 +2,13 @@ pub mod channel_sidebar;
 pub mod clan_sidebar;
 pub mod direct_sidebar;
 
-use gpui::{Div, FontWeight, Pixels, SharedString, div, prelude::*, px, rgb, white};
+use gpui::{App, Div, FontWeight, Pixels, SharedString, div, prelude::*, px, rgb, white};
+use mezon_store::{ChannelId, NotificationSettingStore};
+
+pub(crate) fn dm_muted(channel_id: ChannelId, cx: &App) -> bool {
+    NotificationSettingStore::try_global(cx)
+        .is_some_and(|store| store.read(cx).is_time_muted(channel_id))
+}
 
 pub(crate) fn friend_request_badge(count: usize, text_size: Pixels) -> Div {
     let label = if count >= 100 {

--- a/crates/mezon-ui/src/util/mod.rs
+++ b/crates/mezon-ui/src/util/mod.rs
@@ -2,5 +2,6 @@ pub mod assets;
 pub mod download;
 pub mod imgproxy;
 pub mod reactive;
+pub mod text_edit;
 pub mod text_utils;
 pub mod voice_member;

--- a/crates/mezon-ui/src/util/text_edit.rs
+++ b/crates/mezon-ui/src/util/text_edit.rs
@@ -1,0 +1,173 @@
+use std::any::Any;
+use std::ops::Range;
+use std::rc::Rc;
+
+use gpui::SharedString;
+
+pub(crate) const MAX_UNDO_HISTORY: usize = 256;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CharKind {
+    Whitespace,
+    Word,
+    Punctuation,
+}
+
+fn char_kind(c: char) -> CharKind {
+    if c.is_whitespace() {
+        CharKind::Whitespace
+    } else if c.is_alphanumeric() || c == '_' {
+        CharKind::Word
+    } else {
+        CharKind::Punctuation
+    }
+}
+
+pub(crate) fn previous_word_boundary(text: &str, offset: usize) -> usize {
+    let offset = offset.min(text.len());
+    let mut run_kind: Option<CharKind> = None;
+    let mut boundary = 0;
+    for (idx, c) in text[..offset].char_indices().rev() {
+        let kind = char_kind(c);
+        match run_kind {
+            None => {
+                if kind == CharKind::Whitespace {
+                    continue;
+                }
+                run_kind = Some(kind);
+                boundary = idx;
+            }
+            Some(run) if kind == run => boundary = idx,
+            Some(_) => return idx + c.len_utf8(),
+        }
+    }
+    boundary
+}
+
+pub(crate) fn next_word_boundary(text: &str, offset: usize) -> usize {
+    let offset = offset.min(text.len());
+    let mut run_kind: Option<CharKind> = None;
+    for (idx, c) in text[offset..].char_indices() {
+        let kind = char_kind(c);
+        match run_kind {
+            None => {
+                if kind == CharKind::Whitespace {
+                    continue;
+                }
+                run_kind = Some(kind);
+            }
+            Some(run) if kind == run => {}
+            Some(_) => return offset + idx,
+        }
+    }
+    text.len()
+}
+
+pub(crate) fn line_start(text: &str, offset: usize) -> usize {
+    let offset = offset.min(text.len());
+    text[..offset].rfind('\n').map(|i| i + 1).unwrap_or(0)
+}
+
+pub(crate) fn line_end(text: &str, offset: usize) -> usize {
+    let offset = offset.min(text.len());
+    text[offset..]
+        .find('\n')
+        .map(|i| offset + i)
+        .unwrap_or(text.len())
+}
+
+pub(crate) fn home_target(text: &str, offset: usize) -> usize {
+    let start = line_start(text, offset);
+    let end = line_end(text, offset);
+    let indent_end = text[start..end]
+        .char_indices()
+        .find(|(_, c)| !c.is_whitespace())
+        .map(|(i, _)| start + i)
+        .unwrap_or(start);
+    if offset == indent_end {
+        start
+    } else {
+        indent_end
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct HistoryEntry {
+    pub content: SharedString,
+    pub selected_range: Range<usize>,
+    pub selection_reversed: bool,
+    pub payload: Option<Rc<dyn Any>>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EditKind {
+    Insert,
+    Delete,
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn previous_word_boundary_skips_trailing_space_then_word() {
+        let text = "hello world";
+        assert_eq!(previous_word_boundary(text, 11), 6);
+        assert_eq!(previous_word_boundary(text, 6), 0);
+        assert_eq!(previous_word_boundary(text, 8), 6);
+        assert_eq!(previous_word_boundary(text, 0), 0);
+    }
+
+    #[test]
+    fn next_word_boundary_skips_leading_space_then_word() {
+        let text = "hello world";
+        assert_eq!(next_word_boundary(text, 0), 5);
+        assert_eq!(next_word_boundary(text, 5), 11);
+        assert_eq!(next_word_boundary(text, 2), 5);
+        assert_eq!(next_word_boundary(text, 11), 11);
+    }
+
+    #[test]
+    fn word_boundary_treats_punctuation_as_its_own_run() {
+        let text = "foo.bar baz";
+        assert_eq!(next_word_boundary(text, 0), 3);
+        assert_eq!(next_word_boundary(text, 3), 4);
+        assert_eq!(previous_word_boundary(text, 7), 4);
+        assert_eq!(previous_word_boundary(text, 4), 3);
+    }
+
+    #[test]
+    fn word_boundary_respects_utf8_boundaries() {
+        let text = "chào bạn";
+        assert_eq!("chào".len(), 5);
+        assert_eq!(next_word_boundary(text, 0), 5);
+        assert_eq!(previous_word_boundary(text, text.len()), 6);
+    }
+
+    #[test]
+    fn line_start_and_end_bracket_the_current_line() {
+        let text = "ab\ncde\nf";
+        assert_eq!(line_start(text, 5), 3);
+        assert_eq!(line_end(text, 5), 6);
+        assert_eq!(line_start(text, 0), 0);
+        assert_eq!(line_end(text, 0), 2);
+        assert_eq!(line_start(text, 8), 7);
+        assert_eq!(line_end(text, 8), 8);
+    }
+
+    #[test]
+    fn home_target_toggles_between_indent_and_column_zero() {
+        let text = "    code";
+        assert_eq!(home_target(text, 8), 4);
+        assert_eq!(home_target(text, 4), 0);
+        assert_eq!(home_target(text, 0), 4);
+    }
+
+    #[test]
+    fn home_target_on_unindented_line_is_line_start() {
+        let text = "one\ntwo";
+        assert_eq!(home_target(text, 6), 4);
+        assert_eq!(home_target(text, 4), 4);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ClanLoadScheduler` to load channel, members, roles, permissions, emoji, sticker, and notification settings when the active clan changes.
- Return awaitable `ensure_loaded_task` from emoji/sticker stores and related domain stores for coordinated loading.
- Introduce shared `text_edit` helpers and wire them through input, textarea, and mention text fields for consistent editing behavior.
- Preserve in-voice members when channel lists refetch and tighten native badge coalescing.

## Test plan
- [ ] Switch between clans and verify channels, members, roles, emojis, and stickers load without duplicate fetches
- [ ] Join a voice channel, trigger a channel list refetch, confirm in-voice state persists
- [ ] Edit text in chat input, textarea, and mention field (selection, paste, IME)
- [ ] Confirm tray badge updates coalesce under burst unread events
- [ ] `just lint` and `just test` pass
