### PR TITLE
fix: channel extras, tray close, and message display parity

### DIFF
--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -344,9 +344,7 @@ fn run_app(lock: SingleInstance, initial_url: Option<String>) {
                         .await;
                     foreground
                         .spawn(async move {
-                            if mezon_webview::active_webview_count() > 0 {
-                                mezon_webview::pump_gtk_events();
-                            }
+                            mezon_webview::pump_gtk_events();
                         })
                         .detach();
                 }
@@ -449,10 +447,6 @@ fn run_app(lock: SingleInstance, initial_url: Option<String>) {
 
         cx.set_global(SingleInstanceGlobal(lock));
 
-        // Initialize the app-global OGP preview image cache so message-row
-        // rendering (which only has `&App`) can read it.
-        mezon_ui::image_cache::shared_ogp_cache(cx);
-
         // If we were launched with a deep link, inject it immediately.
         if let Some(url) = initial_url {
             let _ = url_tx.unbounded_send(url);
@@ -491,10 +485,16 @@ fn run_app(lock: SingleInstance, initial_url: Option<String>) {
             let auth_state = auth_state_handle.clone();
             cx.spawn(async move |cx: &mut AsyncApp| {
                 while let Some(url) = url_rx.next().await {
+                    if url == mezon_native::instance::ACTIVATE_MESSAGE {
+                        tracing::debug!("Relaunched while running — showing main window");
+                        cx.update(activate_main_window);
+                        continue;
+                    }
                     tracing::info!(
                         "Received deep link: {}",
                         url.split(['?', '#']).next().unwrap_or_default()
                     );
+                    cx.update(activate_main_window);
                     if url.starts_with("mezonapp://callback") {
                         let flow_pending = cx.update(|cx| {
                             matches!(
@@ -589,7 +589,9 @@ fn run_app(lock: SingleInstance, initial_url: Option<String>) {
             })
         };
 
-        if let Some((tray, tray_tasks)) = setup_tray(cx) {
+        let tray = setup_tray(cx);
+        mezon_ui::app::window_controls::set_runs_in_background(cx, tray.is_some());
+        if let Some((tray, tray_tasks)) = tray {
             cx.set_global(TrayGlobal(tray));
             cx.set_global(TrayTasksGlobal {
                 _deep_link: deep_link_task,
@@ -842,8 +844,7 @@ fn open_main_window(
             std::process::exit(1);
         });
 
-    #[cfg(target_os = "macos")]
-    mezon_ui::app::window_controls::macos::configure_window(cx, window_handle);
+    mezon_ui::app::window_controls::configure_window(cx, window_handle);
 
     (auth_state, window_handle.into())
 }

--- a/crates/mezon-native/src/instance.rs
+++ b/crates/mezon-native/src/instance.rs
@@ -20,6 +20,8 @@ pub struct SingleInstance {
     url_rx: std::sync::Mutex<Option<std::sync::mpsc::Receiver<String>>>,
 }
 
+pub const ACTIVATE_MESSAGE: &str = "mezon-activate";
+
 impl SingleInstance {
     /// Try to acquire the single-instance lock.
     ///
@@ -27,10 +29,10 @@ impl SingleInstance {
     /// Returns `Ok(None)` — another instance is already running.
     pub fn try_acquire() -> anyhow::Result<Option<Self>> {
         #[cfg(unix)]
-        return Self::try_acquire_unix(None);
+        return Self::try_acquire_unix(Some(ACTIVATE_MESSAGE));
 
         #[cfg(windows)]
-        return Self::try_acquire_windows(None);
+        return Self::try_acquire_windows(Some(ACTIVATE_MESSAGE));
 
         #[cfg(not(any(unix, windows)))]
         Ok(Some(Self {}))

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -207,9 +207,15 @@ struct TopicParentBadge {
 }
 
 struct ClanExtras {
-    voice_map: HashMap<ChannelId, Vec<UserId>>,
-    favorite_ids: HashSet<ChannelId>,
-    app_channels: Vec<AppChannel>,
+    voice_map: Option<HashMap<ChannelId, Vec<UserId>>>,
+    favorite_ids: Option<HashSet<ChannelId>>,
+    app_channels: Option<Vec<AppChannel>>,
+}
+
+impl ClanExtras {
+    fn is_complete(&self) -> bool {
+        self.voice_map.is_some() && self.favorite_ids.is_some() && self.app_channels.is_some()
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -224,6 +230,7 @@ struct ChannelUnreadSeed {
 pub struct ChannelList {
     cache: KeyedCache<ClanId, Vec<Category>>,
     app_channels_cache: HashMap<ClanId, Vec<AppChannel>>,
+    favorites: HashMap<ClanId, HashSet<ChannelId>>,
     topic_parent_badges: HashMap<ChannelId, TopicParentBadge>,
     pending_channel_badges: HashMap<ChannelId, u32>,
     pending_badge_seed: HashMap<ClanId, HashMap<ChannelId, ChannelUnreadSeed>>,
@@ -375,6 +382,7 @@ impl ChannelList {
         self.reset_generation = self.reset_generation.wrapping_add(1);
         self.cache.clear();
         self.app_channels_cache.clear();
+        self.favorites.clear();
         self.topic_parent_badges.clear();
         self.pending_channel_badges.clear();
         self.pending_badge_seed.clear();
@@ -450,6 +458,7 @@ impl ChannelList {
         Self {
             cache: KeyedCache::new(None),
             app_channels_cache: HashMap::new(),
+            favorites: HashMap::new(),
             topic_parent_badges: HashMap::new(),
             pending_channel_badges: HashMap::new(),
             pending_badge_seed: HashMap::new(),
@@ -689,17 +698,47 @@ impl ChannelList {
                 if this.reset_generation != generation {
                     return;
                 }
-                this.extras_loaded.insert(clan_id);
-                this.apply_clan_extras(clan_id, extras, cx);
+                this.finish_extras(clan_id, extras, cx);
             });
         })
         .detach();
+    }
+
+    fn finish_extras(&mut self, clan_id: ClanId, extras: ClanExtras, cx: &mut Context<Self>) {
+        let complete = extras.is_complete();
+        let applied = self.apply_clan_extras(clan_id, extras, cx);
+        if applied && complete {
+            self.extras_loaded.insert(clan_id);
+        }
     }
 
     pub fn refresh_clan(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
         self.want_extras.insert(clan_id);
         self.extras_loaded.remove(&clan_id);
         self.fetch_clan(clan_id, cx);
+    }
+
+    fn apply_clan_structure(
+        &mut self,
+        clan_id: ClanId,
+        mut categories: Vec<Category>,
+        cx: &mut Context<Self>,
+    ) {
+        self.consume_badge_seed(clan_id, &mut categories);
+        self.merge_pending_badges(&mut categories);
+        let previous_voice = collect_voice_members(&self.cache, clan_id);
+        merge_previous_voice_members(&mut categories, &previous_voice);
+        let categories = rebuild_favorites(categories, clan_id, self.favorites.get(&clan_id));
+        if seed_in_voice_from_categories(&mut self.in_voice, clan_id, &categories) {
+            cx.emit(ChannelEvent::InVoiceChanged);
+        }
+        self.cache.insert(clan_id, categories, None);
+        self.invalidate_channel_index(clan_id);
+        cx.emit(ChannelEvent::ClanChannelsLoaded(clan_id));
+        cx.notify();
+        if self.want_extras.contains(&clan_id) {
+            self.ensure_extras(clan_id, cx);
+        }
     }
 
     fn fetch_clan(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
@@ -712,26 +751,13 @@ impl ChannelList {
         cx.spawn(async move |this, cx| {
             let result = Self::fetch_clan_structure(&api, clan_id).await;
             match result {
-                Ok(mut categories) => {
+                Ok(categories) => {
                     let _ = this.update(cx, |this, cx| {
                         this.loading.remove(&clan_id);
                         if this.reset_generation != generation {
                             return;
                         }
-                        this.consume_badge_seed(clan_id, &mut categories);
-                        this.merge_pending_badges(&mut categories);
-                        let previous_voice = collect_voice_members(&this.cache, clan_id);
-                        merge_previous_voice_members(&mut categories, &previous_voice);
-                        if seed_in_voice_from_categories(&mut this.in_voice, clan_id, &categories) {
-                            cx.emit(ChannelEvent::InVoiceChanged);
-                        }
-                        this.cache.insert(clan_id, categories, None);
-                        this.invalidate_channel_index(clan_id);
-                        cx.emit(ChannelEvent::ClanChannelsLoaded(clan_id));
-                        cx.notify();
-                        if this.want_extras.contains(&clan_id) {
-                            this.ensure_extras(clan_id, cx);
-                        }
+                        this.apply_clan_structure(clan_id, categories, cx);
                     });
                 }
                 Err(e) => {
@@ -821,8 +847,7 @@ impl ChannelList {
             })
             .collect();
 
-        let categories = build_categories(api_categories, &mut channels);
-        Ok(assemble_with_favorites(categories, clan_id))
+        Ok(build_categories(api_categories, &mut channels))
     }
 
     async fn fetch_clan_extras(api: &AppApi, clan_id: ClanId) -> ClanExtras {
@@ -832,36 +857,33 @@ impl ChannelList {
             api.list_channel_apps(clan_id.get()),
         );
 
-        let voice_users = voice_res.unwrap_or_else(|e| {
-            tracing::warn!("list_voice_channel_users failed: {e}");
-            Vec::new()
-        });
-        let favorite_ids: HashSet<ChannelId> = favorites_res
-            .unwrap_or_else(|e| {
-                tracing::warn!("list_favorite_channels failed: {e}");
-                Vec::new()
-            })
-            .into_iter()
-            .filter_map(|s| s.parse::<ChannelId>().ok())
-            .collect();
-        let app_channels: Vec<AppChannel> = apps_res
-            .unwrap_or_else(|e| {
-                tracing::warn!("list_channel_apps failed: {e}");
-                Vec::new()
-            })
-            .into_iter()
-            .map(AppChannel::from)
-            .collect();
+        let voice_users = voice_res
+            .inspect_err(|e| tracing::warn!("list_voice_channel_users failed: {e}"))
+            .ok();
+        let favorite_ids: Option<HashSet<ChannelId>> = favorites_res
+            .inspect_err(|e| tracing::warn!("list_favorite_channels failed: {e}"))
+            .ok()
+            .map(|ids| {
+                ids.into_iter()
+                    .filter_map(|s| s.parse::<ChannelId>().ok())
+                    .collect()
+            });
+        let app_channels: Option<Vec<AppChannel>> = apps_res
+            .inspect_err(|e| tracing::warn!("list_channel_apps failed: {e}"))
+            .ok()
+            .map(|apps| apps.into_iter().map(AppChannel::from).collect());
 
-        let voice_map: HashMap<ChannelId, Vec<UserId>> = voice_users
-            .into_iter()
-            .map(|v| {
-                (
-                    ChannelId(v.channel_id),
-                    v.user_ids.into_iter().map(UserId).collect(),
-                )
-            })
-            .collect();
+        let voice_map: Option<HashMap<ChannelId, Vec<UserId>>> = voice_users.map(|users| {
+            users
+                .into_iter()
+                .map(|v| {
+                    (
+                        ChannelId(v.channel_id),
+                        v.user_ids.into_iter().map(UserId).collect(),
+                    )
+                })
+                .collect()
+        });
 
         ClanExtras {
             voice_map,
@@ -870,49 +892,59 @@ impl ChannelList {
         }
     }
 
-    fn apply_clan_extras(&mut self, clan_id: ClanId, extras: ClanExtras, cx: &mut Context<Self>) {
-        let app_channels_changed =
-            self.app_channels_cache.get(&clan_id) != Some(&extras.app_channels);
-        self.app_channels_cache.insert(clan_id, extras.app_channels);
+    fn apply_clan_extras(
+        &mut self,
+        clan_id: ClanId,
+        extras: ClanExtras,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let mut app_channels_changed = false;
+        if let Some(app_channels) = extras.app_channels {
+            app_channels_changed = self.app_channels_cache.get(&clan_id) != Some(&app_channels);
+            self.app_channels_cache.insert(clan_id, app_channels);
+        }
+
+        let mut favorites_changed = false;
+        let favorites_len = extras.favorite_ids.as_ref().map(HashSet::len);
+        if let Some(favorite_ids) = extras.favorite_ids {
+            favorites_changed = self.favorites.get(&clan_id) != Some(&favorite_ids);
+            self.favorites.insert(clan_id, favorite_ids);
+        }
 
         let Some(slot) = self.cache.get_mut(&clan_id) else {
             cx.notify();
-            return;
+            return false;
         };
 
         let mut owned = std::mem::take(slot);
         owned.retain(|category| category.id != FAVOR_CATE_ID);
 
-        let mut changed = app_channels_changed;
-        for ch in owned
-            .iter_mut()
-            .flat_map(|category| category.channels.iter_mut())
-        {
-            let is_favorite = extras.favorite_ids.contains(&ch.id);
-            if ch.is_favorite != is_favorite {
-                ch.is_favorite = is_favorite;
-                changed = true;
-            }
-            let members: Vec<VoiceMember> = extras
-                .voice_map
-                .get(&ch.id)
-                .map(|ids| {
-                    ids.iter()
-                        .map(|uid| VoiceMember {
-                            display_name: uid.to_string(),
-                            avatar_url: String::new(),
-                            user_id: *uid,
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
-            if ch.voice_members != members {
-                ch.voice_members = members;
-                changed = true;
+        let mut changed = app_channels_changed || favorites_changed;
+        if let Some(voice_map) = extras.voice_map.as_ref() {
+            for ch in owned
+                .iter_mut()
+                .flat_map(|category| category.channels.iter_mut())
+            {
+                let members: Vec<VoiceMember> = voice_map
+                    .get(&ch.id)
+                    .map(|ids| {
+                        ids.iter()
+                            .map(|uid| VoiceMember {
+                                display_name: uid.to_string(),
+                                avatar_url: String::new(),
+                                user_id: *uid,
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                if ch.voice_members != members {
+                    ch.voice_members = members;
+                    changed = true;
+                }
             }
         }
 
-        let rebuilt = assemble_with_favorites(owned, clan_id);
+        let rebuilt = rebuild_favorites(owned, clan_id, self.favorites.get(&clan_id));
         let in_voice_changed = seed_in_voice_from_categories(&mut self.in_voice, clan_id, &rebuilt);
         if let Some(slot) = self.cache.get_mut(&clan_id) {
             *slot = rebuilt;
@@ -925,14 +957,15 @@ impl ChannelList {
         tracing::debug!(
             target: "clan_load",
             clan_id = clan_id.get(),
-            favorites = extras.favorite_ids.len(),
-            voice_channels = extras.voice_map.len(),
+            favorites = favorites_len,
+            voice_channels = extras.voice_map.as_ref().map(HashMap::len),
             changed,
             "extras patched into cached clan structure"
         );
         if changed || in_voice_changed {
             cx.notify();
         }
+        true
     }
 
     fn notify_channel_list(&self, clan_id: ClanId, cx: &mut Context<Self>) {
@@ -2046,6 +2079,76 @@ impl ChannelList {
         clan_id: ClanId,
         cx: &mut Context<Self>,
     ) {
+        self.apply_favorite_locally(channel_id, clan_id, true, cx);
+
+        let api = self.api.clone();
+        let generation = self.reset_generation;
+        cx.spawn(async move |this, cx| {
+            if let Err(e) = api
+                .add_channel_favorite(channel_id.get(), clan_id.get())
+                .await
+            {
+                tracing::error!("add_channel_favorite failed: {e}");
+                let _ = this.update(cx, |this, cx| {
+                    if this.reset_generation == generation {
+                        this.apply_favorite_locally(channel_id, clan_id, false, cx);
+                    }
+                });
+            }
+        })
+        .detach();
+    }
+
+    pub fn remove_channel_favorite(
+        &mut self,
+        channel_id: ChannelId,
+        clan_id: ClanId,
+        cx: &mut Context<Self>,
+    ) {
+        self.apply_favorite_locally(channel_id, clan_id, false, cx);
+
+        let api = self.api.clone();
+        let generation = self.reset_generation;
+        cx.spawn(async move |this, cx| {
+            if let Err(e) = api
+                .remove_channel_favorite(channel_id.get(), clan_id.get())
+                .await
+            {
+                tracing::error!("remove_channel_favorite failed: {e}");
+                let _ = this.update(cx, |this, cx| {
+                    if this.reset_generation == generation {
+                        this.apply_favorite_locally(channel_id, clan_id, true, cx);
+                    }
+                });
+            }
+        })
+        .detach();
+    }
+
+    fn apply_favorite_locally(
+        &mut self,
+        channel_id: ChannelId,
+        clan_id: ClanId,
+        favorite: bool,
+        cx: &mut Context<Self>,
+    ) {
+        if favorite {
+            self.add_favorite_locally(channel_id, clan_id, cx);
+        } else {
+            self.remove_favorite_locally(channel_id, clan_id, cx);
+        }
+    }
+
+    fn add_favorite_locally(
+        &mut self,
+        channel_id: ChannelId,
+        clan_id: ClanId,
+        cx: &mut Context<Self>,
+    ) {
+        self.favorites
+            .entry(clan_id)
+            .or_default()
+            .insert(channel_id);
         let mut changed = false;
         if let Some(cats) = self.cache.get_mut(&clan_id) {
             let channel = cats
@@ -2083,24 +2186,17 @@ impl ChannelList {
             self.invalidate_channel_index(clan_id);
             cx.notify();
         }
-
-        let api = self.api.clone();
-        let cid = channel_id;
-        let clid = clan_id;
-        cx.spawn(async move |_, _| {
-            if let Err(e) = api.add_channel_favorite(cid.get(), clid.get()).await {
-                tracing::error!("add_channel_favorite failed: {e}");
-            }
-        })
-        .detach();
     }
 
-    pub fn remove_channel_favorite(
+    fn remove_favorite_locally(
         &mut self,
         channel_id: ChannelId,
         clan_id: ClanId,
         cx: &mut Context<Self>,
     ) {
+        if let Some(ids) = self.favorites.get_mut(&clan_id) {
+            ids.remove(&channel_id);
+        }
         let mut changed = false;
         if let Some(cats) = self.cache.get_mut(&clan_id) {
             for cat in cats.iter_mut() {
@@ -2119,16 +2215,6 @@ impl ChannelList {
             self.invalidate_channel_index(clan_id);
             cx.notify();
         }
-
-        let api = self.api.clone();
-        let cid = channel_id;
-        let clid = clan_id;
-        cx.spawn(async move |_, _| {
-            if let Err(e) = api.remove_channel_favorite(cid.get(), clid.get()).await {
-                tracing::error!("remove_channel_favorite failed: {e}");
-            }
-        })
-        .detach();
     }
 }
 
@@ -2520,6 +2606,21 @@ fn merge_previous_voice_members(
             }
         }
     }
+}
+
+fn rebuild_favorites(
+    mut categories: Vec<Category>,
+    clan_id: ClanId,
+    favorite_ids: Option<&HashSet<ChannelId>>,
+) -> Vec<Category> {
+    categories.retain(|category| category.id != FAVOR_CATE_ID);
+    for ch in categories
+        .iter_mut()
+        .flat_map(|category| category.channels.iter_mut())
+    {
+        ch.is_favorite = favorite_ids.is_some_and(|ids| ids.contains(&ch.id));
+    }
+    assemble_with_favorites(categories, clan_id)
 }
 
 fn seed_in_voice_from_categories(
@@ -3414,6 +3515,7 @@ mod tests {
             badge_count: 0,
             creator_id: 0,
             clan_name: String::new(),
+            channel_avatar: String::new(),
         };
         let channel = channel_from_desc(desc, 0, vec![UserId(42)], false);
         let vm = &channel.voice_members[0];
@@ -3468,6 +3570,413 @@ mod tests {
         assert_eq!(result[0].id, FAVOR_CATE_ID);
         assert!(result[0].channels.is_empty());
         assert_eq!(result[1].id, "1");
+    }
+
+    fn structure_with_two_channels() -> Vec<Category> {
+        let api_cats = vec![ApiCategoryDesc {
+            category_id: 1,
+            category_name: "General".into(),
+            clan_id: 1,
+            category_order: 0,
+        }];
+        let mut channels = vec![
+            {
+                let mut ch = make_channel(1, "normal", "1");
+                ch.clan_id = ClanId(1);
+                ch
+            },
+            {
+                let mut ch = make_channel(2, "fav-ch", "1");
+                ch.clan_id = ClanId(1);
+                ch
+            },
+        ];
+        build_categories(api_cats, &mut channels)
+    }
+
+    fn favorite_extras(ids: &[ChannelId]) -> ClanExtras {
+        ClanExtras {
+            voice_map: Some(HashMap::new()),
+            favorite_ids: Some(ids.iter().copied().collect()),
+            app_channels: Some(Vec::new()),
+        }
+    }
+
+    const VOICE_CHANNEL: ChannelId = ChannelId(2);
+    const VOICE_USER: UserId = UserId(7);
+
+    fn voice_extras(voice_map: HashMap<ChannelId, Vec<UserId>>) -> ClanExtras {
+        ClanExtras {
+            voice_map: Some(voice_map),
+            favorite_ids: Some([VOICE_CHANNEL].into_iter().collect()),
+            app_channels: Some(Vec::new()),
+        }
+    }
+
+    fn one_user_in_voice() -> HashMap<ChannelId, Vec<UserId>> {
+        [(VOICE_CHANNEL, vec![VOICE_USER])].into_iter().collect()
+    }
+
+    fn voice_members_of(channels: &ChannelList, category_ix: usize) -> Vec<UserId> {
+        channels.categories_for_clan(ClanId(1))[category_ix]
+            .channels
+            .iter()
+            .find(|ch| ch.id == VOICE_CHANNEL)
+            .map(|ch| ch.voice_members.iter().map(|m| m.user_id).collect())
+            .unwrap_or_default()
+    }
+
+    fn assert_voice_member_on_both_copies(channels: &ChannelList, context: &str) {
+        assert_eq!(
+            voice_members_of(channels, 0),
+            vec![VOICE_USER],
+            "{context}: favorite copy lost its voice member"
+        );
+        assert_eq!(
+            voice_members_of(channels, 1),
+            vec![VOICE_USER],
+            "{context}: source channel lost its voice member"
+        );
+        assert_eq!(
+            channels.in_voice_status(VOICE_USER).map(|i| i.channel_id),
+            Some(VOICE_CHANNEL),
+            "{context}: in_voice index lost the user"
+        );
+    }
+
+    #[gpui::test]
+    fn extras_patch_voice_members_onto_the_favorite_copy_too(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_extras(ClanId(1), voice_extras(one_user_in_voice()), cx);
+
+                assert_voice_member_on_both_copies(channels, "extras apply");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn failed_voice_fetch_keeps_the_members_it_already_knows(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_extras(ClanId(1), voice_extras(one_user_in_voice()), cx);
+
+                channels.apply_clan_extras(
+                    ClanId(1),
+                    ClanExtras {
+                        voice_map: None,
+                        favorite_ids: None,
+                        app_channels: None,
+                    },
+                    cx,
+                );
+
+                assert_voice_member_on_both_copies(channels, "failed voice fetch");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn an_empty_voice_response_clears_the_members(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_extras(ClanId(1), voice_extras(one_user_in_voice()), cx);
+
+                channels.apply_clan_extras(ClanId(1), voice_extras(HashMap::new()), cx);
+
+                assert!(voice_members_of(channels, 0).is_empty());
+                assert!(voice_members_of(channels, 1).is_empty());
+                assert!(channels.in_voice_status(VOICE_USER).is_none());
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn realtime_voice_join_survives_a_structure_refetch(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_extras(ClanId(1), voice_extras(HashMap::new()), cx);
+
+                channels.handle_event(
+                    &RealtimeEvent::VoiceJoined(mezon_proto::realtime::VoiceJoinedEvent {
+                        clan_id: 1,
+                        user_id: VOICE_USER.get(),
+                        voice_channel_id: VOICE_CHANNEL.get(),
+                        participant: "someone".into(),
+                        ..Default::default()
+                    }),
+                    cx,
+                );
+                assert_voice_member_on_both_copies(channels, "realtime join");
+
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                assert_voice_member_on_both_copies(channels, "structure refetch");
+            });
+        });
+    }
+
+    #[test]
+    fn rebuild_favorites_derives_the_favor_cate_from_the_id_set() {
+        let ids: HashSet<ChannelId> = [ChannelId(2)].into_iter().collect();
+        let result = rebuild_favorites(structure_with_two_channels(), ClanId(1), Some(&ids));
+
+        assert_eq!(result[0].id, FAVOR_CATE_ID);
+        assert_eq!(result[0].channels.len(), 1);
+        assert_eq!(result[0].channels[0].id, ChannelId(2));
+        let source = result[1].channels.iter().find(|ch| ch.id == ChannelId(2));
+        assert!(source.is_some_and(|ch| ch.is_favorite));
+    }
+
+    #[test]
+    fn rebuild_favorites_keeps_a_single_favor_cate_when_run_twice() {
+        let once = rebuild_favorites(structure_with_two_channels(), ClanId(1), None);
+        let twice = rebuild_favorites(once, ClanId(1), None);
+
+        assert_eq!(
+            twice.iter().filter(|c| c.id == FAVOR_CATE_ID).count(),
+            1,
+            "assembling twice must not stack favor categories"
+        );
+        assert!(twice[0].channels.is_empty());
+    }
+
+    fn init_channel_list(cx: &mut App) -> Entity<ChannelList> {
+        let api = Arc::new(mezon_client::AppApi::new(
+            Arc::new(mezon_client::TransportClient::new(String::new())),
+            String::new(),
+        ));
+        RealtimeDispatch::init(api.clone(), cx);
+        let auth_state = cx.new(|_| crate::AuthState::NotAuthenticated);
+        crate::badge::BadgeService::init(auth_state, cx);
+        crate::clan::ClanList::init(api.clone(), cx);
+        cx.new(|cx| ChannelList::new(api, cx))
+    }
+
+    #[gpui::test]
+    fn refetching_a_clan_structure_keeps_favorites_without_refetching_them(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_extras(ClanId(1), favorite_extras(&[ChannelId(2)]), cx);
+                channels.extras_loaded.insert(ClanId(1));
+                assert_eq!(channels.categories_for_clan(ClanId(1))[0].channels.len(), 1);
+
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+
+                let favor = &channels.categories_for_clan(ClanId(1))[0];
+                assert_eq!(favor.id, FAVOR_CATE_ID);
+                assert_eq!(
+                    favor.channels.len(),
+                    1,
+                    "a TTL-expiry refetch must not empty the favorites category"
+                );
+                assert!(
+                    channels.extras_loaded.contains(&ClanId(1)),
+                    "the cached favorite ids survive a refetch, so no extra API call is needed"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn toggling_a_favorite_survives_a_structure_refetch(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_extras(ClanId(1), favorite_extras(&[]), cx);
+
+                channels.add_channel_favorite(ChannelId(1), ClanId(1), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                assert_eq!(
+                    channels.categories_for_clan(ClanId(1))[0].channels.len(),
+                    1,
+                    "an optimistic favorite must survive a refetch"
+                );
+
+                channels.remove_channel_favorite(ChannelId(1), ClanId(1), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                assert!(
+                    channels.categories_for_clan(ClanId(1))[0]
+                        .channels
+                        .is_empty(),
+                    "an unfavorited channel must not come back on a refetch"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn a_rolled_back_favorite_does_not_survive_a_structure_refetch(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_extras(ClanId(1), favorite_extras(&[]), cx);
+                channels.extras_loaded.insert(ClanId(1));
+
+                channels.apply_favorite_locally(ChannelId(1), ClanId(1), true, cx);
+                assert_eq!(channels.categories_for_clan(ClanId(1))[0].channels.len(), 1);
+
+                channels.apply_favorite_locally(ChannelId(1), ClanId(1), false, cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+
+                assert!(
+                    channels.categories_for_clan(ClanId(1))[0]
+                        .channels
+                        .is_empty(),
+                    "a favorite whose api call failed must not be re-applied from the local set"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn a_rolled_back_unfavorite_is_restored_on_a_structure_refetch(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_extras(ClanId(1), favorite_extras(&[ChannelId(2)]), cx);
+                channels.extras_loaded.insert(ClanId(1));
+
+                channels.apply_favorite_locally(ChannelId(2), ClanId(1), false, cx);
+                assert!(
+                    channels.categories_for_clan(ClanId(1))[0]
+                        .channels
+                        .is_empty()
+                );
+
+                channels.apply_favorite_locally(ChannelId(2), ClanId(1), true, cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+
+                assert_eq!(
+                    channels.categories_for_clan(ClanId(1))[0].channels.len(),
+                    1,
+                    "an unfavorite whose api call failed must leave the favorite in place"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn failed_favorites_fetch_keeps_favorites_and_stays_unloaded(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.finish_extras(ClanId(1), favorite_extras(&[ChannelId(2)]), cx);
+                assert!(channels.extras_loaded.contains(&ClanId(1)));
+
+                channels.extras_loaded.remove(&ClanId(1));
+                channels.finish_extras(
+                    ClanId(1),
+                    ClanExtras {
+                        voice_map: Some(HashMap::new()),
+                        favorite_ids: None,
+                        app_channels: None,
+                    },
+                    cx,
+                );
+
+                let favor = &channels.categories_for_clan(ClanId(1))[0];
+                assert_eq!(
+                    favor.channels.len(),
+                    1,
+                    "a failed list_favorite_channels must not wipe known favorites"
+                );
+                assert!(
+                    !channels.extras_loaded.contains(&ClanId(1)),
+                    "a failed fetch must leave the gate open so the next clan entry retries"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn re_entering_a_clan_after_a_failed_extras_fetch_starts_a_new_one(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.load_for_clan(ClanId(1), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.finish_extras(
+                    ClanId(1),
+                    ClanExtras {
+                        voice_map: None,
+                        favorite_ids: None,
+                        app_channels: None,
+                    },
+                    cx,
+                );
+                channels.extras_loading.clear();
+
+                assert!(channels.cache.is_fresh(&ClanId(1), crate::CACHE_TTL));
+                channels.load_for_clan(ClanId(1), cx);
+                assert!(
+                    channels.extras_loading.contains(&ClanId(1)),
+                    "re-entering the clan must issue the extras calls again"
+                );
+
+                channels.extras_loading.clear();
+                channels.finish_extras(ClanId(1), favorite_extras(&[ChannelId(2)]), cx);
+                channels.load_for_clan(ClanId(1), cx);
+                assert!(
+                    channels.extras_loading.is_empty(),
+                    "once loaded, re-entering must not re-issue them"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn a_successful_extras_fetch_closes_the_gate(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.finish_extras(ClanId(1), favorite_extras(&[ChannelId(2)]), cx);
+
+                assert!(
+                    channels.extras_loaded.contains(&ClanId(1)),
+                    "a complete fetch must not be repeated on the next clan entry"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn extras_arriving_before_the_structure_stay_unloaded(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.finish_extras(ClanId(1), favorite_extras(&[ChannelId(2)]), cx);
+                assert!(
+                    !channels.extras_loaded.contains(&ClanId(1)),
+                    "extras that could not be applied must be re-requested"
+                );
+
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                assert_eq!(
+                    channels.categories_for_clan(ClanId(1))[0].channels.len(),
+                    1,
+                    "the favorite ids are kept even when the structure arrives later"
+                );
+            });
+        });
     }
 
     const PARENT_CHANNEL: ChannelId = ChannelId(10);
@@ -3622,6 +4131,7 @@ mod tests {
             badge_count: 2,
             creator_id: 0,
             clan_name: String::new(),
+            channel_avatar: String::new(),
         };
         let seed = unread_seed_from_descs(vec![desc(10, 1), desc(11, 8), desc(12, 10)]);
 

--- a/crates/mezon-store/src/clan_members.rs
+++ b/crates/mezon-store/src/clan_members.rs
@@ -296,8 +296,17 @@ impl ClanMembersStore {
                             .read(cx)
                             .current_user_id(cx)
                             .map(|uid| uid.0);
-                        let online_users = online_result.unwrap_or_default();
-                        let online_ids = online_ids_from_users(&online_users, self_id);
+                        let mut degraded = false;
+                        let online_ids = match online_result {
+                            Ok(online_users) => online_ids_from_users(&online_users, self_id),
+                            Err(e) => {
+                                degraded = true;
+                                tracing::warn!(
+                                    "list_user_online failed for {clan_id}, keeping the known online set: {e}"
+                                );
+                                previous_online_ids(&this.cache, clan_id)
+                            }
+                        };
                         let mut bucket = ClanBucket::default();
                         for cu in users {
                             if let Some(mut member) = clan_member_from_proto(cu) {
@@ -323,9 +332,19 @@ impl ClanMembersStore {
                         prune_self_roles(&this.cache, &mut this.self_role_ids);
                         let online_uids: Vec<UserId> =
                             online_ids.iter().map(|id| UserId(*id)).collect();
-                        let statuses = status_result
-                            .map(user_statuses_from_list)
-                            .unwrap_or_default();
+                        let statuses = match status_result {
+                            Ok(list) => user_statuses_from_list(list),
+                            Err(e) => {
+                                degraded = true;
+                                tracing::warn!(
+                                    "list_clan_users_status failed for {clan_id}: {e}"
+                                );
+                                Vec::new()
+                            }
+                        };
+                        if degraded {
+                            this.cache.mark_stale(&clan_id);
+                        }
                         PresenceStore::global(cx).update(cx, |presence, cx| {
                             presence.seed_presence(&online_uids, &statuses, cx);
                         });
@@ -518,6 +537,20 @@ fn user_statuses_from_list(list: api::ClanUserStatusList) -> Vec<(UserId, String
         .filter(|e| e.user_id != 0)
         .map(|e| (UserId(e.user_id), e.user_status))
         .collect()
+}
+
+fn previous_online_ids(cache: &KeyedCache<ClanId, ClanBucket>, clan_id: ClanId) -> HashSet<i64> {
+    cache
+        .get(&clan_id)
+        .map(|bucket| {
+            bucket
+                .by_id
+                .values()
+                .filter(|member| member.online)
+                .map(|member| member.user.id.0)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn online_ids_from_users(users: &[api::User], self_id: Option<i64>) -> HashSet<i64> {
@@ -782,6 +815,34 @@ mod tests {
             "x",
             "y"
         ));
+    }
+
+    #[test]
+    fn previous_online_ids_carries_the_last_known_online_set() {
+        let mut online_member = member(1, "online");
+        online_member.online = true;
+        let cache = bucket_with(vec![online_member, member(2, "offline")]);
+
+        let carried = previous_online_ids(&cache, ClanId(1));
+        assert_eq!(carried, [1].into_iter().collect::<HashSet<i64>>());
+        assert!(previous_online_ids(&cache, ClanId(99)).is_empty());
+    }
+
+    #[test]
+    fn a_degraded_member_fetch_is_not_pinned_fresh_for_the_ttl() {
+        let mut cache = bucket_with(vec![member(1, "a")]);
+        assert!(cache.is_fresh(&ClanId(1), crate::CACHE_TTL));
+
+        cache.mark_stale(&ClanId(1));
+
+        assert!(
+            !cache.is_fresh(&ClanId(1), crate::CACHE_TTL),
+            "a partial fetch must be refetched on the next clan entry"
+        );
+        assert!(
+            cache.get(&ClanId(1)).is_some(),
+            "the members already loaded must still be served"
+        );
     }
 
     #[test]

--- a/crates/mezon-store/src/gallery.rs
+++ b/crates/mezon-store/src/gallery.rs
@@ -304,20 +304,11 @@ fn is_video_type(filetype: &str, url: &str) -> bool {
 }
 
 fn is_image_type(filetype: &str, url: &str) -> bool {
-    if filetype.starts_with("image/") || filetype == "sticker" {
-        return true;
-    }
-    matches!(
-        extension(url).as_deref(),
-        Some("png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "svg" | "avif")
-    )
+    crate::message::is_image_type(filetype, url)
 }
 
 fn extension(url: &str) -> Option<String> {
-    url.split(['?', '#'])
-        .next()
-        .and_then(|u| u.rsplit('.').next())
-        .map(|ext| ext.to_ascii_lowercase())
+    crate::message::url_extension(url)
 }
 
 fn format_day(ts: i64) -> String {

--- a/crates/mezon-store/src/message.rs
+++ b/crates/mezon-store/src/message.rs
@@ -33,6 +33,34 @@ pub struct MessageAttachment {
     pub upload_failed: bool,
 }
 
+pub const STICKER_FILETYPE: &str = "sticker";
+
+pub fn url_extension(url: &str) -> Option<String> {
+    let path = url.split(['?', '#']).next()?;
+    let name = path.rsplit('/').next()?;
+    let tail = name.rsplit('@').next().unwrap_or(name);
+    let ext = if tail.contains('.') {
+        tail.rsplit('.').next()?
+    } else {
+        tail
+    };
+    (!ext.is_empty()).then(|| ext.to_ascii_lowercase())
+}
+
+pub fn is_image_type(filetype: &str, url: &str) -> bool {
+    let mime_image =
+        (filetype.starts_with("image") || filetype == STICKER_FILETYPE) && !is_svg_type(filetype);
+    mime_image
+        || matches!(
+            url_extension(url).as_deref(),
+            Some("png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "avif")
+        )
+}
+
+fn is_svg_type(filetype: &str) -> bool {
+    filetype.contains("svg+xml")
+}
+
 pub fn format_file_size(bytes: u64) -> String {
     if bytes >= 1_000_000 {
         format!("{:.1} MB", bytes as f64 / 1_000_000.0)
@@ -49,16 +77,7 @@ impl MessageAttachment {
     }
 
     pub fn is_image(&self) -> bool {
-        self.filetype.starts_with("image/")
-            || matches!(
-                self.url
-                    .split(['?', '#'])
-                    .next()
-                    .and_then(|u| u.rsplit('.').next())
-                    .map(|ext| ext.to_ascii_lowercase())
-                    .as_deref(),
-                Some("png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "svg" | "avif")
-            )
+        is_image_type(&self.filetype, &self.url)
     }
 
     pub fn media_is_video(filetype: &str, url: &str) -> bool {
@@ -185,6 +204,9 @@ pub struct MessageReference {
     pub message_ref_id: MessageId,
     pub sender_id: UserId,
     pub sender_name: String,
+    pub sender_clan_nick: String,
+    pub sender_display_name: String,
+    pub sender_username: String,
     pub sender_avatar: String,
     pub content: String,
     pub content_preview: SharedString,
@@ -1448,6 +1470,16 @@ impl Message {
             && !self.send_failed
     }
 
+    /// `day_label`, `time_hhmm` and `local_date` are all derived from `create_time`, so they
+    /// must only ever move as a unit — assigning `create_time` alone leaves the rendered
+    /// timestamp describing the *previous* value (or blank, when the other value was 0).
+    pub fn set_create_time(&mut self, create_time: i64) {
+        self.create_time = create_time;
+        self.day_label = local_day_key(create_time);
+        self.time_hhmm = format_local_time_hhmm(create_time).into();
+        self.local_date = local_datetime(create_time).map(|dt| dt.date_naive());
+    }
+
     pub fn token_transaction_parts(&self) -> (SharedString, SharedString) {
         let tx = split_token_transaction(&self.content);
         (tx.title, tx.detail)
@@ -1956,6 +1988,54 @@ mod tests {
             url: url.into(),
             ..Default::default()
         }
+    }
+
+    const STICKER_IMGPROXY_URL: &str = "https://imgproxy.mezon.ai/K0YUZRIosDOcz5lY6qrgC6UIXmQgWzLjZv7VJ1RAA8c/rs:fit:100:100:1/mb:2097152/plain/https://cdn.mezon.ai/stickers/2039232970027438080.webp@webp";
+
+    #[test]
+    fn sticker_filetype_is_an_image_not_a_document() {
+        assert!(attachment(STICKER_FILETYPE, STICKER_IMGPROXY_URL).is_image());
+        assert!(attachment(STICKER_FILETYPE, "https://cdn.mezon.ai/stickers/1.webp").is_image());
+        assert!(attachment(STICKER_FILETYPE, "").is_image());
+    }
+
+    #[test]
+    fn imgproxy_output_format_is_read_as_the_extension() {
+        assert_eq!(url_extension(STICKER_IMGPROXY_URL).as_deref(), Some("webp"));
+        assert!(attachment("", STICKER_IMGPROXY_URL).is_image());
+    }
+
+    #[test]
+    fn svg_is_a_file_row_not_an_image() {
+        assert!(!attachment("image/svg+xml", "https://cdn.example/logo.svg").is_image());
+        assert!(!attachment("", "https://cdn.example/logo.svg").is_image());
+    }
+
+    #[test]
+    fn heic_and_bare_image_prefix_are_images() {
+        assert!(attachment("image/heic", "https://cdn.example/a.heic").is_image());
+        assert!(attachment("image", "https://cdn.example/a").is_image());
+    }
+
+    #[test]
+    fn url_extension_handles_plain_query_and_extensionless_urls() {
+        assert_eq!(
+            url_extension("https://cdn.example/a/b/photo.PNG").as_deref(),
+            Some("png")
+        );
+        assert_eq!(
+            url_extension("https://cdn.example/photo.jpg?w=1#frag").as_deref(),
+            Some("jpg")
+        );
+        assert_eq!(
+            url_extension("https://cdn.example/asset@2x.png").as_deref(),
+            Some("png")
+        );
+        assert_eq!(
+            url_extension("https://cdn.example/no-extension").as_deref(),
+            Some("no-extension")
+        );
+        assert!(!attachment("", "https://cdn.example/no-extension").is_image());
     }
 
     #[test]

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -41,9 +41,7 @@ use crate::message::{
     recompute_message_grouping, rollback_reaction, sort_messages, spans_only_emoji,
     viewer_highlight_direct,
 };
-use crate::message_time::{
-    format_local_time_hhmm, local_datetime, local_day_key, unix_now_seconds,
-};
+use crate::message_time::unix_now_seconds;
 use crate::presign;
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
 use crate::topics::TopicsStore;
@@ -58,7 +56,7 @@ const DIRECTION_AFTER: i32 = 1;
 const DIRECTION_AROUND: i32 = 2;
 const CHANNEL_TYPE_CHANNEL: i32 = 1;
 const CHANNEL_TYPE_THREAD: i32 = 7;
-const STICKER_FILETYPE: &str = "sticker";
+use crate::message::STICKER_FILETYPE;
 const AUDIO_FILETYPE: &str = "audio/mpeg";
 const MAX_MESSAGES_PER_CHANNEL: usize = 200;
 const MAX_CACHED_CHANNELS: usize = 30;
@@ -1949,7 +1947,7 @@ impl MessagesStore {
         }) {
             return;
         }
-        let display_name = AccountStore::global(cx)
+        let account_name = AccountStore::global(cx)
             .read(cx)
             .account
             .as_ref()
@@ -1961,9 +1959,19 @@ impl MessagesStore {
                 }
             })
             .unwrap_or_default();
-        if display_name.is_empty() {
+        if account_name.is_empty() {
             return;
         }
+        let clan_nick = matches!(self.mode, STREAM_MODE_CHANNEL | STREAM_MODE_THREAD)
+            .then(|| ClanMembersStore::try_global(cx).zip(viewer_user_id(cx)))
+            .flatten()
+            .and_then(|(members, me)| {
+                members
+                    .read(cx)
+                    .member(clan_id, me)
+                    .map(|member| member.clan_nick.clone())
+            });
+        let display_name = typing_display_name(self.mode, clan_nick.as_deref(), &account_name);
         self.last_typing_sent = Some((channel_id, now));
         let mode = self.mode;
         let is_public = self.is_public;
@@ -2592,14 +2600,29 @@ impl MessagesStore {
         let references: Vec<mezon_proto::api::MessageRef> = msg
             .references
             .iter()
-            .map(|reference| mezon_proto::api::MessageRef {
-                message_ref_id: reference.message_ref_id.get(),
-                content: reference.content.clone(),
-                has_attachment: reference.has_attachment,
-                message_sender_id: reference.sender_id.get(),
-                message_sender_username: reference.sender_name.to_string(),
-                message_sender_avatar: reference.sender_avatar.to_string(),
-                ..Default::default()
+            .map(|reference| {
+                let (clan_nick, display_name, username, avatar) = reference_sender_fields(
+                    reference.sender_id,
+                    (
+                        &reference.sender_clan_nick,
+                        &reference.sender_display_name,
+                        &reference.sender_username,
+                        &reference.sender_avatar,
+                    ),
+                    Some(clan_id),
+                    cx,
+                );
+                mezon_proto::api::MessageRef {
+                    message_ref_id: reference.message_ref_id.get(),
+                    content: reference.content.clone(),
+                    has_attachment: reference.has_attachment,
+                    message_sender_id: reference.sender_id.get(),
+                    message_sender_username: username,
+                    message_sender_avatar: avatar,
+                    message_sender_clan_nick: clan_nick,
+                    message_sender_display_name: display_name,
+                    ..Default::default()
+                }
             })
             .collect();
         let sender_id = msg.sender_id.parse().unwrap_or(0);
@@ -3392,6 +3415,10 @@ impl MessagesStore {
         );
         let (display_name, avatar_url, avatar_proxied) =
             outgoing_sender_profile(&sender_id, &sender_name, clan_id, cx);
+        let reply_clan_id = (!self.is_dm)
+            .then_some(self.active_clan_id)
+            .flatten()
+            .filter(|clan_id| !clan_id.is_zero());
         let mut optimistic = Message::new(
             temp_id,
             sent.text.clone(),
@@ -3426,11 +3453,25 @@ impl MessagesStore {
             }
         }
         if let Some(draft) = &reply {
+            let (clan_nick, display_name, username, avatar) = reference_sender_fields(
+                draft.sender_id,
+                (
+                    "",
+                    &draft.sender_name,
+                    &draft.sender_name,
+                    &draft.sender_avatar,
+                ),
+                reply_clan_id,
+                cx,
+            );
             optimistic = optimistic.with_references(vec![MessageReference {
                 message_ref_id: draft.message_ref_id,
                 sender_id: draft.sender_id,
-                sender_name: draft.sender_name.clone(),
-                sender_avatar: draft.sender_avatar.clone(),
+                sender_name: name_for_prioritize(&clan_nick, &display_name, &username),
+                sender_clan_nick: clan_nick,
+                sender_display_name: display_name,
+                sender_username: username,
+                sender_avatar: avatar,
                 content_preview: crate::message::reply_preview_line(&draft.content_preview).into(),
                 content: draft.content_preview.clone(),
                 has_attachment: draft.has_attachment,
@@ -3468,15 +3509,31 @@ impl MessagesStore {
         self.emit_appended(old_len, cx);
 
         let api = self.api.clone();
-        let reply_ref = reply.map(|draft| OutgoingReply {
-            message_ref_id: draft.message_ref_id.get(),
-            content: draft.content_preview,
-            has_attachment: draft.has_attachment,
-            message_sender_id: draft.sender_id.get(),
-            message_sender_username: draft.sender_name.clone(),
-            message_sender_avatar: draft.sender_avatar,
-            message_sender_clan_nick: String::new(),
-            message_sender_display_name: draft.sender_name,
+        let reply_sender = reply.as_ref().map(|draft| {
+            reference_sender_fields(
+                draft.sender_id,
+                (
+                    "",
+                    &draft.sender_name,
+                    &draft.sender_name,
+                    &draft.sender_avatar,
+                ),
+                reply_clan_id,
+                cx,
+            )
+        });
+        let reply_ref = reply.zip(reply_sender).map(|(draft, sender)| {
+            let (clan_nick, display_name, username, avatar) = sender;
+            OutgoingReply {
+                message_ref_id: draft.message_ref_id.get(),
+                content: draft.content_preview,
+                has_attachment: draft.has_attachment,
+                message_sender_id: draft.sender_id.get(),
+                message_sender_username: username,
+                message_sender_avatar: avatar,
+                message_sender_clan_nick: clan_nick,
+                message_sender_display_name: display_name,
+            }
         });
         cx.spawn(async move |this, cx| {
             if has_attachments {
@@ -5342,10 +5399,7 @@ fn fill_sparse_topic_ack(
         msg.avatar_proxied = avatar_proxied;
     }
     if gaps.time {
-        msg.create_time = now;
-        msg.day_label = local_day_key(now);
-        msg.time_hhmm = format_local_time_hhmm(now).into();
-        msg.local_date = local_datetime(now).map(|dt| dt.date_naive());
+        msg.set_create_time(now);
     }
 }
 
@@ -5476,8 +5530,7 @@ fn merge_sparse_sender(prior: &Message, mut incoming: Message) -> Message {
         incoming.avatar_proxied = prior.avatar_proxied.clone();
     }
     if prior.id.is_optimistic() {
-        incoming.create_time = prior.create_time;
-        incoming.day_label = prior.day_label.clone();
+        incoming.set_create_time(prior.create_time);
         incoming.row_anchor_id = prior.row_anchor_id;
     }
     if incoming.references.is_empty() && !prior.references.is_empty() {
@@ -5560,6 +5613,53 @@ fn optimistic_create_time_at(messages: &MessageList, sender_id: &str, now: i64) 
 
 pub(crate) fn viewer_user_id(cx: &App) -> Option<UserId> {
     BadgeService::try_global(cx)?.read(cx).current_user_id(cx)
+}
+
+/// `(clan_nick, display_name, username, avatar)` for a reply reference, mirroring React's
+/// per-field `live || baked` fallback in `MessageReply.tsx` rather than an all-or-nothing swap.
+fn reference_sender_fields(
+    sender_id: UserId,
+    baked: (&str, &str, &str, &str),
+    clan_id: Option<ClanId>,
+    cx: &App,
+) -> (String, String, String, String) {
+    let live = clan_id
+        .filter(|clan_id| !clan_id.is_zero())
+        .zip(ClanMembersStore::try_global(cx))
+        .and_then(|(clan_id, members)| {
+            members.read(cx).member(clan_id, sender_id).map(|member| {
+                (
+                    member.clan_nick.clone(),
+                    member.user.display_name.clone(),
+                    member.user.username.clone(),
+                    member.avatar().to_string(),
+                )
+            })
+        });
+    let (clan_nick, display_name, username, avatar) = live.unwrap_or_default();
+    (
+        first_non_empty(&clan_nick, baked.0),
+        first_non_empty(&display_name, baked.1),
+        first_non_empty(&username, baked.2),
+        first_non_empty(&avatar, baked.3),
+    )
+}
+
+fn first_non_empty(preferred: &str, fallback: &str) -> String {
+    if preferred.is_empty() {
+        fallback.to_owned()
+    } else {
+        preferred.to_owned()
+    }
+}
+
+fn typing_display_name(mode: i32, clan_nick: Option<&str>, account_name: &str) -> String {
+    if matches!(mode, STREAM_MODE_CHANNEL | STREAM_MODE_THREAD)
+        && let Some(nick) = clan_nick.map(str::trim).filter(|nick| !nick.is_empty())
+    {
+        return nick.to_owned();
+    }
+    account_name.to_owned()
 }
 
 fn format_thousands(n: i64) -> String {
@@ -6356,13 +6456,11 @@ fn message_reference_from_api(
     r: &mezon_client::transport::ApiMessageRef,
     cfg: Option<&AppConfig>,
 ) -> MessageReference {
-    let sender_name = if !r.message_sender_clan_nick.is_empty() {
-        r.message_sender_clan_nick.clone()
-    } else if !r.message_sender_display_name.is_empty() {
-        r.message_sender_display_name.clone()
-    } else {
-        r.message_sender_username.clone()
-    };
+    let sender_name = name_for_prioritize(
+        &r.message_sender_clan_nick,
+        &r.message_sender_display_name,
+        &r.message_sender_username,
+    );
     let parsed =
         serde_json::from_str::<mezon_client::transport::ApiMessageContent>(&r.content).ok();
     let content = parsed
@@ -6383,12 +6481,25 @@ fn message_reference_from_api(
         message_ref_id: MessageId(r.message_ref_id),
         sender_id: UserId(r.message_sender_id),
         sender_name,
+        sender_clan_nick: r.message_sender_clan_nick.clone(),
+        sender_display_name: r.message_sender_display_name.clone(),
+        sender_username: r.message_sender_username.clone(),
         sender_avatar,
         content,
         content_preview,
         has_attachment: r.has_attachment,
         has_embed,
         is_poll,
+    }
+}
+
+pub fn name_for_prioritize(clan_nick: &str, display_name: &str, username: &str) -> String {
+    if !clan_nick.is_empty() {
+        clan_nick.to_owned()
+    } else if !display_name.is_empty() {
+        display_name.to_owned()
+    } else {
+        username.to_owned()
     }
 }
 
@@ -6494,6 +6605,136 @@ mod tests {
     use super::*;
     use crate::ids::UserId;
     use crate::message::MessageSpan;
+
+    #[test]
+    fn name_for_prioritize_matches_reacts_order() {
+        assert_eq!(name_for_prioritize("nick", "display", "user"), "nick");
+        assert_eq!(name_for_prioritize("", "display", "user"), "display");
+        assert_eq!(name_for_prioritize("", "", "user"), "user");
+        assert_eq!(name_for_prioritize("", "", ""), "");
+    }
+
+    #[test]
+    fn first_non_empty_prefers_the_live_value() {
+        assert_eq!(first_non_empty("live", "baked"), "live");
+        assert_eq!(first_non_empty("", "baked"), "baked");
+        assert_eq!(first_non_empty("", ""), "");
+    }
+
+    #[gpui::test]
+    fn reference_sender_fields_split_the_three_names_from_the_clan_member(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let api = Arc::new(mezon_client::AppApi::new(
+                Arc::new(mezon_client::TransportClient::new(String::new())),
+                String::new(),
+            ));
+            crate::realtime::RealtimeDispatch::init(api.clone(), cx);
+            ClanMembersStore::init(api, cx);
+            ClanMembersStore::global(cx).update(cx, |members, _| {
+                members.seed_members_for_test(
+                    ClanId(1),
+                    vec![crate::clan_members::ClanMember {
+                        user: crate::clan_members::User {
+                            id: UserId(7),
+                            username: "wumpus".into(),
+                            display_name: "Wumpus".into(),
+                            ..Default::default()
+                        },
+                        clan_nick: "Nick In Clan".into(),
+                        ..Default::default()
+                    }],
+                );
+            });
+
+            assert_eq!(
+                reference_sender_fields(
+                    UserId(7),
+                    ("stale nick", "stale display", "stale user", "stale.png"),
+                    Some(ClanId(1)),
+                    cx
+                ),
+                (
+                    "Nick In Clan".to_string(),
+                    "Wumpus".to_string(),
+                    "wumpus".to_string(),
+                    "stale.png".to_string()
+                ),
+                "an empty live field falls back per-field, not all-or-nothing"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn reference_sender_fields_fall_back_to_the_baked_values(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let api = Arc::new(mezon_client::AppApi::new(
+                Arc::new(mezon_client::TransportClient::new(String::new())),
+                String::new(),
+            ));
+            crate::realtime::RealtimeDispatch::init(api.clone(), cx);
+            ClanMembersStore::init(api, cx);
+
+            let input = ("", "Baked Name", "Baked Name", "baked.png");
+            let baked = (
+                String::new(),
+                "Baked Name".to_string(),
+                "Baked Name".to_string(),
+                "baked.png".to_string(),
+            );
+            assert_eq!(
+                reference_sender_fields(UserId(7), input, None, cx),
+                baked,
+                "a DM reply carries no clan nick"
+            );
+            assert_eq!(
+                reference_sender_fields(UserId(7), input, Some(ClanId(0)), cx),
+                baked
+            );
+            assert_eq!(
+                reference_sender_fields(UserId(404), input, Some(ClanId(1)), cx),
+                baked,
+                "an uncached member must not blank the reference"
+            );
+        });
+    }
+
+    #[test]
+    fn typing_name_prefers_the_clan_nick_in_a_channel_or_thread() {
+        for mode in [STREAM_MODE_CHANNEL, STREAM_MODE_THREAD] {
+            assert_eq!(
+                typing_display_name(mode, Some("Nick In Clan"), "Global Name"),
+                "Nick In Clan"
+            );
+        }
+    }
+
+    #[test]
+    fn typing_name_falls_back_to_the_account_name_without_a_usable_nick() {
+        assert_eq!(
+            typing_display_name(STREAM_MODE_CHANNEL, None, "Global Name"),
+            "Global Name"
+        );
+        assert_eq!(
+            typing_display_name(STREAM_MODE_CHANNEL, Some(""), "Global Name"),
+            "Global Name"
+        );
+        assert_eq!(
+            typing_display_name(STREAM_MODE_CHANNEL, Some("   "), "Global Name"),
+            "Global Name"
+        );
+    }
+
+    #[test]
+    fn typing_name_ignores_the_clan_nick_outside_a_clan_channel() {
+        for mode in [3, 4] {
+            assert_eq!(
+                typing_display_name(mode, Some("Nick In Clan"), "Global Name"),
+                "Global Name"
+            );
+        }
+    }
 
     #[test]
     fn parse_embed_accent_accepts_normalized_hex_colors() {
@@ -7197,6 +7438,53 @@ mod tests {
     }
 
     #[test]
+    fn merge_sparse_sender_keeps_the_timestamp_and_its_rendered_fields_in_sync() {
+        let optimistic = Message::new(
+            MessageId::next_optimistic(),
+            "hi",
+            "42",
+            "Me",
+            1_700_000_000,
+        );
+        assert!(!optimistic.time_hhmm.is_empty());
+
+        let sparse_ack = Message::new(MessageId(99), "hi", "0", String::new(), 0);
+        assert!(sparse_ack.time_hhmm.is_empty(), "the ack carries no time");
+
+        let merged = merge_sparse_sender(&optimistic, sparse_ack);
+
+        assert_eq!(merged.create_time, optimistic.create_time);
+        assert_eq!(
+            merged.time_hhmm, optimistic.time_hhmm,
+            "the head timestamp must not blank out when the ack replaces the optimistic row"
+        );
+        assert_eq!(merged.local_date, optimistic.local_date);
+        assert_eq!(merged.day_label, optimistic.day_label);
+    }
+
+    #[test]
+    fn merge_sparse_sender_rewrites_the_rendered_time_from_the_kept_timestamp() {
+        let optimistic = Message::new(
+            MessageId::next_optimistic(),
+            "hi",
+            "42",
+            "Me",
+            1_700_000_000,
+        );
+        let later_ack = Message::new(MessageId(99), "hi", "42", "Me", 1_700_003_600);
+        assert_ne!(optimistic.time_hhmm, later_ack.time_hhmm);
+
+        let merged = merge_sparse_sender(&optimistic, later_ack);
+
+        assert_eq!(merged.create_time, optimistic.create_time);
+        assert_eq!(
+            merged.time_hhmm, optimistic.time_hhmm,
+            "keeping the optimistic create_time must also keep its rendered time"
+        );
+        assert_eq!(merged.local_date, optimistic.local_date);
+    }
+
+    #[test]
     fn merge_sparse_sender_keeps_optimistic_avatar_and_name() {
         let optimistic = Message::new(MessageId::next_optimistic(), "2", "42", "huy.lexuan", 100)
             .with_avatar("avatar.png");
@@ -7752,12 +8040,9 @@ mod tests {
                     message_ref_id: MessageId(42),
                     sender_id: UserId(1),
                     sender_name: "x".into(),
-                    sender_avatar: String::new(),
                     content: "orig".into(),
                     content_preview: "orig".into(),
-                    has_attachment: false,
-                    has_embed: false,
-                    is_poll: false,
+                    ..Default::default()
                 },
             ]),
         ]);

--- a/crates/mezon-store/src/threads.rs
+++ b/crates/mezon-store/src/threads.rs
@@ -14,6 +14,7 @@ use crate::channel_permissions::{ChannelPermissionsStore, PERMISSION_MANAGE_THRE
 use crate::clan::ClanList;
 use crate::clan_members::ClanMembersStore;
 use crate::ids::{ChannelId, ClanId};
+use crate::messages::MessagesStore;
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
 
 pub const THREAD_STATUS_ARCHIVED: i32 = 0;
@@ -423,19 +424,15 @@ impl ThreadsStore {
     }
 
     pub fn can_create_thread(&self, cx: &App) -> bool {
-        let Some(list_id) = self.list_channel_id.as_deref() else {
+        let is_dm = MessagesStore::try_global(cx).is_some_and(|store| store.read(cx).is_dm());
+        let Some((channel_id, clan_id)) = thread_creation_scope(
+            is_dm,
+            self.list_channel_id.as_deref(),
+            self.clan_id.as_deref(),
+        ) else {
             return false;
         };
-        let Ok(channel_id) = list_id.parse::<ChannelId>() else {
-            return false;
-        };
-        let Some(clan_id) = self
-            .clan_id
-            .as_deref()
-            .and_then(|s| s.parse::<ClanId>().ok())
-            .filter(|id| !id.is_zero())
-            .or_else(|| ClanList::global(cx).read(cx).active_clan_id)
-        else {
+        let Some(clan_id) = clan_id.or_else(|| ClanList::global(cx).read(cx).active_clan_id) else {
             return false;
         };
         ChannelPermissionsStore::global(cx).read(cx).has_permission(
@@ -446,19 +443,15 @@ impl ThreadsStore {
     }
 
     pub fn ensure_create_permissions(&mut self, cx: &mut Context<Self>) {
-        let Some(list_id) = self.list_channel_id.as_deref() else {
+        let is_dm = MessagesStore::try_global(cx).is_some_and(|store| store.read(cx).is_dm());
+        let Some((channel_id, clan_id)) = thread_creation_scope(
+            is_dm,
+            self.list_channel_id.as_deref(),
+            self.clan_id.as_deref(),
+        ) else {
             return;
         };
-        let Ok(channel_id) = list_id.parse::<ChannelId>() else {
-            return;
-        };
-        let Some(clan_id) = self
-            .clan_id
-            .as_deref()
-            .and_then(|s| s.parse::<ClanId>().ok())
-            .filter(|id| !id.is_zero())
-            .or_else(|| ClanList::global(cx).read(cx).active_clan_id)
-        else {
+        let Some(clan_id) = clan_id.or_else(|| ClanList::global(cx).read(cx).active_clan_id) else {
             return;
         };
         ChannelPermissionsStore::global(cx).update(cx, |store, cx| {
@@ -820,6 +813,21 @@ fn list_channel_id_for(channel: &Channel) -> String {
     }
 }
 
+fn thread_creation_scope(
+    is_dm: bool,
+    list_channel_id: Option<&str>,
+    clan_id: Option<&str>,
+) -> Option<(ChannelId, Option<ClanId>)> {
+    if is_dm {
+        return None;
+    }
+    let channel_id = list_channel_id?.parse::<ChannelId>().ok()?;
+    let clan_id = clan_id
+        .and_then(|raw| raw.parse::<ClanId>().ok())
+        .filter(|id| !id.is_zero());
+    Some((channel_id, clan_id))
+}
+
 fn page_has_more(batch_len: usize) -> bool {
     batch_len >= THREAD_LIST_LIMIT as usize
 }
@@ -941,6 +949,34 @@ pub fn group_threads(threads: &[ThreadSummary]) -> (Vec<usize>, Vec<usize>, Vec<
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn thread_creation_scope_is_none_in_a_dm() {
+        assert_eq!(thread_creation_scope(true, Some("77"), Some("5")), None);
+        assert_eq!(thread_creation_scope(true, Some("77"), Some("0")), None);
+    }
+
+    #[test]
+    fn thread_creation_scope_drops_a_zero_clan_so_the_caller_can_fall_back() {
+        assert_eq!(
+            thread_creation_scope(false, Some("77"), Some("0")),
+            Some((ChannelId(77), None))
+        );
+        assert_eq!(
+            thread_creation_scope(false, Some("77"), None),
+            Some((ChannelId(77), None))
+        );
+    }
+
+    #[test]
+    fn thread_creation_scope_keeps_a_real_clan_channel() {
+        assert_eq!(
+            thread_creation_scope(false, Some("77"), Some("5")),
+            Some((ChannelId(77), Some(ClanId(5))))
+        );
+        assert_eq!(thread_creation_scope(false, None, Some("5")), None);
+        assert_eq!(thread_creation_scope(false, Some("nope"), Some("5")), None);
+    }
 
     #[test]
     fn page_has_more_when_batch_full() {

--- a/crates/mezon-ui/src/app/window_controls.rs
+++ b/crates/mezon-ui/src/app/window_controls.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    CursorStyle, Decorations, Div, MouseButton, ResizeEdge, Tiling, TitlebarOptions, Window,
-    WindowDecorations, div, prelude::*, px,
+    App, CursorStyle, Decorations, Div, Global, MouseButton, QuitMode, ResizeEdge, Tiling,
+    TitlebarOptions, Window, WindowDecorations, WindowHandle, div, prelude::*, px,
 };
 
 #[cfg(any(target_os = "linux", target_os = "windows"))]
@@ -47,6 +47,43 @@ pub const CLAN_SIDEBAR_HEADER_TOP: f32 = CLAN_SIDEBAR_STICKY_TOP;
 /// Returns an empty element on macOS, where the native traffic lights are used.
 pub fn render_controls(theme: &Theme, window: &Window) -> impl IntoElement {
     platform::render_controls(theme, window)
+}
+
+struct RunsInBackground(bool);
+impl Global for RunsInBackground {}
+
+pub fn set_runs_in_background(cx: &mut App, tray_available: bool) {
+    let enabled = tray_available || cfg!(target_os = "macos");
+    cx.set_global(RunsInBackground(enabled));
+    cx.set_quit_mode(if enabled {
+        QuitMode::Explicit
+    } else {
+        QuitMode::Default
+    });
+}
+
+fn runs_in_background(cx: &App) -> bool {
+    cx.try_global::<RunsInBackground>()
+        .map_or(cfg!(target_os = "macos"), |global| global.0)
+}
+
+pub fn hide_main_window(window: &mut Window, cx: &App) -> bool {
+    if !runs_in_background(cx) {
+        return false;
+    }
+    window.hide_window();
+    true
+}
+
+pub fn configure_window<V: 'static>(cx: &mut App, handle: WindowHandle<V>) {
+    if let Err(error) = cx.update_window(handle.into(), |_, window, cx| {
+        window.on_window_should_close(cx, |window, cx| !hide_main_window(window, cx));
+
+        #[cfg(target_os = "macos")]
+        platform::disable_window_fullscreen(window);
+    }) {
+        tracing::warn!("Failed to configure main window: {error}");
+    }
 }
 
 pub fn window_title_options() -> TitlebarOptions {

--- a/crates/mezon-ui/src/app/window_controls/linux.rs
+++ b/crates/mezon-ui/src/app/window_controls/linux.rs
@@ -1,9 +1,9 @@
-use gpui::{Div, MouseButton, Pixels, Rgba, StyleRefinement, Window, prelude::*, px, rgb};
+use gpui::{App, Div, MouseButton, Pixels, Rgba, StyleRefinement, Window, prelude::*, px, rgb};
 
 use crate::components::primitives::{Icon, IconName};
 use crate::theme::Theme;
 
-use super::{CONTROL_CLOSE_HOVER, control_button, controls_row};
+use super::{CONTROL_CLOSE_HOVER, control_button, controls_row, hide_main_window};
 
 pub fn render_controls(theme: &Theme, window: &Window) -> impl IntoElement {
     let hover = theme.bg_hover;
@@ -21,21 +21,25 @@ pub fn render_controls(theme: &Theme, window: &Window) -> impl IntoElement {
             icon_size,
             IconName::WindowMinimize,
             move |style| style.bg(hover),
-            |window| window.minimize_window(),
+            |window, _| window.minimize_window(),
         ))
         .child(window_control_button(
             color,
             icon_size,
             zoom_icon,
             move |style| style.bg(hover),
-            |window| window.zoom_window(),
+            |window, _| window.zoom_window(),
         ))
         .child(window_control_button(
             color,
             icon_size,
             IconName::WindowClose,
             |style| style.bg(rgb(CONTROL_CLOSE_HOVER)).text_color(gpui::white()),
-            |window| window.remove_window(),
+            |window, cx| {
+                if !hide_main_window(window, cx) {
+                    window.remove_window();
+                }
+            },
         ))
 }
 
@@ -44,13 +48,13 @@ fn window_control_button(
     icon_size: Pixels,
     icon: IconName,
     hover: impl FnOnce(StyleRefinement) -> StyleRefinement + 'static,
-    on_click: impl Fn(&mut Window) + 'static,
+    on_click: impl Fn(&mut Window, &mut App) + 'static,
 ) -> Div {
     control_button(color)
         .hover(hover)
         .on_mouse_down(MouseButton::Left, move |_, window, cx| {
             cx.stop_propagation();
-            on_click(window);
+            on_click(window, cx);
         })
         .child(Icon::new(icon).size(icon_size).text_color(color))
 }

--- a/crates/mezon-ui/src/app/window_controls/macos.rs
+++ b/crates/mezon-ui/src/app/window_controls/macos.rs
@@ -1,5 +1,5 @@
 use block::ConcreteBlock;
-use gpui::{App, Window, WindowHandle, div, prelude::*};
+use gpui::{App, Window, div, prelude::*};
 use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
@@ -39,19 +39,6 @@ pub fn minimize_active_window(cx: &mut App) {
 pub fn disable_window_fullscreen(window: &Window) {
     if let Some(view) = appkit_view(window) {
         disable_fullscreen(view);
-    }
-}
-
-pub fn configure_window<V: 'static>(cx: &mut App, handle: WindowHandle<V>) {
-    if let Err(error) = cx.update_window(handle.into(), |_, window, cx| {
-        window.on_window_should_close(cx, |window, _| {
-            hide_window(window);
-            false
-        });
-
-        disable_window_fullscreen(window);
-    }) {
-        tracing::warn!("Failed to configure window: {error}");
     }
 }
 

--- a/crates/mezon-ui/src/auth/login_view.rs
+++ b/crates/mezon-ui/src/auth/login_view.rs
@@ -35,6 +35,7 @@ pub struct LoginView {
     qr_login_id: Option<String>,
     qr_expired: bool,
     qr_image: Option<Arc<RenderImage>>,
+    qr_image_blurred: Option<Arc<RenderImage>>,
     is_remember: bool,
     pending_reset: bool,
     pending_otp_clear: bool,
@@ -95,6 +96,7 @@ impl LoginView {
             qr_login_id: None,
             qr_expired: false,
             qr_image: None,
+            qr_image_blurred: None,
             is_remember: false,
             pending_reset: false,
             pending_otp_clear: false,
@@ -122,6 +124,7 @@ impl LoginView {
         self.is_remember = false;
         self.qr_login_id = None;
         self.qr_image = None;
+        self.qr_image_blurred = None;
         self.qr_expired = false;
         self.loading = false;
         self.show_loading = false;
@@ -276,11 +279,16 @@ impl LoginView {
             };
             let exec = cx.background_executor().clone();
             let login_id_for_qr = login_id.clone();
-            let qr_image = exec
-                .spawn(async move { build_qr_image(&login_id_for_qr) })
+            let qr_images = exec
+                .spawn(async move { build_qr_images(&login_id_for_qr) })
                 .await;
             let _ = this.update(cx, |this, cx| {
-                this.qr_image = qr_image;
+                let (sharp, blurred) = match qr_images {
+                    Some(images) => (Some(images.0), Some(images.1)),
+                    None => (None, None),
+                };
+                this.qr_image = sharp;
+                this.qr_image_blurred = blurred;
                 this.qr_login_id = Some(login_id.clone());
                 cx.notify();
             });
@@ -525,6 +533,7 @@ impl LoginView {
         entity.update(cx, |this, cx| {
             this.qr_login_id = None;
             this.qr_image = None;
+            this.qr_image_blurred = None;
             this.qr_expired = false;
             let auth_state = this.auth_state.clone();
             this._qr_poll_task = Some(Self::start_qr_flow(auth_state, cx));
@@ -739,10 +748,15 @@ impl LoginView {
             .justify_center()
             .overflow_hidden();
 
-        if let Some(image) = &self.qr_image {
-            let mut qr_img = img(image.clone()).size(px(168.));
+        let shown = if expired {
+            self.qr_image_blurred.as_ref().or(self.qr_image.as_ref())
+        } else {
+            self.qr_image.as_ref()
+        };
+        if let Some(image) = shown {
+            let mut qr_img = img(image.clone()).size(px(QR_DISPLAY_PX));
             if expired {
-                qr_img = qr_img.opacity(0.5);
+                qr_img = qr_img.opacity(QR_EXPIRED_OPACITY);
             }
             qr_box = qr_box.child(qr_img);
         } else if !expired {
@@ -981,7 +995,7 @@ impl Render for LoginView {
     }
 }
 
-fn build_qr_image(data: &str) -> Option<Arc<RenderImage>> {
+fn build_qr_images(data: &str) -> Option<(Arc<RenderImage>, Arc<RenderImage>)> {
     let code = qrcode::QrCode::new(data.as_bytes()).ok()?;
     let width = code.width();
     if width == 0 {
@@ -1007,9 +1021,33 @@ fn build_qr_image(data: &str) -> Option<Arc<RenderImage>> {
             }
         }
     }
-    Some(Arc::new(RenderImage::new(vec![image::Frame::new(buf)])))
+    let blur_dim = qr_blur_bitmap_dim(dim);
+    let downscaled = image::imageops::resize(
+        &buf,
+        blur_dim,
+        blur_dim,
+        image::imageops::FilterType::Triangle,
+    );
+    let blurred = image::imageops::blur(&downscaled, qr_expired_blur_sigma(blur_dim));
+    Some((
+        Arc::new(RenderImage::new(vec![image::Frame::new(buf)])),
+        Arc::new(RenderImage::new(vec![image::Frame::new(blurred)])),
+    ))
 }
 
+fn qr_blur_bitmap_dim(bitmap_dim: u32) -> u32 {
+    (bitmap_dim / QR_EXPIRED_BLUR_DOWNSCALE).max(QR_EXPIRED_BLUR_MIN_DIM)
+}
+
+fn qr_expired_blur_sigma(bitmap_dim: u32) -> f32 {
+    QR_EXPIRED_BLUR_PX * bitmap_dim as f32 / QR_DISPLAY_PX
+}
+
+const QR_DISPLAY_PX: f32 = 168.;
+const QR_EXPIRED_BLUR_PX: f32 = 12.;
+const QR_EXPIRED_BLUR_DOWNSCALE: u32 = 4;
+const QR_EXPIRED_BLUR_MIN_DIM: u32 = 48;
+const QR_EXPIRED_OPACITY: f32 = 0.5;
 const MAX_ERROR_LEN: usize = 120;
 const ERROR_SLOT_HEIGHT: f32 = 32.;
 const FORM_MIN_HEIGHT: f32 = 256.;
@@ -1216,6 +1254,39 @@ fn required_label(label: &str) -> gpui::AnyElement {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn expired_qr_blur_is_scaled_from_display_px_to_bitmap_px() {
+        assert_eq!(qr_expired_blur_sigma(QR_DISPLAY_PX as u32), 12.);
+        assert_eq!(qr_expired_blur_sigma(336), 24.);
+    }
+
+    #[test]
+    fn build_qr_images_blurs_a_downscaled_copy_not_the_full_bitmap() {
+        let (sharp, blurred) = build_qr_images("mezon-login-id").expect("qr images");
+        let sharp_len = sharp.as_ref().as_bytes(0).expect("sharp frame").len();
+        let blurred_len = blurred.as_ref().as_bytes(0).expect("blurred frame").len();
+
+        assert!(blurred_len > 0);
+        assert!(
+            blurred_len < sharp_len,
+            "the expired QR is upscaled from a small blur, so it must not carry the full bitmap"
+        );
+    }
+
+    #[test]
+    fn qr_blur_downscale_keeps_a_usable_bitmap_and_a_small_kernel() {
+        assert_eq!(qr_blur_bitmap_dim(320), 80);
+        assert_eq!(
+            qr_blur_bitmap_dim(96),
+            QR_EXPIRED_BLUR_MIN_DIM,
+            "a tiny QR must not be downscaled past the floor"
+        );
+        assert!(
+            qr_expired_blur_sigma(qr_blur_bitmap_dim(320)) < 6.0,
+            "blur cost is driven by the kernel, which grows with sigma"
+        );
+    }
 
     #[test]
     fn extracts_message_from_http_error() {

--- a/crates/mezon-ui/src/chat/input_bar.rs
+++ b/crates/mezon-ui/src/chat/input_bar.rs
@@ -1,5 +1,6 @@
 use crate::chat::{MentionInput, ReplyTarget};
 use crate::components::primitives::{Icon, IconName};
+use crate::image_cache::LruImageCache;
 use crate::theme::{ActiveTheme, Theme};
 use gpui::{
     Context, Entity, FontWeight, ObjectFit, Render, SharedString, Subscription, Window, div, img,
@@ -22,6 +23,7 @@ pub struct InputBar {
     _settings_observe: Subscription,
     _mention_observe: Subscription,
     _messages_sub: Subscription,
+    ogp_image_cache: Entity<LruImageCache>,
 }
 
 impl InputBar {
@@ -49,6 +51,7 @@ impl InputBar {
             _settings_observe: settings_observe,
             _mention_observe: mention_observe,
             _messages_sub: messages_sub,
+            ogp_image_cache: crate::image_cache::ogp_aux_cache("composer-ogp", cx),
         }
     }
 
@@ -136,7 +139,7 @@ impl InputBar {
         theme: &Theme,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let ogp_image_cache = crate::image_cache::shared_ogp_cache(cx);
+        let ogp_image_cache = self.ogp_image_cache.clone();
         let mut text_col = div()
             .flex()
             .flex_col()
@@ -271,7 +274,8 @@ impl InputBar {
 
 impl Render for InputBar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        crate::image_cache::sweep_ogp_cache(window, cx);
+        self.ogp_image_cache
+            .update(cx, |cache, cx| cache.sweep_once_per_frame(window, cx));
         self.render_bar(cx.theme().clone(), cx)
     }
 }

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -25,10 +25,11 @@ use mezon_store::{
 };
 
 use super::audio_player::{AudioActivation, AudioPlayerView};
-use super::context::{OnboardingContext, RowCtx, RowMemo, WelcomeContext};
+use super::context::{OnboardingContext, RecentEmojiCell, RowCtx, RowMemo, WelcomeContext};
 use super::dispatch::render_message_item;
 use super::gif_video::GifVideoView;
 use super::message_context_menu;
+use super::parts::recent_emoji_cells;
 use super::reaction_picker::{ReactionPicker, ReactionPickerEvent};
 use super::selection::{MessageSelectionState, SelPoint, SharedSelection, TextSegment, word_range};
 use super::skeleton::message_skeleton;
@@ -456,6 +457,7 @@ const IDLE_CACHE_SWEEP_INTERVAL: Duration = Duration::from_millis(100);
 const HOVER_SHOW_DELAY_MS: u64 = 200;
 const HOVER_HIDE_DELAY_MS: u64 = 100;
 const SCROLL_RELIEF_DELAY: Duration = Duration::from_millis(1500);
+const RECENT_EMOJI_COUNT: usize = 3;
 const MAX_GIF_VIDEOS: usize = 6;
 const MAX_AUDIO_PLAYERS: usize = 8;
 
@@ -1108,6 +1110,7 @@ pub struct ChannelMessages {
     avatar_image_cache: Entity<LruImageCache>,
     small_avatar_image_cache: Entity<LruImageCache>,
     icon_image_cache: Entity<LruImageCache>,
+    ogp_image_cache: Entity<LruImageCache>,
     active_videos: Rc<HashMap<(MessageId, usize), Entity<VideoPlayerView>>>,
     active_audios: Rc<indexmap::IndexMap<(MessageId, usize), Entity<AudioPlayerView>>>,
     gif_videos: Rc<HashMap<(MessageId, usize), Entity<GifVideoView>>>,
@@ -1174,7 +1177,7 @@ pub struct ChannelMessages {
     context_menu_target: Option<(MessageId, Point<Pixels>)>,
     context_menu_forward_all: bool,
     reaction_submenu_open: bool,
-    emoji_recent: Rc<Vec<Emoji>>,
+    emoji_recent: Rc<Vec<RecentEmojiCell>>,
     _emoji_observe: Subscription,
     channel_permissions_fp: Option<(bool, bool, bool)>,
     _channel_permissions_observe: Subscription,
@@ -1680,6 +1683,7 @@ impl ChannelMessages {
                 cx,
             )
         });
+        let ogp_image_cache = crate::image_cache::ogp_timeline_cache("message-ogp", cx);
         let last_cold_inputs = Self::cold_inputs(cx);
         let (welcome, onboarding) = Self::compute_indicator_contexts(cx);
         let cached_unread_boundary = unread_boundary(&MessagesStore::global(cx), None, cx);
@@ -1688,24 +1692,28 @@ impl ChannelMessages {
         let (identity_inputs, cached_current_user_id, cached_role_ids, cached_is_clan_owner) =
             Self::compute_identity(cx);
         let emoji_store = EmojiStore::global(cx);
-        let emoji_recent: Rc<Vec<Emoji>> = Rc::new(
-            emoji_store
+        let recent: Vec<Emoji> = emoji_store
+            .read(cx)
+            .recent(RECENT_EMOJI_COUNT)
+            .into_iter()
+            .cloned()
+            .collect();
+        let emoji_recent: Rc<Vec<RecentEmojiCell>> = Rc::new(recent_emoji_cells(&recent, cx));
+        let emoji_observe = cx.observe(&emoji_store, |this, store, cx| {
+            let next: Vec<Emoji> = store
                 .read(cx)
-                .recent(3)
+                .recent(RECENT_EMOJI_COUNT)
                 .into_iter()
                 .cloned()
-                .collect(),
-        );
-        let emoji_observe = cx.observe(&emoji_store, |this, store, cx| {
-            let next: Vec<Emoji> = store.read(cx).recent(3).into_iter().cloned().collect();
+                .collect();
             let changed = this.emoji_recent.len() != next.len()
                 || this
                     .emoji_recent
                     .iter()
                     .zip(&next)
-                    .any(|(a, b)| a.id != b.id);
+                    .any(|(a, b)| a.id.as_ref() != b.id.as_str());
             if changed {
-                this.emoji_recent = Rc::new(next);
+                this.emoji_recent = Rc::new(recent_emoji_cells(&next, cx));
                 cx.notify();
             }
         });
@@ -1748,6 +1756,7 @@ impl ChannelMessages {
             avatar_image_cache,
             small_avatar_image_cache,
             icon_image_cache,
+            ogp_image_cache,
             active_videos: Rc::new(HashMap::new()),
             active_audios: Rc::new(indexmap::IndexMap::new()),
             gif_videos: Rc::new(HashMap::new()),
@@ -3939,6 +3948,7 @@ impl ChannelMessages {
         let context_menu_message = self.context_menu_target.map(|(id, _)| id);
         let avatar_image_cache = self.avatar_image_cache.clone();
         let small_avatar_image_cache = self.small_avatar_image_cache.clone();
+        let ogp_image_cache = self.ogp_image_cache.clone();
         let icon_image_cache = self.icon_image_cache.clone();
         let reply_highlight_id = TopicsStore::global(cx)
             .read(cx)
@@ -4000,6 +4010,7 @@ impl ChannelMessages {
                         avatar_cache: small_avatar_image_cache.clone(),
                         large_avatar_cache: avatar_image_cache.clone(),
                         icon_cache: icon_image_cache.clone(),
+                        ogp_cache: ogp_image_cache.clone(),
                         unread_boundary_id: None,
                         highlight_id: None,
                         reply_highlight_id,
@@ -4103,7 +4114,8 @@ impl ChannelMessages {
 
 impl Render for ChannelMessages {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        crate::image_cache::sweep_ogp_cache(window, cx);
+        self.ogp_image_cache
+            .update(cx, |cache, cx| cache.sweep_once_per_frame(window, cx));
         {
             let mut selection = self.selection.borrow_mut();
             selection.begin_render();
@@ -4185,6 +4197,7 @@ impl Render for ChannelMessages {
         let context_menu_message = self.context_menu_target.map(|(id, _)| id);
         let avatar_image_cache = self.avatar_image_cache.clone();
         let small_avatar_image_cache = self.small_avatar_image_cache.clone();
+        let ogp_image_cache = self.ogp_image_cache.clone();
         let icon_image_cache = self.icon_image_cache.clone();
         let unread_boundary_id = self.cached_unread_boundary;
         let highlight_id = self.highlight_id;
@@ -4253,6 +4266,7 @@ impl Render for ChannelMessages {
                         avatar_cache: small_avatar_image_cache.clone(),
                         large_avatar_cache: avatar_image_cache.clone(),
                         icon_cache: icon_image_cache.clone(),
+                        ogp_cache: ogp_image_cache.clone(),
                         unread_boundary_id,
                         highlight_id,
                         reply_highlight_id,

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -1695,6 +1695,9 @@ fn render_social_link_card(
         .flex()
         .flex_col()
         .gap_1()
+        .when(kind != LinkKind::Plain, |card| {
+            card.flex_basis(relative(1.))
+        })
         .w_full()
         .min_w_0()
         .max_w(px(400.))

--- a/crates/mezon-ui/src/chat/message/context.rs
+++ b/crates/mezon-ui/src/chat/message/context.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use gpui::{App, Entity, HighlightStyle, Hsla, SharedString, WeakEntity};
 use mezon_store::{
-    ChannelType, ClanId, Emoji, MessageId, ProfileContext, RichClick, RichLayout, Settings, UserId,
+    ChannelType, ClanId, MessageId, ProfileContext, RichClick, RichLayout, Settings, UserId,
 };
 
 use super::audio_player::AudioPlayerView;
@@ -68,6 +68,7 @@ pub struct RowCtx<'a> {
     pub avatar_cache: Entity<LruImageCache>,
     pub large_avatar_cache: Entity<LruImageCache>,
     pub icon_cache: Entity<LruImageCache>,
+    pub ogp_cache: Entity<LruImageCache>,
     pub unread_boundary_id: Option<MessageId>,
     pub highlight_id: Option<MessageId>,
     pub reply_highlight_id: Option<MessageId>,
@@ -92,7 +93,7 @@ pub struct RowCtx<'a> {
     pub editing_id: Option<MessageId>,
     pub edit_input: Option<Entity<MentionInput>>,
     /// Up to 3 most-recently-used emoji for the hover toolbar's quick-react pills.
-    pub emoji_recent: &'a [Emoji],
+    pub emoji_recent: &'a [RecentEmojiCell],
     /// `common.comingSoon`, resolved once per render pass (not per row).
     pub coming_soon: SharedString,
     /// Cross-frame memo for per-row derived values that are expensive to
@@ -101,6 +102,16 @@ pub struct RowCtx<'a> {
     /// locale change and day rollover.
     pub row_memo: Rc<RefCell<RowMemo>>,
     pub selection: super::selection::SharedSelection,
+}
+
+/// Per-frame view model for the quick-reaction strip. The proxied url and the
+/// element-id prefix are identical for every row, so they are resolved once per
+/// frame instead of rebuilt inside each row's hover actions.
+pub struct RecentEmojiCell {
+    pub id: SharedString,
+    pub shortname: SharedString,
+    pub src: SharedString,
+    pub element_key: SharedString,
 }
 
 #[derive(Default)]

--- a/crates/mezon-ui/src/chat/message/invite_card.rs
+++ b/crates/mezon-ui/src/chat/message/invite_card.rs
@@ -31,6 +31,11 @@ pub(crate) fn selectable_invite_text(invite: &InvitePreview, locale: &str) -> St
     )
 }
 
+const INVITE_AVATAR_BOX: f32 = 72.0;
+const INVITE_AVATAR_BORDER: f32 = 4.0;
+const INVITE_AVATAR_RADIUS: f32 = 22.0;
+const INVITE_AVATAR_INNER_RADIUS: f32 = INVITE_AVATAR_RADIUS - INVITE_AVATAR_BORDER;
+
 pub fn render_invite_card(
     invite: &InvitePreview,
     base: Option<usize>,
@@ -74,6 +79,7 @@ pub fn render_invite_card(
         avatar_inner = avatar_inner.child(
             img(invite.image_proxied.clone())
                 .size_full()
+                .rounded(px(INVITE_AVATAR_INNER_RADIUS))
                 .object_fit(ObjectFit::Cover),
         );
     }
@@ -233,10 +239,10 @@ pub fn render_invite_card(
                 .absolute()
                 .top(px(40.))
                 .left(px(16.))
-                .w(px(72.))
-                .h(px(72.))
+                .w(px(INVITE_AVATAR_BOX))
+                .h(px(INVITE_AVATAR_BOX))
                 .overflow_hidden()
-                .rounded(px(22.))
+                .rounded(px(INVITE_AVATAR_RADIUS))
                 .border_4()
                 .border_color(theme.tokens.border_primary)
                 .bg(theme.tokens.theme_setting_primary)

--- a/crates/mezon-ui/src/chat/message/ogp_embed.rs
+++ b/crates/mezon-ui/src/chat/message/ogp_embed.rs
@@ -19,13 +19,12 @@ pub fn render_ogp_embed(
 ) -> Option<AnyElement> {
     let can_remove =
         !ctx.current_user_id.is_empty() && msg.sender_id.as_str() == ctx.current_user_id;
-    let og_cache = crate::image_cache::ogp_image_cache(ctx.app);
     render_ogp_preview_impl(
         msg.ogp.as_deref()?,
         msg.row_anchor_id,
         ctx.theme,
         can_remove,
-        og_cache,
+        ctx.ogp_cache.clone(),
         Some((base, selection_context, ctx.selection.clone())),
     )
 }
@@ -34,16 +33,9 @@ pub fn render_ogp_preview(
     ogp: &OgpPreview,
     message_id: MessageId,
     theme: &Theme,
-    app: &gpui::App,
+    ogp_cache: Entity<LruImageCache>,
 ) -> Option<AnyElement> {
-    render_ogp_preview_impl(
-        ogp,
-        message_id,
-        theme,
-        false,
-        crate::image_cache::ogp_image_cache(app),
-        None,
-    )
+    render_ogp_preview_impl(ogp, message_id, theme, false, ogp_cache, None)
 }
 
 fn render_ogp_preview_impl(
@@ -51,7 +43,7 @@ fn render_ogp_preview_impl(
     message_id: MessageId,
     theme: &Theme,
     can_remove: bool,
-    og_cache: Option<Entity<LruImageCache>>,
+    og_cache: Entity<LruImageCache>,
     selectable: Option<(
         usize,
         &SelectableTextContext,
@@ -125,7 +117,7 @@ fn render_ogp_preview_impl(
         .flex()
         .items_center()
         .justify_center()
-        .when_some(og_cache, |image_box, cache| image_box.image_cache(cache))
+        .image_cache(og_cache)
         .child(ogp_image(ogp.image_proxied.clone(), theme.text_muted));
 
     Some(

--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -7,9 +7,9 @@ use gpui::{
     SharedString, Transformation, Window, div, img, prelude::*, px, radians, rems, rgba,
 };
 use mezon_store::{
-    AlbumLayout, AppConfig, ChannelType, ClanMembersStore, Message, MessageAttachment, MessageCode,
-    MessageId, MessageReference, MessagesStore, PlatformStore, Reaction, ThreadsStore, TopicsStore,
-    ViewerMedia, resolve_avatar_url,
+    AlbumLayout, AppConfig, ChannelType, ClanId, ClanMembersStore, Emoji, Message,
+    MessageAttachment, MessageCode, MessageId, MessageReference, MessagesStore, PlatformStore,
+    ProfileContext, Reaction, ThreadsStore, TopicsStore, UserId, ViewerMedia, resolve_avatar_url,
 };
 use smallvec::SmallVec;
 
@@ -17,7 +17,7 @@ use super::audio_player::{
     AudioActivation, audio_failed_pill, audio_pill, audio_sending_pill, audio_time_label,
 };
 use super::content::{SELECTION_BG, SelectableTextContext, profile_popover_trigger};
-use super::context::{REPLY_USERNAME_COLOR, ROW_MEMO_CAPACITY, RowCtx};
+use super::context::{REPLY_USERNAME_COLOR, ROW_MEMO_CAPACITY, RecentEmojiCell, RowCtx};
 use super::gif_video::GifVideoView;
 use super::reaction_detail::{UserReactionPanel, emoji_error_fallback};
 use super::selection::{SelectableRegion, TextSegment};
@@ -88,12 +88,78 @@ pub fn resolve_message_display_name(msg: &Message, ctx: &RowCtx, cx: &App) -> Sh
     msg.sender_name.clone()
 }
 
+fn is_anonymous_sender(sender_id: &str, cx: &App) -> bool {
+    AppConfig::try_global(cx)
+        .map(|config| !config.anonymous_user_id.is_empty() && sender_id == config.anonymous_user_id)
+        .unwrap_or(false)
+}
+
+fn is_anonymous_user_id(user_id: UserId, cx: &App) -> bool {
+    AppConfig::try_global(cx)
+        .and_then(|config| config.anonymous_user_id.parse::<i64>().ok())
+        .is_some_and(|anonymous| anonymous == user_id.get())
+}
+
+fn reference_avatar(
+    clan_id: ClanId,
+    user_id: UserId,
+    ctx: &RowCtx,
+    cx: &App,
+) -> Option<SharedString> {
+    if let Some(cached) = ctx.row_memo.borrow().avatars.get(&user_id) {
+        return cached.as_ref().map(|(_, proxied)| proxied.clone());
+    }
+    let resolved = resolve_avatar_url(user_id, ProfileContext::Clan(clan_id), cx)
+        .filter(|url| !url.is_empty())
+        .map(|url| {
+            let proxied = SharedString::from(crate::util::imgproxy::avatar_url(cx, &url));
+            (SharedString::from(url), proxied)
+        });
+    ctx.row_memo
+        .borrow_mut()
+        .avatars
+        .insert(user_id, resolved.clone());
+    resolved.map(|(_, proxied)| proxied)
+}
+
+fn resolve_reference_identity(
+    reference: &MessageReference,
+    ctx: &RowCtx,
+    cx: &App,
+) -> (SharedString, SharedString) {
+    let baked_name = || SharedString::from(reference.sender_name.clone());
+    let baked_avatar = || SharedString::from(reference.sender_avatar.clone());
+    let clan_id = role_scope(ctx.profile_context)
+        .filter(|_| !reference.sender_id.is_zero())
+        .filter(|_| !is_anonymous_user_id(reference.sender_id, cx));
+    let Some(clan_id) = clan_id else {
+        return (baked_name(), baked_avatar());
+    };
+    let members = ClanMembersStore::global(cx);
+    let member = members.read(cx).member(clan_id, reference.sender_id);
+    let name = match member {
+        Some(member) => SharedString::from(mezon_store::name_for_prioritize(
+            first_non_empty(&member.clan_nick, &reference.sender_clan_nick),
+            first_non_empty(&member.user.display_name, &reference.sender_display_name),
+            first_non_empty(&member.user.username, &reference.sender_username),
+        )),
+        None => baked_name(),
+    };
+    let avatar =
+        reference_avatar(clan_id, reference.sender_id, ctx, cx).unwrap_or_else(baked_avatar);
+    (name, avatar)
+}
+
+fn first_non_empty<'a>(preferred: &'a str, fallback: &'a str) -> &'a str {
+    if preferred.is_empty() {
+        fallback
+    } else {
+        preferred
+    }
+}
+
 pub fn avatar_element(msg: &Message, ctx: &RowCtx, cx: &App) -> AnyElement {
-    let is_anonymous = AppConfig::try_global(cx)
-        .map(|config| {
-            !config.anonymous_user_id.is_empty() && msg.sender_id == config.anonymous_user_id
-        })
-        .unwrap_or(false);
+    let is_anonymous = is_anonymous_sender(&msg.sender_id, cx);
     let (raw_url, proxied) = resolve_message_avatar_urls(msg, ctx, cx);
     let display_name = resolve_message_display_name(msg, ctx, cx);
     let mut avatar = Avatar::new()
@@ -272,15 +338,16 @@ pub fn render_reply(reference: &MessageReference, ctx: &RowCtx) -> AnyElement {
 
     let has_attachment_ref = reference.has_attachment || reference.has_embed;
     let is_deleted = reference.content == DELETED_REPLY_PREVIEW;
-    let avatar = if reference.sender_avatar.is_empty() {
+    let (sender_name, sender_avatar) = resolve_reference_identity(reference, ctx, ctx.app);
+    let avatar = if sender_avatar.is_empty() {
         Avatar::new()
-            .name(reference.sender_name.clone())
+            .name(sender_name.clone())
             .size_px(px(20.))
             .image_cache(ctx.avatar_cache.clone())
     } else {
         Avatar::new()
-            .name(reference.sender_name.clone())
-            .src(reference.sender_avatar.clone())
+            .name(sender_name.clone())
+            .src(sender_avatar)
             .size_px(px(20.))
             .image_cache(ctx.avatar_cache.clone())
     };
@@ -321,7 +388,7 @@ pub fn render_reply(reference: &MessageReference, ctx: &RowCtx) -> AnyElement {
                 .font_weight(FontWeight::BOLD)
                 .text_color(gpui::rgb(REPLY_USERNAME_COLOR))
                 .hover(|s| s.underline())
-                .child(reference.sender_name.clone()),
+                .child(sender_name),
         )
         .child(if has_attachment_ref {
             div()
@@ -1307,6 +1374,21 @@ fn add_reaction_button(message_id: MessageId, ctx: &RowCtx) -> AnyElement {
 
 const REACTION_EMOJI_PX: f32 = 16.;
 const REACTION_EMOJI_SOURCE_PX: u32 = 32;
+const RECENT_EMOJI_PX: f32 = 20.;
+const RECENT_EMOJI_SOURCE_PX: u32 = 40;
+
+pub fn recent_emoji_cells(emojis: &[Emoji], cx: &App) -> Vec<RecentEmojiCell> {
+    emojis
+        .iter()
+        .map(|emoji| RecentEmojiCell {
+            id: emoji.id.clone().into(),
+            shortname: emoji.shortname.clone().into(),
+            src: crate::util::imgproxy::emoji_url_sized(cx, &emoji.id, RECENT_EMOJI_SOURCE_PX)
+                .into(),
+            element_key: format!("recent-emoji-{}", emoji.id).into(),
+        })
+        .collect()
+}
 
 fn reaction_emoji_src(reaction: &Reaction, app: &gpui::App) -> SharedString {
     if reaction.emoji_id.is_empty() || reaction.emoji_id.as_ref() == "0" {
@@ -1490,11 +1572,8 @@ pub fn render_hover_actions(
         for emoji in ctx.emoji_recent {
             let emoji_id = emoji.id.clone();
             let shortname = emoji.shortname.clone();
-            let src = crate::util::imgproxy::emoji_url(ctx.app, &emoji.id);
-            let cell_id =
-                SharedString::from(format!("recent-emoji-{}-{}", msg.row_anchor_id.0, emoji.id));
             let mut cell = div()
-                .id(cell_id)
+                .id((emoji.element_key.clone(), msg.row_anchor_id.0 as usize))
                 .flex()
                 .items_center()
                 .justify_center()
@@ -1504,15 +1583,19 @@ pub fn render_hover_actions(
                 .hover(move |s| s.bg(bg_hover))
                 .on_click(move |_, _, cx| {
                     MessagesStore::global(cx).update(cx, |store, cx| {
-                        store.add_reaction(msg_id, emoji_id.clone(), shortname.clone(), cx);
+                        store.add_reaction(msg_id, emoji_id.to_string(), shortname.to_string(), cx);
                     });
                 });
-            if !src.is_empty() {
+            if !emoji.src.is_empty() {
                 cell = cell.child(
-                    img(src)
-                        .size(px(20.))
+                    img(emoji.src.clone())
+                        .size(px(RECENT_EMOJI_PX))
                         .object_fit(ObjectFit::ScaleDown)
-                        .with_fallback(emoji_error_fallback(px(20.), theme.text_secondary)),
+                        .image_cache(&ctx.icon_cache)
+                        .with_fallback(emoji_error_fallback(
+                            px(RECENT_EMOJI_PX),
+                            theme.text_secondary,
+                        )),
                 );
             }
             row = row.child(cell);

--- a/crates/mezon-ui/src/chat/message/reaction_detail.rs
+++ b/crates/mezon-ui/src/chat/message/reaction_detail.rs
@@ -54,9 +54,11 @@ impl Render for UserReactionPanel {
             .unwrap_or((0, Vec::new()));
         let emoji_src = crate::util::imgproxy::emoji_url(cx, &self.emoji_id);
         let current_uid = BadgeService::global(cx).read(cx).current_user_id(cx);
-        let clan_id = ClanList::global(cx).read(cx).active_clan_id;
-        let dm_context = clan_id
-            .is_none()
+        let is_dm = MessagesStore::global(cx).read(cx).is_dm();
+        let clan_id = (!is_dm)
+            .then(|| ClanList::global(cx).read(cx).active_clan_id)
+            .flatten();
+        let dm_context = is_dm
             .then(|| {
                 let direct = DirectMessageStore::global(cx);
                 let direct = direct.read(cx);
@@ -72,8 +74,7 @@ impl Render for UserReactionPanel {
                     })
             })
             .flatten();
-        let self_profile = clan_id
-            .is_none()
+        let self_profile = is_dm
             .then(|| {
                 AccountStore::try_global(cx).and_then(|store| {
                     store.read(cx).account.as_ref().map(|account| {

--- a/crates/mezon-ui/src/chat/message_search.rs
+++ b/crates/mezon-ui/src/chat/message_search.rs
@@ -165,6 +165,7 @@ pub struct MessageSearchPanel {
     last_results_page: i32,
     avatar_image_cache: Entity<LruImageCache>,
     attachment_image_cache: Entity<LruImageCache>,
+    ogp_image_cache: Entity<LruImageCache>,
     cached_rows: Rc<Vec<SearchListRow>>,
     cached_highlights: Rc<Vec<String>>,
     rows_cache_fp: Option<(u64, u64)>,
@@ -233,6 +234,7 @@ impl MessageSearchPanel {
                     cx,
                 )
             }),
+            ogp_image_cache: crate::image_cache::ogp_aux_cache("message-search-ogp", cx),
             _subs: subs,
         }
     }
@@ -271,7 +273,8 @@ impl MessageSearchPanel {
 
 impl Render for MessageSearchPanel {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        crate::image_cache::sweep_ogp_cache(window, cx);
+        self.ogp_image_cache
+            .update(cx, |cache, cx| cache.sweep_once_per_frame(window, cx));
         self.avatar_image_cache
             .update(cx, |cache, cx| cache.sweep_once_per_frame(window, cx));
         self.attachment_image_cache
@@ -379,6 +382,7 @@ impl Render for MessageSearchPanel {
             let highlight_terms = self.cached_highlights.clone();
             let avatar_cache = self.avatar_image_cache.clone();
             let attachment_cache = self.attachment_image_cache.clone();
+            let ogp_cache = self.ogp_image_cache.clone();
             let pagination = (page_count > 1)
                 .then(|| render_search_pagination(&theme, current_page, page_count, panel));
             if self.list_state.item_count() != self.cached_rows.len() {
@@ -425,6 +429,7 @@ impl Render for MessageSearchPanel {
                                         is_direct,
                                         avatar_cache.clone(),
                                         attachment_cache.clone(),
+                                        ogp_cache.clone(),
                                         cx,
                                     ))
                                     .into_any_element()
@@ -690,6 +695,7 @@ fn render_search_row(
     is_direct: bool,
     avatar_image_cache: Entity<LruImageCache>,
     attachment_image_cache: Entity<LruImageCache>,
+    ogp_image_cache: Entity<LruImageCache>,
     cx: &App,
 ) -> gpui::AnyElement {
     let hit_for_jump = hit.clone();
@@ -867,8 +873,12 @@ fn render_search_row(
                                     )
                                 })
                                 .children(ogp.as_ref().and_then(|ogp| {
-                                    let preview =
-                                        render_ogp_preview(ogp, hit.message_id, theme, cx)?;
+                                    let preview = render_ogp_preview(
+                                        ogp,
+                                        hit.message_id,
+                                        theme,
+                                        ogp_image_cache.clone(),
+                                    )?;
                                     Some(
                                         div()
                                             .w_full()

--- a/crates/mezon-ui/src/components/primitives/context_menu.rs
+++ b/crates/mezon-ui/src/components/primitives/context_menu.rs
@@ -74,6 +74,8 @@ pub struct ContextMenu {
 
 const SUBMENU_WIDTH: f32 = 240.;
 const MENU_WIDTH_ESTIMATE: f32 = 240.;
+const QUICK_REACTION_EMOJI_PX: f32 = 24.;
+const QUICK_REACTION_EMOJI_SOURCE_PX: u32 = 48;
 
 impl ContextMenu {
     pub fn new() -> Self {
@@ -347,7 +349,11 @@ impl RenderOnce for ContextMenu {
             for (index, reaction) in self.quick_reactions.into_iter().enumerate() {
                 let emoji_id = reaction.emoji_id.clone();
                 let shortname = reaction.shortname.clone();
-                let src = crate::util::imgproxy::emoji_url(cx, &reaction.emoji_id);
+                let src = crate::util::imgproxy::emoji_url_sized(
+                    cx,
+                    &reaction.emoji_id,
+                    QUICK_REACTION_EMOJI_SOURCE_PX,
+                );
                 let dismiss_click = dismiss.clone();
                 let on_react = on_quick_reaction.clone();
                 let mut cell = div()
@@ -369,22 +375,24 @@ impl RenderOnce for ContextMenu {
                     });
                 if !src.is_empty() {
                     let fallback_color = muted;
-                    cell = cell.child(img(SharedString::from(src)).size(px(24.)).with_fallback(
-                        move || {
-                            div()
-                                .size(px(24.))
-                                .rounded(px(4.))
-                                .flex()
-                                .items_center()
-                                .justify_center()
-                                .child(
-                                    Icon::new(IconName::ImageThumbnail)
-                                        .size(px(16.))
-                                        .text_color(fallback_color),
-                                )
-                                .into_any_element()
-                        },
-                    ));
+                    cell = cell.child(
+                        img(SharedString::from(src))
+                            .size(px(QUICK_REACTION_EMOJI_PX))
+                            .with_fallback(move || {
+                                div()
+                                    .size(px(QUICK_REACTION_EMOJI_PX))
+                                    .rounded(px(4.))
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .child(
+                                        Icon::new(IconName::ImageThumbnail)
+                                            .size(px(16.))
+                                            .text_color(fallback_color),
+                                    )
+                                    .into_any_element()
+                            }),
+                    );
                 }
                 reaction_row = reaction_row.child(cell);
             }
@@ -630,7 +638,11 @@ impl RenderOnce for ContextMenu {
                         for (ri, reaction) in reactions.iter().enumerate() {
                             let emoji_id = reaction.emoji_id.clone();
                             let shortname = reaction.shortname.clone();
-                            let src = crate::util::imgproxy::emoji_url(cx, &reaction.emoji_id);
+                            let src = crate::util::imgproxy::emoji_url_sized(
+                                cx,
+                                &reaction.emoji_id,
+                                QUICK_REACTION_EMOJI_SOURCE_PX,
+                            );
                             let shortname_label = SharedString::from(reaction.shortname.clone());
                             let on_react = on_react.clone();
                             let dismiss_r = dismiss.clone();
@@ -655,11 +667,11 @@ impl RenderOnce for ContextMenu {
                             if !src.is_empty() {
                                 row = row.child(
                                     img(SharedString::from(src))
-                                        .size(px(24.))
+                                        .size(px(QUICK_REACTION_EMOJI_PX))
                                         .flex_none()
                                         .with_fallback(move || {
                                             div()
-                                                .size(px(24.))
+                                                .size(px(QUICK_REACTION_EMOJI_PX))
                                                 .flex()
                                                 .items_center()
                                                 .justify_center()

--- a/crates/mezon-ui/src/image_cache.rs
+++ b/crates/mezon-ui/src/image_cache.rs
@@ -141,44 +141,32 @@ impl Global for SharedRoleIconCache {}
 struct SharedRoleIconPreviewCache(Entity<LruImageCache>);
 impl Global for SharedRoleIconPreviewCache {}
 
-struct SharedOgpCache(Entity<LruImageCache>);
-impl Global for SharedOgpCache {}
+const OGP_TIMELINE_CACHE_CAPACITY: usize = 12;
+const OGP_TIMELINE_CACHE_BYTES: u64 = 6 * 1024 * 1024;
+const OGP_AUX_CACHE_CAPACITY: usize = 4;
+const OGP_AUX_CACHE_BYTES: u64 = 2 * 1024 * 1024;
+const OGP_ENTRY_MAX_BYTES: u64 = 1024 * 1024;
 
-const OGP_SHARED_CACHE_CAPACITY: usize = 16;
-const OGP_SHARED_CACHE_BYTES: u64 = 8 * 1024 * 1024;
-const OGP_SHARED_ENTRY_MAX_BYTES: u64 = 2 * 1024 * 1024;
-
-/// App-global, bounded, aspect-preserving cache for OGP link-preview images
-/// (decode-capped at [`OGP_THUMB_DECODE_MAX_PX`]), so previews never share/evict
-/// the message image cache and large external OG images decode downscaled. Must
-/// be initialized once with a `&mut App`; read from render via [`ogp_image_cache`].
-pub fn shared_ogp_cache(cx: &mut App) -> Entity<LruImageCache> {
-    if let Some(existing) = cx.try_global::<SharedOgpCache>() {
-        return existing.0.clone();
-    }
-    let cache = cx.new(|cx| {
-        LruImageCache::ogp_thumbnail(
-            "ogp-shared",
-            OGP_SHARED_CACHE_CAPACITY,
-            OGP_SHARED_CACHE_BYTES,
-            OGP_SHARED_ENTRY_MAX_BYTES,
-            cx,
-        )
-    });
-    cx.set_global(SharedOgpCache(cache.clone()));
-    cache
+pub fn ogp_timeline_cache(label: &'static str, cx: &mut App) -> Entity<LruImageCache> {
+    ogp_preview_cache(
+        label,
+        OGP_TIMELINE_CACHE_CAPACITY,
+        OGP_TIMELINE_CACHE_BYTES,
+        cx,
+    )
 }
 
-/// The app-global OGP image cache if [`shared_ogp_cache`] has been initialized.
-pub fn ogp_image_cache(app: &App) -> Option<Entity<LruImageCache>> {
-    app.try_global::<SharedOgpCache>()
-        .map(|cache| cache.0.clone())
+pub fn ogp_aux_cache(label: &'static str, cx: &mut App) -> Entity<LruImageCache> {
+    ogp_preview_cache(label, OGP_AUX_CACHE_CAPACITY, OGP_AUX_CACHE_BYTES, cx)
 }
 
-pub fn sweep_ogp_cache(window: &mut Window, cx: &mut App) {
-    if let Some(cache) = ogp_image_cache(cx) {
-        cache.update(cx, |cache, cx| cache.sweep_once_per_frame(window, cx));
-    }
+fn ogp_preview_cache(
+    label: &'static str,
+    capacity: usize,
+    bytes: u64,
+    cx: &mut App,
+) -> Entity<LruImageCache> {
+    cx.new(|cx| LruImageCache::ogp_thumbnail(label, capacity, bytes, OGP_ENTRY_MAX_BYTES, cx))
 }
 
 /// Shared decode cache for role icons. They render at 12-20px everywhere, so
@@ -1835,7 +1823,13 @@ mod tests {
         assert_eq!(PREVIEW_IMAGE_CACHE_CAPACITY, 64);
         assert_eq!(PREVIEW_IMAGE_CACHE_BYTES, 32 * 1024 * 1024);
         assert_eq!(SHARED_IMAGE_CACHE_BYTES, 24 * 1024 * 1024);
-        assert_eq!(OGP_SHARED_CACHE_BYTES, 8 * 1024 * 1024);
+        assert_eq!(OGP_TIMELINE_CACHE_BYTES, 6 * 1024 * 1024);
+        assert_eq!(OGP_AUX_CACHE_BYTES, 2 * 1024 * 1024);
+        assert_eq!(
+            OGP_TIMELINE_CACHE_BYTES + 3 * OGP_AUX_CACHE_BYTES,
+            12 * 1024 * 1024,
+            "one timeline plus the search and two composer caches must stay near the old single-cache budget"
+        );
         assert_eq!(IDLE_TRIM_INTERVAL, Duration::from_secs(30));
         assert_eq!(IDLE_TRIM_TTL, Duration::from_secs(60));
     }
@@ -1863,6 +1857,25 @@ mod tests {
             GRACE_PERIOD + Duration::from_millis(1),
             GRACE_PERIOD
         ));
+    }
+
+    #[gpui::test]
+    fn each_view_gets_its_own_ogp_cache(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let timeline = ogp_timeline_cache("timeline-ogp", cx);
+            let composer = ogp_aux_cache("composer-ogp", cx);
+
+            assert_ne!(
+                timeline.read(cx).instance,
+                composer.read(cx).instance,
+                "sharing one OGP cache lets a sweep from the view that rendered this frame \
+                 evict previews that are still on screen in a view that did not"
+            );
+            assert!(
+                timeline.read(cx).max_bytes > composer.read(cx).max_bytes,
+                "the timeline holds many previews at once; the composer holds at most the pending one"
+            );
+        });
     }
 
     #[test]

--- a/crates/mezon-webview/src/linux.rs
+++ b/crates/mezon-webview/src/linux.rs
@@ -47,7 +47,18 @@ pub fn init_gtk() -> Result<()> {
     Ok(())
 }
 
+const GTK_EVENTS_PER_PUMP: usize = 32;
+
 pub fn pump_gtk_events() {
+    for _ in 0..GTK_EVENTS_PER_PUMP {
+        if !gtk::events_pending() {
+            return;
+        }
+        gtk::main_iteration_do(false);
+    }
+}
+
+fn drain_gtk_events() {
     while gtk::events_pending() {
         gtk::main_iteration_do(false);
     }
@@ -59,19 +70,19 @@ pub fn destroy_webview(webview: ChannelAppWebView) {
     if let Err(error) = webview.set_visible(false) {
         tracing::warn!("channel app webview hide failed: {error:#}");
     }
-    pump_gtk_events();
+    drain_gtk_events();
 
     let gtk_window = wry_gtk_window(&gtk_webview);
     unsafe {
         gtk_webview.destroy();
     }
-    pump_gtk_events();
+    drain_gtk_events();
 
     if let Some(gtk_window) = gtk_window {
         unsafe {
             gtk_window.destroy();
         }
-        pump_gtk_events();
+        drain_gtk_events();
     }
 
     sync_x11_display();
@@ -109,7 +120,7 @@ pub fn create(
     builder: WebViewBuilder<'_>,
 ) -> Result<ChannelAppWebView> {
     init_gtk()?;
-    pump_gtk_events();
+    drain_gtk_events();
 
     let handle = parent.window_handle()?.as_raw();
     let webview = match handle {


### PR DESCRIPTION
## Summary

- Harden `ChannelList` clan extras/favorites loading and structure merge
- Hide main window to tray on close when tray/background mode is available (Linux/macOS)
- Align typing and reply reference sender display with clan nick
- Polish login QR expired blurred state, message parts rendering, context menu, and image cache

## Test plan

- [ ] `just lint` and `just test` pass
- [ ] Clan channel list loads favorites/voice/app extras without stale partial state
- [ ] Close window with tray enabled → app hides to tray instead of quitting
- [ ] Close window without tray (Linux) → app quits normally
- [ ] Typing indicator and reply preview show clan nick when set
- [ ] Login QR shows blurred image when expired
