### PR TITLE
fix(vendor): implement hide-to-tray on Linux and Windows

### DIFF
--- a/crates/vendor/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/vendor/gpui_linux/src/linux/wayland/window.rs
@@ -92,6 +92,12 @@ struct InProgressConfigure {
 pub struct WaylandWindowState {
     surface_state: WaylandSurfaceState,
     acknowledged_first_configure: bool,
+    /// mezon vendor edit: set while the surface is unmapped by
+    /// `PlatformWindow::hide` (hide-to-tray). xdg-shell has no hide request, so
+    /// hiding means attaching a null buffer; rendering must stay gated until
+    /// `activate` restarts the configure cycle, otherwise the next present
+    /// re-attaches a buffer and silently maps the window again.
+    unmapped: bool,
     parent: Option<WaylandWindowStatePtr>,
     children: FxHashSet<ObjectId>,
     pub surface: wl_surface::WlSurface,
@@ -368,6 +374,7 @@ impl WaylandWindowState {
         Ok(Self {
             surface_state,
             acknowledged_first_configure: false,
+            unmapped: false,
             parent,
             children: FxHashSet::default(),
             surface,
@@ -1270,6 +1277,22 @@ impl PlatformWindow for WaylandWindow {
     }
 
     fn activate(&self) {
+        // mezon vendor edit: undo a `hide()` (hide-to-tray). Committing without a
+        // buffer restarts the xdg_surface configure cycle; `handle_xdg_surface_event`
+        // acks it and drives the first frame, which attaches a buffer and maps the
+        // window again.
+        {
+            let mut state = self.borrow_mut();
+            if state.unmapped {
+                state.unmapped = false;
+                // The remap frame must actually present, otherwise no buffer is
+                // attached and the surface stays invisible. Nothing else marks
+                // the window dirty here, so force the frame.
+                state.force_render_after_recovery = true;
+                state.surface.commit();
+            }
+        }
+
         // Try to request an activation token. Even though the activation is likely going to be rejected,
         // KWin and Mutter can use the app_id to visually indicate we're requesting attention.
         let state = self.borrow();
@@ -1334,6 +1357,22 @@ impl PlatformWindow for WaylandWindow {
         if let Some(toplevel) = self.borrow().surface_state.toplevel() {
             toplevel.set_minimized();
         }
+    }
+
+    /// mezon vendor edit: implement hide-to-tray. xdg-shell has no hide request,
+    /// so unmap the surface by attaching a null buffer. Per xdg-shell the surface
+    /// then returns to its initial unconfigured state, which is why
+    /// `acknowledged_first_configure` is reset — `activate` recommits to restart
+    /// the configure handshake and remap.
+    fn hide(&self) {
+        let mut state = self.borrow_mut();
+        if state.unmapped {
+            return;
+        }
+        state.unmapped = true;
+        state.acknowledged_first_configure = false;
+        state.surface.attach(None, 0, 0);
+        state.surface.commit();
     }
 
     fn zoom(&self) {
@@ -1411,6 +1450,12 @@ impl PlatformWindow for WaylandWindow {
     fn draw(&self, scene: &Scene) {
         let mut state = self.borrow_mut();
 
+        // mezon vendor edit: presenting attaches a buffer, which would remap a
+        // surface hidden to tray. Stay dark until `activate` unmaps the flag.
+        if state.unmapped {
+            return;
+        }
+
         if state.renderer.device_lost() {
             let raw_window = RawWindow {
                 window: state.surface.id().as_ptr().cast::<std::ffi::c_void>(),
@@ -1445,7 +1490,9 @@ impl PlatformWindow for WaylandWindow {
 
         // Work around a bug in old versions of wlroots where committing without a buffer attached
         // can cause invalid synchronization that leads to graphical corruption.
-        if !state.renderer_presented {
+        // mezon vendor edit: skip while unmapped — this commit would restart the
+        // configure cycle behind `activate`'s back and remap the hidden window.
+        if !state.renderer_presented && !state.unmapped {
             state.surface.commit();
         }
 

--- a/crates/vendor/gpui_linux/src/linux/x11/window.rs
+++ b/crates/vendor/gpui_linux/src/linux/x11/window.rs
@@ -276,6 +276,10 @@ pub struct X11WindowState {
     maximized_vertical: bool,
     maximized_horizontal: bool,
     hidden: bool,
+    /// mezon vendor edit: set while the window is unmapped by `PlatformWindow::hide`
+    /// (hide-to-tray). Distinct from `hidden`, which mirrors `_NET_WM_STATE_HIDDEN`
+    /// (iconified by the window manager) and is recomputed from WM properties.
+    unmapped: bool,
     active: bool,
     hovered: bool,
     pub(crate) force_render_after_recovery: bool,
@@ -434,11 +438,21 @@ impl X11WindowState {
 
         let visual_set = find_visuals(xcb, x_screen_index);
 
-        let visual = match visual_set.transparent {
-            Some(visual) => visual,
-            None => {
-                log::warn!("Unable to find a transparent visual",);
-                visual_set.inherit
+        // mezon vendor edit: opt-out from the 32-bit ARGB visual. Mesa's software
+        // rasterizer (llvmpipe/lavapipe) presents nothing to an ARGB32 X window —
+        // the window stays pure black while the render loop runs normally — so
+        // running the app under software rendering (containers, VMs, CI) needs the
+        // plain opaque visual. Real GPU drivers are unaffected; this is off unless
+        // GPUI_X11_OPAQUE_VISUAL is set.
+        let visual = if std::env::var_os("GPUI_X11_OPAQUE_VISUAL").is_some() {
+            visual_set.inherit
+        } else {
+            match visual_set.transparent {
+                Some(visual) => visual,
+                None => {
+                    log::warn!("Unable to find a transparent visual",);
+                    visual_set.inherit
+                }
             }
         };
         log::info!("Using {:?}", visual);
@@ -799,6 +813,7 @@ impl X11WindowState {
                 maximized_vertical: false,
                 maximized_horizontal: false,
                 hidden: false,
+                unmapped: false,
                 appearance,
                 handle,
                 background_appearance: WindowBackgroundAppearance::Opaque,
@@ -1460,6 +1475,18 @@ impl PlatformWindow for X11Window {
     }
 
     fn activate(&self) {
+        // mezon vendor edit: undo a `hide()` (hide-to-tray) before requesting
+        // focus — an unmapped window cannot be focused or activated, so without
+        // remapping first the activation request is dropped by the WM.
+        if self.0.state.borrow().unmapped {
+            self.0.state.borrow_mut().unmapped = false;
+            check_reply(
+                || "X11 MapWindow failed.",
+                self.0.xcb.map_window(self.0.x_window),
+            )
+            .log_err();
+        }
+
         let data = [1, xproto::Time::CURRENT_TIME.into(), 0, 0, 0];
         let message = xproto::ClientMessageEvent::new(
             32,
@@ -1576,6 +1603,25 @@ impl PlatformWindow for X11Window {
                     .is_some_and(|ctx| ctx.supports_dual_source_blending())
             })
             .unwrap_or_default()
+    }
+
+    /// mezon vendor edit: implement hide-to-tray by unmapping the window.
+    /// Upstream leaves the `PlatformWindow::hide` default no-op on X11, so the
+    /// only way off screen was destroying the window.
+    fn hide(&self) {
+        {
+            let mut state = self.0.state.borrow_mut();
+            if state.unmapped {
+                return;
+            }
+            state.unmapped = true;
+        }
+        check_reply(
+            || "X11 UnmapWindow failed.",
+            self.0.xcb.unmap_window(self.0.x_window),
+        )
+        .log_err();
+        xcb_flush(&self.0.xcb);
     }
 
     fn minimize(&self) {

--- a/crates/vendor/gpui_windows/src/window.rs
+++ b/crates/vendor/gpui_windows/src/window.rs
@@ -82,6 +82,12 @@ pub struct WindowsWindowState {
     pub invalidate_devices: Arc<AtomicBool>,
     fullscreen: Cell<Option<StyleAndBounds>>,
     initial_placement: Cell<Option<WindowOpenStatus>>,
+    /// mezon vendor edit: set by `PlatformWindow::hide` (hide-to-tray) so
+    /// `activate` knows it must `SW_SHOW` the window before trying to focus it.
+    /// Tracked explicitly rather than read back via `IsWindowVisible` so the
+    /// initial-placement path (which shows the window asynchronously) is not
+    /// mistaken for a hidden window.
+    pub(crate) hidden: Cell<bool>,
     hwnd: HWND,
     pub(crate) a11y: RefCell<Option<A11yState>>,
 }
@@ -174,6 +180,7 @@ impl WindowsWindowState {
             display: Cell::new(display),
             fullscreen: Cell::new(fullscreen),
             initial_placement: Cell::new(initial_placement),
+            hidden: Cell::new(false),
             hwnd,
             invalidate_devices,
             direct_manipulation,
@@ -764,6 +771,13 @@ impl PlatformWindow for WindowsWindow {
                 this.set_window_placement().log_err();
 
                 unsafe {
+                    // mezon vendor edit: undo a `hide()` (hide-to-tray) before
+                    // focusing — a `SW_HIDE`-den window cannot become active or
+                    // foreground, so activating it would silently do nothing.
+                    if this.state.hidden.replace(false) {
+                        ShowWindowAsync(hwnd, SW_SHOW).ok().log_err();
+                    }
+
                     // If the window is minimized, restore it.
                     if IsIconic(hwnd).as_bool() {
                         ShowWindowAsync(hwnd, SW_RESTORE).ok().log_err();
@@ -860,6 +874,16 @@ impl PlatformWindow for WindowsWindow {
 
     fn minimize(&self) {
         unsafe { ShowWindowAsync(self.0.hwnd, SW_MINIMIZE).ok().log_err() };
+    }
+
+    /// mezon vendor edit: implement hide-to-tray. Upstream leaves the
+    /// `PlatformWindow::hide` default no-op on Windows; without this the window
+    /// stays on screen and the only way off it is destroying the window.
+    fn hide(&self) {
+        if self.state.hidden.replace(true) {
+            return;
+        }
+        unsafe { ShowWindowAsync(self.0.hwnd, SW_HIDE).ok().log_err() };
     }
 
     fn zoom(&self) {


### PR DESCRIPTION
## Summary

- Implement `PlatformWindow::hide` / `activate` for Wayland, X11, and Windows so close-to-tray actually hides the window
- Wayland: unmap via null buffer and gate presents until re-activation
- X11: unmap/remap window; add `GPUI_X11_OPAQUE_VISUAL` opt-in for llvmpipe/lavapipe software rendering
- Windows: `SW_HIDE` / `SW_SHOW` with explicit hidden state tracking

## Test plan

- [ ] Linux Wayland with tray: close window → app hides to tray; tray click restores window
- [ ] Linux X11 with tray: same hide/restore flow
- [ ] Windows with tray: close hides window; restore from tray works
- [ ] Linux X11 software rendering (`GPUI_X11_OPAQUE_VISUAL=1`): window is not pure black
- [ ] Close without tray enabled still quits normally
