### PR TITLE
fix: wallet hardening, send-token UX, badge worker, and store polish

### DIFF
--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -318,7 +318,14 @@ impl MezonTransport {
                         Some(executor) => {
                             let _ = executor.sender.send((code, message));
                         }
-                        None => dispatch_realtime_push(cid, &message, on_event.as_ref()),
+                        None => {
+                            tracing::debug!(
+                                target: "cid_match",
+                                "no pending request for cid={cid} code={code} len={}; routing as push",
+                                message.len()
+                            );
+                            dispatch_realtime_push(cid, &message, on_event.as_ref())
+                        }
                     }
                 } else {
                     dispatch_realtime_push(cid, &message, on_event.as_ref());
@@ -390,7 +397,7 @@ impl MezonTransport {
             .await
             .map_err(|_| {
                 self.pending_requests.lock().remove(&cid);
-                anyhow::anyhow!("Request timed out")
+                anyhow::anyhow!("Request timed out (cid={cid}, {}ms)", timeout.as_millis())
             })?
             .map_err(|_| anyhow::anyhow!("Response channel closed"))?;
         Ok(result)
@@ -4106,7 +4113,8 @@ impl MezonTransport {
         let parsed_clan_id: i64 = clan_id;
         let parsed_channel_id: i64 = channel_id;
         tracing::debug!(
-            "send_channel_message: clan_id={} channel_id={} is_public={} content_len={} attachments={}",
+            "send_channel_message: cid={} clan_id={} channel_id={} is_public={} content_len={} attachments={}",
+            cid,
             parsed_clan_id,
             parsed_channel_id,
             is_public,

--- a/crates/mezon-client/src/transport_runtime.rs
+++ b/crates/mezon-client/src/transport_runtime.rs
@@ -15,22 +15,20 @@ use tokio::io::AsyncWriteExt as _;
 use tokio::runtime::Runtime;
 
 static TRANSPORT_RUNTIME: OnceLock<Runtime> = OnceLock::new();
-static HTTP_CLIENT: OnceLock<ReqwestClient> = OnceLock::new();
-static HTTP_CLIENT_ARC: OnceLock<Arc<dyn HttpClient>> = OnceLock::new();
+static HTTP_CLIENT: OnceLock<Arc<ReqwestClient>> = OnceLock::new();
 
 const HTTP_TRANSFER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
+fn shared_http_client() -> &'static Arc<ReqwestClient> {
+    HTTP_CLIENT.get_or_init(|| Arc::new(new_http_client()))
+}
+
 pub(crate) fn http_client() -> &'static ReqwestClient {
-    HTTP_CLIENT.get_or_init(new_http_client)
+    shared_http_client()
 }
 
 pub fn http_client_arc() -> Arc<dyn HttpClient> {
-    HTTP_CLIENT_ARC
-        .get_or_init(|| {
-            let _guard = runtime().enter();
-            Arc::new(ReqwestClient::new()) as Arc<dyn HttpClient>
-        })
-        .clone()
+    shared_http_client().clone()
 }
 
 pub fn new_http_client() -> ReqwestClient {

--- a/crates/mezon-native/src/badge.rs
+++ b/crates/mezon-native/src/badge.rs
@@ -104,39 +104,92 @@ fn set_badge_macos(count: u32) {
 
 #[cfg(target_os = "windows")]
 fn set_badge_windows(count: u32) {
-    if let Err(e) = try_set_overlay_icon(count) {
-        tracing::warn!("Windows badge count failed: {e}");
+    use windows::Win32::UI::Input::KeyboardAndMouse::GetActiveWindow;
+
+    let stored = MAIN_HWND.load(std::sync::atomic::Ordering::Relaxed);
+    let hwnd = if stored != 0 {
+        stored
+    } else {
+        unsafe { GetActiveWindow() }.0 as isize
+    };
+    if hwnd == 0 {
+        return;
     }
+    let _ = badge_worker().try_send((hwnd, count));
 }
 
 #[cfg(target_os = "windows")]
-fn try_set_overlay_icon(count: u32) -> windows::core::Result<()> {
-    use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx};
-    use windows::Win32::UI::Input::KeyboardAndMouse::GetActiveWindow;
-    use windows::Win32::UI::Shell::{ITaskbarList3, TaskbarList};
-    use windows::Win32::UI::WindowsAndMessaging::{DestroyIcon, HICON};
+fn badge_worker() -> &'static crossbeam_channel::Sender<(isize, u32)> {
+    static WORKER: std::sync::OnceLock<crossbeam_channel::Sender<(isize, u32)>> =
+        std::sync::OnceLock::new();
+    WORKER.get_or_init(|| {
+        let (tx, rx) = crossbeam_channel::bounded::<(isize, u32)>(4);
+        if let Err(e) = std::thread::Builder::new()
+            .name("mezon-taskbar-badge".into())
+            .spawn(move || badge_worker_loop(&rx))
+        {
+            tracing::warn!("Failed to spawn taskbar badge thread: {e}");
+        }
+        tx
+    })
+}
 
-    use windows::Win32::Foundation::HWND;
+#[cfg(target_os = "windows")]
+fn badge_worker_loop(rx: &crossbeam_channel::Receiver<(isize, u32)>) {
+    use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx};
+    use windows::Win32::UI::Shell::ITaskbarList3;
 
     unsafe {
         let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
     }
 
-    let stored = MAIN_HWND.load(std::sync::atomic::Ordering::Relaxed);
-    let hwnd = if stored != 0 {
-        HWND(stored as *mut core::ffi::c_void)
-    } else {
-        unsafe { GetActiveWindow() }
-    };
+    let mut taskbar: Option<ITaskbarList3> = None;
+    while let Ok(mut job) = rx.recv() {
+        while let Ok(newer) = rx.try_recv() {
+            job = newer;
+        }
 
-    let taskbar: ITaskbarList3 = unsafe {
-        windows::Win32::System::Com::CoCreateInstance(
-            &TaskbarList,
-            None,
-            windows::Win32::System::Com::CLSCTX_INPROC_SERVER,
-        )?
-    };
+        if taskbar.is_none() {
+            match create_taskbar_list() {
+                Ok(list) => taskbar = Some(list),
+                Err(e) => {
+                    tracing::warn!("Windows taskbar interface unavailable: {e}");
+                    continue;
+                }
+            }
+        }
+
+        let Some(list) = taskbar.as_ref() else {
+            continue;
+        };
+        if let Err(e) = apply_overlay_icon(list, job.0, job.1) {
+            tracing::warn!("Windows badge count failed: {e}");
+            taskbar = None;
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn create_taskbar_list() -> windows::core::Result<windows::Win32::UI::Shell::ITaskbarList3> {
+    use windows::Win32::System::Com::{CLSCTX_INPROC_SERVER, CoCreateInstance};
+    use windows::Win32::UI::Shell::{ITaskbarList3, TaskbarList};
+
+    let taskbar: ITaskbarList3 =
+        unsafe { CoCreateInstance(&TaskbarList, None, CLSCTX_INPROC_SERVER)? };
     unsafe { taskbar.HrInit()? };
+    Ok(taskbar)
+}
+
+#[cfg(target_os = "windows")]
+fn apply_overlay_icon(
+    taskbar: &windows::Win32::UI::Shell::ITaskbarList3,
+    hwnd: isize,
+    count: u32,
+) -> windows::core::Result<()> {
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::{DestroyIcon, HICON};
+
+    let hwnd = HWND(hwnd as *mut core::ffi::c_void);
 
     if count == 0 {
         // Pass null icon to clear the overlay.
@@ -150,39 +203,55 @@ fn try_set_overlay_icon(count: u32) -> windows::core::Result<()> {
         return Ok(());
     }
 
-    // Build a 16×16 badge bitmap with the count text.
     let hicon = build_count_icon(count)?;
     let description = windows::core::HSTRING::from(format!("{count} unread"));
-
+    let result = unsafe { taskbar.SetOverlayIcon(hwnd, hicon, &description) };
     unsafe {
-        taskbar.SetOverlayIcon(hwnd, hicon, &description)?;
         let _ = DestroyIcon(hicon);
     }
-    Ok(())
+    result
 }
 
 /// Generate a 16×16 `HICON` with the badge count centred on a red circle
-/// (matching the in-app `#DA373C` unread badges). A monochrome AND-mask makes
-/// the pixels outside the circle transparent so the overlay reads as a dot, not
-/// a square.
+/// (matching the in-app `#DA373C` unread badges).
 #[cfg(target_os = "windows")]
 fn build_count_icon(
     count: u32,
 ) -> windows::core::Result<windows::Win32::UI::WindowsAndMessaging::HICON> {
-    use windows::Win32::Foundation::{COLORREF, RECT};
+    use windows::Win32::Foundation::{COLORREF, RECT, SIZE};
     use windows::Win32::Graphics::Gdi::{
-        CreateBitmap, CreateCompatibleBitmap, CreateCompatibleDC, CreateSolidBrush,
-        DEFAULT_GUI_FONT, DeleteDC, DeleteObject, Ellipse, FillRect, GetDC, GetStockObject,
-        NULL_PEN, ReleaseDC, SelectObject, SetBkMode, SetTextColor, TRANSPARENT, TextOutW,
+        ANTIALIASED_QUALITY, BI_RGB, BITMAPINFO, BITMAPV5HEADER, CLIP_DEFAULT_PRECIS, CreateBitmap,
+        CreateCompatibleDC, CreateDIBSection, CreateFontW, CreateSolidBrush, DEFAULT_CHARSET,
+        DEFAULT_PITCH, DIB_RGB_COLORS, DeleteDC, DeleteObject, Ellipse, FF_DONTCARE, FW_BOLD,
+        FillRect, GdiFlush, GetDC, GetStockObject, GetTextExtentPoint32W, NULL_PEN,
+        OUT_DEFAULT_PRECIS, ReleaseDC, SelectObject, SetBkMode, SetTextColor, TRANSPARENT,
+        TextOutW,
     };
     use windows::Win32::UI::WindowsAndMessaging::{CreateIconIndirect, ICONINFO};
+    use windows::core::PCWSTR;
 
-    const SIZE: i32 = 16;
-    // #DA373C danger red (matches every in-app badge); white text. COLORREF is 0x00BBGGRR.
+    const ICON_SIZE: i32 = 16;
+    const SS: i32 = 4;
+    const HI: i32 = ICON_SIZE * SS;
     const BG_COLOR: u32 = 0x003C_37DA;
     const TEXT_COLOR: u32 = 0x00FF_FFFF;
-    const WHITE: u32 = 0x00FF_FFFF;
     const BLACK: u32 = 0x0000_0000;
+
+    fn argb_header(width: i32, height: i32) -> BITMAPV5HEADER {
+        BITMAPV5HEADER {
+            bV5Size: size_of::<BITMAPV5HEADER>() as u32,
+            bV5Width: width,
+            bV5Height: -height,
+            bV5Planes: 1,
+            bV5BitCount: 32,
+            bV5Compression: BI_RGB,
+            bV5RedMask: 0x00FF_0000,
+            bV5GreenMask: 0x0000_FF00,
+            bV5BlueMask: 0x0000_00FF,
+            bV5AlphaMask: 0xFF00_0000,
+            ..Default::default()
+        }
+    }
 
     let label = if count > 99 {
         "99+".to_owned()
@@ -190,77 +259,176 @@ fn build_count_icon(
         count.to_string()
     };
     let text: Vec<u16> = label.encode_utf16().collect();
-    let text_x = match text.len() {
-        1 => 5,
-        2 => 2,
-        _ => 0,
-    };
-
-    let full = RECT {
-        left: 0,
-        top: 0,
-        right: SIZE,
-        bottom: SIZE,
-    };
+    let face: Vec<u16> = "Segoe UI\0".encode_utf16().collect();
 
     let hdc_screen = unsafe { GetDC(None) };
     let hdc = unsafe { CreateCompatibleDC(Some(hdc_screen)) };
-    let hbmp_color = unsafe { CreateCompatibleBitmap(hdc_screen, SIZE, SIZE) };
-    // The AND-mask must be a 1bpp monochrome bitmap: white = transparent, black = opaque.
-    let hbmp_mask = unsafe { CreateBitmap(SIZE, SIZE, 1, 1, None) };
+
+    let hi_header = argb_header(HI, HI);
+    let mut hi_bits: *mut core::ffi::c_void = std::ptr::null_mut();
+    let hi_dib = unsafe {
+        CreateDIBSection(
+            Some(hdc_screen),
+            &hi_header as *const BITMAPV5HEADER as *const BITMAPINFO,
+            DIB_RGB_COLORS,
+            &mut hi_bits,
+            None,
+            0,
+        )
+    };
+    let lo_header = argb_header(ICON_SIZE, ICON_SIZE);
+    let mut lo_bits: *mut core::ffi::c_void = std::ptr::null_mut();
+    let lo_dib = unsafe {
+        CreateDIBSection(
+            Some(hdc_screen),
+            &lo_header as *const BITMAPV5HEADER as *const BITMAPINFO,
+            DIB_RGB_COLORS,
+            &mut lo_bits,
+            None,
+            0,
+        )
+    };
     unsafe { ReleaseDC(None, hdc_screen) };
 
+    let (hi_dib, lo_dib) = match (hi_dib, lo_dib) {
+        (Ok(hi), Ok(lo)) => (hi, lo),
+        (hi, lo) => {
+            unsafe {
+                if let Ok(hi) = hi {
+                    let _ = DeleteObject(hi.into());
+                }
+                if let Ok(lo) = lo {
+                    let _ = DeleteObject(lo.into());
+                }
+                let _ = DeleteDC(hdc);
+            }
+            return Err(windows::core::Error::from_win32());
+        }
+    };
+
     unsafe {
-        let old_bmp = SelectObject(hdc, hbmp_color.into());
+        let old_bmp = SelectObject(hdc, hi_dib.into());
         let old_pen = SelectObject(hdc, GetStockObject(NULL_PEN));
 
-        // ── Colour bitmap: transparent (black) background + red filled circle + text ──
+        let full = RECT {
+            left: 0,
+            top: 0,
+            right: HI,
+            bottom: HI,
+        };
         let black_brush = CreateSolidBrush(COLORREF(BLACK));
         FillRect(hdc, &full, black_brush);
         let _ = DeleteObject(black_brush.into());
 
         let red_brush = CreateSolidBrush(COLORREF(BG_COLOR));
         let old_brush = SelectObject(hdc, red_brush.into());
-        let _ = Ellipse(hdc, 0, 0, SIZE, SIZE);
+        let _ = Ellipse(hdc, 0, 0, HI, HI);
         SelectObject(hdc, old_brush);
         let _ = DeleteObject(red_brush.into());
 
-        let old_font = SelectObject(hdc, GetStockObject(DEFAULT_GUI_FONT));
         SetBkMode(hdc, TRANSPARENT);
         SetTextColor(hdc, COLORREF(TEXT_COLOR));
-        let _ = TextOutW(hdc, text_x, 2, &text);
-        SelectObject(hdc, old_font);
 
-        // ── Monochrome mask: white (transparent) everywhere, black (opaque) circle ──
-        SelectObject(hdc, hbmp_mask.into());
-        let white_brush = CreateSolidBrush(COLORREF(WHITE));
-        FillRect(hdc, &full, white_brush);
-        let _ = DeleteObject(white_brush.into());
-        let mask_black = CreateSolidBrush(COLORREF(BLACK));
-        let mask_old_brush = SelectObject(hdc, mask_black.into());
-        let _ = Ellipse(hdc, 0, 0, SIZE, SIZE);
-        SelectObject(hdc, mask_old_brush);
-        let _ = DeleteObject(mask_black.into());
+        let mut extent = SIZE::default();
+        let mut old_font = None;
+        for height in [HI * 5 / 8, HI / 2, HI * 7 / 16, HI * 3 / 8, HI / 4] {
+            let font = CreateFontW(
+                -height,
+                0,
+                0,
+                0,
+                FW_BOLD.0 as i32,
+                0,
+                0,
+                0,
+                DEFAULT_CHARSET,
+                OUT_DEFAULT_PRECIS,
+                CLIP_DEFAULT_PRECIS,
+                ANTIALIASED_QUALITY,
+                (DEFAULT_PITCH.0 | FF_DONTCARE.0) as u32,
+                PCWSTR(face.as_ptr()),
+            );
+            let previous = SelectObject(hdc, font.into());
+            if old_font.is_none() {
+                old_font = Some(previous);
+            } else {
+                let _ = DeleteObject(previous);
+            }
+            let _ = GetTextExtentPoint32W(hdc, &text, &mut extent);
+            if extent.cx <= HI * 3 / 4 {
+                break;
+            }
+        }
 
+        let _ = TextOutW(hdc, (HI - extent.cx) / 2, (HI - extent.cy) / 2, &text);
+
+        if let Some(old_font) = old_font {
+            let current = SelectObject(hdc, old_font);
+            let _ = DeleteObject(current);
+        }
         SelectObject(hdc, old_pen);
         SelectObject(hdc, old_bmp);
+        let _ = GdiFlush();
+
+        let src = std::slice::from_raw_parts(hi_bits as *const u32, (HI * HI) as usize);
+        let dst =
+            std::slice::from_raw_parts_mut(lo_bits as *mut u32, (ICON_SIZE * ICON_SIZE) as usize);
+        for y in 0..ICON_SIZE {
+            for x in 0..ICON_SIZE {
+                let (mut covered, mut r, mut g, mut b) = (0u32, 0u32, 0u32, 0u32);
+                for sy in 0..SS {
+                    for sx in 0..SS {
+                        let px = src[((y * SS + sy) * HI + x * SS + sx) as usize];
+                        if px & 0x00FF_FFFF == 0 {
+                            continue;
+                        }
+                        covered += 1;
+                        r += (px >> 16) & 0xFF;
+                        g += (px >> 8) & 0xFF;
+                        b += px & 0xFF;
+                    }
+                }
+                let samples = (SS * SS) as u32;
+                let alpha = covered * 255 / samples;
+                let out = if covered == 0 {
+                    0
+                } else {
+                    let scale = |c: u32| (c / covered) * alpha / 255;
+                    (alpha << 24) | (scale(r) << 16) | (scale(g) << 8) | scale(b)
+                };
+                dst[(y * ICON_SIZE + x) as usize] = out;
+            }
+        }
+
+        let _ = DeleteObject(hi_dib.into());
         let _ = DeleteDC(hdc);
     }
+
+    let mask_bits = vec![0xFFu8; (ICON_SIZE * ICON_SIZE / 8) as usize];
+    let hbmp_mask = unsafe {
+        CreateBitmap(
+            ICON_SIZE,
+            ICON_SIZE,
+            1,
+            1,
+            Some(mask_bits.as_ptr() as *const core::ffi::c_void),
+        )
+    };
 
     let icon_info = ICONINFO {
         fIcon: true.into(),
         xHotspot: 0,
         yHotspot: 0,
         hbmMask: hbmp_mask,
-        hbmColor: hbmp_color,
+        hbmColor: lo_dib,
     };
 
-    let hicon = unsafe { CreateIconIndirect(&icon_info)? };
+    let created = unsafe { CreateIconIndirect(&icon_info) };
 
     unsafe {
-        let _ = DeleteObject(hbmp_color.into());
+        let _ = DeleteObject(lo_dib.into());
         let _ = DeleteObject(hbmp_mask.into());
     }
 
-    Ok(hicon)
+    Ok(created?)
 }

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -498,12 +498,12 @@ impl ChannelList {
     fn consume_badge_seed(&mut self, clan_id: ClanId, categories: &mut [Category]) {
         if let Some(seed) = self.pending_badge_seed.remove(&clan_id) {
             let applied = apply_unread_seed_into(&seed, categories);
-            tracing::info!(
-                target: "unread_seed",
+            tracing::debug!(
+                target: "clan_load",
                 clan_id = clan_id.get(),
                 seeded = seed.len(),
                 applied,
-                "CONSUME parked badge seed on structure insert"
+                "consumed parked badge seed on structure insert"
             );
         }
     }
@@ -514,6 +514,10 @@ impl ChannelList {
         }
     }
 
+    pub fn cancel_badge_seed(&mut self, clan_id: ClanId) {
+        self.badge_seeding.remove(&clan_id);
+    }
+
     pub fn seed_badges(&mut self, clan_id: ClanId, cx: &mut Context<Self>) -> Task<()> {
         if self.badge_seeded.contains(&clan_id) || !self.badge_seeding.insert(clan_id) {
             return Task::ready(());
@@ -522,7 +526,7 @@ impl ChannelList {
         let generation = self.reset_generation;
         cx.spawn(async move |this, cx| {
             if let Err(e) = api.join_clan_chat(clan_id.get()).await {
-                tracing::error!(target: "unread_seed", "join_clan_chat failed for clan {clan_id}: {e}");
+                tracing::error!(target: "clan_load", "join_clan_chat failed for clan {clan_id}: {e}");
             }
             let mut attempt = 0u32;
             let descs = loop {
@@ -561,43 +565,40 @@ impl ChannelList {
                     .filter(|(_, s)| !s.last_sent_message_id.is_zero())
                     .map(|(id, s)| (*id, s.last_sent_message_id))
                     .collect();
-                let badged: Vec<ChannelId> = seed
-                    .iter()
-                    .filter(|(_, s)| s.badge_count > 0)
-                    .map(|(id, _)| *id)
-                    .collect();
-                let with_badge = badged.len();
                 let applied = match this.cache.get_mut(&clan_id) {
                     Some(categories) => apply_unread_seed_into(&seed, categories),
                     None => false,
                 };
-                let badged_rows: Vec<String> = badged
-                    .iter()
-                    .map(|id| match this.channel(clan_id, *id) {
-                        Some(ch) => format!(
-                            "{}#{} type={:?} badge={} muted={} thread={}",
-                            ch.name,
-                            id.get(),
-                            ch.channel_type,
-                            ch.badge_count,
-                            ch.muted,
-                            ch.parent_id.is_some()
-                        ),
-                        None => format!("MISSING#{}", id.get()),
-                    })
-                    .collect();
-                tracing::info!(
-                    target: "unread_seed",
-                    clan_id = clan_id.get(),
-                    desc_count,
-                    seeded = seed.len(),
-                    with_badge,
-                    cached = this.cache.contains(&clan_id),
-                    applied,
-                    active = this.active_clan_id == Some(clan_id),
-                    rows = ?badged_rows,
-                    "SEED badge counts"
-                );
+                if tracing::enabled!(target: "clan_load", tracing::Level::DEBUG) {
+                    let badged_rows: Vec<String> = seed
+                        .iter()
+                        .filter(|(_, s)| s.badge_count > 0)
+                        .map(|(id, _)| match this.channel(clan_id, *id) {
+                            Some(ch) => format!(
+                                "{}#{} type={:?} badge={} muted={} thread={}",
+                                ch.name,
+                                id.get(),
+                                ch.channel_type,
+                                ch.badge_count,
+                                ch.muted,
+                                ch.parent_id.is_some()
+                            ),
+                            None => format!("MISSING#{}", id.get()),
+                        })
+                        .collect();
+                    tracing::debug!(
+                        target: "clan_load",
+                        clan_id = clan_id.get(),
+                        desc_count,
+                        seeded = seed.len(),
+                        with_badge = badged_rows.len(),
+                        cached = this.cache.contains(&clan_id),
+                        applied,
+                        active = this.active_clan_id == Some(clan_id),
+                        rows = ?badged_rows,
+                        "seeded badge counts"
+                    );
+                }
                 this.pending_badge_seed.insert(clan_id, seed);
                 if applied {
                     this.notify_channel_list(clan_id, cx);
@@ -867,6 +868,8 @@ impl ChannelList {
     }
 
     fn apply_clan_extras(&mut self, clan_id: ClanId, extras: ClanExtras, cx: &mut Context<Self>) {
+        let app_channels_changed =
+            self.app_channels_cache.get(&clan_id) != Some(&extras.app_channels);
         self.app_channels_cache.insert(clan_id, extras.app_channels);
 
         let Some(slot) = self.cache.get_mut(&clan_id) else {
@@ -877,7 +880,7 @@ impl ChannelList {
         let mut owned = std::mem::take(slot);
         owned.retain(|category| category.id != FAVOR_CATE_ID);
 
-        let mut changed = false;
+        let mut changed = app_channels_changed;
         for ch in owned
             .iter_mut()
             .flat_map(|category| category.channels.iter_mut())
@@ -916,15 +919,17 @@ impl ChannelList {
         if in_voice_changed {
             cx.emit(ChannelEvent::InVoiceChanged);
         }
-        tracing::info!(
-            target: "unread_seed",
+        tracing::debug!(
+            target: "clan_load",
             clan_id = clan_id.get(),
             favorites = extras.favorite_ids.len(),
             voice_channels = extras.voice_map.len(),
             changed,
-            "EXTRAS patched into cached clan structure"
+            "extras patched into cached clan structure"
         );
-        cx.notify();
+        if changed || in_voice_changed {
+            cx.notify();
+        }
     }
 
     fn notify_channel_list(&self, clan_id: ClanId, cx: &mut Context<Self>) {

--- a/crates/mezon-store/src/clan.rs
+++ b/crates/mezon-store/src/clan.rs
@@ -167,6 +167,22 @@ impl ClanOverviewDraft {
     }
 }
 
+fn carry_live_badges(previous: &[Clan], next: &mut [Clan]) {
+    if previous.is_empty() {
+        return;
+    }
+    let live: std::collections::HashMap<ClanId, (u32, bool)> = previous
+        .iter()
+        .map(|clan| (clan.id, (clan.badge_count, clan.has_unread)))
+        .collect();
+    for clan in next {
+        if let Some(&(badge_count, has_unread)) = live.get(&clan.id) {
+            clan.badge_count = badge_count;
+            clan.has_unread = has_unread;
+        }
+    }
+}
+
 fn proto_channel_id(id: Option<ChannelId>) -> i64 {
     id.map(|id| id.get())
         .filter(|id| *id != 0)
@@ -222,6 +238,7 @@ pub struct ClanList {
     pub active_clan_id: Option<ClanId>,
     api: Arc<AppApi>,
     loading: bool,
+    badges_loaded: bool,
     reset_generation: u64,
     _connection_watch: Task<()>,
 }
@@ -253,6 +270,7 @@ impl ClanList {
         self.reset_generation = self.reset_generation.wrapping_add(1);
         self.clans.clear();
         self.loading = false;
+        self.badges_loaded = false;
         if self.active_clan_id.take().is_some() {
             cx.emit(ClanEvent::ActiveClanChanged(None));
         }
@@ -267,6 +285,7 @@ impl ClanList {
             active_clan_id: None,
             api,
             loading: false,
+            badges_loaded: false,
             reset_generation: 0,
             _connection_watch: connection_watch,
         }
@@ -322,12 +341,18 @@ impl ClanList {
         self.loading = true;
         let api = self.api.clone();
         let generation = self.reset_generation;
+        let fetch_badges = !self.badges_loaded;
         cx.spawn(async move |this, cx| {
             const MAX_RETRIES: u32 = 3;
             let mut attempt = 0u32;
             let (clans, badges_result) = loop {
-                let (clans_result, badges_result) =
-                    tokio::join!(api.list_clan_descs(), api.list_clan_badge_count());
+                let (clans_result, badges_result) = if fetch_badges {
+                    let (clans, badges) =
+                        tokio::join!(api.list_clan_descs(), api.list_clan_badge_count());
+                    (clans, Some(badges))
+                } else {
+                    (api.list_clan_descs().await, None)
+                };
                 match clans_result {
                     Ok(c) => break (c, badges_result),
                     Err(e) if attempt < MAX_RETRIES => {
@@ -348,14 +373,20 @@ impl ClanList {
                     }
                 }
             };
-            let badge_map: std::collections::HashMap<String, (i32, bool)> = badges_result
-                .unwrap_or_else(|e| {
+            let mut badges_fetched = false;
+            let badge_map: std::collections::HashMap<String, (i32, bool)> = match badges_result {
+                Some(Ok(list)) => {
+                    badges_fetched = true;
+                    list.into_iter()
+                        .map(|(id, badge, has_unread)| (id, (badge, has_unread)))
+                        .collect()
+                }
+                Some(Err(e)) => {
                     tracing::warn!("clan badge count fetch failed: {e}");
-                    Vec::new()
-                })
-                .into_iter()
-                .map(|(id, badge, has_unread)| (id, (badge, has_unread)))
-                .collect();
+                    std::collections::HashMap::new()
+                }
+                None => std::collections::HashMap::new(),
+            };
             let mapped: Vec<Clan> = clans
                 .into_iter()
                 .map(|c| {
@@ -372,6 +403,7 @@ impl ClanList {
                     return;
                 }
                 this.loading = false;
+                this.badges_loaded = this.badges_loaded || badges_fetched;
                 this.update_clans(mapped, cx);
                 if let Some(clan_id) = this.active_clan_id {
                     this.fire_join_clan_chat(clan_id, cx);
@@ -561,8 +593,9 @@ impl ClanList {
         cx.notify();
     }
 
-    pub fn update_clans(&mut self, clans: Vec<Clan>, cx: &mut Context<Self>) {
+    pub fn update_clans(&mut self, mut clans: Vec<Clan>, cx: &mut Context<Self>) {
         let prev_active = self.active_clan_id;
+        carry_live_badges(&self.clans, &mut clans);
         self.clans = clans;
         let active_missing = self
             .active_clan_id
@@ -1073,6 +1106,38 @@ mod tests {
             prevent_anonymous: false,
         };
         assert_eq!(Clan::from(desc).creator_id, UserId(7));
+    }
+
+    #[test]
+    fn refetched_clans_keep_live_badges() {
+        let mut previous = clans();
+        previous[0].badge_count = 4;
+        previous[0].has_unread = true;
+        let mut refetched = clans();
+        carry_live_badges(&previous, &mut refetched);
+        assert_eq!(refetched[0].badge_count, 4);
+        assert!(refetched[0].has_unread);
+        assert_eq!(refetched[1].badge_count, 0);
+    }
+
+    #[test]
+    fn first_load_takes_server_badges() {
+        let mut fresh = clans();
+        fresh[0].badge_count = 7;
+        fresh[0].has_unread = true;
+        carry_live_badges(&[], &mut fresh);
+        assert_eq!(fresh[0].badge_count, 7);
+        assert!(fresh[0].has_unread);
+    }
+
+    #[test]
+    fn newly_joined_clan_takes_server_badge() {
+        let previous = vec![make_clan(1, "One", None)];
+        let mut refetched = clans();
+        refetched[1].badge_count = 9;
+        carry_live_badges(&previous, &mut refetched);
+        assert_eq!(refetched[0].badge_count, 0);
+        assert_eq!(refetched[1].badge_count, 9);
     }
 
     #[test]

--- a/crates/mezon-store/src/clan_load.rs
+++ b/crates/mezon-store/src/clan_load.rs
@@ -1,4 +1,4 @@
-use gpui::{App, AppContext, AsyncApp, Context, Entity, Global, Subscription, WeakEntity};
+use gpui::{App, AppContext, AsyncApp, Context, Entity, Global, Subscription, Task, WeakEntity};
 
 use crate::channel::ChannelList;
 use crate::clan::{ClanEvent, ClanList};
@@ -12,6 +12,8 @@ use crate::sticker::StickerStore;
 
 pub struct ClanLoadScheduler {
     generation: u64,
+    loading_clan: Option<ClanId>,
+    load_task: Option<Task<()>>,
     _clan_sub: Subscription,
 }
 
@@ -34,8 +36,9 @@ impl ClanLoadScheduler {
             .map(|g| g.0.clone())
     }
 
-    pub fn reset(&mut self) {
+    pub fn reset(&mut self, cx: &mut Context<Self>) {
         self.generation = self.generation.wrapping_add(1);
+        self.cancel_in_flight(cx);
     }
 
     fn new(cx: &mut Context<Self>) -> Self {
@@ -43,22 +46,33 @@ impl ClanLoadScheduler {
             if let ClanEvent::ActiveClanChanged(active) = event {
                 match active {
                     Some(clan_id) => this.start(*clan_id, cx),
-                    None => this.reset(),
+                    None => this.reset(cx),
                 }
             }
         });
 
         Self {
             generation: 0,
+            loading_clan: None,
+            load_task: None,
             _clan_sub: clan_sub,
         }
     }
 
+    fn cancel_in_flight(&mut self, cx: &mut Context<Self>) {
+        self.load_task = None;
+        if let Some(previous) = self.loading_clan.take() {
+            ChannelList::global(cx).update(cx, |channels, _| channels.cancel_badge_seed(previous));
+        }
+    }
+
     fn start(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+        self.cancel_in_flight(cx);
         self.generation = self.generation.wrapping_add(1);
         let generation = self.generation;
+        self.loading_clan = Some(clan_id);
 
-        cx.spawn(async move |this, cx| {
+        self.load_task = Some(cx.spawn(async move |this, cx| {
             cx.update(|cx| {
                 ChannelList::global(cx)
                     .update(cx, |channels, cx| channels.load_for_clan(clan_id, cx));
@@ -103,8 +117,14 @@ impl ClanLoadScheduler {
                 NotificationSettingStore::global(cx)
                     .update(cx, |store, cx| store.prefetch_clan(clan_id, cx));
             });
-        })
-        .detach();
+
+            this.update(cx, |this, _| {
+                if this.generation == generation {
+                    this.loading_clan = None;
+                }
+            })
+            .ok();
+        }));
     }
 }
 

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -148,6 +148,7 @@ pub use mezon_client::{
     search_content_highlight_terms, search_dropdown_mode, search_filter_chip_ranges,
     search_page_count, search_page_numbers, should_show_search_dropdown,
 };
+pub use mmn_client::{DECIMAL_FACTOR as TOKEN_DECIMAL_FACTOR, DECIMALS as TOKEN_DECIMALS};
 pub use notification_push::NotificationPushStore;
 pub use notification_setting::{NotificationSettingEvent, NotificationSettingStore};
 pub use ogp::{OgpResult, OutgoingOgp, fetch_ogp, first_previewable_url};

--- a/crates/mezon-store/src/login.rs
+++ b/crates/mezon-store/src/login.rs
@@ -106,7 +106,7 @@ impl LoginStore {
 
     pub fn reset_all_user_stores(cx: &mut App) {
         if let Some(e) = crate::clan_load::ClanLoadScheduler::try_global(cx) {
-            e.update(cx, |s, _| s.reset());
+            e.update(cx, |s, cx| s.reset(cx));
         }
         if let Some(e) = crate::account::AccountStore::try_global(cx) {
             e.update(cx, |s, cx| s.reset(cx));

--- a/crates/mezon-store/src/wallet.rs
+++ b/crates/mezon-store/src/wallet.rs
@@ -5,10 +5,10 @@ use mezon_audio::{AudioPlayer, decode_audio};
 use mezon_client::RealtimeEvent;
 use mezon_client::transport_runtime::http_client_arc;
 use mmn_client::{
-    AddTxResponse, ClaimRedEnvelopeQrRequest, ClaimRedEnvelopeQrResponse, DongClient,
+    AddTxResponse, ClaimRedEnvelopeQrRequest, ClaimRedEnvelopeQrResponse, DECIMALS, DongClient,
     EphemeralKeyPair, ExtraInfo, GetZkProofRequest, IndexerClient, MmnClient,
     SendTransactionRequest, ZkClient, ZkClientType, ZkProof, address_from_user_id,
-    generate_ephemeral_key_pair, scale_amount_to_decimals,
+    generate_ephemeral_key_pair, is_secure_endpoint, scale_amount_to_decimals,
 };
 
 use mezon_client::Session;
@@ -18,7 +18,6 @@ use crate::config::{AppConfig, INDEXER_CHAIN_ID};
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
 use crate::wallet_persist::{self, PersistedWalletState};
 
-const DECIMALS: u32 = 6;
 const GIVE_COFFEE_AMOUNT: i64 = 10_000;
 
 static BANK_SOUND: &[u8] = include_bytes!("../assets/audio/bankSound.mp3");
@@ -160,6 +159,18 @@ impl WalletStore {
         if config.mmn_api_url.is_empty() || config.zk_api_url.is_empty() {
             return None;
         }
+        let endpoints = [
+            ("mmn_api_url", config.mmn_api_url.as_str()),
+            ("zk_api_url", config.zk_api_url.as_str()),
+            ("indexer_api_url", config.indexer_api_url.as_str()),
+            ("dong_service_api_url", config.dong_service_api_url.as_str()),
+        ];
+        for (name, url) in endpoints {
+            if !url.is_empty() && !is_secure_endpoint(url) {
+                tracing::error!("wallet disabled: {name} is not an https endpoint");
+                return None;
+            }
+        }
         let http = http_client_arc();
         Some(Arc::new(WalletClients {
             mmn: MmnClient::new(http.clone(), config.mmn_api_url.clone()),
@@ -264,6 +275,14 @@ impl WalletStore {
         let Some(clients) = self.clients.clone() else {
             return;
         };
+        let switching_user = self
+            .enabled_user
+            .as_deref()
+            .or(self.enabling_user.as_deref())
+            .is_some_and(|current| current != user_id.as_str());
+        if switching_user {
+            self.reset(cx);
+        }
         let generation = self.reset_generation;
         self.enabling_user = Some(user_id.clone());
         self.enable_task = Some(cx.spawn(async move |this, cx| {
@@ -329,13 +348,18 @@ impl WalletStore {
                 if this.reset_generation != generation {
                     return;
                 }
-                if let Ok(account) = account {
-                    this.wallet = Some(WalletDetail {
-                        address: account.address,
-                        balance: account.balance,
-                    });
-                    cx.emit(WalletEvent::BalanceChanged);
-                    cx.notify();
+                match account {
+                    Ok(account) => {
+                        this.wallet = Some(WalletDetail {
+                            address: account.address,
+                            balance: account.balance,
+                        });
+                        cx.emit(WalletEvent::BalanceChanged);
+                        cx.notify();
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "wallet: balance refresh failed");
+                    }
                 }
             })
             .ok();

--- a/crates/mezon-ui/src/chat/area.rs
+++ b/crates/mezon-ui/src/chat/area.rs
@@ -164,7 +164,9 @@ impl ChatArea {
                         if replying_to.is_some()
                             && let Some(input) = this.chat_area.mention_input.clone()
                         {
-                            input.update(cx, |input, cx| input.focus_input(window, cx));
+                            window.defer(cx, move |window, cx| {
+                                input.update(cx, |input, cx| input.focus_input(window, cx));
+                            });
                         }
                         this.chat_area.replying_to = replying_to;
                         cx.notify();

--- a/crates/mezon-ui/src/chat/create_topic_panel.rs
+++ b/crates/mezon-ui/src/chat/create_topic_panel.rs
@@ -67,8 +67,10 @@ impl TopicPanel {
                 }
                 let reply_id = store.read(cx).reply_target().map(|d| d.message_ref_id);
                 if reply_id.is_some() && reply_id != this.reply_target_id {
-                    this.mention_input
-                        .update(cx, |input, cx| input.focus_input(window, cx));
+                    let input = this.mention_input.clone();
+                    window.defer(cx, move |window, cx| {
+                        input.update(cx, |input, cx| input.focus_input(window, cx));
+                    });
                 }
                 this.reply_target_id = reply_id;
             },

--- a/crates/mezon-ui/src/chat/mention_input/text_field.rs
+++ b/crates/mezon-ui/src/chat/mention_input/text_field.rs
@@ -22,7 +22,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use crate::theme::ActiveTheme;
 use crate::util::text_edit::{
     EditKind, HistoryEntry, MAX_UNDO_HISTORY, home_target, line_end, line_start,
-    next_word_boundary, previous_word_boundary,
+    next_word_boundary, previous_word_boundary, should_coalesce,
 };
 
 const MASK: char = '\u{2022}';
@@ -657,8 +657,7 @@ impl MentionInputState {
     }
 
     fn record_history(&mut self, kind: EditKind) {
-        let coalesce = matches!(kind, EditKind::Insert | EditKind::Delete)
-            && self.last_edit_kind == Some(kind);
+        let coalesce = should_coalesce(self.last_edit_kind, kind);
         self.redo_stack.clear();
         if !coalesce {
             self.undo_stack.push(self.history_snapshot());

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -438,6 +438,11 @@ mod selection_copy_tests {
     }
 }
 
+const FAB_SIZE: f32 = 32.;
+const FAB_HOVER_GROW: f32 = 4.;
+const FAB_HOVER_SIZE: f32 = FAB_SIZE + FAB_HOVER_GROW;
+const FAB_BOTTOM: f32 = 20.;
+const FAB_RIGHT: f32 = 12.;
 const LOAD_MORE_ITEM_THRESHOLD: usize = 12;
 const LIST_OVERDRAW: f32 = 1024.;
 const LIST_BOTTOM_PADDING: f32 = 20.;
@@ -1101,6 +1106,7 @@ pub struct ChannelMessages {
     image_cache: Entity<LruImageCache>,
     avatar_image_cache: Entity<LruImageCache>,
     small_avatar_image_cache: Entity<LruImageCache>,
+    icon_image_cache: Entity<LruImageCache>,
     active_videos: Rc<HashMap<(MessageId, usize), Entity<VideoPlayerView>>>,
     active_audios: Rc<indexmap::IndexMap<(MessageId, usize), Entity<AudioPlayerView>>>,
     gif_videos: Rc<HashMap<(MessageId, usize), Entity<GifVideoView>>>,
@@ -1640,6 +1646,15 @@ impl ChannelMessages {
             )
         });
         let avatar_image_cache = crate::image_cache::shared_avatar_cache(cx);
+        let icon_image_cache = cx.new(|cx| {
+            crate::image_cache::LruImageCache::icon_thumbnail(
+                "message-icons",
+                1024,
+                8 * 1024 * 1024,
+                256 * 1024,
+                cx,
+            )
+        });
         let small_avatar_image_cache = cx.new(|cx| {
             crate::image_cache::LruImageCache::avatar_thumbnail_small(
                 "message-authors",
@@ -1715,6 +1730,7 @@ impl ChannelMessages {
             image_cache,
             avatar_image_cache,
             small_avatar_image_cache,
+            icon_image_cache,
             active_videos: Rc::new(HashMap::new()),
             active_audios: Rc::new(indexmap::IndexMap::new()),
             gif_videos: Rc::new(HashMap::new()),
@@ -3112,9 +3128,9 @@ impl ChannelMessages {
         div()
             .id("scroll-down-fab")
             .absolute()
-            .bottom(px(20.))
-            .right(px(12.))
-            .size(px(32.))
+            .bottom(px(FAB_BOTTOM))
+            .right(px(FAB_RIGHT))
+            .size(px(FAB_SIZE))
             .rounded_full()
             .bg(theme.bg_tertiary)
             .border_1()
@@ -3126,6 +3142,13 @@ impl ChannelMessages {
             .when(visible, |el| {
                 el.cursor_pointer()
                     .occlude()
+                    .hover(|style| {
+                        style
+                            .size(px(FAB_HOVER_SIZE))
+                            .bottom(px(FAB_BOTTOM - FAB_HOVER_GROW / 2.))
+                            .right(px(FAB_RIGHT - FAB_HOVER_GROW / 2.))
+                            .bg(theme.bg_hover)
+                    })
                     .on_click(cx.listener(|this, _event, _window, cx| {
                         this.scroll_down_clicked(cx);
                     }))
@@ -3881,6 +3904,7 @@ impl ChannelMessages {
         let context_menu_message = self.context_menu_target.map(|(id, _)| id);
         let avatar_image_cache = self.avatar_image_cache.clone();
         let small_avatar_image_cache = self.small_avatar_image_cache.clone();
+        let icon_image_cache = self.icon_image_cache.clone();
         let reply_highlight_id = TopicsStore::global(cx)
             .read(cx)
             .reply_target()
@@ -3940,6 +3964,7 @@ impl ChannelMessages {
                         context_menu_message,
                         avatar_cache: small_avatar_image_cache.clone(),
                         large_avatar_cache: avatar_image_cache.clone(),
+                        icon_cache: icon_image_cache.clone(),
                         unread_boundary_id: None,
                         highlight_id: None,
                         reply_highlight_id,
@@ -4124,6 +4149,7 @@ impl Render for ChannelMessages {
         let context_menu_message = self.context_menu_target.map(|(id, _)| id);
         let avatar_image_cache = self.avatar_image_cache.clone();
         let small_avatar_image_cache = self.small_avatar_image_cache.clone();
+        let icon_image_cache = self.icon_image_cache.clone();
         let unread_boundary_id = self.cached_unread_boundary;
         let highlight_id = self.highlight_id;
         let reply_highlight_id = store.read(cx).reply_target().map(|d| d.message_ref_id);
@@ -4190,6 +4216,7 @@ impl Render for ChannelMessages {
                         context_menu_message,
                         avatar_cache: small_avatar_image_cache.clone(),
                         large_avatar_cache: avatar_image_cache.clone(),
+                        icon_cache: icon_image_cache.clone(),
                         unread_boundary_id,
                         highlight_id,
                         reply_highlight_id,

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -1741,14 +1741,19 @@ fn render_emoji_span(
             .child(name.clone())
             .into_any_element();
     }
-    img(src)
-        .size(size)
+    div()
         .flex_none()
-        .object_fit(ObjectFit::Contain)
-        .with_fallback(super::reaction_detail::emoji_error_fallback(
-            size,
-            ctx.theme.text_muted,
-        ))
+        .size(size)
+        .image_cache(ctx.icon_cache.clone())
+        .child(
+            img(src)
+                .size(size)
+                .object_fit(ObjectFit::Contain)
+                .with_fallback(super::reaction_detail::emoji_error_fallback(
+                    size,
+                    ctx.theme.text_muted,
+                )),
+        )
         .into_any_element()
 }
 

--- a/crates/mezon-ui/src/chat/message/context.rs
+++ b/crates/mezon-ui/src/chat/message/context.rs
@@ -67,6 +67,7 @@ pub struct RowCtx<'a> {
     pub context_menu_message: Option<MessageId>,
     pub avatar_cache: Entity<LruImageCache>,
     pub large_avatar_cache: Entity<LruImageCache>,
+    pub icon_cache: Entity<LruImageCache>,
     pub unread_boundary_id: Option<MessageId>,
     pub highlight_id: Option<MessageId>,
     pub reply_highlight_id: Option<MessageId>,

--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -1270,11 +1270,14 @@ fn add_reaction_button(message_id: MessageId, ctx: &RowCtx) -> AnyElement {
         .into_any_element()
 }
 
+const REACTION_EMOJI_PX: f32 = 16.;
+const REACTION_EMOJI_SOURCE_PX: u32 = 32;
+
 fn reaction_emoji_src(reaction: &Reaction, app: &gpui::App) -> SharedString {
     if reaction.emoji_id.is_empty() || reaction.emoji_id.as_ref() == "0" {
         return SharedString::default();
     }
-    crate::util::imgproxy::emoji_url(app, &reaction.emoji_id).into()
+    crate::util::imgproxy::emoji_url_sized(app, &reaction.emoji_id, REACTION_EMOJI_SOURCE_PX).into()
 }
 
 fn reaction_pill(reaction: &Reaction, message_id: MessageId, ctx: &RowCtx) -> AnyElement {
@@ -1352,13 +1355,20 @@ fn reaction_pill(reaction: &Reaction, message_id: MessageId, ctx: &RowCtx) -> An
             .child(glyph)
             .into_any_element()
     } else {
-        img(src)
+        div()
             .absolute()
             .left(px(5.))
             .top(px(4.))
-            .size(px(16.))
-            .object_fit(ObjectFit::ScaleDown)
-            .with_fallback(emoji_error_fallback(px(16.), theme.text_muted))
+            .image_cache(ctx.icon_cache.clone())
+            .child(
+                img(src)
+                    .size(px(REACTION_EMOJI_PX))
+                    .object_fit(ObjectFit::ScaleDown)
+                    .with_fallback(emoji_error_fallback(
+                        px(REACTION_EMOJI_PX),
+                        theme.text_muted,
+                    )),
+            )
             .into_any_element()
     };
 

--- a/crates/mezon-ui/src/chat/message/send_token_modal.rs
+++ b/crates/mezon-ui/src/chat/message/send_token_modal.rs
@@ -15,7 +15,7 @@ use crate::components::primitives::{
 };
 use crate::theme::ActiveTheme;
 
-const DECIMAL_FACTOR: i128 = 1_000_000;
+use mezon_store::TOKEN_DECIMAL_FACTOR as DECIMAL_FACTOR;
 const MAX_CANDIDATES_SHOWN: usize = 50;
 
 #[derive(Clone)]
@@ -68,11 +68,9 @@ impl SendTokenModal {
                 ))
             });
             let amount = cx.new(|cx| {
-                InputState::new(window, cx)
-                    .placeholder(tr(
-                        "userProfile.statusProfile.sendTokenModal.placeholders.amountPlaceholder",
-                    ))
-                    .validate(|value, _cx| value.chars().all(|c| c.is_ascii_digit()))
+                InputState::new(window, cx).placeholder(tr(
+                    "userProfile.statusProfile.sendTokenModal.placeholders.amountPlaceholder",
+                ))
             });
             let note = cx.new(|cx| {
                 InputState::new(window, cx).placeholder(tr(
@@ -95,13 +93,25 @@ impl SendTokenModal {
                     }
                 },
             );
-            let amount_sub = cx.subscribe(
+            let amount_sub = cx.subscribe_in(
                 &amount,
-                |this: &mut Self, _input, event: &InputEvent, cx| {
-                    if matches!(event, InputEvent::Change) {
-                        this.error = None;
-                        cx.notify();
+                window,
+                |this: &mut Self, input, event: &InputEvent, window, cx| {
+                    if !matches!(event, InputEvent::Change) {
+                        return;
                     }
+                    this.error = None;
+                    let raw = input.read(cx).value().to_string();
+                    let formatted = format_amount_input(&raw, &this.locale);
+                    if formatted != raw {
+                        let input = input.clone();
+                        window.defer(cx, move |window, cx| {
+                            input.update(cx, |input, cx| {
+                                input.set_value(formatted, window, cx);
+                            });
+                        });
+                    }
+                    cx.notify();
                 },
             );
 
@@ -232,36 +242,29 @@ impl SendTokenModal {
     }
 
     fn amount_value(&self, cx: &App) -> i64 {
-        self.amount
-            .read(cx)
-            .value()
-            .chars()
-            .filter(|c| c.is_ascii_digit())
-            .collect::<String>()
-            .parse()
-            .unwrap_or(0)
+        parse_whole_token_amount(self.amount.read(cx).value())
     }
 
-    fn exceeds_balance(&self, cx: &App) -> bool {
-        let amount = self.amount_value(cx);
+    fn exceeds_balance_for(&self, amount: i64, cx: &App) -> bool {
         if amount <= 0 {
             return false;
         }
-        let balance =
-            WalletStore::try_global(cx).and_then(|w| w.read(cx).balance().map(|b| b.to_string()));
-        let Some(balance) = balance else {
+        let Some(wallet) = WalletStore::try_global(cx) else {
             return false;
         };
-        let scaled = (amount as i128).saturating_mul(DECIMAL_FACTOR);
-        let available: i128 = balance.trim().parse().unwrap_or(0);
-        scaled > available
+        let Some(balance) = wallet.read(cx).balance() else {
+            return false;
+        };
+        amount_exceeds_balance(amount, balance)
+    }
+
+    fn can_send_with(&self, amount: i64, exceeds: bool) -> bool {
+        !self.sending && self.selected.is_some() && amount > 0 && !exceeds
     }
 
     fn can_send(&self, cx: &App) -> bool {
-        !self.sending
-            && self.selected.is_some()
-            && self.amount_value(cx) > 0
-            && !self.exceeds_balance(cx)
+        let amount = self.amount_value(cx);
+        self.can_send_with(amount, self.exceeds_balance_for(amount, cx))
     }
 
     fn send(&mut self, cx: &mut Context<Self>) {
@@ -360,8 +363,9 @@ impl Render for SendTokenModal {
         let entity = cx.entity();
         let locale = self.locale.clone();
         let tk = |key: &'static str| mezon_i18n::t(&locale, key).to_string();
-        let can_send = self.can_send(cx);
-        let exceeds = self.exceeds_balance(cx);
+        let amount = self.amount_value(cx);
+        let exceeds = self.exceeds_balance_for(amount, cx);
+        let can_send = self.can_send_with(amount, exceeds);
 
         let header = div()
             .flex()
@@ -615,16 +619,46 @@ impl Render for SendTokenModal {
     }
 }
 
-fn format_thousands(n: i64) -> String {
-    let digits = n.unsigned_abs().to_string();
+fn parse_whole_token_amount(raw: &str) -> i64 {
+    let digits: String = raw.chars().filter(|c| c.is_ascii_digit()).collect();
+    digits.parse().unwrap_or(0)
+}
+
+fn amount_exceeds_balance(amount: i64, balance: &str) -> bool {
+    if amount <= 0 {
+        return false;
+    }
+    let scaled = (amount as i128).saturating_mul(DECIMAL_FACTOR);
+    let available: i128 = balance.trim().parse().unwrap_or(0);
+    scaled > available
+}
+
+fn group_separator(locale: &str) -> char {
+    if locale.starts_with("vi") { '.' } else { ',' }
+}
+
+fn format_amount_input(raw: &str, locale: &str) -> String {
+    if raw.is_empty() {
+        return String::new();
+    }
+    group_digits(parse_whole_token_amount(raw), group_separator(locale))
+}
+
+fn group_digits(value: i64, separator: char) -> String {
+    let digits = value.unsigned_abs().to_string();
     let bytes = digits.as_bytes();
-    let mut out = String::new();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
     for (index, byte) in bytes.iter().enumerate() {
         if index > 0 && (bytes.len() - index).is_multiple_of(3) {
-            out.push(',');
+            out.push(separator);
         }
         out.push(*byte as char);
     }
+    out
+}
+
+fn format_thousands(n: i64) -> String {
+    let out = group_digits(n, ',');
     if n < 0 { format!("-{out}") } else { out }
 }
 
@@ -636,4 +670,90 @@ fn section(theme: &crate::theme::Theme, label: impl Into<SharedString>) -> gpui:
             .text_color(theme.tokens.text_theme_primary)
             .child(label.into()),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DECIMAL_FACTOR, amount_exceeds_balance, format_amount_input, format_thousands,
+        parse_whole_token_amount,
+    };
+
+    #[test]
+    fn keeps_digits_like_the_react_handler() {
+        assert_eq!(parse_whole_token_amount("1000"), 1000);
+        assert_eq!(parse_whole_token_amount("12abc34"), 1234);
+        assert_eq!(parse_whole_token_amount("-5"), 5);
+        assert_eq!(parse_whole_token_amount(""), 0);
+        assert_eq!(parse_whole_token_amount("   "), 0);
+    }
+
+    #[test]
+    fn strips_group_separators_of_both_locales() {
+        assert_eq!(parse_whole_token_amount("1,000"), 1000);
+        assert_eq!(parse_whole_token_amount("1.000"), 1000);
+        assert_eq!(parse_whole_token_amount("12,345,678"), 12_345_678);
+        assert_eq!(parse_whole_token_amount("12.345.678"), 12_345_678);
+    }
+
+    #[test]
+    fn overlong_digit_runs_fall_back_to_zero_not_panic() {
+        assert_eq!(parse_whole_token_amount(&"9".repeat(40)), 0);
+    }
+
+    #[test]
+    fn amount_input_groups_by_locale_like_intl_number_format() {
+        assert_eq!(format_amount_input("1000", "en"), "1,000");
+        assert_eq!(format_amount_input("1000", "vi"), "1.000");
+        assert_eq!(format_amount_input("12345678", "vi"), "12.345.678");
+        assert_eq!(format_amount_input("999", "en"), "999");
+    }
+
+    #[test]
+    fn amount_input_reformats_its_own_output_idempotently() {
+        for locale in ["en", "vi"] {
+            let once = format_amount_input("12345678", locale);
+            assert_eq!(format_amount_input(&once, locale), once);
+            assert_eq!(parse_whole_token_amount(&once), 12_345_678);
+        }
+    }
+
+    #[test]
+    fn balance_check_scales_the_amount_before_comparing() {
+        assert!(!amount_exceeds_balance(1, "1000000"));
+        assert!(!amount_exceeds_balance(1, "2000000"));
+        assert!(amount_exceeds_balance(2, "1000000"));
+        assert!(amount_exceeds_balance(1, "999999"));
+    }
+
+    #[test]
+    fn balance_check_is_inert_for_non_positive_amounts() {
+        assert!(!amount_exceeds_balance(0, "0"));
+        assert!(!amount_exceeds_balance(-1, "0"));
+    }
+
+    #[test]
+    fn unparseable_balance_blocks_the_send() {
+        assert!(amount_exceeds_balance(1, "abc"));
+        assert!(amount_exceeds_balance(1, ""));
+        assert!(!amount_exceeds_balance(1, " 1000000 "));
+    }
+
+    #[test]
+    fn oversized_amount_saturates_instead_of_overflowing() {
+        assert!(amount_exceeds_balance(i64::MAX, "1000000"));
+    }
+
+    #[test]
+    fn clearing_the_amount_field_stays_empty() {
+        assert_eq!(format_amount_input("", "vi"), "");
+        assert_eq!(format_amount_input("abc", "vi"), "0");
+    }
+
+    #[test]
+    fn grouped_output_round_trips_through_the_parser() {
+        for value in [1i64, 999, 1000, 1_234_567, i64::MAX / DECIMAL_FACTOR as i64] {
+            assert_eq!(parse_whole_token_amount(&format_thousands(value)), value);
+        }
+    }
 }

--- a/crates/mezon-ui/src/chat/message/transaction_history_modal.rs
+++ b/crates/mezon-ui/src/chat/message/transaction_history_modal.rs
@@ -8,7 +8,7 @@ use crate::app::shell::Shell;
 use crate::components::primitives::{Icon, IconName};
 use crate::theme::ActiveTheme;
 
-const DECIMAL_FACTOR: i128 = 1_000_000;
+use mezon_store::TOKEN_DECIMAL_FACTOR as DECIMAL_FACTOR;
 const PAGE_LIMIT: i64 = 50;
 const FILTER_ALL: i32 = 0;
 const FILTER_RECEIVED: i32 = 1;

--- a/crates/mezon-ui/src/components/compositions/footer_profile_popup.rs
+++ b/crates/mezon-ui/src/components/compositions/footer_profile_popup.rs
@@ -9,7 +9,7 @@ use crate::chat::message::{CustomStatusModal, SendTokenModal, TransactionHistory
 use crate::components::primitives::{Avatar, Icon, IconName};
 use crate::theme::ActiveTheme;
 
-const DECIMAL_FACTOR: i128 = 1_000_000;
+use mezon_store::TOKEN_DECIMAL_FACTOR as DECIMAL_FACTOR;
 const CURRENCY_SYMBOL: &str = "đồng";
 
 const STATUS_ONLINE: &str = "Online";

--- a/crates/mezon-ui/src/components/primitives/textarea.rs
+++ b/crates/mezon-ui/src/components/primitives/textarea.rs
@@ -15,7 +15,7 @@ use mezon_widgets::blink_manager::{CaretBlink, HasCaretBlink};
 
 use crate::util::text_edit::{
     EditKind, HistoryEntry, MAX_UNDO_HISTORY, home_target, line_end, line_start,
-    next_word_boundary, previous_word_boundary,
+    next_word_boundary, previous_word_boundary, should_coalesce,
 };
 
 const KEY_CONTEXT: &str = "MezonTextArea";
@@ -700,8 +700,7 @@ impl TextArea {
     }
 
     fn record_history(&mut self, kind: EditKind) {
-        let coalesce = matches!(kind, EditKind::Insert | EditKind::Delete)
-            && self.last_edit_kind == Some(kind);
+        let coalesce = should_coalesce(self.last_edit_kind, kind);
         self.redo_stack.clear();
         if !coalesce {
             self.undo_stack.push(self.history_snapshot());

--- a/crates/mezon-ui/src/image_cache.rs
+++ b/crates/mezon-ui/src/image_cache.rs
@@ -465,6 +465,7 @@ enum LoaderKind {
     /// animated full-resolution source costs ~100 KB of RAM. Used for avatars.
     AvatarThumbnail,
     AvatarThumbnailSmall,
+    IconThumbnail,
     GalleryThumbnail,
     /// Aspect-preserving thumbnail for OGP link previews, capped at
     /// [`OGP_THUMB_DECODE_MAX_PX`].
@@ -549,6 +550,23 @@ impl LruImageCache {
         Self::with_loader(
             label,
             LoaderKind::AvatarThumbnailSmall,
+            max_items,
+            max_bytes,
+            max_entry_bytes,
+            cx,
+        )
+    }
+
+    pub fn icon_thumbnail(
+        label: &'static str,
+        max_items: usize,
+        max_bytes: u64,
+        max_entry_bytes: u64,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self::with_loader(
+            label,
+            LoaderKind::IconThumbnail,
             max_items,
             max_bytes,
             max_entry_bytes,
@@ -952,6 +970,9 @@ impl LruImageCache {
             LoaderKind::AvatarThumbnailSmall => {
                 AssetLogger::<AvatarImageLoaderSmall>::load(resource.clone(), cx).boxed()
             }
+            LoaderKind::IconThumbnail => {
+                AssetLogger::<IconImageLoader>::load(resource.clone(), cx).boxed()
+            }
             LoaderKind::GalleryThumbnail => {
                 AssetLogger::<GalleryImageLoader>::load(resource.clone(), cx).boxed()
             }
@@ -1013,6 +1034,7 @@ impl ImageCache for LruImageCache {
 /// keeps a single avatar at ~100 KB regardless of the source file.
 const AVATAR_DECODE_MAX_PX: u32 = 160;
 const AVATAR_SMALL_DECODE_MAX_PX: u32 = 80;
+const ICON_DECODE_MAX_PX: u32 = 64;
 const GALLERY_THUMB_DECODE_MAX_PX: u32 = 320;
 /// OGP link-preview thumbnails render at ≤200px tall; decode to 512px longest
 /// side (aspect-preserving, ~2x for retina) so a large external OG image
@@ -1122,6 +1144,20 @@ impl Asset for AvatarImageLoaderSmall {
         cx: &mut App,
     ) -> impl Future<Output = Self::Output> + Send + 'static {
         load_avatar_scaled(source, AVATAR_SMALL_DECODE_MAX_PX, cx)
+    }
+}
+
+pub enum IconImageLoader {}
+
+impl Asset for IconImageLoader {
+    type Source = Resource;
+    type Output = Result<Arc<RenderImage>, ImageCacheError>;
+
+    fn load(
+        source: Self::Source,
+        cx: &mut App,
+    ) -> impl Future<Output = Self::Output> + Send + 'static {
+        load_avatar_scaled(source, ICON_DECODE_MAX_PX, cx)
     }
 }
 

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
@@ -52,6 +52,7 @@ pub struct ChannelSidebar {
     channel_list: Entity<ChannelList>,
     settings: Entity<Settings>,
     items: Rc<Vec<SidebarItem>>,
+    icon_image_cache: Entity<crate::image_cache::LruImageCache>,
     list_state: ListState,
     first_badged_index: Option<usize>,
     active_clan_name: String,
@@ -156,6 +157,15 @@ impl ChannelSidebar {
             channel_list,
             settings,
             items: Rc::new(Vec::new()),
+            icon_image_cache: cx.new(|cx| {
+                crate::image_cache::LruImageCache::icon_thumbnail(
+                    "channel-app-icons",
+                    128,
+                    2 * 1024 * 1024,
+                    256 * 1024,
+                    cx,
+                )
+            }),
             list_state,
             first_badged_index: None,
             active_clan_name: String::new(),
@@ -676,6 +686,7 @@ impl Render for ChannelSidebar {
         let list_element = list(list_state, {
             let sidebar = sidebar.clone();
             let locale = locale.clone();
+            let icon_cache = self.icon_image_cache.clone();
             move |ix, _window, cx| {
                 render_sidebar_item(
                     &items,
@@ -686,6 +697,7 @@ impl Render for ChannelSidebar {
                     sidebar.clone(),
                     suppress_hover,
                     &locale,
+                    icon_cache.clone(),
                 )
             }
         })
@@ -1103,6 +1115,7 @@ fn render_banner_and_events(
     cx: &App,
     suppress_hover: bool,
     locale: &str,
+    icon_cache: Entity<crate::image_cache::LruImageCache>,
 ) -> AnyElement {
     let theme = cx.theme();
     let divider_color = theme.border;
@@ -1191,9 +1204,9 @@ fn render_banner_and_events(
                 SharedString::from(app.app_name.clone())
             };
             let icon_el: AnyElement = if let Some(logo) = &slot.app_logo {
-                gpui::img(logo.clone())
-                    .w(px(24.))
-                    .h(px(24.))
+                div()
+                    .image_cache(icon_cache.clone())
+                    .child(gpui::img(logo.clone()).w(px(24.)).h(px(24.)))
                     .into_any_element()
             } else {
                 gpui::svg()
@@ -1279,6 +1292,7 @@ fn render_sidebar_item(
     sidebar: WeakEntity<ChannelSidebar>,
     suppress_hover: bool,
     locale: &str,
+    icon_cache: Entity<crate::image_cache::LruImageCache>,
 ) -> AnyElement {
     let theme = cx.theme();
     let Some(item) = items.get(ix) else {
@@ -1296,6 +1310,7 @@ fn render_sidebar_item(
             cx,
             suppress_hover,
             locale,
+            icon_cache,
         ),
 
         SidebarItem::Category {

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
@@ -15,6 +15,8 @@ use crate::components::primitives::{ContextMenu, SubmenuOption, mention_count_ba
 use crate::router::{Route, Router};
 use crate::theme::ActiveTheme;
 
+pub(super) const CLAN_ROW_HEIGHT: f32 = 56.;
+
 const CLAN_NOTI_LEVELS: [(i32, &str); 3] = [
     (
         NOTIFICATION_ALL_MESSAGE,
@@ -261,7 +263,7 @@ pub(super) fn render_clan_row(
         .group(clan.group_name.clone())
         .relative()
         .w_full()
-        .h(px(56.))
+        .h(px(CLAN_ROW_HEIGHT))
         .flex()
         .items_center()
         .justify_center()

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/mod.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use gpui::{
     AnyElement, App, Context, Entity, ListState, Pixels, Point, SharedString, Subscription, Window,
-    div, img, list, prelude::*, px,
+    div, img, list, prelude::*, px, size,
 };
 use mezon_store::{
     AccountStore, ClanId, ClanList, DirectMessageStore, FriendStore, NotificationSettingStore,
@@ -18,7 +18,7 @@ use crate::theme::{ActiveTheme, Theme};
 
 mod clan_row;
 mod direct_unread_list;
-use clan_row::{ClanRow, build_clan_rail_menu, render_clan_row, render_pill};
+use clan_row::{CLAN_ROW_HEIGHT, ClanRow, build_clan_rail_menu, render_clan_row, render_pill};
 
 pub(super) struct ClanPanelMenu {
     position: Point<Pixels>,
@@ -248,6 +248,11 @@ impl ClanSidebar {
         self.rows = Rc::new(rows);
         if needs_reset {
             self.list_state.reset(item_count);
+            self.list_state.splice_with_size_hint(
+                0..item_count,
+                item_count,
+                size(px(0.), px(CLAN_ROW_HEIGHT)),
+            );
         }
         true
     }

--- a/crates/mezon-ui/src/util/imgproxy.rs
+++ b/crates/mezon-ui/src/util/imgproxy.rs
@@ -39,3 +39,9 @@ pub fn emoji_url(cx: &App, emoji_id: &str) -> String {
         .map(|cfg| cfg.emoji_src(emoji_id))
         .unwrap_or_default()
 }
+
+pub fn emoji_url_sized(cx: &App, emoji_id: &str, size: u32) -> String {
+    AppConfig::try_global(cx)
+        .map(|cfg| cfg.emoji_src_sized(emoji_id, size))
+        .unwrap_or_default()
+}

--- a/crates/mezon-ui/src/util/text_edit.rs
+++ b/crates/mezon-ui/src/util/text_edit.rs
@@ -1,4 +1,4 @@
 pub(crate) use mezon_widgets::text_edit::{
     EditKind, HistoryEntry, MAX_UNDO_HISTORY, home_target, line_end, line_start,
-    next_word_boundary, previous_word_boundary,
+    next_word_boundary, previous_word_boundary, should_coalesce,
 };

--- a/crates/mezon-updater/src/lib.rs
+++ b/crates/mezon-updater/src/lib.rs
@@ -923,5 +923,4 @@ mod tests {
         let body = "version: 1.5.0\nsha512: abc=\n";
         assert!(parse_manifest(body).is_err());
     }
-
 }

--- a/crates/mezon-widgets/src/input.rs
+++ b/crates/mezon-widgets/src/input.rs
@@ -17,7 +17,7 @@ use mezon_theme::ActiveTheme;
 
 use crate::text_edit::{
     EditKind, HistoryEntry, MAX_UNDO_HISTORY, home_target, line_end, line_start,
-    next_word_boundary, previous_word_boundary,
+    next_word_boundary, previous_word_boundary, should_coalesce,
 };
 
 const MASK: char = '\u{2022}';
@@ -609,8 +609,7 @@ impl InputState {
     }
 
     fn record_history(&mut self, kind: EditKind) {
-        let coalesce = matches!(kind, EditKind::Insert | EditKind::Delete)
-            && self.last_edit_kind == Some(kind);
+        let coalesce = should_coalesce(self.last_edit_kind, kind);
         self.redo_stack.clear();
         if !coalesce {
             self.undo_stack.push(self.history_snapshot());

--- a/crates/mezon-widgets/src/text_edit.rs
+++ b/crates/mezon-widgets/src/text_edit.rs
@@ -106,6 +106,10 @@ pub enum EditKind {
     Other,
 }
 
+pub fn should_coalesce(last: Option<EditKind>, kind: EditKind) -> bool {
+    matches!(kind, EditKind::Insert | EditKind::Delete) && last == Some(kind)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mmn-client/src/crypto.rs
+++ b/crates/mmn-client/src/crypto.rs
@@ -157,6 +157,21 @@ fn normalize_decimal(value: &str) -> (bool, String) {
     }
 }
 
+pub fn is_integer_amount(value: &str) -> bool {
+    let trimmed = value.trim();
+    let rest = trimmed
+        .strip_prefix('-')
+        .or_else(|| trimmed.strip_prefix('+'))
+        .unwrap_or(trimmed);
+    !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit())
+}
+
 pub fn validate_amount(balance: &str, amount_scaled: &str) -> bool {
+    if !is_integer_amount(balance) || !is_integer_amount(amount_scaled) {
+        return false;
+    }
+    if amount_scaled.trim_start().starts_with('-') {
+        return false;
+    }
     compare_big_decimal(amount_scaled, balance) != Ordering::Greater
 }

--- a/crates/mmn-client/src/http.rs
+++ b/crates/mmn-client/src/http.rs
@@ -10,6 +10,23 @@ use crate::error::{MmnError, Result};
 
 pub(crate) type Headers = BTreeMap<String, String>;
 
+const MAX_RESPONSE_BYTES: u64 = 8 * 1024 * 1024;
+
+pub fn is_secure_endpoint(url: &str) -> bool {
+    if url.starts_with("https://") {
+        return true;
+    }
+    #[cfg(debug_assertions)]
+    if let Some(rest) = url.strip_prefix("http://") {
+        return ["localhost", "127.0.0.1", "[::1]"].iter().any(|host| {
+            rest.strip_prefix(host).is_some_and(|tail| {
+                tail.is_empty() || tail.starts_with(':') || tail.starts_with('/')
+            })
+        });
+    }
+    false
+}
+
 pub(crate) async fn execute(
     http: Arc<dyn HttpClient>,
     method: http::Method,
@@ -41,9 +58,15 @@ pub(crate) async fn execute(
             let mut buffer = Vec::new();
             response
                 .into_body()
+                .take(MAX_RESPONSE_BYTES + 1)
                 .read_to_end(&mut buffer)
                 .await
                 .map_err(|e| MmnError::Http(e.to_string()))?;
+            if buffer.len() as u64 > MAX_RESPONSE_BYTES {
+                return Err(MmnError::Http(format!(
+                    "response exceeds {MAX_RESPONSE_BYTES} bytes"
+                )));
+            }
 
             if !status.is_success() {
                 let message = String::from_utf8_lossy(&buffer).trim().to_string();

--- a/crates/mmn-client/src/lib.rs
+++ b/crates/mmn-client/src/lib.rs
@@ -9,11 +9,12 @@ mod mmn_client;
 mod zk_client;
 
 pub use crypto::{
-    address_from_user_id, compare_big_decimal, generate_ephemeral_key_pair,
+    address_from_user_id, compare_big_decimal, generate_ephemeral_key_pair, is_integer_amount,
     scale_amount_to_decimals, validate_address, validate_amount,
 };
 pub use dong_client::DongClient;
 pub use error::{MmnError, Result};
+pub use http::is_secure_endpoint;
 pub use indexer_client::{FILTER_ALL, FILTER_RECEIVED, FILTER_SENT, IndexerClient};
 pub use mmn_client::MmnClient;
 pub use types::*;
@@ -201,5 +202,66 @@ mod tests {
         assert_eq!(super::types::TRANSFER_TYPE_TRANSFER_TOKEN, "transfer_token");
         assert_eq!(super::types::TRANSFER_TYPE_UNLOCK_ITEM, "unlock_item");
         assert_eq!(super::types::DECIMALS, 6);
+        assert_eq!(super::types::DECIMAL_FACTOR, 1_000_000);
+    }
+
+    #[test]
+    fn validate_amount_rejects_non_integer_input() {
+        assert!(!crypto::validate_amount("1", "0.5"));
+        assert!(!crypto::validate_amount("1.5", "1"));
+        assert!(!crypto::validate_amount("1000000", "1e6"));
+        assert!(!crypto::validate_amount("1000000", ""));
+        assert!(!crypto::validate_amount("", "1000000"));
+    }
+
+    #[test]
+    fn validate_amount_rejects_negative_amount() {
+        assert!(!crypto::validate_amount("1000000", "-1000000"));
+        assert!(crypto::validate_amount("1000000", "+1000000"));
+    }
+
+    #[test]
+    fn is_secure_endpoint_requires_https_outside_localhost() {
+        assert!(super::is_secure_endpoint("https://mmn.example.com"));
+        assert!(!super::is_secure_endpoint("http://mmn.example.com"));
+        assert!(!super::is_secure_endpoint("http://localhost.evil.com"));
+        assert!(!super::is_secure_endpoint("ftp://mmn.example.com"));
+        assert!(!super::is_secure_endpoint(""));
+        assert_eq!(
+            super::is_secure_endpoint("http://localhost:3000/prove"),
+            cfg!(debug_assertions)
+        );
+    }
+
+    #[test]
+    fn ephemeral_key_pair_debug_redacts_private_key() {
+        let pair = crypto::generate_ephemeral_key_pair().unwrap();
+        let rendered = format!("{pair:?}");
+        assert!(!rendered.contains(pair.private_key.as_str()));
+        assert!(rendered.contains("<redacted>"));
+        assert!(rendered.contains(pair.public_key.as_str()));
+    }
+
+    #[test]
+    fn secret_request_debug_redacts_credentials() {
+        let request = super::types::SendTransactionRequest {
+            private_key: "SECRET_KEY".into(),
+            sender: "SENDER".into(),
+            ..Default::default()
+        };
+        let rendered = format!("{request:?}");
+        assert!(!rendered.contains("SECRET_KEY"));
+        assert!(rendered.contains("SENDER"));
+
+        let zk = super::types::GetZkProofRequest {
+            user_id: "1".into(),
+            ephemeral_public_key: "pk".into(),
+            jwt: "SECRET_JWT".into(),
+            address: "addr".into(),
+            client_type: super::types::ZkClientType::Mezon,
+        };
+        let rendered = format!("{zk:?}");
+        assert!(!rendered.contains("SECRET_JWT"));
+        assert!(rendered.contains("addr"));
     }
 }

--- a/crates/mmn-client/src/types.rs
+++ b/crates/mmn-client/src/types.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize as _;
 
 pub const TRANSFER_TYPE_GIVE_COFFEE: &str = "give_coffee";
 pub const TRANSFER_TYPE_TRANSFER_TOKEN: &str = "transfer_token";
@@ -11,11 +13,29 @@ pub const TX_TYPE_TRANSFER_BY_KEY: u8 = 1;
 pub const TX_TYPE_USER_CONTENT: u8 = 2;
 
 pub const DECIMALS: u32 = 6;
+pub const DECIMAL_FACTOR: i128 = 10i128.pow(DECIMALS);
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+const REDACTED: &str = "<redacted>";
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EphemeralKeyPair {
     pub private_key: String,
     pub public_key: String,
+}
+
+impl fmt::Debug for EphemeralKeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EphemeralKeyPair")
+            .field("private_key", &REDACTED)
+            .field("public_key", &self.public_key)
+            .finish()
+    }
+}
+
+impl Drop for EphemeralKeyPair {
+    fn drop(&mut self) {
+        self.private_key.zeroize();
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -84,7 +104,7 @@ pub struct SignedTx {
     pub signature: String,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct SendTransactionBase {
     pub sender: String,
     pub recipient: String,
@@ -96,7 +116,22 @@ pub struct SendTransactionBase {
     pub extra_info: Option<ExtraInfo>,
 }
 
-#[derive(Debug, Clone, Default)]
+impl fmt::Debug for SendTransactionBase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SendTransactionBase")
+            .field("sender", &self.sender)
+            .field("recipient", &self.recipient)
+            .field("amount", &self.amount)
+            .field("nonce", &self.nonce)
+            .field("timestamp", &self.timestamp)
+            .field("text_data", &self.text_data)
+            .field("private_key", &REDACTED)
+            .field("extra_info", &self.extra_info)
+            .finish()
+    }
+}
+
+#[derive(Clone, Default)]
 pub struct SendTransactionRequest {
     pub sender: String,
     pub recipient: String,
@@ -109,6 +144,24 @@ pub struct SendTransactionRequest {
     pub zk_proof: String,
     pub zk_pub: String,
     pub public_key: String,
+}
+
+impl fmt::Debug for SendTransactionRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SendTransactionRequest")
+            .field("sender", &self.sender)
+            .field("recipient", &self.recipient)
+            .field("amount", &self.amount)
+            .field("nonce", &self.nonce)
+            .field("timestamp", &self.timestamp)
+            .field("text_data", &self.text_data)
+            .field("private_key", &REDACTED)
+            .field("extra_info", &self.extra_info)
+            .field("zk_proof", &self.zk_proof)
+            .field("zk_pub", &self.zk_pub)
+            .field("public_key", &self.public_key)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -269,13 +322,25 @@ impl ZkClientType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct GetZkProofRequest {
     pub user_id: String,
     pub ephemeral_public_key: String,
     pub jwt: String,
     pub address: String,
     pub client_type: ZkClientType,
+}
+
+impl fmt::Debug for GetZkProofRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GetZkProofRequest")
+            .field("user_id", &self.user_id)
+            .field("ephemeral_public_key", &self.ephemeral_public_key)
+            .field("jwt", &REDACTED)
+            .field("address", &self.address)
+            .field("client_type", &self.client_type)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/vendor/gpui/src/elements/list.rs
+++ b/crates/vendor/gpui/src/elements/list.rs
@@ -843,6 +843,10 @@ impl ListState {
         new_items.append(old_items.suffix(), ());
         drop(old_items);
         state.items = new_items;
+        // Upstream re-arms full measurement in `reset` but not here, so a
+        // `measure_all` list keeps spliced-in items unmeasured and reports a wrong
+        // content height. No-op for `Visible`; re-apply on snapshot bump.
+        state.measuring_behavior.reset();
 
         if let Some(ListOffset {
             item_ix,


### PR DESCRIPTION
## Summary
- Validate MMN/ZK/indexer/dong endpoints require HTTPS before enabling wallet clients
- Reset wallet state when switching users; harden enable path on top of #149 persist flow
- Improve send-token modal amount input formatting and validation UX
- Run Windows taskbar badge updates on a dedicated worker thread (COM-safe)
- Channel/clan store, image cache, imgproxy, transport, and mmn-client follow-ups

## Test plan
- [ ] Fresh login + wallet enable/send token/give coffee
- [ ] Switch account clears prior wallet state
- [ ] Send-token modal accepts formatted amounts
- [ ] Windows tray badge updates without blocking UI thread
- [ ] `cargo check -p mezon-app` green
