### PR TITLE
fix(wallet): persist proofs and fetch ZK only on fresh login

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,11 @@ jobs:
       NX_CHAT_APP_GOOGLE_CLIENT_ID: 391688022389-1k9kb377ea6dccpqii7m5pifjj0agsjc.apps.googleusercontent.com
       NX_DOMAIN_URL: https://mezon.ai
       NX_CHAT_APP_REDIRECT_URI: https://mezon.ai
-      NX_LOGO_MEZON: https://cdn.komu.vn/images/mezon_logo.png
-      NX_BASE_IMG_URL: https://cdn.komu.vn
+      NX_LOGO_MEZON: https://cdn.mezon.ai/images/mezon_logo.png
+      NX_BASE_IMG_URL: https://cdn.mezon.ai
+      NX_UPLOAD_IMG_URL: https://cdn-api.mezon.ai
       NX_PROFILE_IMG_URL: https://profile.mezon.ai
-      NX_IMGPROXY_BASE_URL: https://imgproxy.komu.vn
+      NX_IMGPROXY_BASE_URL: https://imgproxy.mezon.ai
       NX_IMGPROXY_KEY: ${{ secrets.NX_IMGPROXY_KEY }}
       NX_CHAT_APP_API_KLIPY_KEY: ${{ secrets.NX_CHAT_APP_API_KLIPY_KEY }}
       NX_CHAT_APP_API_KLIPY_URL: https://api.klipy.com/api/v1
@@ -46,6 +47,9 @@ jobs:
       NX_CHAT_APP_API_MEZONTREASURY_KEY: ${{ secrets.NX_CHAT_APP_API_MEZONTREASURY_KEY }}
       NX_CHAT_APP_CONTRACT_ADDRESS: "0x4F17a94dD6E1B2D6241C4D1956C6c7a07ba2Ec50"
       NX_CHAT_APP_MEZON_TREASURY_URL_NETWORK: https://sepolia.etherscan.io
