### PR TITLE
feat(compose): persist per-channel message drafts across navigation

### DIFF
--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -750,6 +750,7 @@ fn open_main_window(
     mezon_store::NotificationPushStore::init(api.clone(), auth_state.clone(), cx);
     mezon_store::ClanLoadScheduler::init(cx);
     mezon_store::QuickMenuStore::init(api.clone(), cx);
+    mezon_store::ComposeStore::init(cx);
     mezon_store::WalletStore::init(auth_state.clone(), cx);
     mezon_ui::WalletToastBridge::init(cx);
     mezon_ui::chat::channel_settings::channel_acl::init(api.clone(), cx);

--- a/crates/mezon-store/src/compose.rs
+++ b/crates/mezon-store/src/compose.rs
@@ -1,0 +1,274 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use gpui::{App, AppContext, Entity, Global};
+
+use crate::ids::ChannelId;
+
+pub const MAX_DRAFT_CHANNELS: usize = 50;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ComposeTokenKind {
+    Mention { user_id: String, role_id: String },
+    Hashtag { channel_id: String },
+    Emoji { emoji_id: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComposeToken {
+    pub kind: ComposeTokenKind,
+    pub display: String,
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingAttachment {
+    pub path: PathBuf,
+    pub filename: String,
+    pub filetype: String,
+    pub size: u64,
+    pub is_image: bool,
+    pub is_video: bool,
+    pub width: u32,
+    pub height: u32,
+    pub duration: i32,
+    pub poster_jpeg: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ComposeDraft {
+    pub text: String,
+    pub tokens: Vec<ComposeToken>,
+    pub attachments: Vec<PendingAttachment>,
+}
+
+impl ComposeDraft {
+    pub fn is_empty(&self) -> bool {
+        self.text.trim().is_empty() && self.attachments.is_empty()
+    }
+}
+
+pub struct ComposeStore {
+    by_channel: HashMap<ChannelId, ComposeDraft>,
+    recent: Vec<ChannelId>,
+}
+
+struct GlobalComposeStore(Entity<ComposeStore>);
+impl Global for GlobalComposeStore {}
+
+impl ComposeStore {
+    pub fn init(cx: &mut App) -> Entity<Self> {
+        let entity = cx.new(|_| Self::new());
+        cx.set_global(GlobalComposeStore(entity.clone()));
+        entity
+    }
+
+    pub fn global(cx: &App) -> Entity<Self> {
+        cx.global::<GlobalComposeStore>().0.clone()
+    }
+
+    pub fn try_global(cx: &App) -> Option<Entity<Self>> {
+        cx.try_global::<GlobalComposeStore>()
+            .map(|global| global.0.clone())
+    }
+
+    fn new() -> Self {
+        Self {
+            by_channel: HashMap::new(),
+            recent: Vec::new(),
+        }
+    }
+
+    pub fn draft(&self, channel_id: ChannelId) -> Option<&ComposeDraft> {
+        self.by_channel.get(&channel_id)
+    }
+
+    pub fn set_draft(&mut self, channel_id: ChannelId, draft: ComposeDraft) {
+        if draft.is_empty() {
+            self.clear_draft(channel_id);
+            return;
+        }
+        self.by_channel.insert(channel_id, draft);
+        self.touch(channel_id);
+        self.evict_oldest();
+    }
+
+    pub fn take_draft(&mut self, channel_id: ChannelId) -> Option<ComposeDraft> {
+        self.recent.retain(|id| *id != channel_id);
+        self.by_channel.remove(&channel_id)
+    }
+
+    pub fn clear_draft(&mut self, channel_id: ChannelId) {
+        if self.by_channel.remove(&channel_id).is_some() {
+            self.recent.retain(|id| *id != channel_id);
+        }
+    }
+
+    pub fn clear_all(&mut self) {
+        self.by_channel.clear();
+        self.recent.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_channel.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_channel.is_empty()
+    }
+
+    fn touch(&mut self, channel_id: ChannelId) {
+        self.recent.retain(|id| *id != channel_id);
+        self.recent.push(channel_id);
+    }
+
+    fn evict_oldest(&mut self) {
+        while self.recent.len() > MAX_DRAFT_CHANNELS {
+            let oldest = self.recent.remove(0);
+            self.by_channel.remove(&oldest);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_draft(text: &str) -> ComposeDraft {
+        ComposeDraft {
+            text: text.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn attachment() -> PendingAttachment {
+        PendingAttachment {
+            path: PathBuf::from("a.png"),
+            filename: "a.png".to_string(),
+            filetype: "image/png".to_string(),
+            size: 10,
+            is_image: true,
+            is_video: false,
+            width: 1,
+            height: 1,
+            duration: 0,
+            poster_jpeg: None,
+        }
+    }
+
+    #[test]
+    fn draft_round_trips_per_channel() {
+        let mut store = ComposeStore::new();
+        store.set_draft(ChannelId(1), text_draft("hello"));
+        store.set_draft(ChannelId(2), text_draft("world"));
+
+        assert_eq!(
+            store.draft(ChannelId(1)).map(|d| d.text.as_str()),
+            Some("hello")
+        );
+        assert_eq!(
+            store.draft(ChannelId(2)).map(|d| d.text.as_str()),
+            Some("world")
+        );
+        assert!(store.draft(ChannelId(3)).is_none());
+    }
+
+    #[test]
+    fn blank_draft_clears_instead_of_storing() {
+        let mut store = ComposeStore::new();
+        store.set_draft(ChannelId(1), text_draft("hello"));
+        store.set_draft(ChannelId(1), text_draft("   \n "));
+
+        assert!(store.draft(ChannelId(1)).is_none());
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn blank_text_with_attachment_is_kept() {
+        let mut store = ComposeStore::new();
+        store.set_draft(
+            ChannelId(1),
+            ComposeDraft {
+                text: String::new(),
+                tokens: Vec::new(),
+                attachments: vec![attachment()],
+            },
+        );
+
+        assert_eq!(
+            store.draft(ChannelId(1)).map(|d| d.attachments.len()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn take_draft_removes_it() {
+        let mut store = ComposeStore::new();
+        store.set_draft(ChannelId(1), text_draft("hello"));
+
+        assert_eq!(
+            store.take_draft(ChannelId(1)).map(|d| d.text),
+            Some("hello".to_string())
+        );
+        assert!(store.draft(ChannelId(1)).is_none());
+        assert!(store.take_draft(ChannelId(1)).is_none());
+    }
+
+    #[test]
+    fn tokens_survive_the_round_trip() {
+        let mut store = ComposeStore::new();
+        store.set_draft(
+            ChannelId(1),
+            ComposeDraft {
+                text: "hi @bob".to_string(),
+                tokens: vec![ComposeToken {
+                    kind: ComposeTokenKind::Mention {
+                        user_id: "42".to_string(),
+                        role_id: String::new(),
+                    },
+                    display: "@bob".to_string(),
+                    start: 3,
+                    end: 7,
+                }],
+                attachments: Vec::new(),
+            },
+        );
+
+        let tokens = &store.draft(ChannelId(1)).expect("draft").tokens;
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].start, 3);
+        assert_eq!(tokens[0].end, 7);
+    }
+
+    #[test]
+    fn evicts_least_recently_updated_channel_at_cap() {
+        let mut store = ComposeStore::new();
+        for id in 0..MAX_DRAFT_CHANNELS as i64 {
+            store.set_draft(ChannelId(id), text_draft("draft"));
+        }
+        store.set_draft(ChannelId(0), text_draft("refreshed"));
+        store.set_draft(ChannelId(999), text_draft("newest"));
+
+        assert_eq!(store.len(), MAX_DRAFT_CHANNELS);
+        assert!(store.draft(ChannelId(1)).is_none());
+        assert_eq!(
+            store.draft(ChannelId(0)).map(|d| d.text.as_str()),
+            Some("refreshed")
+        );
+        assert_eq!(
+            store.draft(ChannelId(999)).map(|d| d.text.as_str()),
+            Some("newest")
+        );
+    }
+
+    #[test]
+    fn clear_all_empties_the_store() {
+        let mut store = ComposeStore::new();
+        store.set_draft(ChannelId(1), text_draft("hello"));
+        store.clear_all();
+
+        assert!(store.is_empty());
+        assert!(store.draft(ChannelId(1)).is_none());
+    }
+}

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -17,6 +17,7 @@ pub mod channel_users;
 pub mod clan;
 pub mod clan_load;
 pub mod clan_members;
+pub mod compose;
 pub mod config;
 pub mod connection;
 pub mod direct;
@@ -109,6 +110,7 @@ pub use clan_load::ClanLoadScheduler;
 pub use clan_members::{
     ClanMember, ClanMembersEvent, ClanMembersStore, User, split_members_by_status,
 };
+pub use compose::{ComposeDraft, ComposeStore, ComposeToken, ComposeTokenKind, PendingAttachment};
 pub use config::AppConfig;
 pub use connection::{ConnectionStore, resolve_initial_auth_state};
 pub use direct::{

--- a/crates/mezon-ui/src/chat/layout.rs
+++ b/crates/mezon-ui/src/chat/layout.rs
@@ -1241,18 +1241,21 @@ impl ChatLayout {
         changed
     }
 
-    fn focus_composer_on_channel_switch(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    fn sync_composer_on_channel_switch(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let active_channel_id = Router::global(cx).read(cx).conversation_channel_id();
         if active_channel_id == self.focused_channel_id {
             return;
         }
         self.focused_channel_id = active_channel_id;
-        if active_channel_id.is_none() {
-            return;
-        }
         let Some(input) = self.chat_area.mention_input.clone() else {
             return;
         };
+        input.update(cx, |input, cx| {
+            input.bind_channel(active_channel_id, window, cx)
+        });
+        if active_channel_id.is_none() {
+            return;
+        }
         window.defer(cx, move |window, cx| {
             input.update(cx, |input, cx| input.focus_input(window, cx));
         });
@@ -1480,7 +1483,7 @@ impl Render for ChatLayout {
         crate::trace_render!("ChatLayout");
         self.chat_area.ensure_input(window, cx);
         self.chat_area.bind_window(window, cx);
-        self.focus_composer_on_channel_switch(window, cx);
+        self.sync_composer_on_channel_switch(window, cx);
         self.maybe_prefetch_voice_token(cx);
         self.voice_store
             .update(cx, |store, cx| store.flush_texture_drops(Some(window), cx));

--- a/crates/mezon-ui/src/chat/mention_input/attachments.rs
+++ b/crates/mezon-ui/src/chat/mention_input/attachments.rs
@@ -1,24 +1,12 @@
 use std::path::{Path, PathBuf};
 
+pub use mezon_store::PendingAttachment;
+
 pub const MAX_FILE_ATTACHMENTS: usize = 50;
 pub const IMAGE_MAX_FILE_SIZE: u64 = 50 * 1024 * 1024;
 pub const MAX_FILE_SIZE: u64 = 1024 * 1024 * 1024;
 
 pub const POSTER_MAX_EDGE: u32 = 480;
-
-#[derive(Debug, Clone)]
-pub struct PendingAttachment {
-    pub path: PathBuf,
-    pub filename: String,
-    pub filetype: String,
-    pub size: u64,
-    pub is_image: bool,
-    pub is_video: bool,
-    pub width: u32,
-    pub height: u32,
-    pub duration: i32,
-    pub poster_jpeg: Option<Vec<u8>>,
-}
 
 pub enum AttachmentLimit {
     Count,

--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -19,11 +19,11 @@ use mezon_client::transport::QUICK_MENU_TYPE_FLASH;
 use mezon_store::{
     AccountEvent, AccountStore, AudioStore, BadgeService, Channel, ChannelEvent, ChannelId,
     ChannelList, ChannelMembersEvent, ChannelMembersStore, ClanList, ClanMembersEvent,
-    ClanMembersStore, DirectEvent, DirectMessageStore, Emoji, EmojiEvent, EmojiStore,
-    GroupMembersEvent, GroupMembersStore, MENTION_HERE_ID, MessageSpan, MessagesStore, OgpResult,
-    OutgoingAttachment, OutgoingContent, OutgoingEmoji, OutgoingHashtag, OutgoingMention,
-    OutgoingOgp, QuickMenuStore, RolesEvent, RolesStore, Settings, fetch_ogp,
-    first_previewable_url,
+    ClanMembersStore, ComposeDraft, ComposeStore, ComposeToken, ComposeTokenKind, DirectEvent,
+    DirectMessageStore, Emoji, EmojiEvent, EmojiStore, GroupMembersEvent, GroupMembersStore,
+    MENTION_HERE_ID, MessageSpan, MessagesStore, OgpResult, OutgoingAttachment, OutgoingContent,
+    OutgoingEmoji, OutgoingHashtag, OutgoingMention, OutgoingOgp, QuickMenuStore, RolesEvent,
+    RolesStore, Settings, fetch_ogp, first_previewable_url,
 };
 use std::time::Duration;
 
@@ -190,6 +190,45 @@ struct CommittedToken {
     display: String,
     start: usize,
     end: usize,
+}
+
+impl CommittedToken {
+    fn to_compose(&self) -> ComposeToken {
+        let kind = match &self.kind {
+            TokenKind::Mention { user_id, role_id } => ComposeTokenKind::Mention {
+                user_id: user_id.clone(),
+                role_id: role_id.clone(),
+            },
+            TokenKind::Hashtag { channel_id } => ComposeTokenKind::Hashtag {
+                channel_id: channel_id.clone(),
+            },
+            TokenKind::Emoji { emoji_id } => ComposeTokenKind::Emoji {
+                emoji_id: emoji_id.clone(),
+            },
+        };
+        ComposeToken {
+            kind,
+            display: self.display.clone(),
+            start: self.start,
+            end: self.end,
+        }
+    }
+
+    fn from_compose(token: ComposeToken) -> Self {
+        let kind = match token.kind {
+            ComposeTokenKind::Mention { user_id, role_id } => {
+                TokenKind::Mention { user_id, role_id }
+            }
+            ComposeTokenKind::Hashtag { channel_id } => TokenKind::Hashtag { channel_id },
+            ComposeTokenKind::Emoji { emoji_id } => TokenKind::Emoji { emoji_id },
+        };
+        Self {
+            kind,
+            display: token.display,
+            start: token.start,
+            end: token.end,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -364,6 +403,8 @@ pub struct MentionInput {
     overflow_to_file: bool,
     overflow_counter: Option<isize>,
     last_content: SharedString,
+    draft_channel: Option<ChannelId>,
+    suppress_typing: bool,
     ogp_preview: Option<OgpResult>,
     ogp_url: Option<String>,
     ogp_generation: u64,
@@ -552,6 +593,8 @@ impl MentionInput {
             overflow_to_file: false,
             overflow_counter: None,
             last_content: SharedString::default(),
+            draft_channel: None,
+            suppress_typing: false,
             ogp_preview: None,
             ogp_url: None,
             ogp_generation: 0,
@@ -579,6 +622,77 @@ impl MentionInput {
     pub fn focus_input(&self, window: &mut Window, cx: &mut App) {
         let handle = self.input.read(cx).focus_handle(cx);
         window.focus(&handle, cx);
+    }
+
+    pub fn bind_channel(
+        &mut self,
+        channel_id: Option<ChannelId>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.draft_channel == channel_id {
+            return;
+        }
+        let Some(store) = ComposeStore::try_global(cx) else {
+            self.draft_channel = channel_id;
+            return;
+        };
+        let leaving = self.draft_channel;
+        let outgoing = self.take_draft(cx);
+        let incoming = store.update(cx, |store, _| {
+            if let Some(leaving) = leaving {
+                match outgoing {
+                    Some(draft) => store.set_draft(leaving, draft),
+                    None => store.clear_draft(leaving),
+                }
+            }
+            channel_id.and_then(|channel_id| store.take_draft(channel_id))
+        });
+        self.draft_channel = channel_id;
+        self.apply_draft(incoming.unwrap_or_default(), window, cx);
+    }
+
+    fn take_draft(&mut self, cx: &mut Context<Self>) -> Option<ComposeDraft> {
+        let text = self.input.read(cx).value().to_string();
+        let attachments = std::mem::take(&mut self.pending_attachments);
+        if text.trim().is_empty() && attachments.is_empty() {
+            return None;
+        }
+        let tokens = self
+            .committed
+            .iter()
+            .map(CommittedToken::to_compose)
+            .collect();
+        Some(ComposeDraft {
+            text,
+            tokens,
+            attachments,
+        })
+    }
+
+    fn apply_draft(&mut self, draft: ComposeDraft, window: &mut Window, cx: &mut Context<Self>) {
+        let ComposeDraft {
+            text,
+            tokens,
+            attachments,
+        } = draft;
+        self.committed = committed_from_compose_tokens(&text, tokens);
+        self.pending_attachments = attachments;
+        self.reset_popup();
+        self.close_popup();
+        self.clear_suggestions(cx);
+        self.clear_ephemeral(cx);
+        self.clear_ogp_preview(cx);
+        self.overflow_counter = None;
+        self.suppress_typing = true;
+        self.last_content = SharedString::from(text.clone());
+        self.input.update(cx, |input, cx| {
+            input.set_mention_spans(Vec::new(), cx);
+            input.set_value(text, window, cx);
+        });
+        self.sync_ranges(cx);
+        self.sync_history_payload(cx);
+        cx.notify();
     }
 
     pub fn take_payload(
@@ -1218,6 +1332,9 @@ impl MentionInput {
         };
         self.update_ogp_preview(&content, cx);
         self.last_content = content;
+        if std::mem::take(&mut self.suppress_typing) {
+            return;
+        }
         MessagesStore::global(cx).update(cx, |store, cx| store.notify_typing(cx));
     }
 
@@ -2350,6 +2467,14 @@ fn emoji_suggest_pool(cx: &App) -> Vec<EmojiSuggestRaw> {
         .collect()
 }
 
+fn committed_from_compose_tokens(text: &str, tokens: Vec<ComposeToken>) -> Vec<CommittedToken> {
+    tokens
+        .into_iter()
+        .filter(|token| text.get(token.start..token.end) == Some(token.display.as_str()))
+        .map(CommittedToken::from_compose)
+        .collect()
+}
+
 fn committed_from_spans(content: &str, spans: &[MessageSpan]) -> Vec<CommittedToken> {
     let mut committed = Vec::new();
     let mut search_from = 0usize;
@@ -2650,5 +2775,93 @@ mod suggest_tests {
     fn sale_id_is_empty_without_extension() {
         assert_eq!(sale_item_id_from_source("https://cdn.example/emojis"), "");
         assert_eq!(sale_item_id_from_source(""), "");
+    }
+}
+
+#[cfg(test)]
+mod draft_tests {
+    use super::{CommittedToken, TokenKind, committed_from_compose_tokens};
+    use mezon_store::{ComposeToken, ComposeTokenKind};
+
+    fn mention(display: &str, start: usize, end: usize) -> ComposeToken {
+        ComposeToken {
+            kind: ComposeTokenKind::Mention {
+                user_id: "42".to_string(),
+                role_id: String::new(),
+            },
+            display: display.to_string(),
+            start,
+            end,
+        }
+    }
+
+    #[test]
+    fn keeps_tokens_that_still_match_the_text() {
+        let restored = committed_from_compose_tokens("hi @bob", vec![mention("@bob", 3, 7)]);
+
+        assert_eq!(
+            restored,
+            vec![CommittedToken {
+                kind: TokenKind::Mention {
+                    user_id: "42".to_string(),
+                    role_id: String::new(),
+                },
+                display: "@bob".to_string(),
+                start: 3,
+                end: 7,
+            }]
+        );
+    }
+
+    #[test]
+    fn drops_tokens_whose_range_no_longer_holds_the_display() {
+        let restored = committed_from_compose_tokens("hi @amy", vec![mention("@bob", 3, 7)]);
+
+        assert!(restored.is_empty());
+    }
+
+    #[test]
+    fn drops_tokens_pointing_past_the_end_of_the_text() {
+        let restored = committed_from_compose_tokens("hi", vec![mention("@bob", 3, 7)]);
+
+        assert!(restored.is_empty());
+    }
+
+    #[test]
+    fn drops_tokens_straddling_a_char_boundary() {
+        let restored = committed_from_compose_tokens("héllo @bob", vec![mention("@bob", 1, 5)]);
+
+        assert!(restored.is_empty());
+    }
+
+    #[test]
+    fn restores_every_token_kind() {
+        let text = "a @bob #gen :joy:";
+        let tokens = vec![
+            mention("@bob", 2, 6),
+            ComposeToken {
+                kind: ComposeTokenKind::Hashtag {
+                    channel_id: "7".to_string(),
+                },
+                display: "#gen".to_string(),
+                start: 7,
+                end: 11,
+            },
+            ComposeToken {
+                kind: ComposeTokenKind::Emoji {
+                    emoji_id: "9".to_string(),
+                },
+                display: ":joy:".to_string(),
+                start: 12,
+                end: 17,
+            },
+        ];
+
+        let restored = committed_from_compose_tokens(text, tokens);
+
+        assert_eq!(restored.len(), 3);
+        assert!(matches!(restored[0].kind, TokenKind::Mention { .. }));
+        assert!(matches!(restored[1].kind, TokenKind::Hashtag { .. }));
+        assert!(matches!(restored[2].kind, TokenKind::Emoji { .. }));
     }
 }


### PR DESCRIPTION
## Summary
- Add `ComposeStore` with per-channel drafts (text, mention/hashtag/emoji tokens, pending attachments).
- Move `PendingAttachment` to `mezon-store` so drafts and the composer share one type.
- `MentionInput::bind_channel` saves the outgoing draft and restores the incoming one on channel switch.
- `ChatLayout` calls `bind_channel` before refocusing the composer.

## Test plan
- [ ] Type a message in channel A, switch to channel B — A's draft is preserved when switching back.
- [ ] Attach files and add @mentions in a draft — tokens and attachments restore correctly.
- [ ] Send/clear composer — draft clears for that channel on next navigation away.
- [ ] `cargo test -p mezon-store compose` passes.

