### PR TITLE
feat: HTTP socket fallback, token renewal, and connecting splash

### DIFF
--- a/crates/mezon-client/src/app_api.rs
+++ b/crates/mezon-client/src/app_api.rs
@@ -8,7 +8,7 @@ use crate::{
     transport::{
         ApiAccount, ApiAttachment, ApiCanvas, ApiCanvasDetail, ApiCategoryDesc, ApiChannelApp,
         ApiChannelAttachment, ApiChannelDesc, ApiClanDesc, ApiDirectChannel, ApiFriend, ApiMessage,
-        ApiPinMessage, ApiThreadDesc, ApiVoiceChannelUser, RealtimeEvent,
+        ApiPinMessage, ApiThreadDesc, ApiVoiceChannelUser, HttpFallbackSession, RealtimeEvent,
     },
 };
 
@@ -180,6 +180,10 @@ impl AppApi {
             status_tx: Arc::new(status_tx),
             base_img_url,
         }
+    }
+
+    pub fn set_http_fallback(&self, fallback: Option<HttpFallbackSession>) {
+        self.transport.set_http_fallback(fallback);
     }
 
     pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<RealtimeEvent> {

--- a/crates/mezon-client/src/auth.rs
+++ b/crates/mezon-client/src/auth.rs
@@ -45,7 +45,6 @@ struct ApiSession {
     #[allow(dead_code)]
     #[serde(default)]
     created: bool,
-    #[allow(dead_code)]
     #[serde(default)]
     is_remember: bool,
     /// Socket credential returned after auth (used for WebSocket `token=` query param).
@@ -277,6 +276,7 @@ impl MezonClient {
             id_token: api.id_token,
             session_id: api.session_id.unwrap_or_default(),
             expires_at: expires_at.unwrap_or(0),
+            is_remember: api.is_remember,
             api_url: api.api_url,
             api_host,
             api_port,

--- a/crates/mezon-client/src/lib.rs
+++ b/crates/mezon-client/src/lib.rs
@@ -64,8 +64,8 @@ pub use transport::RealtimeEvent;
 pub use transport::{
     ApiCanvas, ApiCanvasDetail, ApiCategoryDesc, ApiChannelApp, ApiChannelAttachment,
     ApiChannelDesc, ApiFriend, ApiPinMessage, ApiThreadDesc, ApiVoiceChannelUser,
-    CANVAS_LIST_LIMIT, CANVAS_STATUS_CREATED, CANVAS_STATUS_UPDATE, parse_search_attachment_field,
-    parse_search_mentions_field,
+    CANVAS_LIST_LIMIT, CANVAS_STATUS_CREATED, CANVAS_STATUS_UPDATE, HttpFallbackSession,
+    parse_search_attachment_field, parse_search_mentions_field,
 };
 pub use transport_adapter::TransportAdapter;
 pub use transport_runtime::TransportClient;

--- a/crates/mezon-client/src/notification_setting.rs
+++ b/crates/mezon-client/src/notification_setting.rs
@@ -72,11 +72,24 @@ impl ChannelNotificationSetting {
         self.mute_until_ms == i64::from(MUTE_INFINITY) || self.mute_until_ms > now_ms
     }
 
+    pub fn apply_realtime(&mut self, dto: &api::NotificationUserChannel, channel_id: i64) {
+        self.id = channel_id;
+        self.mute_until_ms = Self::expiry_from_epoch_seconds(dto.time_mute_seconds);
+    }
+
     pub fn expiry_from_duration(now_ms: i64, mute_seconds: i32) -> i64 {
         match mute_seconds {
             MUTE_UNMUTE => 0,
             MUTE_INFINITY => i64::from(MUTE_INFINITY),
             seconds => now_ms + i64::from(seconds) * 1000,
+        }
+    }
+
+    pub fn expiry_from_epoch_seconds(epoch_seconds: i32) -> i64 {
+        match epoch_seconds {
+            MUTE_UNMUTE => 0,
+            MUTE_INFINITY => i64::from(MUTE_INFINITY),
+            seconds => i64::from(seconds) * 1000,
         }
     }
 
@@ -215,6 +228,64 @@ mod tests {
             ChannelNotificationSetting::from_api_at(&dto, now),
             setting(7, NOTIFICATION_MENTION_MESSAGE, now + 3_600_000)
         );
+    }
+
+    #[test]
+    fn apply_realtime_reads_an_absolute_epoch_not_a_duration() {
+        let now = 1_700_000_000_000;
+        let expires_at_s = 1_700_003_600;
+        let dto = api::NotificationUserChannel {
+            id: 7,
+            notification_setting_type: NOTIFICATION_MENTION_MESSAGE,
+            time_mute_seconds: expires_at_s,
+            ..Default::default()
+        };
+        let mut applied = setting(0, NOTIFICATION_DEFAULT, 0);
+        applied.apply_realtime(&dto, 42);
+        assert_eq!(applied.mute_until_ms, i64::from(expires_at_s) * 1000);
+        assert_eq!(applied.muted_until_ms(now), Some(now + 3_600_000));
+        assert_ne!(
+            applied.mute_until_ms,
+            ChannelNotificationSetting::from_api_at(&dto, now).mute_until_ms
+        );
+    }
+
+    #[test]
+    fn apply_realtime_keeps_the_level_and_marks_an_override() {
+        let dto = api::NotificationUserChannel {
+            id: 0,
+            notification_setting_type: NOTIFICATION_DEFAULT,
+            time_mute_seconds: 1_700_003_600,
+            ..Default::default()
+        };
+        let mut applied = setting(9, NOTIFICATION_MENTION_MESSAGE, 0);
+        applied.apply_realtime(&dto, 42);
+        assert_eq!(applied.level, NOTIFICATION_MENTION_MESSAGE);
+        assert_eq!(applied.id, 42);
+        assert!(applied.is_muted(None, None));
+    }
+
+    #[test]
+    fn apply_realtime_preserves_infinity_and_unmute_sentinels() {
+        let mut inf = setting(9, NOTIFICATION_DEFAULT, 0);
+        inf.apply_realtime(
+            &api::NotificationUserChannel {
+                time_mute_seconds: MUTE_INFINITY,
+                ..Default::default()
+            },
+            42,
+        );
+        assert_eq!(inf.mute_until_ms, i64::from(MUTE_INFINITY));
+
+        let mut unmuted = setting(9, NOTIFICATION_DEFAULT, 5_000);
+        unmuted.apply_realtime(
+            &api::NotificationUserChannel {
+                time_mute_seconds: MUTE_UNMUTE,
+                ..Default::default()
+            },
+            42,
+        );
+        assert_eq!(unmuted.mute_until_ms, 0);
     }
 
     #[test]

--- a/crates/mezon-client/src/session.rs
+++ b/crates/mezon-client/src/session.rs
@@ -18,6 +18,7 @@ pub struct Session {
     pub session_id: String,
     /// Unix timestamp (seconds) when the token expires
     pub expires_at: u64,
+    pub is_remember: bool,
     /// The WebSocket endpoint URL returned by the server after auth
     pub ws_url: Option<String>,
     /// Parsed WebSocket host returned by the server after auth
@@ -146,5 +147,53 @@ mod tests {
             ..Default::default()
         };
         assert!(session.is_expired());
+    }
+
+    fn fake_jwt(user_id: &str, username: &str, exp: u64) -> String {
+        let claims = format!(r#"{{"uid":"{user_id}","usn":"{username}","exp":{exp}}}"#);
+        format!("header.{}.signature", URL_SAFE_NO_PAD.encode(claims))
+    }
+
+    #[test]
+    fn apply_refresh_adopts_the_new_token_and_its_expiry() {
+        let mut session = Session {
+            token: fake_jwt("7", "ngoc", 1000),
+            refresh_token: "old-refresh".into(),
+            session_id: "old-sid".into(),
+            expires_at: 1000,
+            user_id: "7".into(),
+            username: "ngoc".into(),
+            ..Default::default()
+        };
+
+        let renewed = fake_jwt("7", "ngoc", 9000);
+        session.apply_refresh(&renewed, "new-refresh", "new-sid");
+
+        assert_eq!(session.token, renewed);
+        assert_eq!(session.refresh_token, "new-refresh");
+        assert_eq!(session.session_id, "new-sid");
+        assert_eq!(session.expires_at, 9000);
+    }
+
+    #[test]
+    fn apply_refresh_keeps_fields_the_server_left_empty() {
+        let original = fake_jwt("7", "ngoc", 1000);
+        let mut session = Session {
+            token: original.clone(),
+            refresh_token: "old-refresh".into(),
+            session_id: "old-sid".into(),
+            expires_at: 1000,
+            ..Default::default()
+        };
+
+        session.apply_refresh("", "", "new-sid");
+
+        assert_eq!(
+            session.token, original,
+            "an sid-only push must not clear the token"
+        );
+        assert_eq!(session.refresh_token, "old-refresh");
+        assert_eq!(session.session_id, "new-sid");
+        assert_eq!(session.expires_at, 1000);
     }
 }

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -4,8 +4,10 @@
 /// for interacting with the Mezon backend.
 pub use crate::transport_adapter::TransportAdapter;
 use anyhow::{Context, Result};
+use futures::AsyncReadExt as _;
+use http_client::{AsyncBody, HttpClient, http};
 use mezon_proto::{api, realtime};
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -21,6 +23,8 @@ const DEFAULT_SEND_TIMEOUT_MS: u64 = 10000;
 const DEFAULT_CONNECT_GATE_MS: u64 = 5000;
 const DEFAULT_PING_TIMEOUT_MS: u64 = 5000;
 const MULTIPART_OP_TIMEOUT_MS: u64 = 120000;
+const HTTP_FALLBACK_TIMEOUT: Duration = Duration::from_secs(20);
+const MAX_HTTP_FALLBACK_RESPONSE_BYTES: u64 = 1024 * 1024;
 
 fn parse_id<T>(value: &str) -> Result<T>
 where
@@ -230,6 +234,12 @@ fn encode_envelope_cid_last(mut envelope: realtime::Envelope) -> Vec<u8> {
     bytes
 }
 
+#[derive(Clone)]
+pub struct HttpFallbackSession {
+    pub base_url: String,
+    pub token: String,
+}
+
 /// Main transport client.
 pub struct MezonTransport {
     adapter: Arc<dyn TransportAdapter>,
@@ -243,6 +253,7 @@ pub struct MezonTransport {
     /// Surfaced in the `api_ok` log so a duplicated / repeated call is obvious
     /// (`call#2` for a one-shot List means something is fetching twice).
     api_call_counts: Arc<Mutex<HashMap<String, u64>>>,
+    http_fallback: Arc<RwLock<Option<Arc<HttpFallbackSession>>>>,
     #[allow(dead_code)]
     base_path: String,
 }
@@ -260,6 +271,7 @@ impl MezonTransport {
             connected_tx,
             connected_rx,
             api_call_counts: Arc::new(Mutex::new(HashMap::new())),
+            http_fallback: Arc::new(RwLock::new(None)),
             base_path,
         }
     }
@@ -267,6 +279,10 @@ impl MezonTransport {
     /// Set request timeout.
     pub fn set_timeout(&mut self, timeout_ms: u64) {
         self.send_timeout_ms = Duration::from_millis(timeout_ms);
+    }
+
+    pub fn set_http_fallback(&self, fallback: Option<HttpFallbackSession>) {
+        *self.http_fallback.write() = fallback.map(Arc::new);
     }
 
     /// Generate a unique correlation ID.
@@ -2924,6 +2940,94 @@ impl MezonTransport {
         Ok((code, response))
     }
 
+    async fn send_api_request_over_http(&self, api_name: &str, body: Vec<u8>) -> Result<Vec<u8>> {
+        let fallback = self
+            .http_fallback
+            .read()
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("no session for the HTTP fallback"))?;
+
+        let url = format!(
+            "{}/mezon.api.Mezon/{api_name}",
+            fallback.base_url.trim_end_matches('/')
+        );
+        let request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(&url)
+            .header("Authorization", format!("Bearer {}", fallback.token))
+            .header("Content-Type", "application/proto")
+            .header("Accept", "application/proto")
+            .body(AsyncBody::from(body))
+            .context("failed to build the HTTP fallback request")?;
+
+        let started = Instant::now();
+        let mut response = match tokio::time::timeout(
+            HTTP_FALLBACK_TIMEOUT,
+            crate::transport_runtime::http_client().send(request),
+        )
+        .await
+        {
+            Ok(result) => result.context("network error on the HTTP fallback")?,
+            Err(_) => anyhow::bail!(
+                "HTTP fallback timed out after {}s",
+                HTTP_FALLBACK_TIMEOUT.as_secs()
+            ),
+        };
+
+        let status = response.status();
+        let mut bytes: Vec<u8> = Vec::new();
+        response
+            .body_mut()
+            .take(MAX_HTTP_FALLBACK_RESPONSE_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .await
+            .context("failed to read the HTTP fallback response body")?;
+        if !status.is_success() {
+            anyhow::bail!("HTTP fallback failed with status {}", status.as_u16());
+        }
+        if bytes.len() as u64 > MAX_HTTP_FALLBACK_RESPONSE_BYTES {
+            anyhow::bail!(
+                "HTTP fallback response exceeds {MAX_HTTP_FALLBACK_RESPONSE_BYTES} bytes"
+            );
+        }
+
+        tracing::info!(
+            target: "socket",
+            "api_http_ok: action={api_name} bytes={} took={}ms",
+            bytes.len(),
+            started.elapsed().as_millis()
+        );
+        Ok(bytes)
+    }
+
+    /// Send over the socket, falling back to HTTP only while the socket is closed.
+    ///
+    /// The fallback deliberately never retries a request the socket already accepted: a send that
+    /// fails *after* the frame left the client (a timeout, a dropped reply) proves nothing about
+    /// whether the server applied it, and replaying a non-idempotent call like SendChannelMessage
+    /// there posts the message twice. Deciding up front also keeps the success path free of the
+    /// defensive `body` clone that a retry-after-failure shape would need on every single call.
+    async fn send_api_request_with_http_fallback(
+        &self,
+        cid: u16,
+        api_name: &str,
+        body: Vec<u8>,
+    ) -> Result<(u32, Vec<u8>)> {
+        let has_fallback = self.http_fallback.read().is_some();
+        if has_fallback && !self.is_open().await {
+            tracing::warn!(
+                target: "socket",
+                "api_socket_closed: action={api_name} cid={cid} — sending over HTTP"
+            );
+            let response = self
+                .send_api_request_over_http(api_name, body)
+                .await
+                .context("socket closed; HTTP fallback")?;
+            return Ok((0, response));
+        }
+        self.send_api_request(cid, api_name, body).await
+    }
+
     fn account_from_user(
         user: api::User,
         email: Option<String>,
@@ -4258,7 +4362,9 @@ impl MezonTransport {
         }
         .encode_to_vec();
 
-        let (code, response) = self.send_api_request(cid, api_name, body).await?;
+        let (code, response) = self
+            .send_api_request_with_http_fallback(cid, api_name, body)
+            .await?;
 
         if code != 0 {
             return Err(anyhow::anyhow!("API error: code={}", code));
@@ -4271,6 +4377,9 @@ impl MezonTransport {
             ack.channel_id,
             ack.code
         );
+        if ack.message_id == 0 {
+            return Err(anyhow::anyhow!("send returned no message id"));
+        }
         let mut content_tokens = if content_is_json {
             serde_json::from_str(&content_json).unwrap_or_default()
         } else {
@@ -5192,7 +5301,7 @@ impl MezonTransport {
         }
         .encode_to_vec();
         let (code, _response) = self
-            .send_api_request(cid, "SendChannelMessage", body)
+            .send_api_request_with_http_fallback(cid, "SendChannelMessage", body)
             .await?;
         if code != 0 {
             return Err(anyhow::anyhow!("API error: code={}", code));

--- a/crates/mezon-client/src/transport_runtime.rs
+++ b/crates/mezon-client/src/transport_runtime.rs
@@ -423,6 +423,10 @@ impl TransportClient {
         }
     }
 
+    pub fn set_http_fallback(&self, fallback: Option<crate::transport::HttpFallbackSession>) {
+        self.inner.set_http_fallback(fallback);
+    }
+
     pub async fn connect(
         &self,
         host: &str,

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -145,7 +145,7 @@ impl Channel {
     }
 
     pub fn is_archived(&self) -> bool {
-        self.active == CHANNEL_ACTIVE_ARCHIVED
+        self.parent_id.is_some() && self.active == CHANNEL_ACTIVE_ARCHIVED
     }
 
     pub fn visible_in_sidebar(&self) -> bool {
@@ -928,6 +928,19 @@ impl ChannelList {
                 channel_from_desc(c, badge, Vec::new(), false)
             })
             .collect();
+
+        let omitted_active = channels
+            .iter()
+            .filter(|ch| ch.parent_id.is_none() && ch.active == CHANNEL_ACTIVE_ARCHIVED)
+            .count();
+        if omitted_active > 0 {
+            tracing::info!(
+                target: "socket",
+                "list_channel_descs: clan={} channels={} with_active_unset={omitted_active}",
+                clan_id,
+                channels.len()
+            );
+        }
 
         Ok(build_categories(api_categories, &mut channels))
     }
@@ -5198,6 +5211,35 @@ mod tests {
             &thread,
             thread_needs_reactivate(&thread)
         ));
+    }
+
+    #[test]
+    fn plain_channel_stays_visible_when_server_omits_active() {
+        let desc = ApiChannelDesc {
+            channel_id: 11,
+            channel_label: "general".into(),
+            channel_type: ChannelType::Text.as_raw(),
+            clan_id: 1,
+            category_name: String::new(),
+            category_id: 7,
+            channel_private: 0,
+            count_mess_unread: 0,
+            member_count: 0,
+            parent_id: 0,
+            is_mute: false,
+            last_seen_message_id: 0,
+            last_seen_timestamp: 0,
+            last_sent_message_id: 0,
+            last_sent_timestamp: 0,
+            badge_count: 0,
+            active: 0,
+            creator_id: 0,
+            clan_name: String::new(),
+            channel_avatar: String::new(),
+        };
+        let channel = channel_from_desc(desc, 0, Vec::new(), false);
+        assert!(!channel.is_archived());
+        assert!(channel.visible_in_sidebar());
     }
 
     #[test]

--- a/crates/mezon-store/src/connection.rs
+++ b/crates/mezon-store/src/connection.rs
@@ -10,9 +10,9 @@ use gpui::{
     App, AppContext, AsyncApp, BackgroundExecutor, Context, Entity, Global, Subscription, Task,
 };
 use mezon_client::{
-    AppApi, ConnectionStatus, DEFAULT_WS_HOST, NetworkMonitor, RECONNECT_NETWORK_PROBE_TIMEOUT,
-    RealtimeEvent, Session, TransportClient, favicon_probe_url, keychain,
-    probe_network_reachability,
+    AppApi, ConnectionStatus, DEFAULT_WS_HOST, HttpFallbackSession, NetworkMonitor,
+    RECONNECT_NETWORK_PROBE_TIMEOUT, RealtimeEvent, Session, TransportClient, favicon_probe_url,
+    keychain, probe_network_reachability,
 };
 
 use crate::login::{session_credentials, spawn_session_logout};
@@ -122,6 +122,8 @@ impl ConnectionStore {
             .map(|cfg| favicon_probe_url(&cfg.redirect_uri))
             .unwrap_or_else(|| favicon_probe_url(""));
         let tcp_default_port = AppConfig::try_global(cx).and_then(|cfg| cfg.tcp_port);
+        let configured_api_base = AppConfig::try_global(cx).map(configured_api_base_url);
+        let auth_client = crate::login::LoginStore::global(cx).read(cx).client();
         let online_signal = network.online();
 
         let manager = cx.spawn(async move |this, cx| {
@@ -131,6 +133,8 @@ impl ConnectionStore {
             let mut consecutive_failures = 0u32;
             let mut handshake_rejections = 0u32;
             let mut connect_ack_rx = connect_ack_rx;
+            let mut renewal_retry_at: Option<std::time::Instant> = None;
+            let mut renewal_backoff = TOKEN_RENEWAL_RETRY_MIN;
 
             loop {
                 let (session, is_connecting) = cx.update(|cx| match auth_state.read(cx).clone() {
@@ -148,6 +152,7 @@ impl ConnectionStore {
                 });
 
                 let Some(session) = session else {
+                    api.set_http_fallback(None);
                     if connected_user_id.take().is_some() {
                         if let Err(e) = transport.close().await {
                             tracing::warn!("Failed to close TCP transport after logout: {e}");
@@ -157,9 +162,35 @@ impl ConnectionStore {
                     retry_backoff_secs = 1;
                     consecutive_failures = 0;
                     handshake_rejections = 0;
+                    renewal_retry_at = None;
+                    renewal_backoff = TOKEN_RENEWAL_RETRY_MIN;
                     wake.notified().await;
                     continue;
                 };
+
+                // `wake` fires on every heartbeat miss, network flap and status change, so an
+                // ungated renewal here turns one failing endpoint into a REST call per wake-up.
+                let session = if renewal_retry_at.is_some_and(|at| std::time::Instant::now() < at) {
+                    session
+                } else {
+                    let (session, outcome) =
+                        renew_expiring_token(&auth_client, &auth_state, session, cx).await;
+                    match outcome {
+                        RenewalOutcome::Failed => {
+                            renewal_retry_at =
+                                Some(std::time::Instant::now() + renewal_backoff);
+                            renewal_backoff =
+                                (renewal_backoff * 2).min(TOKEN_RENEWAL_RETRY_MAX);
+                        }
+                        RenewalOutcome::Renewed => {
+                            renewal_retry_at = None;
+                            renewal_backoff = TOKEN_RENEWAL_RETRY_MIN;
+                        }
+                        RenewalOutcome::NotNeeded => {}
+                    }
+                    session
+                };
+                api.set_http_fallback(http_fallback_session(&session, configured_api_base.as_deref()));
 
                 if connected_user_id.as_deref() == Some(session.user_id.as_str())
                     && transport.is_open().await
@@ -167,7 +198,10 @@ impl ConnectionStore {
                     retry_backoff_secs = 1;
                     consecutive_failures = 0;
                     handshake_rejections = 0;
-                    wake.notified().await;
+                    tokio::select! {
+                        _ = wake.notified() => {}
+                        _ = exec.timer(token_renewal_delay(&session)) => {}
+                    }
                     continue;
                 }
 
@@ -375,13 +409,18 @@ impl ConnectionStore {
                         return;
                     };
                     connect_ack_tx.send_modify(|n| *n = n.wrapping_add(1));
-                    if ev.session_id.is_empty() {
+                    if ev.session_id.is_empty() && ev.token.is_empty() {
                         return;
                     }
-                    tracing::info!("Session refreshed over socket for user_id={}", ev.user_id);
+                    tracing::info!(
+                        "Session refreshed over socket for user_id={} token_renewed={} sid_renewed={}",
+                        ev.user_id,
+                        !ev.token.is_empty(),
+                        !ev.session_id.is_empty()
+                    );
                     match state {
                         AuthState::Authenticated(session) | AuthState::Connecting(session) => {
-                            session.session_id = ev.session_id.clone();
+                            session.apply_refresh(&ev.token, &ev.refresh_token, &ev.session_id);
                             let session_clone = session.clone();
                             cx.background_executor()
                                 .spawn(async move {
@@ -398,6 +437,121 @@ impl ConnectionStore {
             );
         });
     }
+}
+
+const TOKEN_RENEWAL_SKEW: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+const TOKEN_RENEWAL_MIN_DELAY: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+const TOKEN_RENEWAL_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+const TOKEN_RENEWAL_RETRY_MIN: std::time::Duration = std::time::Duration::from_secs(30);
+const TOKEN_RENEWAL_RETRY_MAX: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RenewalOutcome {
+    NotNeeded,
+    Renewed,
+    Failed,
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn token_renewal_delay(session: &Session) -> std::time::Duration {
+    if session.expires_at == 0 || session.refresh_token.is_empty() {
+        return TOKEN_RENEWAL_MAX_DELAY;
+    }
+    let deadline = session
+        .expires_at
+        .saturating_sub(TOKEN_RENEWAL_SKEW.as_secs());
+    std::time::Duration::from_secs(deadline.saturating_sub(now_secs()))
+        .clamp(TOKEN_RENEWAL_MIN_DELAY, TOKEN_RENEWAL_MAX_DELAY)
+}
+
+fn token_needs_renewal(session: &Session) -> bool {
+    !session.refresh_token.is_empty()
+        && session.expires_at != 0
+        && now_secs() + TOKEN_RENEWAL_SKEW.as_secs() >= session.expires_at
+}
+
+async fn renew_expiring_token(
+    client: &Arc<mezon_client::MezonClient>,
+    auth_state: &Entity<AuthState>,
+    session: Session,
+    cx: &mut AsyncApp,
+) -> (Session, RenewalOutcome) {
+    if !token_needs_renewal(&session) {
+        return (session, RenewalOutcome::NotNeeded);
+    }
+    tracing::info!("JWT expiring — renewing the session over REST");
+    let renewed = match client
+        .refresh_session(&session.refresh_token, session.is_remember)
+        .await
+    {
+        Ok(renewed) => renewed,
+        Err(e) => {
+            tracing::warn!("Session renewal failed ({e}) — keeping the current session");
+            return (session, RenewalOutcome::Failed);
+        }
+    };
+    if renewed.token.is_empty() || renewed.user_id != session.user_id {
+        tracing::warn!("Session renewal returned an unusable session — keeping the current one");
+        return (session, RenewalOutcome::Failed);
+    }
+
+    let applied = cx.update(|cx| {
+        auth_state.update(cx, |state, cx| {
+            let current = match state {
+                AuthState::Authenticated(s) | AuthState::Connecting(s) => s,
+                _ => return false,
+            };
+            if current.user_id != renewed.user_id {
+                return false;
+            }
+            *current = renewed.clone();
+            cx.notify();
+            true
+        })
+    });
+    if !applied {
+        return (session, RenewalOutcome::Failed);
+    }
+
+    let persisted = renewed.clone();
+    cx.background_executor()
+        .spawn(async move {
+            if let Err(e) = keychain::save_session(&persisted) {
+                tracing::warn!("Failed to persist the renewed session: {e}");
+            }
+        })
+        .detach();
+    (renewed, RenewalOutcome::Renewed)
+}
+
+fn configured_api_base_url(config: &AppConfig) -> String {
+    let scheme = if config.api_secure { "https" } else { "http" };
+    format!("{scheme}://{}:{}", config.api_host, config.api_port)
+}
+
+fn http_fallback_session(
+    session: &Session,
+    configured_api_base: Option<&str>,
+) -> Option<HttpFallbackSession> {
+    if session.token.is_empty() {
+        return None;
+    }
+    let base_url = session
+        .api_url
+        .as_deref()
+        .filter(|url| !url.is_empty())
+        .or(configured_api_base)?
+        .to_string();
+    Some(HttpFallbackSession {
+        base_url,
+        token: session.token.clone(),
+    })
 }
 
 fn requires_network_probe(consecutive_failures: u32) -> bool {
@@ -473,6 +627,95 @@ pub fn resolve_initial_auth_state() -> AuthState {
 mod tests {
     use super::*;
     use mezon_client::Session;
+
+    fn session_expiring_in(secs: u64) -> Session {
+        Session {
+            token: "jwt".into(),
+            refresh_token: "refresh".into(),
+            expires_at: now_secs() + secs,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn token_renewal_triggers_inside_the_skew_window() {
+        assert!(!token_needs_renewal(&session_expiring_in(3600)));
+        assert!(token_needs_renewal(&session_expiring_in(60)));
+
+        let expired = Session {
+            expires_at: now_secs().saturating_sub(60),
+            ..session_expiring_in(0)
+        };
+        assert!(token_needs_renewal(&expired));
+    }
+
+    #[test]
+    fn token_renewal_needs_a_refresh_token_and_a_known_expiry() {
+        let no_refresh = Session {
+            refresh_token: String::new(),
+            ..session_expiring_in(60)
+        };
+        assert!(!token_needs_renewal(&no_refresh));
+
+        let no_expiry = Session {
+            expires_at: 0,
+            ..session_expiring_in(60)
+        };
+        assert!(!token_needs_renewal(&no_expiry));
+    }
+
+    #[test]
+    fn token_renewal_delay_stays_within_its_bounds() {
+        assert_eq!(
+            token_renewal_delay(&session_expiring_in(0)),
+            TOKEN_RENEWAL_MIN_DELAY
+        );
+        assert_eq!(
+            token_renewal_delay(&session_expiring_in(48 * 3600)),
+            TOKEN_RENEWAL_MAX_DELAY
+        );
+
+        let mid = token_renewal_delay(&session_expiring_in(TOKEN_RENEWAL_SKEW.as_secs() + 15 * 60));
+        assert!(mid > TOKEN_RENEWAL_MIN_DELAY && mid < TOKEN_RENEWAL_MAX_DELAY);
+    }
+
+    #[test]
+    fn http_fallback_prefers_server_issued_api_url() {
+        let s = Session {
+            token: "jwt".into(),
+            api_url: Some("https://api.mezon.ai".into()),
+            ..Default::default()
+        };
+        let fallback = http_fallback_session(&s, Some("https://baked:8088")).expect("fallback");
+        assert_eq!(fallback.base_url, "https://api.mezon.ai");
+        assert_eq!(fallback.token, "jwt");
+    }
+
+    #[test]
+    fn http_fallback_falls_back_to_configured_base() {
+        let s = Session {
+            token: "jwt".into(),
+            api_url: Some(String::new()),
+            ..Default::default()
+        };
+        let fallback = http_fallback_session(&s, Some("https://baked:8088")).expect("fallback");
+        assert_eq!(fallback.base_url, "https://baked:8088");
+    }
+
+    #[test]
+    fn http_fallback_needs_a_token_and_a_base() {
+        let no_token = Session {
+            api_url: Some("https://api.mezon.ai".into()),
+            ..Default::default()
+        };
+        assert!(http_fallback_session(&no_token, Some("https://baked:8088")).is_none());
+
+        let no_base = Session {
+            token: "jwt".into(),
+            ..Default::default()
+        };
+        assert!(http_fallback_session(&no_base, None).is_none());
+    }
 
     #[test]
     fn resolve_tcp_port_uses_tcp_port_field_first() {

--- a/crates/mezon-store/src/direct.rs
+++ b/crates/mezon-store/src/direct.rs
@@ -1184,6 +1184,7 @@ mod tests {
             creator_id,
             clan_name: String::new(),
             channel_avatar: String::new(),
+            active: 1,
         }
     }
 

--- a/crates/mezon-store/src/notification_setting.rs
+++ b/crates/mezon-store/src/notification_setting.rs
@@ -97,6 +97,11 @@ impl NotificationSettingStore {
                     &entity,
                     |store, event, cx| store.handle_realtime(event, cx),
                 );
+                dispatch.on(
+                    crate::realtime::RealtimeKind::Unmute,
+                    &entity,
+                    |store, event, cx| store.handle_unmute(event, cx),
+                );
             });
             this
         });
@@ -118,14 +123,48 @@ impl NotificationSettingStore {
         if channel_id.is_zero() {
             return;
         }
-        let setting = ChannelNotificationSetting::from_api(dto);
-        self.settings.insert(channel_id, setting);
+        let entry = self.settings.entry(channel_id).or_default();
+        entry.apply_realtime(dto, channel_id.get());
+        let setting = *entry;
         cx.emit(NotificationSettingEvent::Changed(channel_id));
         cx.notify();
         let muted = setting.is_time_muted(now_ms());
         crate::channel::ChannelList::global(cx).update(cx, |channels, cx| {
             channels.set_channel_muted_any_clan(channel_id, muted, cx);
         });
+    }
+
+    fn handle_unmute(&mut self, event: &mezon_client::RealtimeEvent, cx: &mut Context<Self>) {
+        let mezon_client::RealtimeEvent::Unmute(ev) = event else {
+            return;
+        };
+        let mut changed = false;
+
+        let channel_id = ChannelId(ev.channel_id);
+        if !channel_id.is_zero()
+            && let Some(entry) = self.settings.get_mut(&channel_id)
+            && entry.mute_until_ms != 0
+        {
+            entry.mute_until_ms = 0;
+            changed = true;
+            cx.emit(NotificationSettingEvent::Changed(channel_id));
+            crate::channel::ChannelList::global(cx).update(cx, |channels, cx| {
+                channels.set_channel_muted_any_clan(channel_id, false, cx);
+            });
+        }
+
+        if ev.category_id != 0
+            && self
+                .category_mute
+                .remove(&ev.category_id.to_string())
+                .is_some()
+        {
+            changed = true;
+        }
+
+        if changed {
+            cx.notify();
+        }
     }
 
     pub fn global(cx: &App) -> Entity<Self> {

--- a/crates/mezon-store/src/realtime.rs
+++ b/crates/mezon-store/src/realtime.rs
@@ -54,6 +54,7 @@ pub enum RealtimeKind {
     UserChannelRemoved,
     ChannelArchive,
     NotifUserChannel,
+    Unmute,
     Notifications,
     AddFriend,
     RemoveFriend,
@@ -103,6 +104,7 @@ impl RealtimeKind {
             RealtimeEvent::UserChannelRemoved(_) => Self::UserChannelRemoved,
             RealtimeEvent::ChannelArchive(_) => Self::ChannelArchive,
             RealtimeEvent::NotifUserChannel(_) => Self::NotifUserChannel,
+            RealtimeEvent::Unmute(_) => Self::Unmute,
             RealtimeEvent::Notifications(_) => Self::Notifications,
             RealtimeEvent::AddFriend(_) => Self::AddFriend,
             RealtimeEvent::RemoveFriend(_) => Self::RemoveFriend,
@@ -322,10 +324,10 @@ mod tests {
     }
 
     #[test]
-    fn kind_of_returns_none_for_unhandled() {
+    fn kind_of_routes_unmute() {
         assert_eq!(
             RealtimeKind::of(&RealtimeEvent::Unmute(realtime::UnmuteEvent::default())),
-            None
+            Some(RealtimeKind::Unmute)
         );
     }
 

--- a/crates/mezon-ui/src/app/main_window.rs
+++ b/crates/mezon-ui/src/app/main_window.rs
@@ -27,21 +27,32 @@ pub fn main_window_bounds(cx: &mut App) -> Option<Bounds<Pixels>> {
         })
 }
 
+/// Read a placement straight off a live `Window`. Callers that already hold the main window —
+/// every click handler does — must use this rather than [`window_placement_for`]: reaching for
+/// the main window through `cx.update_window` while that same window is mid-update fails, and the
+/// resulting `None` silently downgrades an overlay to [`overlay_fallback_placement`].
+pub fn overlay_placement_from_window(
+    window: &Window,
+    cx: &App,
+) -> (WindowBounds, Option<DisplayId>) {
+    let display_id = window.display(cx).map(|d| d.id());
+    let bounds = window.bounds();
+    let window_bounds = if window.is_fullscreen() {
+        WindowBounds::Fullscreen(bounds)
+    } else if window.is_maximized() {
+        WindowBounds::Maximized(bounds)
+    } else {
+        WindowBounds::Windowed(bounds)
+    };
+    (window_bounds, display_id)
+}
+
 pub fn window_placement_for(
     handle: AnyWindowHandle,
     cx: &mut App,
 ) -> Option<(WindowBounds, Option<DisplayId>)> {
     cx.update_window(handle, |_, window, cx| {
-        let display_id = window.display(cx).map(|d| d.id());
-        let bounds = window.bounds();
-        let window_bounds = if window.is_fullscreen() {
-            WindowBounds::Fullscreen(bounds)
-        } else if window.is_maximized() {
-            WindowBounds::Maximized(bounds)
-        } else {
-            WindowBounds::Windowed(bounds)
-        };
-        (window_bounds, display_id)
+        overlay_placement_from_window(window, cx)
     })
     .ok()
 }

--- a/crates/mezon-ui/src/app/root.rs
+++ b/crates/mezon-ui/src/app/root.rs
@@ -4,8 +4,7 @@ use crate::auth::login_view::LoginView;
 use crate::chat::channel_settings::ChannelSettingScreen;
 use crate::chat::layout::ChatLayout;
 use crate::clan::settings::{ClanSettingScreen, ClanSettingsPage};
-use crate::components::primitives::Sizable;
-use crate::components::primitives::{Button, Icon, IconName, Size, Spinner};
+use crate::components::primitives::{Button, Icon, IconName};
 use crate::image_cache::{
     LruImageCache, SHARED_ENTRY_MAX_BYTES, SHARED_IMAGE_CACHE_BYTES, SHARED_IMAGE_CACHE_CAPACITY,
 };
@@ -13,10 +12,11 @@ use crate::router::{Route, Router};
 use crate::settings::SettingsScreen;
 use crate::theme::{ActiveTheme, Theme, resolve_theme};
 use gpui::{
-    AnyView, App, ClickEvent, Context, Entity, FontWeight, MouseButton, NavigationDirection,
-    StyleRefinement, Window, div, img, prelude::*, px,
+    Animation, AnimationExt as _, AnyView, App, ClickEvent, Context, Entity, FontWeight,
+    MouseButton, NavigationDirection, StyleRefinement, Task, Window, div, img, prelude::*, px,
 };
 use mezon_store::{AuthState, ChannelList, ClanId, ClanList, ConnectionStore, Settings};
+use std::time::{Duration, Instant};
 
 pub struct RootView {
     title_bar: Entity<TitleBar>,
@@ -29,6 +29,17 @@ pub struct RootView {
     applied_theme: String,
     cached_locale: String,
     image_cache: Entity<LruImageCache>,
+    connecting_since: Option<Instant>,
+    _splash_delay: Option<Task<()>>,
+}
+
+fn spawn_splash_delay(cx: &mut Context<RootView>) -> Task<()> {
+    cx.spawn(async move |this, cx| {
+        cx.background_executor()
+            .timer(Duration::from_millis(SPLASH_QUIET_MS))
+            .await;
+        let _ = this.update(cx, |_, cx| cx.notify());
+    })
 }
 
 impl RootView {
@@ -74,7 +85,16 @@ impl RootView {
         })
         .detach();
 
-        cx.observe(&auth_state, |_, auth_state, cx| {
+        cx.observe(&auth_state, |this, auth_state, cx| {
+            if matches!(*auth_state.read(cx), AuthState::Connecting(_)) {
+                if this.connecting_since.is_none() {
+                    this.connecting_since = Some(Instant::now());
+                    this._splash_delay = Some(spawn_splash_delay(cx));
+                }
+            } else {
+                this.connecting_since = None;
+                this._splash_delay = None;
+            }
             if matches!(*auth_state.read(cx), AuthState::NotAuthenticated) {
                 crate::image_viewer::close_image_viewer(cx);
                 crate::chat::media_channel::close_media_image_modal(cx);
@@ -159,6 +179,12 @@ impl RootView {
                 cx,
             )
         });
+        let connecting_at_start = matches!(*auth_state.read(cx), AuthState::Connecting(_));
+        let (connecting_since, splash_delay) = if connecting_at_start {
+            (Some(Instant::now()), Some(spawn_splash_delay(cx)))
+        } else {
+            (None, None)
+        };
         Self {
             title_bar,
             auth_state,
@@ -170,6 +196,8 @@ impl RootView {
             applied_theme,
             cached_locale,
             image_cache,
+            connecting_since,
+            _splash_delay: splash_delay,
         }
     }
 
@@ -250,8 +278,19 @@ impl Render for RootView {
             }
             AuthState::AwaitingCallback => render_awaiting_callback(theme, locale),
             AuthState::Connecting(_) => {
-                let attempt = ConnectionStore::global(cx).read(cx).connecting_attempt();
-                render_connecting(theme, locale, attempt)
+                let (attempt, online) = {
+                    let store = ConnectionStore::global(cx).read(cx);
+                    (store.connecting_attempt(), store.is_online())
+                };
+                let waited = self
+                    .connecting_since
+                    .map(|since| since.elapsed())
+                    .unwrap_or_default();
+                if should_show_splash(attempt, online, waited) {
+                    render_connecting(locale, attempt, window.is_window_active())
+                } else {
+                    render_quiet_startup()
+                }
             }
             AuthState::Authenticated(_) => {
                 let route = Router::global(cx).read(cx).route();
@@ -367,30 +406,158 @@ fn render_awaiting_callback(theme: &Theme, locale: &str) -> gpui::AnyElement {
         .into_any_element()
 }
 
-fn render_connecting(theme: &Theme, locale: &str, attempt: u32) -> gpui::AnyElement {
+const SPLASH_BG: u32 = 0x1e1f22;
+const SPLASH_ACCENT: u32 = 0x5865f2;
+const SPLASH_ACCENT_END: u32 = 0x7289da;
+const SPLASH_STATUS_TEXT: u32 = 0xd1d5db;
+const SPLASH_LOGO_WIDTH: f32 = 280.;
+const SPLASH_LOGO_HEIGHT: f32 = 50.;
+const SPLASH_LOGO_VIEWPORT_FRACTION: f32 = 0.72;
+const SPLASH_DOT_BASE_SIZE: f32 = 6.;
+const SPLASH_DOT_CYCLE_MS: u64 = 1400;
+const SPLASH_DOT_STAGGER_MS: u64 = 200;
+const SPLASH_PROGRESS_MS: u64 = 30_000;
+const SPLASH_PROGRESS_HEIGHT: f32 = 3.;
+const SPLASH_QUIET_MS: u64 = 600;
+const SPLASH_FADE_MS: u64 = 250;
+
+fn splash_progress_fraction(delta: f32) -> f32 {
+    if delta <= 0.8 {
+        delta / 0.8 * 0.85
+    } else {
+        0.85 + (delta - 0.8) / 0.2 * 0.1
+    }
+}
+
+fn splash_dot_intensity(delta: f32, offset: f32) -> f32 {
+    let phase = (delta + offset).rem_euclid(1.0);
+    if phase <= 0.4 {
+        phase / 0.4
+    } else if phase <= 0.8 {
+        1.0 - (phase - 0.4) / 0.4
+    } else {
+        0.0
+    }
+}
+
+/// `animate: false` renders the dots as plain static circles. The animation repeats forever, and a
+/// connect that never succeeds leaves this screen up indefinitely — driving a frame request per
+/// tick on the root view for as long as the machine stays offline. Nobody is watching a background
+/// window, so the pulse is dropped there.
+fn render_splash_dots(animate: bool) -> gpui::AnyElement {
+    let mut row = div().flex().flex_row().gap(px(6.)).mt(px(4.));
+    for index in 0..3u64 {
+        let offset = (index * SPLASH_DOT_STAGGER_MS) as f32 / SPLASH_DOT_CYCLE_MS as f32;
+        let dot = div()
+            .rounded_full()
+            .bg(gpui::rgb(SPLASH_ACCENT))
+            .size(px(SPLASH_DOT_BASE_SIZE));
+        row = row.child(if animate {
+            dot.with_animation(
+                gpui::ElementId::Integer(index),
+                Animation::new(Duration::from_millis(SPLASH_DOT_CYCLE_MS)).repeat(),
+                move |el, delta| {
+                    let intensity = splash_dot_intensity(delta, offset);
+                    el.opacity(0.2 + 0.8 * intensity)
+                        .size(px(SPLASH_DOT_BASE_SIZE * (0.8 + 0.4 * intensity)))
+                },
+            )
+            .into_any_element()
+        } else {
+            dot.opacity(0.6).into_any_element()
+        });
+    }
+    row.into_any_element()
+}
+
+fn render_splash_progress_bar() -> gpui::AnyElement {
+    div()
+        .absolute()
+        .top_0()
+        .left_0()
+        .h(px(SPLASH_PROGRESS_HEIGHT))
+        .rounded_r(px(2.))
+        .bg(gpui::linear_gradient(
+            90.,
+            gpui::linear_color_stop(gpui::rgb(SPLASH_ACCENT), 0.),
+            gpui::linear_color_stop(gpui::rgb(SPLASH_ACCENT_END), 1.),
+        ))
+        .with_animation(
+            "splash-progress",
+            Animation::new(Duration::from_millis(SPLASH_PROGRESS_MS)),
+            |el, delta| el.w(gpui::relative(splash_progress_fraction(delta))),
+        )
+        .into_any_element()
+}
+
+fn should_show_splash(attempt: u32, online: bool, waited: Duration) -> bool {
+    attempt > 0 || !online || waited >= Duration::from_millis(SPLASH_QUIET_MS)
+}
+
+fn render_quiet_startup() -> gpui::AnyElement {
+    div()
+        .flex_1()
+        .size_full()
+        .bg(gpui::rgb(SPLASH_BG))
+        .into_any_element()
+}
+
+fn render_connecting(locale: &str, attempt: u32, animate: bool) -> gpui::AnyElement {
     let label = if attempt > 0 {
         mezon_i18n::t(locale, "root.reconnectingAttempt").replace("{{count}}", &attempt.to_string())
     } else {
         mezon_i18n::t(locale, "root.loading").to_string()
     };
+    let fade = |id: &'static str| {
+        (
+            id,
+            Animation::new(Duration::from_millis(SPLASH_FADE_MS)).with_easing(gpui::ease_in_out),
+        )
+    };
+    let (bar_id, bar_anim) = fade("splash-bar-fade");
+    let (body_id, body_anim) = fade("splash-body-fade");
     div()
+        .relative()
         .flex()
         .flex_1()
+        .size_full()
         .items_center()
         .justify_center()
         .flex_col()
-        .gap_4()
+        .bg(gpui::rgb(SPLASH_BG))
         .child(
-            Spinner::new()
-                .with_size(Size::Large)
-                .color(theme.brand.into()),
+            div()
+                .absolute()
+                .top_0()
+                .left_0()
+                .w_full()
+                .child(render_splash_progress_bar())
+                .with_animation(bar_id, bar_anim, |el, delta| el.opacity(delta)),
         )
         .child(
             div()
-                .text_xl()
-                .font_weight(FontWeight::BOLD)
-                .text_color(theme.text_primary)
-                .child(label),
+                .flex()
+                .flex_col()
+                .items_center()
+                .child(
+                    img(crate::util::assets::MEZON_LOGO)
+                        .w(px(SPLASH_LOGO_WIDTH))
+                        .h(px(SPLASH_LOGO_HEIGHT))
+                        .max_w(gpui::relative(SPLASH_LOGO_VIEWPORT_FRACTION))
+                        .object_fit(gpui::ObjectFit::Contain)
+                        .mb(px(24.)),
+                )
+                .child(render_splash_dots(animate))
+                .child(
+                    div()
+                        .text_size(px(12.))
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(gpui::rgb(SPLASH_STATUS_TEXT))
+                        .mt(px(10.))
+                        .mb(px(12.))
+                        .child(label),
+                )
+                .with_animation(body_id, body_anim, |el, delta| el.opacity(delta)),
         )
         .into_any_element()
 }
@@ -453,4 +620,51 @@ fn render_not_found(theme: &Theme, locale: &str) -> gpui::AnyElement {
         )
         .child(back_btn)
         .into_any_element()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quiet_startup_stays_silent_while_the_first_connect_is_quick() {
+        assert!(!should_show_splash(0, true, Duration::ZERO));
+        assert!(!should_show_splash(
+            0,
+            true,
+            Duration::from_millis(SPLASH_QUIET_MS - 1)
+        ));
+    }
+
+    #[test]
+    fn splash_appears_once_the_quiet_window_elapses() {
+        assert!(should_show_splash(
+            0,
+            true,
+            Duration::from_millis(SPLASH_QUIET_MS)
+        ));
+    }
+
+    #[test]
+    fn splash_shows_immediately_while_reconnecting_or_offline() {
+        assert!(should_show_splash(1, true, Duration::ZERO));
+        assert!(should_show_splash(0, false, Duration::ZERO));
+        assert!(should_show_splash(3, false, Duration::ZERO));
+    }
+
+    #[test]
+    fn progress_bar_never_reaches_full_width() {
+        assert_eq!(splash_progress_fraction(0.0), 0.0);
+        assert!((splash_progress_fraction(0.8) - 0.85).abs() < f32::EPSILON);
+        assert!((splash_progress_fraction(1.0) - 0.95).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn dots_are_staggered_so_they_do_not_pulse_together() {
+        let offset = 200. / 1400.;
+        let at_peak = splash_dot_intensity(0.4, 0.0);
+        assert!((at_peak - 1.0).abs() < f32::EPSILON);
+        assert!(splash_dot_intensity(0.4, offset) < at_peak);
+        assert_eq!(splash_dot_intensity(0.9, 0.0), 0.0);
+    }
 }

--- a/crates/mezon-ui/src/app/window_controls/linux.rs
+++ b/crates/mezon-ui/src/app/window_controls/linux.rs
@@ -36,7 +36,12 @@ pub fn render_controls(theme: &Theme, window: &Window) -> impl IntoElement {
             IconName::WindowClose,
             |style| style.bg(rgb(CONTROL_CLOSE_HOVER)).text_color(gpui::white()),
             |window, cx| {
-                if !hide_main_window(window, cx) {
+                // Hide-to-tray belongs to the main window alone. These controls are shared by
+                // every window that uses the app title bar, and hiding a secondary window instead
+                // of closing it leaves it alive but unmapped: reopening then re-maps it and the
+                // window manager, not the app, picks where it lands.
+                let is_main = crate::app::main_window::handle(cx) == Some(window.window_handle());
+                if !is_main || !hide_main_window(window, cx) {
                     window.remove_window();
                 }
             },

--- a/crates/mezon-ui/src/chat/media_channel/media_image_modal.rs
+++ b/crates/mezon-ui/src/chat/media_channel/media_image_modal.rs
@@ -2,18 +2,18 @@ use std::sync::Arc;
 
 use gpui::http_client::HttpClient;
 use gpui::{
-    AnyView, App, AppContext, Bounds, Context, Corners, Entity, FocusHandle, Focusable, ImageCache,
-    KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, ObjectFit, Pixels, Point, Render,
-    RenderImage, Resource, ScrollDelta, ScrollWheelEvent, SharedString, SharedUri,
-    Size as GpuiSize, StyleRefinement, Subscription, UniformListScrollHandle, Window, WindowHandle,
-    WindowOptions, canvas, div, img, point, prelude::*, px, size, uniform_list,
+    AnyView, App, AppContext, Bounds, Context, Corners, DisplayId, Entity, FocusHandle, Focusable,
+    ImageCache, KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, ObjectFit, Pixels,
+    Point, Render, RenderImage, Resource, ScrollDelta, ScrollWheelEvent, SharedString, SharedUri,
+    Size as GpuiSize, StyleRefinement, Subscription, UniformListScrollHandle, Window, WindowBounds,
+    WindowHandle, WindowOptions, canvas, div, img, point, prelude::*, px, size, uniform_list,
 };
 use mezon_store::{AppConfig, ChannelTimelineAttachment, Settings};
 use ui::{ScrollAxes, Scrollbars, WithScrollbar};
 
 use crate::app::main_window::{
-    activate_main_window, handle as main_window_handle, overlay_placement_for_main,
-    overlay_window_kind, sync_overlay_to_main,
+    activate_main_window, apply_overlay_bounds, handle as main_window_handle,
+    overlay_placement_from_window, overlay_window_kind, sync_overlay_to_main,
 };
 use crate::app::title_bar::TitleBar;
 use crate::app::window_controls;
@@ -88,7 +88,7 @@ pub fn close_media_image_modal(cx: &mut App) {
 pub fn open_media_image_modal(
     attachments: Vec<ChannelTimelineAttachment>,
     attachment_index: usize,
-    _window: &mut Window,
+    window: &mut Window,
     cx: &mut App,
 ) {
     let uploaded: Vec<_> = attachments
@@ -106,10 +106,12 @@ pub fn open_media_image_modal(
         return;
     };
 
+    let placement = overlay_placement_from_window(window, cx);
     let mut pending = Some((uploaded, index));
     if let Some(handle) = cx.try_global::<GlobalMediaImageModal>().map(|g| g.0) {
         let _ = handle.update(cx, |modal, window, cx| {
             if let Some((uploaded, index)) = pending.take() {
+                apply_overlay_bounds(window, placement.0);
                 window.activate_window();
                 window.focus(&modal.focus_handle, cx);
                 modal.set_attachments(uploaded, index, window, cx);
@@ -122,7 +124,7 @@ pub fn open_media_image_modal(
         let Some((uploaded, index)) = pending else {
             return;
         };
-        spawn_media_image_modal_window(uploaded, index, settings, cx);
+        spawn_media_image_modal_window(uploaded, index, settings, placement, cx);
         return;
     }
 
@@ -130,17 +132,18 @@ pub fn open_media_image_modal(
         return;
     };
 
-    spawn_media_image_modal_window(uploaded, index, settings, cx);
+    spawn_media_image_modal_window(uploaded, index, settings, placement, cx);
 }
 
 fn spawn_media_image_modal_window(
     uploaded: Vec<ChannelTimelineAttachment>,
     index: usize,
     settings: Entity<Settings>,
+    placement: (WindowBounds, Option<DisplayId>),
     cx: &mut App,
 ) {
     let main_app = main_window_handle(cx);
-    let (window_bounds, display_id) = overlay_placement_for_main(cx);
+    let (window_bounds, display_id) = placement;
     let kind = overlay_window_kind();
     let options = WindowOptions {
         window_bounds: Some(window_bounds),

--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -898,9 +898,15 @@ fn render_album(
             tile_element = tile_element.when(
                 !att.uploading && !att.upload_failed && !raw_url.is_empty(),
                 |d| {
-                    d.cursor_pointer().on_click(move |_, _window, cx| {
+                    d.cursor_pointer().on_click(move |_, window, cx| {
                         if !selection.borrow().has_selection() {
-                            open_viewer_from_message(&settings, raw_url.clone(), anchor, cx);
+                            open_viewer_from_message(
+                                &settings,
+                                raw_url.clone(),
+                                anchor,
+                                window,
+                                cx,
+                            );
                         }
                     })
                 },
@@ -927,9 +933,9 @@ fn render_album(
                             .object_fit(ObjectFit::Cover),
                     )
                 })
-                .on_click(move |_, _window, cx| {
+                .on_click(move |_, window, cx| {
                     if !selection.borrow().has_selection() {
-                        open_viewer_from_message(&settings, raw_url.clone(), anchor, cx);
+                        open_viewer_from_message(&settings, raw_url.clone(), anchor, window, cx);
                     }
                 });
         }
@@ -1047,9 +1053,9 @@ fn render_photo(
             .overflow_hidden()
             .bg(theme.bg_tertiary);
         el = el.when(!sending && !att.upload_failed && !raw_url.is_empty(), |d| {
-            d.cursor_pointer().on_click(move |_, _window, cx| {
+            d.cursor_pointer().on_click(move |_, window, cx| {
                 if !selection.borrow().has_selection() {
-                    open_viewer_from_message(&settings, raw_url.clone(), anchor, cx);
+                    open_viewer_from_message(&settings, raw_url.clone(), anchor, window, cx);
                 }
             })
         });
@@ -1125,9 +1131,9 @@ fn render_photo(
         .overflow_hidden()
         .bg(theme.bg_tertiary);
     el = el.when(!is_sticker && !att.upload_failed, |d| {
-        d.cursor_pointer().on_click(move |_, _window, cx| {
+        d.cursor_pointer().on_click(move |_, window, cx| {
             if !selection.borrow().has_selection() {
-                open_viewer_from_message(&settings, raw_url.clone(), anchor, cx);
+                open_viewer_from_message(&settings, raw_url.clone(), anchor, window, cx);
             }
         })
     });
@@ -1883,6 +1889,7 @@ fn open_viewer_from_message(
     settings: &Entity<mezon_store::Settings>,
     url: SharedString,
     anchor_before: u32,
+    window: &gpui::Window,
     cx: &mut gpui::App,
 ) {
     use crate::image_viewer::{OpenViewerRequest, open_image_viewer, resolve_channel_label};
@@ -1919,6 +1926,7 @@ fn open_viewer_from_message(
             selected_url: Some(url),
             anchor_before: Some(anchor_before),
         },
+        window,
         cx,
     );
 }

--- a/crates/mezon-ui/src/gallery/mod.rs
+++ b/crates/mezon-ui/src/gallery/mod.rs
@@ -389,6 +389,7 @@ impl GalleryModal {
                 selected_url: None,
                 anchor_before: None,
             },
+            window,
             cx,
         );
     }

--- a/crates/mezon-ui/src/image_viewer/mod.rs
+++ b/crates/mezon-ui/src/image_viewer/mod.rs
@@ -4,11 +4,11 @@ use std::time::{Duration, Instant};
 use gpui::Size as GpuiSize;
 use gpui::http_client::HttpClient;
 use gpui::{
-    App, AppContext, BackgroundExecutor, Bounds, Context, Corners, Entity, FocusHandle, Focusable,
-    ImageCache, KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, ObjectFit, Pixels,
-    Point, Render, RenderImage, Resource, ScrollDelta, ScrollWheelEvent, SharedString, SharedUri,
-    Subscription, UniformListScrollHandle, Window, WindowHandle, WindowOptions, canvas, div, img,
-    point, prelude::*, px, relative, size, uniform_list,
+    App, AppContext, BackgroundExecutor, Bounds, Context, Corners, DisplayId, Entity, FocusHandle,
+    Focusable, ImageCache, KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, ObjectFit,
+    Pixels, Point, Render, RenderImage, Resource, ScrollDelta, ScrollWheelEvent, SharedString,
+    SharedUri, Subscription, UniformListScrollHandle, Window, WindowBounds, WindowHandle,
+    WindowOptions, canvas, div, img, point, prelude::*, px, relative, size, uniform_list,
 };
 use mezon_store::{
     AppConfig, ChannelAttachment, ChannelId, ChannelList, ClanId, DirectMessageStore, GalleryStore,
@@ -17,8 +17,8 @@ use mezon_store::{
 use ui::{ScrollAxes, Scrollbars, WithScrollbar};
 
 use crate::app::main_window::{
-    activate_main_window, handle as main_window_handle, overlay_placement_for_main,
-    overlay_window_kind, sync_overlay_to_main,
+    activate_main_window, apply_overlay_bounds, handle as main_window_handle,
+    overlay_placement_from_window, overlay_window_kind, sync_overlay_to_main,
 };
 use crate::app::shell::Shell;
 use crate::app::title_bar::TitleBar;
@@ -108,16 +108,24 @@ pub fn close_image_viewer(cx: &mut App) {
     clear_image_viewer_global(cx);
 }
 
-/// Open the image viewer, replacing any existing viewer window.
-pub fn open_image_viewer(request: OpenViewerRequest, cx: &mut App) {
-    open_image_viewer_now(request, cx);
+/// Open the image viewer, replacing any existing viewer window. `window` is the window the user
+/// clicked in — its placement is what the viewer is opened at, so it must be read here rather than
+/// looked up from the global handle, which is unreachable while that window is mid-update.
+pub fn open_image_viewer(request: OpenViewerRequest, window: &Window, cx: &mut App) {
+    let placement = overlay_placement_from_window(window, cx);
+    open_image_viewer_now(request, placement, cx);
 }
 
-fn open_image_viewer_now(request: OpenViewerRequest, cx: &mut App) {
+fn open_image_viewer_now(
+    request: OpenViewerRequest,
+    placement: (WindowBounds, Option<DisplayId>),
+    cx: &mut App,
+) {
     let mut pending = Some(request);
     if let Some(handle) = cx.try_global::<GlobalImageViewer>().map(|g| g.0) {
         let _ = handle.update(cx, |viewer, window, cx| {
             if let Some(request) = pending.take() {
+                apply_overlay_bounds(window, placement.0);
                 window.activate_window();
                 window.focus(&viewer.focus_handle, cx);
                 viewer.set_request(request, window, cx);
@@ -130,18 +138,22 @@ fn open_image_viewer_now(request: OpenViewerRequest, cx: &mut App) {
         let Some(request) = pending.take() else {
             return;
         };
-        spawn_image_viewer_window(request, cx);
+        spawn_image_viewer_window(request, placement, cx);
         return;
     }
     let Some(request) = pending else {
         return;
     };
-    spawn_image_viewer_window(request, cx);
+    spawn_image_viewer_window(request, placement, cx);
 }
 
-fn spawn_image_viewer_window(request: OpenViewerRequest, cx: &mut App) {
+fn spawn_image_viewer_window(
+    request: OpenViewerRequest,
+    placement: (WindowBounds, Option<DisplayId>),
+    cx: &mut App,
+) {
     let main_app = main_window_handle(cx);
-    let (window_bounds, display_id) = overlay_placement_for_main(cx);
+    let (window_bounds, display_id) = placement;
     let kind = overlay_window_kind();
     let options = WindowOptions {
         window_bounds: Some(window_bounds),

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
@@ -1261,17 +1261,17 @@ fn render_banner_and_events(
         .when(event_count > 0, |row| {
             row.child(
                 div()
-                    .min_w(px(22.))
-                    .h(px(22.))
+                    .min_w(px(20.))
+                    .h(px(20.))
                     .px_1()
                     .flex()
                     .items_center()
                     .justify_center()
                     .rounded_full()
-                    .bg(theme.status_dnd)
+                    .bg(gpui::rgb(0xdc2626))
                     .text_color(gpui::white())
                     .text_size(px(12.))
-                    .font_weight(gpui::FontWeight::BOLD)
+                    .font_weight(gpui::FontWeight::MEDIUM)
                     .child(event_count.to_string()),
             )
         })

--- a/crates/mezon-ui/src/util/assets.rs
+++ b/crates/mezon-ui/src/util/assets.rs
@@ -7,8 +7,6 @@ use rust_embed::RustEmbed;
 pub const AVATAR_GROUP: &str = "images/avatar-group.png";
 pub const MEZON_LOGO: &str = "images/logoflashsceenmezon.png";
 pub const STREAM_THUMBNAIL: &str = "images/flahstream.png";
-pub const MEZON_LOGO_ICON: &str = "images/mezon-logo-white.svg";
-pub const MEZON_LOGO_QR: &str = "images/icon-logo-mezon.svg";
 pub const MEZON_COMMUNITY: &str = "images/mezon-community.png";
 
 #[derive(RustEmbed)]
@@ -33,5 +31,23 @@ impl AssetSource for Assets {
         Ok(Self::iter()
             .filter_map(|p| p.starts_with(path).then(|| p.into()))
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_declared_asset_is_embedded() {
+        for path in [AVATAR_GROUP, MEZON_LOGO, STREAM_THUMBNAIL, MEZON_COMMUNITY] {
+            let loaded = Assets
+                .load(path)
+                .unwrap_or_else(|e| panic!("{path} is declared but not embedded: {e}"));
+            assert!(
+                loaded.is_some_and(|bytes| !bytes.is_empty()),
+                "{path} embedded but empty"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add HTTP REST fallback for socket API calls when abridged TCP transport fails
- Renew expiring tokens proactively in `ConnectionStore` with capped backoff
- Apply full session refresh payload (token + refresh_token + session_id) from socket events
- Rebuild connecting/reconnecting splash UI with quiet-start delay and progress animation
- Fix notification mute realtime to treat `time_mute_seconds` as absolute epoch
- Treat only thread channels as archived when server omits `active`; keep plain channels visible

## Test plan

- [ ] `just lint` and `just test` pass
- [ ] Login and connect — quick connect shows no splash; slow connect shows splash after quiet window
- [ ] Reconnect/offline states show splash immediately
- [ ] Socket down but HTTP reachable — API calls succeed via fallback
- [ ] Token near expiry renews without logout loop
- [ ] Realtime channel mute updates apply correct expiry
- [ ] Plain text channels stay visible when server sends `active=0`