+      NX_CHAT_APP_MMN_API_URL: https://dong.mezon.ai/mmn-api/
+      NX_CHAT_APP_ZK_API_URL: https://dong.mezon.ai/zk-api/
+      NX_CHAT_APP_INDEXER_API_URL: https://dong.mezon.ai/indexer-api/
       NX_WEBRTC_ICESERVERS_URL: turn:relay.mezon.ai:5349
       NX_WEBRTC_ICESERVERS_USERNAME: turnmezon
       NX_WEBRTC_ICESERVERS_CREDENTIAL: ${{ secrets.NX_WEBRTC_ICESERVERS_CREDENTIAL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
       NX_CHAT_APP_MEET_WS_URL: wss://meet.mezon.ai
       NX_CHAT_APP_NOTIFICATION_WS_URL: wss://gotify.mezon.ai
       NX_CHAT_APP_OAUTH2_AUTHORIZE_URL: https://oauth2.mezon.ai/oauth2/auth
-      NX_CHAT_APP_OAUTH2_CLIENT_ID: 25f63a1f-16b8-488b-8b14-68520eeab77f
-      NX_CHAT_APP_OAUTH2_REDIRECT_URI: http://127.0.0.1:4200/login/callback
+      NX_CHAT_APP_OAUTH2_CLIENT_ID: f049f29e-12a9-464c-938f-0a2f60c3210b
+      NX_CHAT_APP_OAUTH2_REDIRECT_URI: https://mezon.ai/login/callback
       NX_CHAT_APP_OAUTH2_RESPONSE_TYPE: code
       NX_CHAT_APP_OAUTH2_SCOPE: openid+offline
       NX_CHAT_APP_OAUTH2_CODE_CHALLENGE_METHOD: S256
@@ -35,11 +35,11 @@ jobs:
       NX_CHAT_APP_GOOGLE_CLIENT_ID: 391688022389-1k9kb377ea6dccpqii7m5pifjj0agsjc.apps.googleusercontent.com
       NX_DOMAIN_URL: https://mezon.ai
       NX_CHAT_APP_REDIRECT_URI: https://mezon.ai
-      NX_LOGO_MEZON: https://cdn.mezon.ai/images/mezon_logo.png
-      NX_BASE_IMG_URL: https://cdn.mezon.ai
+      NX_LOGO_MEZON: https://cdn.komu.vn/images/mezon_logo.png
+      NX_BASE_IMG_URL: https://cdn.komu.vn
       NX_UPLOAD_IMG_URL: https://cdn-api.mezon.ai
       NX_PROFILE_IMG_URL: https://profile.mezon.ai
-      NX_IMGPROXY_BASE_URL: https://imgproxy.mezon.ai
+      NX_IMGPROXY_BASE_URL: https://imgproxy.komu.vn
       NX_IMGPROXY_KEY: ${{ secrets.NX_IMGPROXY_KEY }}
       NX_CHAT_APP_API_KLIPY_KEY: ${{ secrets.NX_CHAT_APP_API_KLIPY_KEY }}
       NX_CHAT_APP_API_KLIPY_URL: https://api.klipy.com/api/v1

--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -449,9 +449,18 @@ fn run_app(lock: SingleInstance, initial_url: Option<String>) {
                                         .detach();
                                     cx.update(|cx| {
                                         auth.update(cx, |state, cx| {
-                                            *state = AuthState::Connecting(session);
+                                            *state = AuthState::Connecting(session.clone());
                                             cx.notify();
                                         });
+                                        if !session.id_token.is_empty() {
+                                            mezon_store::WalletStore::global(cx).update(
+                                                cx,
+                                                |wallet, cx| {
+                                                    wallet
+                                                        .fetch_zk_proofs_after_login(&session, cx);
+                                                },
+                                            );
+                                        }
                                         mezon_ui::router::replace(
                                             cx,
                                             mezon_ui::router::Route::Chat,

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -48,6 +48,7 @@ pub mod user_profile;
 pub mod users_by_user;
 pub mod voice;
 pub mod wallet;
+mod wallet_persist;
 pub mod webhook;
 
 use anyhow::{Context, Result};
@@ -474,4 +475,19 @@ pub enum AuthState {
     Connecting(Session),
     /// Token received, transport connected, and session is valid.
     Authenticated(Session),
+}
+
+impl AuthState {
+    pub fn session_credentials(&self) -> Option<(String, String)> {
+        match self {
+            Self::Authenticated(session) | Self::Connecting(session) => {
+                if session.id_token.is_empty() || session.user_id.is_empty() {
+                    None
+                } else {
+                    Some((session.id_token.clone(), session.user_id.clone()))
+                }
+            }
+            _ => None,
+        }
+    }
 }

--- a/crates/mezon-store/src/login.rs
+++ b/crates/mezon-store/src/login.rs
@@ -180,6 +180,9 @@ impl LoginStore {
         if let Some(e) = crate::voice::VoiceStore::try_global(cx) {
             e.update(cx, |s, cx| s.logout_teardown(cx));
         }
+        if let Some(e) = crate::wallet::WalletStore::try_global(cx) {
+            e.update(cx, |s, cx| s.reset(cx));
+        }
     }
 }
 

--- a/crates/mezon-store/src/wallet.rs
+++ b/crates/mezon-store/src/wallet.rs
@@ -11,16 +11,19 @@ use mmn_client::{
     generate_ephemeral_key_pair, scale_amount_to_decimals,
 };
 
+use mezon_client::Session;
+
 use crate::AuthState;
 use crate::config::{AppConfig, INDEXER_CHAIN_ID};
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
+use crate::wallet_persist::{self, PersistedWalletState};
 
 const DECIMALS: u32 = 6;
 const GIVE_COFFEE_AMOUNT: i64 = 10_000;
 
 static BANK_SOUND: &[u8] = include_bytes!("../assets/audio/bankSound.mp3");
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct WalletDetail {
     pub address: String,
     pub balance: String,
@@ -189,27 +192,70 @@ impl WalletStore {
     }
 
     fn sync_from_auth(&mut self, cx: &mut Context<Self>) {
-        let snapshot = {
-            match self.auth_state.read(cx) {
-                AuthState::Authenticated(session) => {
-                    Some(Some((session.id_token.clone(), session.user_id.clone())))
-                }
-                AuthState::NotAuthenticated => Some(None),
-                _ => None,
+        let user_id = match self.auth_state.read(cx) {
+            AuthState::NotAuthenticated => {
+                self.reset(cx);
+                return;
             }
+            AuthState::Authenticated(session) | AuthState::Connecting(session) => {
+                session.user_id.clone()
+            }
+            _ => return,
         };
-        match snapshot {
-            Some(Some((jwt, user_id))) => self.enable_wallet(jwt, user_id, cx),
-            Some(None) => self.reset(cx),
-            None => {}
-        }
+        self.try_restore_persisted(&user_id, cx);
     }
 
-    fn enable_wallet(&mut self, jwt: String, user_id: String, cx: &mut Context<Self>) {
+    fn try_restore_persisted(&mut self, user_id: &str, cx: &mut Context<Self>) {
+        if user_id.is_empty() {
+            return;
+        }
+        if self.is_enabled && self.enabled_user.as_deref() == Some(user_id) {
+            return;
+        }
+        let Some(stored) = wallet_persist::load_wallet() else {
+            return;
+        };
+        if stored.user_id != user_id {
+            return;
+        }
+        if !stored.is_enabled {
+            return;
+        }
+        let (Some(zk_proofs), Some(ephemeral)) = (stored.zk_proofs, stored.ephemeral) else {
+            return;
+        };
+        self.wallet = stored.wallet;
+        self.zk_proofs = Some(zk_proofs);
+        self.ephemeral = Some(ephemeral);
+        self.is_enabled = true;
+        self.enabled_user = Some(user_id.to_string());
+        cx.notify();
+    }
+
+    pub fn fetch_zk_proofs_after_login(&mut self, session: &Session, cx: &mut Context<Self>) {
+        if session.id_token.is_empty() || session.user_id.is_empty() {
+            return;
+        }
+        self.enable_wallet(session.id_token.clone(), session.user_id.clone(), true, cx);
+    }
+
+    pub fn enable_wallet_for_current_user(&mut self, cx: &mut Context<Self>) {
+        let Some((jwt, user_id)) = self
+            .auth_state
+            .read(cx)
+            .session_credentials()
+            .filter(|(jwt, uid)| !jwt.is_empty() && !uid.is_empty())
+        else {
+            return;
+        };
+        self.enable_wallet(jwt, user_id, false, cx);
+    }
+
+    fn enable_wallet(&mut self, jwt: String, user_id: String, force: bool, cx: &mut Context<Self>) {
         if jwt.is_empty() || user_id.is_empty() {
             return;
         }
-        if self.is_enabled && self.enabled_user.as_deref() == Some(user_id.as_str()) {
+        if !force && self.is_enabled && self.enabled_user.as_deref() == Some(user_id.as_str()) {
             return;
         }
         if self.enabling_user.as_deref() == Some(user_id.as_str()) {
@@ -257,13 +303,14 @@ impl WalletStore {
                 this.ephemeral = Some(ephemeral);
                 this.zk_proofs = Some(zk_proofs);
                 this.is_enabled = true;
-                this.enabled_user = Some(user_id);
+                this.enabled_user = Some(user_id.clone());
                 if let Some(account) = account {
                     this.wallet = Some(WalletDetail {
                         address: account.address,
                         balance: account.balance,
                     });
                 }
+                this.persist_wallet_state();
                 cx.emit(WalletEvent::Enabled);
                 cx.notify();
             })
@@ -571,7 +618,32 @@ impl WalletStore {
         self.reset_generation
     }
 
-    fn reset(&mut self, cx: &mut Context<Self>) {
+    fn persist_wallet_state(&self) {
+        let Some(user_id) = self.enabled_user.clone() else {
+            return;
+        };
+        if !self.is_enabled {
+            return;
+        }
+        let state = PersistedWalletState {
+            user_id,
+            is_enabled: self.is_enabled,
+            wallet: self.wallet.clone(),
+            zk_proofs: self.zk_proofs.clone(),
+            ephemeral: self.ephemeral.clone(),
+        };
+        if let Err(error) = wallet_persist::save_wallet(&state) {
+            tracing::warn!(%error, "wallet: failed to persist wallet state");
+        }
+    }
+
+    fn clear_persisted_wallet() {
+        if let Err(error) = wallet_persist::clear_wallet() {
+            tracing::warn!(%error, "wallet: failed to clear persisted wallet state");
+        }
+    }
+
+    pub(crate) fn reset(&mut self, cx: &mut Context<Self>) {
         if !self.is_enabled
             && self.wallet.is_none()
             && self.zk_proofs.is_none()
@@ -590,6 +662,7 @@ impl WalletStore {
         self.is_enabled = false;
         self.pending_give_coffee = false;
         self.enabled_user = None;
+        Self::clear_persisted_wallet();
         cx.notify();
     }
 }

--- a/crates/mezon-store/src/wallet_persist.rs
+++ b/crates/mezon-store/src/wallet_persist.rs
@@ -1,0 +1,137 @@
+use anyhow::{Context, Result};
+use mmn_client::{EphemeralKeyPair, ZkProof};
+use serde::{Deserialize, Serialize};
+
+use crate::wallet::WalletDetail;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedWalletState {
+    pub user_id: String,
+    pub is_enabled: bool,
+    pub wallet: Option<WalletDetail>,
+    pub zk_proofs: Option<ZkProof>,
+    pub ephemeral: Option<EphemeralKeyPair>,
+}
+
+fn parse_wallet(json: &str) -> Option<PersistedWalletState> {
+    match serde_json::from_str::<PersistedWalletState>(json) {
+        Ok(state) if state.is_enabled => Some(state),
+        Ok(_) => None,
+        Err(e) => {
+            tracing::warn!("Failed to deserialise stored wallet, ignoring: {e}");
+            None
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+mod dev_file {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn persist_path() -> PathBuf {
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("mezon")
+            .join("dev-wallet.json")
+    }
+
+    pub fn save_wallet(state: &PersistedWalletState) -> Result<()> {
+        let path = persist_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        let json = serde_json::to_string(state)?;
+        std::fs::write(&path, json).with_context(|| format!("write {}", path.display()))?;
+        Ok(())
+    }
+
+    pub fn load_wallet() -> Option<PersistedWalletState> {
+        let path = persist_path();
+        let json = std::fs::read_to_string(&path).ok()?;
+        parse_wallet(&json)
+    }
+
+    pub fn clear_wallet() -> Result<()> {
+        let path = persist_path();
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(e).with_context(|| format!("remove {}", path.display()));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(not(debug_assertions))]
+mod keychain_store {
+    use keyring::Entry;
+
+    use super::*;
+
+    const SERVICE: &str = "mezon-desktop";
+    const USERNAME: &str = "wallet";
+
+    pub fn save_wallet(state: &PersistedWalletState) -> Result<()> {
+        let json = serde_json::to_string(state)?;
+        let entry = Entry::new(SERVICE, USERNAME)?;
+        entry.set_password(&json)?;
+        Ok(())
+    }
+
+    pub fn load_wallet() -> Option<PersistedWalletState> {
+        let entry = Entry::new(SERVICE, USERNAME).ok()?;
+        let json = entry.get_password().ok()?;
+        parse_wallet(&json)
+    }
+
+    pub fn clear_wallet() -> Result<()> {
+        let entry = Entry::new(SERVICE, USERNAME)?;
+        entry.delete_credential()?;
+        Ok(())
+    }
+}
+
+#[cfg(debug_assertions)]
+pub use dev_file::{clear_wallet, load_wallet, save_wallet};
+
+#[cfg(not(debug_assertions))]
+pub use keychain_store::{clear_wallet, load_wallet, save_wallet};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wallet::WalletDetail;
+
+    #[test]
+    fn persisted_wallet_roundtrip() {
+        let state = PersistedWalletState {
+            user_id: "42".to_string(),
+            is_enabled: true,
+            wallet: Some(WalletDetail {
+                address: "0xabc".to_string(),
+                balance: "1000000".to_string(),
+            }),
+            zk_proofs: Some(ZkProof {
+                proof: "proof".to_string(),
+                public_input: "input".to_string(),
+            }),
+            ephemeral: Some(EphemeralKeyPair {
+                private_key: "priv".to_string(),
+                public_key: "pub".to_string(),
+            }),
+        };
+        let json = serde_json::to_string(&state).expect("serialize");
+        let parsed = parse_wallet(&json).expect("parse");
+        assert_eq!(parsed.user_id, "42");
+        assert!(parsed.is_enabled);
+        assert_eq!(
+            parsed.wallet.as_ref().map(|w| w.address.as_str()),
+            Some("0xabc")
+        );
+    }
+}

--- a/crates/mezon-ui/src/auth/login_view.rs
+++ b/crates/mezon-ui/src/auth/login_view.rs
@@ -6,7 +6,7 @@ use gpui::{
     Subscription, Task, Window, div, img, linear_color_stop, linear_gradient, prelude::*, px, rgb,
     rgba, svg, white,
 };
-use mezon_store::{AuthState, LoginMethod, LoginStore, Session, Settings};
+use mezon_store::{AuthState, LoginMethod, LoginStore, Session, Settings, WalletStore};
 
 use crate::app::window_controls;
 use crate::components::compositions::OtpInput;
@@ -488,10 +488,16 @@ impl LoginView {
             .detach();
 
         auth_state.update(cx, |state, cx| {
-            *state = AuthState::Connecting(session);
+            *state = AuthState::Connecting(session.clone());
             tracing::debug!("User authenticated, connecting transport.");
             cx.notify();
         });
+
+        if !session.id_token.is_empty() {
+            WalletStore::global(cx).update(cx, |wallet, cx| {
+                wallet.fetch_zk_proofs_after_login(&session, cx);
+            });
+        }
     }
 
     fn start_countdown(&mut self, cx: &mut Context<Self>) {

--- a/crates/mmn-client/src/types.rs
+++ b/crates/mmn-client/src/types.rs
@@ -12,7 +12,7 @@ pub const TX_TYPE_USER_CONTENT: u8 = 2;
 
 pub const DECIMALS: u32 = 6;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EphemeralKeyPair {
     pub private_key: String,
     pub public_key: String,


### PR DESCRIPTION
## Summary
- Persist wallet zk proofs + ephemeral key pair (React `persist:wallet` parity)
- Restore persisted wallet on session boot instead of auto-calling ZK with stale `id_token`
- Fetch ZK proofs only after fresh login (email/OAuth/QR) or manual enable
- Bake prod MMN/ZK/indexer URLs and CDN/OAuth env into CI release builds

## Why
Desktop was calling `enable_wallet` on every reconnect with an expired JWT, causing `zk proof fetch failed: authentication failed`. React only fetches ZK on fresh login and restores from persist on cold start.

## Test plan
- [ ] Cold start with existing session: no ZK fetch on boot when wallet was previously enabled
- [ ] Fresh login: ZK proofs fetched and persisted
- [ ] Logout clears persisted wallet state
- [ ] Give coffee / send token works after restore without re-login
- [ ] CI Build artifacts include MMN/ZK API URLs


Made with [Cursor](https://cursor.com)