### PR TITLE
fix(store): add keyring dep for release wallet persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5929,6 +5929,7 @@ dependencies = [
  "flume",
  "gpui",
  "image",
+ "keyring",
  "mezon-audio",
  "mezon-client",
  "mezon-i18n",

--- a/crates/mezon-store/Cargo.toml
+++ b/crates/mezon-store/Cargo.toml
@@ -25,6 +25,7 @@ serde_json.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 dirs.workspace = true
+keyring.workspace = true
 flume.workspace = true
 url.workspace = true
 tokio.workspace = true

--- a/crates/mezon-store/src/wallet_persist.rs
+++ b/crates/mezon-store/src/wallet_persist.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use mmn_client::{EphemeralKeyPair, ZkProof};
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +27,8 @@ fn parse_wallet(json: &str) -> Option<PersistedWalletState> {
 #[cfg(debug_assertions)]
 mod dev_file {
     use std::path::PathBuf;
+
+    use anyhow::Context;
 
     use super::*;
 


### PR DESCRIPTION
## Summary
- Add `keyring` workspace dependency to `mezon-store` so release builds compile `wallet_persist` keychain storage
- Scope `anyhow::Context` import to the debug-only dev file module to avoid release unused-import warnings

## Context
Linux CI release build failed after #154 merge:
```
error[E0432]: unresolved import `keyring`
  --> crates/mezon-store/src/wallet_persist.rs:72:9
```

## Test plan
- [x] `cargo check -p mezon-app --release` locally
- [ ] CI + Build workflows green on PR