### PR TITLE
feat: add app reload shortcut to rebuild shell and reconnect

### DIFF
--- a/crates/mezon-store/src/connection.rs
+++ b/crates/mezon-store/src/connection.rs
@@ -39,6 +39,8 @@ enum ConnectOutcome {
 pub struct ConnectionStore {
     online: bool,
     connecting_attempt: u32,
+    transport: Arc<TransportClient>,
+    wake: Arc<tokio::sync::Notify>,
     _manager: Task<()>,
     _auth_observe: Subscription,
     _heartbeat: Task<()>,
@@ -73,6 +75,19 @@ impl ConnectionStore {
 
     pub fn global(cx: &App) -> Entity<Self> {
         cx.global::<GlobalConnectionStore>().0.clone()
+    }
+
+    pub fn reconnect(&self, cx: &mut Context<Self>) {
+        let transport = self.transport.clone();
+        let wake = self.wake.clone();
+        cx.background_executor()
+            .spawn(async move {
+                if let Err(e) = transport.close().await {
+                    tracing::warn!("Failed to close the transport before reconnect: {e}");
+                }
+                wake.notify_one();
+            })
+            .detach();
     }
 
     fn new(
@@ -117,6 +132,8 @@ impl ConnectionStore {
         };
 
         let heartbeat = Self::spawn_heartbeat(transport.clone(), api.clone(), wake.clone(), cx);
+        let transport_handle = transport.clone();
+        let wake_handle = wake.clone();
 
         let probe_url = AppConfig::try_global(cx)
             .map(|cfg| favicon_probe_url(&cfg.redirect_uri))
@@ -362,6 +379,8 @@ impl ConnectionStore {
         Self {
             online,
             connecting_attempt: 0,
+            transport: transport_handle,
+            wake: wake_handle,
             _manager: manager,
             _auth_observe: auth_observe,
             _heartbeat: heartbeat,

--- a/crates/mezon-ui/src/app/root.rs
+++ b/crates/mezon-ui/src/app/root.rs
@@ -201,6 +201,39 @@ impl RootView {
         }
     }
 
+    pub fn reload(window: &mut Window, cx: &mut App) {
+        let Some(settings) = Settings::try_global(cx) else {
+            tracing::warn!("Reload skipped — settings global is missing");
+            return;
+        };
+        let auth_state = mezon_store::LoginStore::global(cx).read(cx).auth_state();
+
+        crate::image_viewer::close_image_viewer(cx);
+        crate::chat::media_channel::close_media_image_modal(cx);
+        crate::channel_app::close_channel_app_window(cx);
+        crate::image_cache::clear_all_image_caches(cx);
+        mezon_canvas::reset_canvas_image_caches(cx);
+        mezon_store::LoginStore::reset_all_user_stores(cx);
+
+        let reconnecting = auth_state.update(cx, |state, cx| {
+            if let AuthState::Authenticated(session) = state {
+                *state = AuthState::Connecting(session.clone());
+                cx.notify();
+                true
+            } else {
+                false
+            }
+        });
+        if reconnecting {
+            ConnectionStore::global(cx).update(cx, |store, cx| store.reconnect(cx));
+        }
+
+        let title_bar = cx.new(|cx| TitleBar::new(settings.clone(), cx));
+        window.replace_root(cx, |_, cx| {
+            RootView::new(title_bar, auth_state, settings, cx)
+        });
+    }
+
     fn sync_settings_page(&mut self, cx: &mut Context<Self>) {
         let page = match Router::global(cx).read(cx).route() {
             Route::SettingsProfile => {

--- a/crates/mezon-ui/src/app/window_controls/macos.rs
+++ b/crates/mezon-ui/src/app/window_controls/macos.rs
@@ -116,6 +116,10 @@ unsafe fn handle_shortcut(event: *mut Object, async_app: &gpui::AsyncApp) -> boo
             async_app.update(|cx| cx.quit());
             true
         }
+        b'r' => {
+            async_app.update(crate::reload_app);
+            true
+        }
         _ => false,
     }
 }

--- a/crates/mezon-ui/src/lib.rs
+++ b/crates/mezon-ui/src/lib.rs
@@ -53,7 +53,8 @@ gpui::actions!(
         HideWindow,
         MinimizeWindow,
         HideApp,
-        OpenCommandPalette
+        OpenCommandPalette,
+        ReloadApp
     ]
 );
 
@@ -99,6 +100,8 @@ pub fn init(cx: &mut gpui::App) {
     cx.on_action(|_: &OpenCommandPalette, cx: &mut gpui::App| {
         command_palette::CommandPaletteModal::try_toggle_authenticated(cx);
     });
+    cx.bind_keys([gpui::KeyBinding::new("secondary-r", ReloadApp, None)]);
+    cx.on_action(|_: &ReloadApp, cx: &mut gpui::App| reload_app(cx));
     components::primitives::init_input(cx);
     components::primitives::init_textarea(cx);
     chat::mention_input::init(cx);
@@ -108,6 +111,18 @@ pub fn init(cx: &mut gpui::App) {
     command_palette::init(cx);
     router::Router::init(cx);
     init_menus(cx);
+}
+
+pub fn reload_app(cx: &mut gpui::App) {
+    let Some(handle) = app::main_window::handle(cx) else {
+        return;
+    };
+    tracing::info!("Reload requested — rebuilding the app shell");
+    cx.defer(move |cx| {
+        if let Err(e) = handle.update(cx, |_, window, cx| RootView::reload(window, cx)) {
+            tracing::warn!("Reload failed: {e}");
+        }
+    });
 }
 
 /// macOS menu bar and standard shortcuts. Edit items reuse the input component's clipboard actions.


### PR DESCRIPTION
## Summary
- Add `ReloadApp` action bound to Cmd+R (`secondary-r`) to rebuild the app shell without quitting.
- `RootView::reload` closes secondary windows/modals, clears image caches, resets user stores, and replaces the root view.
- `ConnectionStore::reconnect` closes the transport and wakes the connection manager when the session is authenticated.

## Test plan
- [ ] Log in and press Cmd+R — app shell rebuilds and socket reconnects without logging out.
- [ ] Open image viewer / channel app window, press Cmd+R — secondary windows close before reload.
- [ ] Reload while logged out — root view rebuilds without attempting transport reconnect.
