### PR TITLE
feat(thread): auto-add users to thread on send and reaction

### DIFF
--- a/crates/mezon-client/src/app_api.rs
+++ b/crates/mezon-client/src/app_api.rs
@@ -1896,6 +1896,8 @@ impl AppApi {
         message_id: i64,
         content: &str,
         mentions: Vec<crate::transport::OutgoingMention>,
+        hashtags: Vec<crate::transport::OutgoingHashtag>,
+        emojis: Vec<crate::transport::OutgoingEmoji>,
         presign_finish: Vec<String>,
         create_time_seconds: u32,
         mode: i32,
@@ -1910,6 +1912,8 @@ impl AppApi {
                 message_id,
                 content,
                 mentions,
+                hashtags,
+                emojis,
                 presign_finish,
                 create_time_seconds,
                 mode,
@@ -1938,6 +1942,8 @@ impl AppApi {
         message_id: i64,
         content: &str,
         mentions: Vec<crate::transport::OutgoingMention>,
+        hashtags: Vec<crate::transport::OutgoingHashtag>,
+        emojis: Vec<crate::transport::OutgoingEmoji>,
         create_time_seconds: u32,
         presigned: Vec<PresignedAttachment>,
         keys: Vec<String>,
@@ -1976,6 +1982,8 @@ impl AppApi {
                         message_id,
                         content,
                         mentions.clone(),
+                        hashtags.clone(),
+                        emojis.clone(),
                         finished.clone(),
                         create_time_seconds,
                         mode,
@@ -1999,6 +2007,8 @@ impl AppApi {
                     message_id,
                     content,
                     mentions,
+                    hashtags,
+                    emojis,
                     finished,
                     create_time_seconds,
                     mode,
@@ -2580,6 +2590,10 @@ impl AppApi {
         self.transport
             .active_archived_thread(clan_id, channel_id)
             .await
+    }
+
+    pub async fn leave_thread(&self, clan_id: i64, channel_id: i64) -> Result<()> {
+        self.transport.leave_thread(clan_id, channel_id).await
     }
 
     pub async fn list_loged_device(&self) -> Result<Vec<mezon_proto::api::LogedDevice>> {

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -2501,6 +2501,20 @@ pub fn build_send_content(
     }
 }
 
+fn build_presign_finish_content(
+    content: &str,
+    mentions: &[OutgoingMention],
+    hashtags: &[OutgoingHashtag],
+    emojis: &[OutgoingEmoji],
+    presign_finish: &[String],
+    create_time_seconds: u32,
+) -> (String, Vec<OutgoingMention>) {
+    let sent = build_send_content(content, mentions, hashtags, emojis);
+    let content_json = with_presign_finish(sent.json, presign_finish);
+    let content_json = with_create_time_seconds(content_json, create_time_seconds);
+    (content_json, sent.mentions)
+}
+
 fn with_presign_finish(content_json: String, keys: &[String]) -> String {
     let mut value: serde_json::Value =
         serde_json::from_str(&content_json).unwrap_or_else(|_| serde_json::json!({}));
@@ -5361,6 +5375,8 @@ impl MezonTransport {
         message_id: i64,
         content: &str,
         mentions: Vec<OutgoingMention>,
+        hashtags: Vec<OutgoingHashtag>,
+        emojis: Vec<OutgoingEmoji>,
         presign_finish: Vec<String>,
         create_time_seconds: u32,
         mode: i32,
@@ -5369,10 +5385,14 @@ impl MezonTransport {
         is_update_msg_topic: bool,
     ) -> Result<()> {
         let cid = self.generate_cid();
-        let sent = build_send_content(content, &mentions, &[], &[]);
-        let mentions = sent.mentions;
-        let content_json = with_presign_finish(sent.json, &presign_finish);
-        let content_json = with_create_time_seconds(content_json, create_time_seconds);
+        let (content_json, mentions) = build_presign_finish_content(
+            content,
+            &mentions,
+            &hashtags,
+            &emojis,
+            &presign_finish,
+            create_time_seconds,
+        );
         let proto_mentions: Vec<api::MessageMention> = mentions
             .iter()
             .filter_map(OutgoingMention::to_proto)
@@ -6118,6 +6138,20 @@ impl MezonTransport {
         let (code, _) = self
             .send_api_request(cid, "ActiveArchivedThread", body)
             .await?;
+        if code != 0 {
+            return Err(anyhow::anyhow!("API error: code={}", code));
+        }
+        Ok(())
+    }
+
+    pub async fn leave_thread(&self, clan_id: i64, channel_id: i64) -> Result<()> {
+        let cid = self.generate_cid();
+        let body = api::LeaveThreadRequest {
+            clan_id,
+            channel_id,
+        }
+        .encode_to_vec();
+        let (code, _) = self.send_api_request(cid, "LeaveThread", body).await?;
         if code != 0 {
             return Err(anyhow::anyhow!("API error: code={}", code));
         }
@@ -9851,5 +9885,42 @@ mod tests {
         assert!(link.contains("10.5,106.2"));
         assert_eq!(value["lk"][0]["s"], 0);
         assert_eq!(value["mk"][0]["type"], "lk");
+    }
+
+    #[test]
+    fn presign_finish_patch_keeps_emoji_and_hashtag_entities() {
+        let emojis = vec![OutgoingEmoji {
+            emoji_id: "1750123".to_string(),
+            s: 3,
+            e: 8,
+        }];
+        let hashtags = vec![OutgoingHashtag {
+            channel_id: "42".to_string(),
+            s: 9,
+            e: 13,
+        }];
+        let mentions = vec![OutgoingMention {
+            user_id: "7".to_string(),
+            role_id: String::new(),
+            username: "bob".to_string(),
+            s: 14,
+            e: 18,
+        }];
+
+        let (json, _) = build_presign_finish_content(
+            "hi :joy: #gen @bob",
+            &mentions,
+            &hashtags,
+            &emojis,
+            &["key-1".to_string()],
+            1700,
+        );
+        let value: serde_json::Value = serde_json::from_str(&json).expect("json");
+
+        assert_eq!(value["ej"][0]["emojiid"], "1750123");
+        assert_eq!(value["hg"][0]["channelId"], "42");
+        assert_eq!(value["mentions"][0]["user_id"], "7");
+        assert_eq!(value["presign_finish"][0], "key-1");
+        assert_eq!(value["create_time_seconds"], 1700);
     }
 }

--- a/crates/mezon-client/src/transport_runtime.rs
+++ b/crates/mezon-client/src/transport_runtime.rs
@@ -2453,6 +2453,8 @@ impl TransportClient {
         message_id: i64,
         content: &str,
         mentions: Vec<crate::transport::OutgoingMention>,
+        hashtags: Vec<crate::transport::OutgoingHashtag>,
+        emojis: Vec<crate::transport::OutgoingEmoji>,
         presign_finish: Vec<String>,
         create_time_seconds: u32,
         mode: i32,
@@ -2472,6 +2474,8 @@ impl TransportClient {
                         message_id,
                         &content,
                         mentions,
+                        hashtags,
+                        emojis,
                         presign_finish,
                         create_time_seconds,
                         mode,
@@ -2629,6 +2633,15 @@ impl TransportClient {
 
         runtime()
             .spawn(async move { transport.active_archived_thread(clan_id, channel_id).await })
+            .await
+            .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
+    }
+
+    pub async fn leave_thread(&self, clan_id: i64, channel_id: i64) -> Result<()> {
+        let transport = self.inner.clone();
+
+        runtime()
+            .spawn(async move { transport.leave_thread(clan_id, channel_id).await })
             .await
             .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
     }

--- a/crates/mezon-store/src/channel_members.rs
+++ b/crates/mezon-store/src/channel_members.rs
@@ -168,6 +168,22 @@ impl ChannelMembersStore {
         self.cache.contains(&channel_id)
     }
 
+    pub fn apply_members_added(
+        &mut self,
+        channel_id: ChannelId,
+        user_ids: &[UserId],
+        cx: &mut Context<Self>,
+    ) {
+        let Some(bucket) = self.cache.get_mut(&channel_id) else {
+            return;
+        };
+        if !add_members_to_bucket(bucket, user_ids) {
+            return;
+        }
+        cx.emit(ChannelMembersEvent::Changed { channel_id });
+        cx.notify();
+    }
+
     pub fn is_loading(&self, channel_id: ChannelId) -> bool {
         self.loading.get(&channel_id).copied().unwrap_or(false)
     }
@@ -274,6 +290,21 @@ impl ChannelMembersStore {
     }
 }
 
+fn add_members_to_bucket(bucket: &mut ChannelBucket, user_ids: &[UserId]) -> bool {
+    let mut changed = false;
+    for user_id in user_ids {
+        if bucket.members.iter().any(|m| m.user_id == *user_id) {
+            continue;
+        }
+        bucket.upsert(ChannelMember {
+            user_id: *user_id,
+            role_ids: Vec::new(),
+        });
+        changed = true;
+    }
+    changed
+}
+
 fn channel_member_from_proto(cu: &api::channel_user_list::ChannelUser) -> ChannelMember {
     ChannelMember {
         user_id: UserId(cu.user_id),
@@ -305,6 +336,28 @@ mod tests {
         let member = channel_member_from_proto(&proto_channel_user(9));
         assert_eq!(member.user_id, UserId(9));
         assert_eq!(member.role_ids, vec![RoleId(5)]);
+    }
+
+    #[test]
+    fn adding_members_locally_skips_users_already_in_the_bucket() {
+        let mut bucket = ChannelBucket::default();
+        bucket.upsert(channel_member_from_proto(&proto_channel_user(1)));
+
+        assert!(add_members_to_bucket(&mut bucket, &[UserId(1), UserId(2)]));
+        assert_eq!(
+            bucket.members.iter().map(|m| m.user_id).collect::<Vec<_>>(),
+            vec![UserId(1), UserId(2)]
+        );
+        assert_eq!(bucket.members[0].role_ids, vec![RoleId(5)]);
+    }
+
+    #[test]
+    fn adding_only_known_members_reports_no_change() {
+        let mut bucket = ChannelBucket::default();
+        bucket.upsert(channel_member_from_proto(&proto_channel_user(1)));
+
+        assert!(!add_members_to_bucket(&mut bucket, &[UserId(1)]));
+        assert!(!add_members_to_bucket(&mut bucket, &[]));
     }
 
     #[test]

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -15,7 +15,8 @@ use mezon_client::transport::{
     MESSAGE_BUZZ_CODE, OutgoingEmoji as TransportEmoji, OutgoingHashtag as TransportHashtag,
     OutgoingMention as TransportMention, OutgoingMessageFlags, OutgoingOgp, OutgoingReply,
     SHARE_CONTACT_CODE, build_send_content, build_share_contact_content_json, detect_markdown,
-    emoji_content_tokens, hashtag_content_tokens, markdown_content_tokens, mention_content_tokens,
+    emoji_content_tokens, hashtag_content_tokens, is_here_user_id, markdown_content_tokens,
+    mention_content_tokens,
 };
 use mezon_client::{
     AppApi, AttachmentUploadOutcome, ConnectionStatus, MezonTransport, RealtimeEvent, UploadFile,
@@ -29,6 +30,7 @@ use crate::account::AccountStore;
 use crate::album_layout::{AlbumLayout, calculate_album_layout};
 use crate::badge::BadgeService;
 use crate::channel::{ChannelEvent, ChannelList, ChannelType, STREAM_MODE_THREAD};
+use crate::channel_members::ChannelMembersStore;
 use crate::clan_members::ClanMembersStore;
 use crate::direct::{DirectKind, DirectMessageStore};
 use crate::message::{
@@ -44,6 +46,8 @@ use crate::message::{
 use crate::message_time::unix_now_seconds;
 use crate::presign;
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
+use crate::roles::RolesStore;
+use crate::threads::ThreadsStore;
 use crate::topics::TopicsStore;
 use crate::wallet::{SendTokenRequest, WalletEvent, WalletStore};
 
@@ -3558,6 +3562,15 @@ impl MessagesStore {
         });
         cx.spawn(async move |this, cx| {
             ensure_archived_thread_reactivated(&api, &this, channel_id, clan_id, mode, cx).await;
+            ensure_thread_membership_for_send(
+                &api,
+                &this,
+                channel_id,
+                clan_id,
+                &transport_mentions,
+                cx,
+            )
+            .await;
             if has_attachments {
                 let files: Vec<UploadFile> = attachments
                     .into_iter()
@@ -3594,6 +3607,8 @@ impl MessagesStore {
                     .map(|a| presign::normalize_presign_key(&a.url))
                     .collect();
                 let update_mentions = transport_mentions.clone();
+                let update_hashtags = transport_hashtags.clone();
+                let update_emojis = transport_emojis.clone();
                 let sent = match api
                     .send_presigned_message(
                         clan_id.get(),
@@ -3648,6 +3663,8 @@ impl MessagesStore {
                     real_message_id,
                     &content,
                     update_mentions,
+                    update_hashtags,
+                    update_emojis,
                     create_time_seconds,
                     presigned,
                     keys,
@@ -4511,6 +4528,21 @@ impl MessagesStore {
         };
         let message = message_id.get();
         let storage_for_rollback = storage_id;
+        if let Some(reaction_clan_id) = self.active_clan_id {
+            let users = plan_thread_membership_for_reaction(
+                parent_channel_id,
+                reaction_clan_id,
+                current_uid,
+                cx,
+            );
+            if !users.is_empty() {
+                let join_api = api.clone();
+                cx.spawn(async move |this, cx| {
+                    add_thread_members(&join_api, &this, parent_channel_id, users, cx).await;
+                })
+                .detach();
+            }
+        }
         cx.spawn(async move |this, cx| {
             if let Err(e) = api
                 .react_channel_message(
@@ -4908,6 +4940,191 @@ async fn ensure_archived_thread_reactivated(
             tracing::error!("active_archived_thread before send failed: {e}");
         }
     }
+}
+
+fn plan_thread_membership(
+    self_id: Option<UserId>,
+    thread_members: &[UserId],
+    parent_members: &[UserId],
+    mentioned: &[UserId],
+) -> Vec<UserId> {
+    let mut plan = Vec::new();
+    if let Some(self_id) = self_id
+        && !thread_members.contains(&self_id)
+    {
+        plan.push(self_id);
+    }
+    for user_id in mentioned {
+        if Some(*user_id) == self_id
+            || thread_members.contains(user_id)
+            || !parent_members.contains(user_id)
+            || plan.contains(user_id)
+        {
+            continue;
+        }
+        plan.push(*user_id);
+    }
+    plan
+}
+
+fn needs_parent_lookup(thread_members: &[UserId], candidates: &[UserId]) -> bool {
+    candidates
+        .iter()
+        .any(|user_id| !thread_members.contains(user_id))
+}
+
+fn mentioned_thread_candidates(
+    mentions: &[TransportMention],
+    clan_id: ClanId,
+    cx: &App,
+) -> Vec<UserId> {
+    let roles = RolesStore::try_global(cx);
+    let mut candidates = Vec::new();
+    for mention in mentions {
+        if !mention.user_id.is_empty() {
+            if is_here_user_id(&mention.user_id) {
+                continue;
+            }
+            if let Ok(user_id) = mention.user_id.parse::<UserId>() {
+                candidates.push(user_id);
+            }
+            continue;
+        }
+        let Ok(role_id) = mention.role_id.parse::<crate::ids::RoleId>() else {
+            continue;
+        };
+        let Some(roles) = roles.as_ref() else {
+            continue;
+        };
+        candidates.extend(roles.read(cx).role_member_ids(clan_id, role_id));
+    }
+    candidates
+}
+
+struct ThreadSendContext {
+    parent_id: ChannelId,
+    parent_channel_type: Option<i32>,
+    self_id: Option<UserId>,
+    thread_members: Vec<UserId>,
+    parent_members: Option<Vec<UserId>>,
+    mentioned: Vec<UserId>,
+}
+
+fn thread_send_context(
+    channel_id: ChannelId,
+    clan_id: ClanId,
+    mentions: &[TransportMention],
+    cx: &App,
+) -> Option<ThreadSendContext> {
+    let channels = ChannelList::global(cx);
+    let channels = channels.read(cx);
+    let parent_id = channels
+        .channel(clan_id, channel_id)
+        .and_then(|channel| channel.parent_id)
+        .filter(|parent_id| !parent_id.is_zero())?;
+    let parent_channel_type = channels
+        .channel(clan_id, parent_id)
+        .map(|channel| channel.channel_type.as_raw() as i32);
+    let members = ChannelMembersStore::try_global(cx)?;
+    let members = members.read(cx);
+    Some(ThreadSendContext {
+        parent_id,
+        parent_channel_type,
+        self_id: viewer_user_id(cx),
+        thread_members: members.member_ids(channel_id),
+        parent_members: members
+            .has_channel(parent_id)
+            .then(|| members.member_ids(parent_id)),
+        mentioned: mentioned_thread_candidates(mentions, clan_id, cx),
+    })
+}
+
+fn plan_thread_membership_for_reaction(
+    channel_id: ChannelId,
+    clan_id: ClanId,
+    user_id: UserId,
+    cx: &App,
+) -> Vec<UserId> {
+    let Some(ctx) = thread_send_context(channel_id, clan_id, &[], cx) else {
+        return Vec::new();
+    };
+    let parent_members = ctx.parent_members.unwrap_or_default();
+    plan_thread_membership(None, &ctx.thread_members, &parent_members, &[user_id])
+}
+
+async fn add_thread_members(
+    api: &AppApi,
+    this: &WeakEntity<MessagesStore>,
+    channel_id: ChannelId,
+    users: Vec<UserId>,
+    cx: &mut AsyncApp,
+) {
+    let _ = this.update(cx, |_this, cx| {
+        let joining_self = viewer_user_id(cx).is_some_and(|self_id| users.contains(&self_id));
+        if let Some(threads) = ThreadsStore::try_global(cx).filter(|_| joining_self) {
+            threads.update(cx, |threads, cx| {
+                threads.mark_thread_active(&channel_id.to_string(), cx);
+            });
+        }
+    });
+    let user_ids: Vec<String> = users.iter().map(|user_id| user_id.to_string()).collect();
+    if let Err(e) = api.add_channel_users(channel_id.get(), user_ids).await {
+        tracing::error!("add_channel_users for thread {channel_id} failed: {e}");
+        return;
+    }
+    let _ = this.update(cx, |_this, cx| {
+        if let Some(members) = ChannelMembersStore::try_global(cx) {
+            members.update(cx, |members, cx| {
+                members.apply_members_added(channel_id, &users, cx);
+            });
+        }
+    });
+}
+
+async fn ensure_thread_membership_for_send(
+    api: &AppApi,
+    this: &WeakEntity<MessagesStore>,
+    channel_id: ChannelId,
+    clan_id: ClanId,
+    mentions: &[TransportMention],
+    cx: &mut AsyncApp,
+) {
+    let Ok(Some(ctx)) = this.update(cx, |_this, cx| {
+        thread_send_context(channel_id, clan_id, mentions, cx)
+    }) else {
+        return;
+    };
+    let parent_members = match (ctx.parent_members, ctx.parent_channel_type) {
+        (Some(members), _) => members,
+        (None, Some(parent_channel_type))
+            if needs_parent_lookup(&ctx.thread_members, &ctx.mentioned) =>
+        {
+            match api
+                .list_channel_users(clan_id.get(), ctx.parent_id.get(), parent_channel_type)
+                .await
+            {
+                Ok(users) => users.iter().map(|user| UserId(user.user_id)).collect(),
+                Err(e) => {
+                    tracing::error!(
+                        "list_channel_users for thread parent {} failed: {e}",
+                        ctx.parent_id
+                    );
+                    Vec::new()
+                }
+            }
+        }
+        (None, _) => Vec::new(),
+    };
+    let users = plan_thread_membership(
+        ctx.self_id,
+        &ctx.thread_members,
+        &parent_members,
+        &ctx.mentioned,
+    );
+    if users.is_empty() {
+        return;
+    }
+    add_thread_members(api, this, channel_id, users, cx).await;
 }
 
 impl MessagesStore {
@@ -6685,6 +6902,106 @@ mod tests {
     use super::*;
     use crate::ids::UserId;
     use crate::message::MessageSpan;
+
+    #[test]
+    fn thread_send_joins_sender_when_not_a_member() {
+        let plan =
+            plan_thread_membership(Some(UserId(1)), &[UserId(2)], &[UserId(1), UserId(2)], &[]);
+
+        assert_eq!(plan, vec![UserId(1)]);
+    }
+
+    #[test]
+    fn thread_send_does_not_rejoin_an_existing_member() {
+        let plan = plan_thread_membership(
+            Some(UserId(1)),
+            &[UserId(1), UserId(2)],
+            &[UserId(1), UserId(2)],
+            &[],
+        );
+
+        assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn thread_send_adds_mentioned_parent_members_missing_from_the_thread() {
+        let plan = plan_thread_membership(
+            Some(UserId(1)),
+            &[UserId(1)],
+            &[UserId(1), UserId(2), UserId(3)],
+            &[UserId(2), UserId(3)],
+        );
+
+        assert_eq!(plan, vec![UserId(2), UserId(3)]);
+    }
+
+    #[test]
+    fn thread_send_skips_mentions_outside_the_parent_channel() {
+        let plan = plan_thread_membership(
+            Some(UserId(1)),
+            &[UserId(1)],
+            &[UserId(1), UserId(2)],
+            &[UserId(2), UserId(9)],
+        );
+
+        assert_eq!(plan, vec![UserId(2)]);
+    }
+
+    #[test]
+    fn thread_send_skips_mentions_already_in_the_thread() {
+        let plan = plan_thread_membership(
+            Some(UserId(1)),
+            &[UserId(1), UserId(2)],
+            &[UserId(1), UserId(2)],
+            &[UserId(2)],
+        );
+
+        assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn thread_send_lists_the_sender_once_when_also_mentioned() {
+        let plan = plan_thread_membership(
+            Some(UserId(1)),
+            &[],
+            &[UserId(1), UserId(2)],
+            &[UserId(1), UserId(2), UserId(2)],
+        );
+
+        assert_eq!(plan, vec![UserId(1), UserId(2)]);
+    }
+
+    #[test]
+    fn thread_send_without_a_known_viewer_only_adds_mentions() {
+        let plan = plan_thread_membership(None, &[], &[UserId(2)], &[UserId(2)]);
+
+        assert_eq!(plan, vec![UserId(2)]);
+    }
+
+    #[test]
+    fn parent_lookup_is_skipped_when_every_candidate_is_already_in_the_thread() {
+        assert!(!needs_parent_lookup(
+            &[UserId(1), UserId(2)],
+            &[UserId(1), UserId(2)]
+        ));
+        assert!(!needs_parent_lookup(&[UserId(1)], &[]));
+        assert!(needs_parent_lookup(&[UserId(1)], &[UserId(2)]));
+    }
+
+    #[test]
+    fn thread_reaction_joins_a_parent_member() {
+        let plan =
+            plan_thread_membership(None, &[UserId(2)], &[UserId(1), UserId(2)], &[UserId(1)]);
+
+        assert_eq!(plan, vec![UserId(1)]);
+    }
+
+    #[test]
+    fn thread_reaction_does_not_join_a_non_parent_member() {
+        let plan = plan_thread_membership(None, &[UserId(2)], &[UserId(2)], &[UserId(1)]);
+
+        assert!(plan.is_empty());
+    }
 
     #[test]
     fn name_for_prioritize_matches_reacts_order() {

--- a/crates/mezon-store/src/roles.rs
+++ b/crates/mezon-store/src/roles.rs
@@ -61,6 +61,7 @@ pub struct ClanRoleDetail {
     pub max_level_permission: i32,
     pub permissions: Vec<RolePermission>,
     pub member_count: usize,
+    pub member_ids: Vec<UserId>,
     pub channel_ids: Vec<ChannelId>,
     pub role_channel_active: bool,
     pub creator_id: UserId,
@@ -365,6 +366,17 @@ impl RolesStore {
             .get(&role_id)
             .map(|users| users.as_slice())
             .unwrap_or(&[])
+    }
+
+    pub fn role_member_ids(&self, clan_id: ClanId, role_id: RoleId) -> Vec<UserId> {
+        if let Some(users) = self.role_users.get(&role_id) {
+            return users.iter().map(|user| user.id).collect();
+        }
+        self.cache
+            .get(&clan_id)
+            .and_then(|roles| roles.by_id.get(&role_id))
+            .map(|role| role.member_ids.clone())
+            .unwrap_or_default()
     }
 
     pub fn ensure_role_users_loaded(&mut self, role_id: RoleId, cx: &mut Context<Self>) {
@@ -839,15 +851,16 @@ impl RolesStore {
             return false;
         }
         let id = RoleId(r.id);
-        let previous_member_count = self
+        let previous_members = self
             .cache
             .get(&clan_id)
             .and_then(|roles| roles.by_id.get(&id))
-            .map(|role| role.member_count);
+            .map(|role| (role.member_count, role.member_ids.clone()));
         let has_role_users = r.role_user_list.is_some();
         let mut detail = role_detail_from_proto(r);
-        if !has_role_users && let Some(count) = previous_member_count {
+        if !has_role_users && let Some((count, member_ids)) = previous_members {
             detail.member_count = count;
+            detail.member_ids = member_ids;
         }
         let roles = self.cache.get_mut(&clan_id);
         if let Some(roles) = roles {
@@ -1129,10 +1142,11 @@ fn role_detail_from_proto(r: api::Role) -> ClanRoleDetail {
                 .collect()
         })
         .unwrap_or_default();
-    let member_count = r
+    let member_ids: Vec<UserId> = r
         .role_user_list
-        .map(|list| list.role_users.len())
-        .unwrap_or(0);
+        .map(|list| list.role_users.iter().map(|user| UserId(user.id)).collect())
+        .unwrap_or_default();
+    let member_count = member_ids.len();
     ClanRoleDetail {
         name: r.title,
         color: r.color,
@@ -1143,6 +1157,7 @@ fn role_detail_from_proto(r: api::Role) -> ClanRoleDetail {
         max_level_permission: r.max_level_permission,
         permissions,
         member_count,
+        member_ids,
         channel_ids: r.channel_ids.into_iter().map(ChannelId).collect(),
         role_channel_active: r.role_channel_active == 1,
         creator_id: UserId(r.creator_id),
@@ -1759,6 +1774,80 @@ mod tests {
                         .clan_role(TEST_CLAN, RoleId(10))
                         .map(|r| r.member_count),
                     Some(1)
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn role_member_ids_come_from_the_clan_roles_snapshot(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let store = init_roles_store(cx);
+            store.update(cx, |store, _cx| {
+                let mut role = make_role(10, "Admin", "#f00");
+                role.role_user_list = Some(api::RoleUserList {
+                    role_users: vec![
+                        api::role_user_list::RoleUser {
+                            id: 101,
+                            ..Default::default()
+                        },
+                        api::role_user_list::RoleUser {
+                            id: 102,
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                });
+                store
+                    .cache
+                    .insert(TEST_CLAN, roles_map_from_proto(vec![role]), None);
+
+                assert_eq!(
+                    store.role_member_ids(TEST_CLAN, RoleId(10)),
+                    vec![UserId(101), UserId(102)]
+                );
+                assert!(store.role_member_ids(TEST_CLAN, RoleId(99)).is_empty());
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn role_member_ids_prefer_the_fetched_role_user_list(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let store = init_roles_store(cx);
+            store.update(cx, |store, _cx| {
+                let mut role = make_role(10, "Admin", "#f00");
+                role.role_user_list = Some(api::RoleUserList {
+                    role_users: vec![api::role_user_list::RoleUser {
+                        id: 101,
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                });
+                store
+                    .cache
+                    .insert(TEST_CLAN, roles_map_from_proto(vec![role]), None);
+                store.role_users.insert(
+                    RoleId(10),
+                    vec![
+                        RoleUser {
+                            id: UserId(101),
+                            username: String::new(),
+                            display_name: String::new(),
+                            avatar_url: String::new(),
+                        },
+                        RoleUser {
+                            id: UserId(103),
+                            username: String::new(),
+                            display_name: String::new(),
+                            avatar_url: String::new(),
+                        },
+                    ],
+                );
+
+                assert_eq!(
+                    store.role_member_ids(TEST_CLAN, RoleId(10)),
+                    vec![UserId(101), UserId(103)]
                 );
             });
         });

--- a/crates/mezon-store/src/threads.rs
+++ b/crates/mezon-store/src/threads.rs
@@ -51,6 +51,7 @@ pub struct ThreadSummary {
 pub enum ThreadsEvent {
     ThreadCreated { channel_id: String, clan_id: String },
     CreateFailed { message: String },
+    LeaveFailed { message: String },
     OpenPopoverRequested,
 }
 
@@ -92,6 +93,11 @@ impl ThreadsStore {
 
     pub fn global(cx: &App) -> Entity<Self> {
         cx.global::<GlobalThreadsStore>().0.clone()
+    }
+
+    pub fn try_global(cx: &App) -> Option<Entity<Self>> {
+        cx.try_global::<GlobalThreadsStore>()
+            .map(|global| global.0.clone())
     }
 
     fn new(api: Arc<AppApi>, cx: &mut Context<Self>) -> Self {
@@ -140,6 +146,8 @@ impl ThreadsStore {
                 RealtimeKind::ChannelMessage,
                 RealtimeKind::ChannelDeleted,
                 RealtimeKind::ChannelArchive,
+                RealtimeKind::UserChannelAdded,
+                RealtimeKind::UserChannelRemoved,
             ] {
                 dispatch.on(kind, &entity, |this, event, cx| {
                     this.on_realtime_event(event, cx);
@@ -178,6 +186,14 @@ impl ThreadsStore {
     }
 
     fn on_realtime_event(&mut self, event: &RealtimeEvent, cx: &mut Context<Self>) {
+        if let RealtimeEvent::UserChannelAdded(ev) = event {
+            self.apply_user_channel_added(ev, cx);
+            return;
+        }
+        if let RealtimeEvent::UserChannelRemoved(ev) = event {
+            self.apply_user_channel_removed(ev, cx);
+            return;
+        }
         let Some(list_id) = self.list_channel_id.clone() else {
             if let RealtimeEvent::ChannelArchive(ev) = event {
                 self.apply_channel_archive(ev, cx);
@@ -202,6 +218,112 @@ impl ThreadsStore {
             }
             _ => {}
         }
+    }
+
+    fn apply_user_channel_added(
+        &mut self,
+        ev: &realtime::UserChannelAdded,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(desc) = ev.channel_desc.as_ref() else {
+            return;
+        };
+        if desc.r#type != CHANNEL_TYPE_THREAD as i32 || desc.parent_id == 0 {
+            return;
+        }
+        let Some(me) = crate::badge::BadgeService::try_global(cx)
+            .and_then(|badges| badges.read(cx).current_user_id(cx))
+        else {
+            return;
+        };
+        if !ev.users.iter().any(|user| user.user_id == me.get()) {
+            return;
+        }
+        let channel_id = desc.channel_id.to_string();
+        self.set_thread_active(&channel_id, THREAD_STATUS_JOINED, cx);
+        let parent_id = desc.parent_id.to_string();
+        if desc.channel_private == 0 || self.list_channel_id.as_deref() != Some(parent_id.as_str())
+        {
+            return;
+        }
+        let summary = ThreadSummary {
+            channel_id,
+            channel_label: desc.channel_label.clone(),
+            clan_id: desc.clan_id.to_string(),
+            parent_id,
+            channel_private: desc.channel_private,
+            active: THREAD_STATUS_JOINED,
+            creator_id: desc.creator_id.to_string(),
+            last_message_content: String::new(),
+            last_message_sender_id: String::new(),
+            last_message_sender_name: String::new(),
+            last_message_sender_avatar: String::new(),
+            last_sent_timestamp: match i64::from(ev.create_time_seconds) {
+                0 => crate::message_time::unix_now_seconds(),
+                seconds => seconds,
+            },
+            member_count: desc.member_count.max(0),
+        };
+        let before = self.threads.len();
+        merge_threads(&mut self.threads, vec![summary]);
+        if self.threads.len() != before {
+            cx.notify();
+        }
+    }
+
+    fn apply_user_channel_removed(
+        &mut self,
+        ev: &realtime::UserChannelRemoved,
+        cx: &mut Context<Self>,
+    ) {
+        if ev.channel_type != CHANNEL_TYPE_THREAD as i32 {
+            return;
+        }
+        let Some(me) = crate::badge::BadgeService::try_global(cx)
+            .and_then(|badges| badges.read(cx).current_user_id(cx))
+        else {
+            return;
+        };
+        if !ev.user_ids.contains(&me.get()) {
+            return;
+        }
+        let channel_id = ev.channel_id.to_string();
+        if !self.is_private_thread(&channel_id) {
+            return;
+        }
+        self.apply_thread_deleted(&channel_id, cx);
+    }
+
+    fn is_private_thread(&self, channel_id: &str) -> bool {
+        self.threads
+            .iter()
+            .chain(self.search_results.iter().flatten())
+            .any(|thread| thread.channel_id == channel_id && thread.channel_private != 0)
+    }
+
+    pub fn leave_thread(&mut self, clan_id: ClanId, channel_id: ChannelId, cx: &mut Context<Self>) {
+        let api = self.api.clone();
+        cx.spawn(async move |this, cx| {
+            if let Err(e) = api.leave_thread(clan_id.get(), channel_id.get()).await {
+                tracing::error!("leave_thread failed for {channel_id}: {e}");
+                let _ = this.update(cx, |_this, cx| {
+                    cx.emit(ThreadsEvent::LeaveFailed {
+                        message: e.to_string(),
+                    });
+                });
+                return;
+            }
+            let _ = this.update(cx, |this, cx| {
+                ChannelList::global(cx).update(cx, |list, cx| {
+                    list.apply_self_removed_from_channel(channel_id, cx);
+                });
+                let id = channel_id.to_string();
+                if this.is_private_thread(&id) {
+                    this.apply_thread_deleted(&id, cx);
+                }
+            });
+        })
+        .detach();
     }
 
     pub fn mark_thread_active(&mut self, channel_id: &str, cx: &mut Context<Self>) {


### PR DESCRIPTION
## Summary
- Auto-join thread members before sending: add sender and mentioned parent-channel users (incl. role mentions) via `add_channel_users`.
- Preserve emoji/hashtag entities on presigned thread sends so mention metadata survives attachment upload.
- Update local thread member cache and private thread list from `UserChannelAdded` / `UserChannelRemoved` realtime events.

## Test plan
- [ ] Send a message in a thread you are not yet a member of — you are added and message sends.
- [ ] Mention a parent-channel member not in the thread — they are added before send.
- [ ] React in a thread as a non-member parent-channel user — user is joined first.
- [ ] Private thread list updates when you are added/removed via realtime events.
