### PR TITLE
feat(sidebar): drag-to-reorder clans with persisted order

### DIFF
--- a/crates/mezon-store/src/clan.rs
+++ b/crates/mezon-store/src/clan.rs
@@ -360,7 +360,9 @@ pub struct ClanList {
     loading: bool,
     badges_loaded: bool,
     reset_generation: u64,
+    saved_order: Vec<ClanId>,
     _connection_watch: Task<()>,
+    _saved_order_load: Task<()>,
 }
 
 struct GlobalClanList(Entity<ClanList>);
@@ -400,6 +402,18 @@ impl ClanList {
     fn new(api: Arc<AppApi>, cx: &mut Context<Self>) -> Self {
         Self::register_realtime(cx);
         let connection_watch = Self::spawn_connection_watch(api.clone(), cx);
+        let saved_order_load = cx.spawn(async move |this, cx| {
+            let order = cx
+                .background_executor()
+                .spawn(async { crate::Settings::load_sync().clan_order })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.saved_order = order;
+                if this.apply_saved_order_internal() {
+                    cx.notify();
+                }
+            });
+        });
         Self {
             clans: Vec::new(),
             active_clan_id: None,
@@ -407,7 +421,9 @@ impl ClanList {
             loading: false,
             badges_loaded: false,
             reset_generation: 0,
+            saved_order: Vec::new(),
             _connection_watch: connection_watch,
+            _saved_order_load: saved_order_load,
         }
     }
 
@@ -723,6 +739,7 @@ impl ClanList {
         let prev_active = self.active_clan_id;
         carry_live_badges(&self.clans, &mut clans);
         self.clans = clans;
+        self.apply_saved_order_internal();
         let active_missing = self
             .active_clan_id
             .is_some_and(|active| !self.clans.iter().any(|c| c.id == active));
@@ -785,6 +802,7 @@ impl ClanList {
 
     pub fn reorder_clans(&mut self, order: Vec<ClanId>, cx: &mut Context<Self>) {
         apply_clan_order(&mut self.clans, &order);
+        self.saved_order = order.clone();
         cx.notify();
         cx.background_executor()
             .spawn(async move {
@@ -795,8 +813,26 @@ impl ClanList {
             .detach();
     }
 
+    pub fn move_clan(&mut self, from: usize, to: usize, cx: &mut Context<Self>) {
+        let Some(order) = moved_clan_order(&self.clans, from, to) else {
+            return;
+        };
+        self.reorder_clans(order, cx);
+    }
+
     pub fn apply_saved_order(&mut self, order: &[ClanId]) {
+        self.saved_order = order.to_vec();
         apply_clan_order(&mut self.clans, order);
+    }
+
+    fn apply_saved_order_internal(&mut self) -> bool {
+        if self.saved_order.is_empty() || self.clans.is_empty() {
+            return false;
+        }
+        let order = std::mem::take(&mut self.saved_order);
+        apply_clan_order(&mut self.clans, &order);
+        self.saved_order = order;
+        true
     }
 
     pub fn clan_by_id(&self, clan_id: ClanId) -> Option<&Clan> {
@@ -1106,6 +1142,16 @@ fn community_update_request(
     request
 }
 
+fn moved_clan_order(clans: &[Clan], from: usize, to: usize) -> Option<Vec<ClanId>> {
+    if from == to || from >= clans.len() || to >= clans.len() {
+        return None;
+    }
+    let mut ids: Vec<ClanId> = clans.iter().map(|clan| clan.id).collect();
+    let moved = ids.remove(from);
+    ids.insert(to, moved);
+    Some(ids)
+}
+
 fn apply_clan_order(clans: &mut Vec<Clan>, order: &[ClanId]) {
     if order.is_empty() {
         return;
@@ -1224,6 +1270,69 @@ mod tests {
             make_clan(1, "One", None),
             make_clan(2, "Two", Some("old.png")),
         ]
+    }
+
+    fn four_clans() -> Vec<Clan> {
+        vec![
+            make_clan(1, "A", None),
+            make_clan(2, "B", None),
+            make_clan(3, "C", None),
+            make_clan(4, "D", None),
+        ]
+    }
+
+    fn ids_after_move(from: usize, to: usize) -> Vec<i64> {
+        let clans = four_clans();
+        moved_clan_order(&clans, from, to)
+            .expect("move")
+            .into_iter()
+            .map(|id| id.get())
+            .collect()
+    }
+
+    #[test]
+    fn dragging_a_clan_down_lands_it_after_the_target() {
+        assert_eq!(ids_after_move(0, 2), vec![2, 3, 1, 4]);
+    }
+
+    #[test]
+    fn dragging_a_clan_up_lands_it_before_the_target() {
+        assert_eq!(ids_after_move(3, 1), vec![1, 4, 2, 3]);
+    }
+
+    #[test]
+    fn moving_a_clan_onto_itself_or_out_of_range_is_a_no_op() {
+        let clans = four_clans();
+        assert!(moved_clan_order(&clans, 1, 1).is_none());
+        assert!(moved_clan_order(&clans, 9, 1).is_none());
+        assert!(moved_clan_order(&clans, 1, 9).is_none());
+        assert!(moved_clan_order(&[], 0, 0).is_none());
+    }
+
+    #[test]
+    fn a_saved_order_survives_a_clan_list_refetch() {
+        let saved: Vec<ClanId> = [4, 3, 2, 1].into_iter().map(ClanId).collect();
+        let mut clans = four_clans();
+
+        apply_clan_order(&mut clans, &saved);
+
+        let ids: Vec<i64> = clans.iter().map(|clan| clan.id.get()).collect();
+        assert_eq!(ids, vec![4, 3, 2, 1]);
+    }
+
+    #[test]
+    fn a_clan_missing_from_the_saved_order_keeps_its_place_at_the_end() {
+        let saved: Vec<ClanId> = [3, 1].into_iter().map(ClanId).collect();
+        let mut clans = four_clans();
+
+        apply_clan_order(&mut clans, &saved);
+
+        let ids: Vec<i64> = clans.iter().map(|clan| clan.id.get()).collect();
+        assert_eq!(
+            ids,
+            vec![3, 1, 2, 4],
+            "a clan joined after the order was saved must still be listed"
+        );
     }
 
     #[test]

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
@@ -17,6 +17,55 @@ use crate::theme::ActiveTheme;
 
 pub(super) const CLAN_ROW_HEIGHT: f32 = 56.;
 
+const CLAN_DRAG_INDICATOR_COLOR: u32 = 0x3b82f6;
+const CLAN_AVATAR_PX: f32 = 40.;
+
+#[derive(Clone)]
+pub(super) struct ClanReorderDrag {
+    pub(super) index: usize,
+    pub(super) name: SharedString,
+    pub(super) avatar: Option<SharedString>,
+}
+
+pub(super) struct ClanDragPreview {
+    name: SharedString,
+    avatar: Option<SharedString>,
+}
+
+impl Render for ClanDragPreview {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let mut preview = div()
+            .size(px(CLAN_AVATAR_PX))
+            .rounded(px(8.))
+            .overflow_hidden();
+        if let Some(avatar) = self.avatar.clone() {
+            preview = preview.child(
+                img(avatar)
+                    .size(px(CLAN_AVATAR_PX))
+                    .rounded(px(8.))
+                    .object_fit(gpui::ObjectFit::Cover),
+            );
+        } else {
+            let initial = self
+                .name
+                .chars()
+                .next()
+                .map(|c| c.to_uppercase().to_string())
+                .unwrap_or_default();
+            preview = preview
+                .bg(theme.tokens.theme_base_color)
+                .flex()
+                .items_center()
+                .justify_center()
+                .text_color(theme.tokens.text_theme_primary)
+                .text_size(px(20.))
+                .child(SharedString::from(initial));
+        }
+        preview.opacity(0.8)
+    }
+}
+
 const CLAN_NOTI_LEVELS: [(i32, &str); 3] = [
     (
         NOTIFICATION_ALL_MESSAGE,
@@ -132,21 +181,24 @@ pub(super) struct ClanRow {
     pub active: bool,
 }
 
+fn activate_clan(clan_list: &Entity<ClanList>, clan_id: ClanId, cx: &mut App) {
+    clan_list.update(cx, |m, cx| {
+        m.select_clan(clan_id, cx);
+    });
+    if !matches!(
+        Router::global(cx).read(cx).route(),
+        Route::Chat | Route::Channel { .. }
+    ) {
+        crate::router::navigate(cx, Route::Chat);
+    }
+}
+
 fn on_clan_click(
     clan_list: Entity<ClanList>,
     clan_id: SharedString,
 ) -> impl Fn(&ClickEvent, &mut Window, &mut App) {
     move |_: &ClickEvent, _: &mut Window, cx: &mut App| {
-        let id = clan_id.to_string();
-        clan_list.update(cx, |m, cx| {
-            m.select_clan(id.parse().unwrap_or_default(), cx);
-        });
-        if !matches!(
-            Router::global(cx).read(cx).route(),
-            Route::Chat | Route::Channel { .. }
-        ) {
-            crate::router::navigate(cx, Route::Chat);
-        }
+        activate_clan(&clan_list, clan_id.parse().unwrap_or_default(), cx);
     }
 }
 
@@ -286,6 +338,44 @@ pub(super) fn render_clan_row(
                             .bg(theme.tokens.bg_unread_message),
                     ),
             )
+        })
+        .on_drag(
+            ClanReorderDrag {
+                index: ix,
+                name: clan.name.clone(),
+                avatar: clan.proxied_avatar_url.clone(),
+            },
+            |drag, _, _, cx| {
+                cx.stop_propagation();
+                let name = drag.name.clone();
+                let avatar = drag.avatar.clone();
+                cx.new(|_| ClanDragPreview { name, avatar })
+            },
+        )
+        .drag_over::<ClanReorderDrag>(move |style, drag, _, _| {
+            if drag.index == ix {
+                style
+            } else if drag.index > ix {
+                style
+                    .border_t_2()
+                    .border_color(gpui::rgb(CLAN_DRAG_INDICATOR_COLOR))
+            } else {
+                style
+                    .border_b_2()
+                    .border_color(gpui::rgb(CLAN_DRAG_INDICATOR_COLOR))
+            }
+        })
+        .on_drop({
+            let clan_list = clan_list_handle.clone();
+            let clan_num = prefetch_clan_id;
+            move |drag: &ClanReorderDrag, _, cx| {
+                let from = drag.index;
+                if from == ix {
+                    activate_clan(&clan_list, clan_num, cx);
+                    return;
+                }
+                clan_list.update(cx, |list, cx| list.move_clan(from, ix, cx));
+            }
         })
         .on_click(on_clan_click(clan_list_handle, clan_id))
         .on_mouse_down(MouseButton::Right, {


### PR DESCRIPTION
## Summary

- Add drag-and-drop reordering for clan rows in the sidebar with drop indicator
- Persist clan order via `Settings.clan_order` and reload on startup
- Restore saved order after clan list refetch; add `move_clan` API and unit tests

## Test plan

- [ ] `just lint` and `just test` pass
- [ ] Drag a clan up/down in the sidebar — order updates immediately
- [ ] Restart app — clan order is restored
- [ ] Join a new clan — it appears at the end while saved order is preserved
- [ ] Drop on same row still activates the clan

