### PR TITLE
feat(thread): leave flow, locked icons, and channel polish

### DIFF
--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -18,6 +18,7 @@ use crate::clan::{ClanEvent, ClanList};
 use crate::event_targets_user;
 use crate::messages::MessagesStore;
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
+use crate::threads::CHANNEL_TYPE_THREAD;
 
 pub const FAVOR_CATE_ID: &str = "favorCate";
 pub const CATEGORY_NAME_MAX_CHARS: usize = 64;
@@ -28,6 +29,7 @@ const PREVIOUS_CHANNELS_PERSIST_DEBOUNCE: Duration = Duration::from_millis(500);
 const BADGE_SEED_MAX_ATTEMPTS: u32 = 3;
 const BADGE_SEED_RETRY_BACKOFF: Duration = Duration::from_millis(400);
 const THREAD_ARCHIVE_DURATION_SECONDS: i64 = 7 * 24 * 60 * 60;
+const ADDED_THREAD_UNREAD_WINDOW_SECONDS: i64 = 1000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ChannelType {
@@ -1989,6 +1991,25 @@ impl ChannelList {
                 if already_exists {
                     return;
                 }
+                let last_sent = desc.last_sent_message.as_ref();
+                let (last_sent_message_id, last_sent_timestamp) = match last_sent {
+                    Some(header) => (
+                        MessageId(header.id),
+                        i64::from(header.timestamp_seconds).max(0),
+                    ),
+                    None => (MessageId(0), 0),
+                };
+                let is_thread = channel_type == CHANNEL_TYPE_THREAD;
+                let (last_sent_timestamp, last_seen_timestamp) = if is_thread {
+                    seed_added_thread_unread(last_sent_timestamp)
+                } else {
+                    let seen = desc
+                        .last_seen_message
+                        .as_ref()
+                        .map(|header| i64::from(header.timestamp_seconds).max(0))
+                        .unwrap_or(0);
+                    (last_sent_timestamp, seen)
+                };
                 let channel = Channel {
                     id: channel_id,
                     name: desc.channel_label.clone(),
@@ -1996,26 +2017,37 @@ impl ChannelList {
                     private: desc.channel_private != 0,
                     clan_id,
                     clan_name: desc.clan_name.clone(),
-                    category_name: String::new(),
+                    category_name: desc.category_name.clone(),
                     category_id: Some(desc.category_id.to_string())
                         .filter(|s| !s.is_empty() && s != "0"),
-                    member_count: 0,
+                    member_count: desc.member_count.max(0) as u32,
                     badge_count: 0,
-                    muted: false,
+                    muted: desc.is_mute,
                     parent_id: Some(ChannelId(desc.parent_id)).filter(|c| !c.is_zero()),
-                    last_seen_message_id: MessageId(0),
-                    last_seen_timestamp: 0,
-                    last_sent_message_id: MessageId(0),
-                    last_sent_timestamp: 0,
+                    last_seen_message_id: desc
+                        .last_seen_message
+                        .as_ref()
+                        .map(|header| MessageId(header.id))
+                        .unwrap_or(MessageId(0)),
+                    last_seen_timestamp,
+                    last_sent_message_id,
+                    last_sent_timestamp,
                     voice_members: Vec::new(),
                     is_favorite: false,
                     creator_id: UserId(desc.creator_id),
                     active: CHANNEL_ACTIVE_JOINED,
                     avatar_url: desc.channel_avatar.clone(),
                 };
-                let inserted = insert_channel(cats, channel);
+                let inserted = insert_channel(cats, channel.clone());
+                let listed = add_user_channel(
+                    &mut self.user_channels,
+                    &mut self.user_channels_order,
+                    channel,
+                );
                 if inserted {
                     self.invalidate_channel_index(clan_id);
+                }
+                if inserted || listed {
                     cx.notify();
                 }
             }
@@ -2030,24 +2062,7 @@ impl ChannelList {
                 if !event_targets_user(&e.user_ids, me) {
                     return;
                 }
-                let mut removed = false;
-                for cats in self.cache.values_mut() {
-                    removed |= remove_channel(cats, channel_id);
-                }
-                removed |= remove_user_channel(
-                    &mut self.user_channels,
-                    &mut self.user_channels_order,
-                    channel_id,
-                );
-                let in_voice_changed = remove_in_voice_in_channel(&mut self.in_voice, channel_id);
-                if removed {
-                    self.invalidate_channel_index_all();
-                    if self.active_channel_id == Some(channel_id) {
-                        self.active_channel_id = None;
-                        cx.emit(ChannelEvent::ActiveChannelChanged(None));
-                    }
-                }
-                notify_in_voice_change(removed, in_voice_changed, cx);
+                self.apply_self_removed_from_channel(channel_id, cx);
             }
             RealtimeEvent::ChannelArchive(e) => {
                 self.apply_channel_archive_event(e, cx);
@@ -2383,6 +2398,59 @@ impl ChannelList {
         self.reactivating.remove(&channel_id);
     }
 
+    pub fn apply_self_removed_from_channel(
+        &mut self,
+        channel_id: ChannelId,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let leaving = self
+            .cache
+            .iter()
+            .flat_map(|(clan_id, cats)| {
+                cats.iter()
+                    .flat_map(|c| &c.channels)
+                    .map(move |ch| (*clan_id, ch))
+            })
+            .find(|(_, ch)| ch.id == channel_id)
+            .map(|(clan_id, ch)| {
+                (
+                    clan_id,
+                    ch.badge_count,
+                    ch.parent_id.filter(|parent_id| !parent_id.is_zero()),
+                )
+            });
+        let parent_redirect = leaving
+            .and_then(|(clan_id, _, parent_id)| parent_id.map(|parent_id| (clan_id, parent_id)));
+        let mut removed = false;
+        for cats in self.cache.values_mut() {
+            removed |= remove_channel(cats, channel_id);
+        }
+        removed |= remove_user_channel(
+            &mut self.user_channels,
+            &mut self.user_channels_order,
+            channel_id,
+        );
+        let in_voice_changed = remove_in_voice_in_channel(&mut self.in_voice, channel_id);
+        if removed {
+            self.invalidate_channel_index_all();
+            if self.active_channel_id == Some(channel_id) {
+                let redirect = parent_redirect
+                    .filter(|(clan_id, parent_id)| self.channel_in_clan(*clan_id, *parent_id));
+                if let Some((clan_id, parent_id)) = redirect {
+                    self.remembered_channels.insert(clan_id, parent_id);
+                }
+                let target = redirect.map(|(_, parent_id)| parent_id);
+                self.active_channel_id = target;
+                cx.emit(ChannelEvent::ActiveChannelChanged(target));
+            }
+            if let Some((clan_id, badge_count, _)) = leaving {
+                self.sync_clan_after_read(clan_id, badge_count, cx);
+            }
+        }
+        notify_in_voice_change(removed, in_voice_changed, cx);
+        removed
+    }
+
     fn apply_channel_archive_event(
         &mut self,
         e: &mezon_proto::realtime::ChannelArchiveEvent,
@@ -2675,6 +2743,19 @@ fn should_reactivate_thread_after_send(mode: i32, channel: &Channel, archived: b
 
 fn thread_needs_reactivate(channel: &Channel) -> bool {
     channel.is_archived() || thread_is_stale(channel)
+}
+
+fn seed_added_thread_unread(last_sent_timestamp: i64) -> (i64, i64) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or_default();
+    let last_sent = if last_sent_timestamp > 0 {
+        last_sent_timestamp
+    } else {
+        now
+    };
+    (last_sent, (now - ADDED_THREAD_UNREAD_WINDOW_SECONDS).max(0))
 }
 
 fn thread_is_stale(channel: &Channel) -> bool {
@@ -3062,6 +3143,19 @@ fn apply_in_voice_leaved(
         .is_some_and(|info| info.channel_id == channel_id)
     {
         in_voice.remove(&user_id);
+        return true;
+    }
+    false
+}
+
+fn add_user_channel(
+    user_channels: &mut HashMap<ChannelId, Channel>,
+    order: &mut Vec<ChannelId>,
+    channel: Channel,
+) -> bool {
+    let channel_id = channel.id;
+    if user_channels.insert(channel_id, channel).is_none() {
+        order.push(channel_id);
         return true;
     }
     false
@@ -4347,6 +4441,312 @@ mod tests {
         crate::badge::BadgeService::init(auth_state, cx);
         crate::clan::ClanList::init(api.clone(), cx);
         cx.new(|cx| ChannelList::new(api, cx))
+    }
+
+    const REMOVED_SELF: i64 = 77;
+
+    fn init_authenticated_channel_list(cx: &mut App) -> Entity<ChannelList> {
+        let api = Arc::new(mezon_client::AppApi::new(
+            Arc::new(mezon_client::TransportClient::new(String::new())),
+            String::new(),
+        ));
+        RealtimeDispatch::init(api.clone(), cx);
+        let auth_state = cx.new(|_| {
+            crate::AuthState::Authenticated(mezon_client::Session {
+                user_id: REMOVED_SELF.to_string(),
+                ..Default::default()
+            })
+        });
+        crate::badge::BadgeService::init(auth_state, cx);
+        crate::clan::ClanList::init(api.clone(), cx);
+        cx.new(|cx| ChannelList::new(api, cx))
+    }
+
+    fn structure_with_a_thread() -> Vec<Category> {
+        let api_cats = vec![ApiCategoryDesc {
+            category_id: 1,
+            category_name: "General".into(),
+            clan_id: 1,
+            category_order: 0,
+        }];
+        let mut channels = vec![
+            {
+                let mut ch = make_channel(1, "parent", "1");
+                ch.clan_id = ClanId(1);
+                ch
+            },
+            {
+                let mut ch = make_channel(9, "thread", "1");
+                ch.clan_id = ClanId(1);
+                ch.parent_id = Some(ChannelId(1));
+                ch
+            },
+        ];
+        build_categories(api_cats, &mut channels)
+    }
+
+    fn make_clan(id: i64) -> crate::clan::Clan {
+        crate::clan::Clan {
+            id: ClanId(id),
+            creator_id: UserId(0),
+            name: format!("clan-{id}"),
+            avatar_url: None,
+            banner_url: None,
+            badge_count: 0,
+            has_unread: false,
+            muted: false,
+            welcome_channel_id: None,
+            status: 0,
+            is_onboarding: false,
+            is_community: false,
+            prevent_anonymous: false,
+            community_banner: String::new(),
+            about: String::new(),
+            description: String::new(),
+            short_url: String::new(),
+        }
+    }
+
+    fn set_channel_badge(
+        channels: &mut ChannelList,
+        clan_id: ClanId,
+        channel_id: ChannelId,
+        count: u32,
+    ) {
+        let Some(cats) = channels.cache.get_mut(&clan_id) else {
+            return;
+        };
+        for category in cats.iter_mut() {
+            for channel in category.channels.iter_mut() {
+                if channel.id == channel_id {
+                    channel.badge_count = count;
+                }
+            }
+        }
+    }
+
+    fn clan_badge(cx: &App, clan_id: ClanId) -> Option<u32> {
+        crate::clan::ClanList::global(cx)
+            .read(cx)
+            .clan(clan_id)
+            .map(|clan| clan.badge_count)
+    }
+
+    fn removed_from_channel(channel_id: i64, user_ids: &[i64]) -> RealtimeEvent {
+        RealtimeEvent::UserChannelRemoved(mezon_proto::realtime::UserChannelRemoved {
+            channel_id,
+            user_ids: user_ids.to_vec(),
+            channel_type: crate::threads::CHANNEL_TYPE_THREAD as i32,
+            ..Default::default()
+        })
+    }
+
+    fn added_to_channel(channel_id: i64, parent_id: i64, user_ids: &[i64]) -> RealtimeEvent {
+        RealtimeEvent::UserChannelAdded(mezon_proto::realtime::UserChannelAdded {
+            channel_desc: Some(mezon_proto::api::ChannelDescription {
+                channel_id,
+                parent_id,
+                clan_id: 1,
+                channel_label: "added".into(),
+                r#type: crate::threads::CHANNEL_TYPE_THREAD as i32,
+                channel_private: 1,
+                ..Default::default()
+            }),
+            clan_id: 1,
+            users: user_ids
+                .iter()
+                .map(|id| mezon_proto::realtime::UserProfileRedis {
+                    user_id: *id,
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        })
+    }
+
+    #[gpui::test]
+    fn being_added_also_lands_in_the_user_channel_list(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_authenticated_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                assert!(channels.user_channel(ChannelId(42)).is_none());
+
+                channels.handle_event(&added_to_channel(42, 1, &[REMOVED_SELF]), cx);
+
+                assert!(
+                    channels.user_channel(ChannelId(42)).is_some(),
+                    "hashtag suggestions / forward picker / palette read user_channels, \
+                     which is only fetched once per session"
+                );
+                assert!(channels.user_channels().any(|ch| ch.id == ChannelId(42)));
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn being_added_to_a_thread_marks_it_unread(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_authenticated_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+
+                channels.handle_event(&added_to_channel(42, 1, &[REMOVED_SELF]), cx);
+
+                let thread = channels.user_channel(ChannelId(42)).expect("thread");
+                assert!(
+                    thread.is_unread(),
+                    "react seeds lastSeen behind lastSent so a freshly added thread is unread"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn being_added_carries_the_channel_description_fields(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_authenticated_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+
+                let mut event = added_to_channel(42, 1, &[REMOVED_SELF]);
+                if let RealtimeEvent::UserChannelAdded(ref mut e) = event
+                    && let Some(desc) = e.channel_desc.as_mut()
+                {
+                    desc.member_count = 4;
+                    desc.category_name = "General".into();
+                    desc.is_mute = true;
+                    desc.last_sent_message = Some(mezon_proto::api::ChannelMessageHeader {
+                        id: 555,
+                        timestamp_seconds: 1_700_000_000,
+                        ..Default::default()
+                    });
+                }
+                channels.handle_event(&event, cx);
+
+                let thread = channels.user_channel(ChannelId(42)).expect("thread");
+                assert_eq!(thread.member_count, 4);
+                assert_eq!(thread.category_name, "General");
+                assert!(thread.muted);
+                assert_eq!(thread.last_sent_message_id, MessageId(555));
+                assert_eq!(thread.last_sent_timestamp, 1_700_000_000);
+            });
+        });
+    }
+
+    #[test]
+    fn seeding_an_added_thread_keeps_recent_activity_unread() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or_default();
+
+        let (sent, seen) = seed_added_thread_unread(0);
+        assert!(sent > seen);
+
+        let (sent, seen) = seed_added_thread_unread(now - 10);
+        assert!(sent > seen);
+
+        let (sent, seen) = seed_added_thread_unread(now - 5_000);
+        assert!(sent < seen);
+    }
+
+    #[gpui::test]
+    fn leaving_a_thread_drops_its_badge_from_the_clan_total(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_authenticated_channel_list(cx);
+            let clan_list = crate::clan::ClanList::global(cx);
+            clan_list.update(cx, |clans, cx| {
+                clans.update_clans(vec![make_clan(1)], cx);
+            });
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                set_channel_badge(channels, ClanId(1), ChannelId(9), 3);
+                channels.sync_clan_after_read(ClanId(1), 0, cx);
+                assert_eq!(
+                    clan_badge(cx, ClanId(1)),
+                    Some(3),
+                    "the thread's unread count must reach the clan badge first"
+                );
+
+                channels.apply_self_removed_from_channel(ChannelId(9), cx);
+            });
+            assert_eq!(
+                clan_badge(cx, ClanId(1)),
+                Some(0),
+                "react decrements the clan badge by the leaving channel's unread count"
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn user_channel_list_add_and_remove_stay_symmetric(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_authenticated_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+
+                channels.handle_event(&added_to_channel(42, 1, &[REMOVED_SELF]), cx);
+                channels.handle_event(&removed_from_channel(42, &[REMOVED_SELF]), cx);
+
+                assert!(channels.user_channel(ChannelId(42)).is_none());
+                assert!(!channels.user_channels().any(|ch| ch.id == ChannelId(42)));
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn removal_from_an_open_thread_falls_back_to_its_parent(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_authenticated_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                channels.select_channel(ChannelId(9), cx);
+
+                channels.handle_event(&removed_from_channel(9, &[REMOVED_SELF]), cx);
+
+                assert_eq!(channels.active_channel_id, Some(ChannelId(1)));
+                assert_eq!(
+                    channels.remembered_channel(ClanId(1)),
+                    Some(ChannelId(1)),
+                    "the parent must also become the remembered channel so the router follows"
+                );
+                assert!(!channels.channel_in_clan(ClanId(1), ChannelId(9)));
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn removal_from_a_thread_you_are_not_viewing_keeps_the_active_channel(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let channels = init_authenticated_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                channels.select_channel(ChannelId(1), cx);
+
+                channels.handle_event(&removed_from_channel(9, &[REMOVED_SELF]), cx);
+
+                assert_eq!(channels.active_channel_id, Some(ChannelId(1)));
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn removal_targeting_another_user_leaves_the_thread_in_place(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_authenticated_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                channels.select_channel(ChannelId(9), cx);
+
+                channels.handle_event(&removed_from_channel(9, &[REMOVED_SELF + 1]), cx);
+
+                assert_eq!(channels.active_channel_id, Some(ChannelId(9)));
+                assert!(channels.channel_in_clan(ClanId(1), ChannelId(9)));
+            });
+        });
     }
 
     #[gpui::test]

--- a/crates/mezon-store/src/stream.rs
+++ b/crates/mezon-store/src/stream.rs
@@ -443,11 +443,7 @@ impl StreamStore {
 
     pub fn set_volume(&mut self, volume: f32, cx: &mut Context<Self>) {
         self.volume = volume.clamp(0.0, 1.0);
-        if self.volume > 0.0 {
-            self.muted = false;
-        } else {
-            self.muted = true;
-        }
+        self.muted = self.volume <= 0.0;
         self.sync_audio_playback();
         cx.notify();
     }

--- a/crates/mezon-store/src/topics.rs
+++ b/crates/mezon-store/src/topics.rs
@@ -861,6 +861,8 @@ impl TopicsStore {
                     .map(|a| presign::normalize_presign_key(&a.url))
                     .collect();
                 let update_mentions = transport_mentions.clone();
+                let update_hashtags = transport_hashtags.clone();
+                let update_emojis = transport_emojis.clone();
                 let sent = match api
                     .send_topic_presigned_message(
                         clan_id,
@@ -898,6 +900,8 @@ impl TopicsStore {
                     presigned,
                     keys,
                     update_mentions,
+                    update_hashtags,
+                    update_emojis,
                     sent.message_id,
                     sent.create_time.max(0) as u32,
                 ));
@@ -949,8 +953,15 @@ impl TopicsStore {
                 );
             });
 
-            let Some((presigned, keys, update_mentions, real_message_id, create_time_seconds)) =
-                upload_ctx
+            let Some((
+                presigned,
+                keys,
+                update_mentions,
+                update_hashtags,
+                update_emojis,
+                real_message_id,
+                create_time_seconds,
+            )) = upload_ctx
             else {
                 return;
             };
@@ -981,6 +992,8 @@ impl TopicsStore {
                 real_message_id,
                 &content,
                 update_mentions,
+                update_hashtags,
+                update_emojis,
                 create_time_seconds,
                 presigned,
                 keys,

--- a/crates/mezon-ui/src/app/shell/confirm_leave_thread_modal.rs
+++ b/crates/mezon-ui/src/app/shell/confirm_leave_thread_modal.rs
@@ -1,0 +1,85 @@
+use gpui::{Context, FocusHandle, SharedString, Window, div, prelude::*, px};
+use mezon_store::{ChannelId, ClanId, ThreadsStore};
+
+use super::Shell;
+use crate::components::primitives::{Button, ButtonVariants, h_flex, v_flex};
+use crate::theme::ActiveTheme;
+
+pub(super) struct ConfirmLeaveThreadModal {
+    pub(super) focus_handle: FocusHandle,
+    pub(super) clan_id: ClanId,
+    pub(super) channel_id: ChannelId,
+    pub(super) title: SharedString,
+    pub(super) description: SharedString,
+    pub(super) cancel_label: SharedString,
+    pub(super) leave_label: SharedString,
+}
+
+impl Render for ConfirmLeaveThreadModal {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let clan_id = self.clan_id;
+        let channel_id = self.channel_id;
+
+        v_flex()
+            .track_focus(&self.focus_handle)
+            .key_context("menu")
+            .on_action(cx.listener(|_, _: &::menu::Cancel, _window, cx| {
+                Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+            }))
+            .w(px(440.))
+            .overflow_hidden()
+            .rounded_lg()
+            .border_1()
+            .border_color(theme.border)
+            .bg(theme.bg_floating)
+            .shadow_lg()
+            .child(
+                v_flex()
+                    .px(px(16.))
+                    .pt(px(16.))
+                    .pb(px(20.))
+                    .gap_4()
+                    .child(
+                        div()
+                            .text_size(px(20.))
+                            .font_weight(gpui::FontWeight::SEMIBOLD)
+                            .text_color(theme.text_primary)
+                            .child(self.title.clone()),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(15.))
+                            .text_color(theme.text_primary)
+                            .child(self.description.clone()),
+                    ),
+            )
+            .child(
+                h_flex()
+                    .justify_end()
+                    .items_center()
+                    .gap_4()
+                    .p(px(16.))
+                    .bg(theme.bg_secondary)
+                    .child(
+                        Button::new("confirm-leave-thread-cancel")
+                            .label(self.cancel_label.clone())
+                            .ghost()
+                            .on_click(|_, _window, cx| {
+                                Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+                            }),
+                    )
+                    .child(
+                        Button::new("confirm-leave-thread-confirm")
+                            .label(self.leave_label.clone())
+                            .danger()
+                            .on_click(move |_, _window, cx| {
+                                ThreadsStore::global(cx).update(cx, |store, cx| {
+                                    store.leave_thread(clan_id, channel_id, cx);
+                                });
+                                Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+                            }),
+                    ),
+            )
+    }
+}

--- a/crates/mezon-ui/src/app/shell/mod.rs
+++ b/crates/mezon-ui/src/app/shell/mod.rs
@@ -21,6 +21,7 @@ mod confirm_delete_role_modal;
 mod confirm_delete_sound_modal;
 mod confirm_delete_sticker_modal;
 mod confirm_delete_webhook_modal;
+mod confirm_leave_thread_modal;
 mod confirm_remove_friend_modal;
 mod disable_clan_community_modal;
 mod upload_limit_modal;
@@ -32,6 +33,7 @@ use confirm_delete_role_modal::ConfirmDeleteRoleModal;
 use confirm_delete_sound_modal::ConfirmDeleteSoundModal;
 use confirm_delete_sticker_modal::ConfirmDeleteStickerModal;
 use confirm_delete_webhook_modal::{ConfirmDeleteWebhookModal, WebhookDeleteTarget};
+use confirm_leave_thread_modal::ConfirmLeaveThreadModal;
 pub use confirm_remove_friend_modal::FriendRemovalKind;
 use confirm_remove_friend_modal::{ConfirmRemoveFriendModal, interpolate_username};
 use disable_clan_community_modal::DisableClanCommunityModal;
@@ -245,6 +247,41 @@ impl Shell {
             description,
             cancel_label,
             delete_label,
+        });
+        let focus_handle = view.read(cx).focus_handle.clone();
+        window.focus(&focus_handle, cx);
+        self.show_modal(view.into(), cx);
+    }
+
+    pub fn confirm_leave_thread(
+        &mut self,
+        clan_id: mezon_store::ClanId,
+        channel_id: mezon_store::ChannelId,
+        locale: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let title: SharedString =
+            mezon_i18n::t(locale, "channelMenu.modalConFirmLeaveThread.title")
+                .to_string()
+                .into();
+        let description: SharedString =
+            mezon_i18n::t(locale, "channelMenu.modalConFirmLeaveThread.textConfirm")
+                .to_string()
+                .into();
+        let cancel_label: SharedString = mezon_i18n::t(locale, "common.cancel").to_string().into();
+        let leave_label: SharedString =
+            mezon_i18n::t(locale, "channelMenu.modalConFirmLeaveThread.yesButton")
+                .to_string()
+                .into();
+        let view = cx.new(|cx| ConfirmLeaveThreadModal {
+            focus_handle: cx.focus_handle(),
+            clan_id,
+            channel_id,
+            title,
+            description,
+            cancel_label,
+            leave_label,
         });
         let focus_handle = view.read(cx).focus_handle.clone();
         window.focus(&focus_handle, cx);

--- a/crates/mezon-ui/src/chat/area.rs
+++ b/crates/mezon-ui/src/chat/area.rs
@@ -24,6 +24,7 @@ use crate::chat::mention_input::{MentionInput, MentionInputEvent};
 use crate::chat::message::ChannelMessages;
 use crate::chat::message_search::{MESSAGE_SEARCH_PANEL_WIDTH, MessageSearchPanel};
 use crate::chat::pinned_popover::PinnedPopoverPanel;
+use crate::components::compositions::channel_row::ChannelIcon;
 use crate::components::primitives::{Icon, IconName, InputState};
 use crate::image_cache::LruImageCache;
 use crate::theme::ActiveTheme;
@@ -263,6 +264,7 @@ impl ChatArea {
         &mut self,
         locale: &str,
         channel_name: Option<&str>,
+        channel_icon: Option<ChannelIcon>,
         channel_id: Option<ChannelId>,
         show_members_button: bool,
         show_member_panel: bool,
@@ -281,6 +283,7 @@ impl ChatArea {
         self.header.update(cx, |header, cx| {
             header.sync(
                 channel_name,
+                channel_icon,
                 false,
                 None,
                 show_members_button,
@@ -361,6 +364,7 @@ impl ChatArea {
         &mut self,
         locale: &str,
         channel_name: Option<&str>,
+        channel_icon: Option<ChannelIcon>,
         is_dm: bool,
         in_voice: Option<InVoiceInfo>,
         channel_id: Option<ChannelId>,
@@ -404,6 +408,7 @@ impl ChatArea {
         self.header.update(cx, |header, cx| {
             header.sync(
                 channel_name,
+                channel_icon,
                 is_dm,
                 in_voice,
                 show_members_button,

--- a/crates/mezon-ui/src/chat/channel_header.rs
+++ b/crates/mezon-ui/src/chat/channel_header.rs
@@ -15,6 +15,7 @@ use crate::chat::layout::ChatLayout;
 use crate::chat::pinned_popover::{PinnedPopoverPanel, pin_popover_on_open};
 use crate::chat::threads_popover::{ThreadsPopoverPanel, thread_popover_on_open};
 use crate::chat::{CanvasPopoverPanel, canvas_popover_on_open};
+use crate::components::compositions::channel_row::{ChannelIcon, render_channel_icon};
 use crate::components::primitives::{Icon, IconName, InputState};
 use crate::components::{Button, ButtonVariant, ButtonVariants, Sizable, Size};
 use crate::theme::{ActiveTheme, Theme};
@@ -32,6 +33,7 @@ fn canvas_popover_y_offset() -> Pixels {
 
 pub struct ChannelHeader {
     name: String,
+    icon: Option<ChannelIcon>,
     dm: bool,
     muted: bool,
     in_voice: Option<(SharedString, InVoiceInfo)>,
@@ -62,6 +64,7 @@ impl ChannelHeader {
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
+            icon: None,
             dm: false,
             muted: false,
             in_voice: None,
@@ -91,6 +94,11 @@ impl ChannelHeader {
 
     pub fn dm(mut self, dm: bool) -> Self {
         self.dm = dm;
+        self
+    }
+
+    pub fn icon(mut self, icon: Option<ChannelIcon>) -> Self {
+        self.icon = icon;
         self
     }
 
@@ -236,6 +244,7 @@ impl ChannelHeader {
         };
         let ChannelHeader {
             name,
+            icon,
             dm,
             muted: _,
             in_voice,
@@ -316,12 +325,18 @@ impl ChannelHeader {
                     .flex_row()
                     .items_center()
                     .gap_1()
-                    .when(!dm, |this| {
-                        this.child(
-                            Icon::new(IconName::Hashtag)
-                                .size(px(20.0))
-                                .text_color(theme.text_muted),
-                        )
+                    .when_some(icon.filter(|_| !dm), |this, icon| {
+                        let glyph: Hsla = if icon.lock.is_some() {
+                            theme.tokens.bg_icon_theme.into()
+                        } else {
+                            theme.text_muted.into()
+                        };
+                        this.child(render_channel_icon(
+                            icon,
+                            px(20.0),
+                            glyph,
+                            theme.tokens.bg_icon_theme_active.into(),
+                        ))
                     })
                     .child({
                         let name_el = div()
@@ -404,6 +419,7 @@ impl ChannelHeader {
             muted: false,
             notification_trigger: None,
             name: String::new(),
+            icon: None,
             dm: false,
             in_voice: None,
             members_action: false,
@@ -459,6 +475,7 @@ impl ChannelHeader {
             muted: false,
             notification_trigger,
             name: String::new(),
+            icon: None,
             dm: false,
             in_voice: None,
             members_action,
@@ -773,6 +790,7 @@ impl ChannelHeader {
 
 pub struct ChatHeader {
     name: SharedString,
+    icon: Option<ChannelIcon>,
     dm: bool,
     in_voice: Option<InVoiceInfo>,
     members_action: bool,
@@ -812,6 +830,7 @@ impl ChatHeader {
         let _pinned_observe = cx.observe(&PinnedMessagesStore::global(cx), |_, _, cx| cx.notify());
         Self {
             name: SharedString::default(),
+            icon: None,
             dm: false,
             in_voice: None,
             members_action: true,
@@ -841,6 +860,7 @@ impl ChatHeader {
     pub fn sync(
         &mut self,
         name: Option<&str>,
+        icon: Option<ChannelIcon>,
         dm: bool,
         in_voice: Option<InVoiceInfo>,
         members_action: bool,
@@ -867,6 +887,12 @@ impl ChatHeader {
             None if dm => SharedString::default(),
             None => self.name.clone(),
         };
+        let icon = match icon {
+            Some(icon) => Some(icon),
+            None if dm => None,
+            None if resolving => self.icon,
+            None => None,
+        };
         self.inbox_handle = inbox_handle;
         self.pin_handle = pin_handle;
         self.canvas_handle = canvas_handle;
@@ -877,6 +903,7 @@ impl ChatHeader {
             ThreadsStore::global(cx).read(cx).show_threads_popover(cx)
         };
         if self.name == name
+            && self.icon == icon
             && self.dm == dm
             && self.in_voice == in_voice
             && self.members_action == members_action
@@ -895,6 +922,7 @@ impl ChatHeader {
             return;
         }
         self.name = name;
+        self.icon = icon;
         self.dm = dm;
         self.in_voice = in_voice;
         self.members_action = members_action;
@@ -1022,6 +1050,7 @@ impl Render for ChatHeader {
             mezon_i18n::t(&locale, "channelTopbar.tooltips.timelineView").into()
         };
         let mut header = ChannelHeader::new(self.name.to_string())
+            .icon(self.icon)
             .dm(self.dm)
             .members_action(self.members_action)
             .members_active(self.members_active)

--- a/crates/mezon-ui/src/chat/channel_settings/add_mem_role_modal.rs
+++ b/crates/mezon-ui/src/chat/channel_settings/add_mem_role_modal.rs
@@ -364,7 +364,7 @@ impl AddMemRoleModal {
             if failed_users.is_empty() && failed_roles.is_empty() {
                 return;
             }
-            let _ = cx.update(|cx| {
+            cx.update(|cx| {
                 if !failed_users.is_empty() {
                     ChannelUsersStore::global(cx).update(cx, |store, cx| {
                         store.remove_users(channel_id, &failed_users, cx);

--- a/crates/mezon-ui/src/chat/channel_settings/permission_overrides.rs
+++ b/crates/mezon-ui/src/chat/channel_settings/permission_overrides.rs
@@ -502,7 +502,7 @@ impl PermissionOverrides {
                 .await
             {
                 tracing::error!("add_roles_channel_desc failed for {channel_id}: {error}");
-                let _ = cx.update(|cx| {
+                cx.update(|cx| {
                     RolesStore::global(cx).update(cx, |store, cx| {
                         store.remove_role_from_channel(clan_id, role_id, channel_id, cx);
                     });
@@ -529,7 +529,7 @@ impl PermissionOverrides {
                 .await
             {
                 tracing::error!("add_channel_users failed for {channel_id}: {error}");
-                let _ = cx.update(|cx| {
+                cx.update(|cx| {
                     ChannelUsersStore::global(cx).update(cx, |store, cx| {
                         store.remove_users(channel_id, &[user_id], cx);
                     });

--- a/crates/mezon-ui/src/chat/channel_settings/permissions_tab.rs
+++ b/crates/mezon-ui/src/chat/channel_settings/permissions_tab.rs
@@ -422,7 +422,7 @@ impl PermissionsTab {
                 .await
             {
                 tracing::error!("delete_role_channel_desc failed for {role_id}: {error}");
-                let _ = cx.update(|cx| {
+                cx.update(|cx| {
                     RolesStore::global(cx).update(cx, |store, cx| {
                         store.add_roles_to_channel(clan_id, channel_id, &[role_id], cx);
                     });
@@ -459,7 +459,7 @@ impl PermissionsTab {
                 .await
             {
                 tracing::error!("remove_channel_users failed for {channel_id}: {error}");
-                let _ = cx.update(|cx| {
+                cx.update(|cx| {
                     super::permission_overrides::report_acl_failure(&locale, cx);
                 });
                 return;

--- a/crates/mezon-ui/src/chat/layout.rs
+++ b/crates/mezon-ui/src/chat/layout.rs
@@ -28,6 +28,7 @@ use crate::chat::pinned_popover::PinnedPopoverPanel;
 use crate::chat::threads_popover::ThreadsPopoverPanel;
 use crate::chat::voice_sound_picker::{VoiceSoundPicker, VoiceSoundPickerEvent};
 use crate::chat::{CanvasPopoverPanel, CanvasView};
+use crate::components::compositions::channel_row::channel_icon;
 use crate::components::compositions::user_info_bar::UserInfoBar;
 use crate::components::primitives::{
     Icon, IconName, InputEvent, InputState, Slider, SliderEvent, SliderState,
@@ -1932,7 +1933,7 @@ impl ChatLayout {
                 self.navigate_to_thread(channel_id, clan_id, "", "", cx);
                 ThreadsStore::global(cx).update(cx, |store, cx| store.refresh(cx));
             }
-            ThreadsEvent::CreateFailed { message } => {
+            ThreadsEvent::CreateFailed { message } | ThreadsEvent::LeaveFailed { message } => {
                 Shell::global(cx).update(cx, |shell, cx| {
                     shell.error(message.clone(), cx);
                 });
@@ -2541,6 +2542,7 @@ impl ChatLayout {
                     .render(
                         &locale,
                         Some(dm.label.as_str()),
+                        None,
                         true,
                         in_voice,
                         Some(dm.id),
@@ -2578,6 +2580,7 @@ impl ChatLayout {
                     .chat_area
                     .render(
                         &locale,
+                        None,
                         None,
                         true,
                         None,
@@ -2617,6 +2620,7 @@ impl ChatLayout {
             {
                 let channel_name = ch.name.clone();
                 let active_channel_id = ch.id;
+                let header_icon = channel_icon(ch.channel_type, ch.private);
                 let canvas = self
                     .ensure_canvas_view(clan_id, channel_id, canvas_id, window, cx)
                     .into_any_element();
@@ -2625,6 +2629,7 @@ impl ChatLayout {
                     .render_canvas(
                         &locale,
                         Some(channel_name.as_str()),
+                        Some(header_icon),
                         Some(active_channel_id),
                         true,
                         self.show_member_list && !show_results_panel && !topic_open,
@@ -2732,6 +2737,7 @@ impl ChatLayout {
                             .render(
                                 &locale,
                                 Some(channel.name.as_str()),
+                                Some(channel_icon(channel.channel_type, channel.private)),
                                 false,
                                 None,
                                 Some(channel.id),
@@ -2809,6 +2815,7 @@ impl ChatLayout {
                 .render(
                     &locale,
                     Some(channel_name.as_str()),
+                    Some(channel_icon(ch.channel_type, ch.private)),
                     false,
                     None,
                     Some(channel_id),
@@ -2855,6 +2862,7 @@ impl ChatLayout {
                 .render(
                     &locale,
                     None,
+                    None,
                     false,
                     None,
                     None,
@@ -2887,13 +2895,13 @@ impl ChatLayout {
 
         let placeholder = match route {
             Route::Chat => self.render_placeholder(
-                &theme,
+                theme,
                 crate::components::primitives::IconName::Inbox,
                 mezon_i18n::t(&locale, "nav.chat"),
                 &current_path,
             ),
             Route::Direct => self.render_placeholder(
-                &theme,
+                theme,
                 crate::components::primitives::IconName::People,
                 mezon_i18n::t(&locale, "dm.title"),
                 &current_path,
@@ -2902,7 +2910,7 @@ impl ChatLayout {
                 direct_id,
                 message_type: _,
             } => self.render_placeholder(
-                &theme,
+                theme,
                 crate::components::primitives::IconName::People,
                 &format!("Direct {direct_id}"),
                 &current_path,
@@ -2911,31 +2919,31 @@ impl ChatLayout {
                 div().into_any_element()
             }
             Route::Friends => self.render_placeholder(
-                &theme,
+                theme,
                 crate::components::primitives::IconName::IconFriends,
                 mezon_i18n::t(&locale, "directMessage.friends"),
                 &current_path,
             ),
             Route::Thread { channel_id, .. } => self.render_placeholder(
-                &theme,
+                theme,
                 crate::components::primitives::IconName::Hashtag,
                 &format!("Thread #{channel_id}"),
                 &current_path,
             ),
             Route::Canvas { channel_id, .. } => self.render_placeholder(
-                &theme,
+                theme,
                 crate::components::primitives::IconName::Hashtag,
                 &format!("Canvas #{channel_id}"),
                 &current_path,
             ),
             Route::AddFriend { username } => self.render_placeholder(
-                &theme,
+                theme,
                 crate::components::primitives::IconName::People,
                 &format!("Add Friend: {username}"),
                 &current_path,
             ),
             Route::Invite { invite_id } => self.render_placeholder(
-                &theme,
+                theme,
                 crate::components::primitives::IconName::People,
                 &format!("Invite: {invite_id}"),
                 &current_path,

--- a/crates/mezon-ui/src/chat/message/system_row.rs
+++ b/crates/mezon-ui/src/chat/message/system_row.rs
@@ -10,6 +10,7 @@ use super::content::{
 };
 use super::context::{CONTENT_INSET, OnboardingContext, RowCtx, WelcomeContext};
 use super::time::format_message_time;
+use crate::components::compositions::channel_row::{channel_icon, render_channel_icon};
 use crate::components::primitives::{Avatar, Icon, IconName};
 use crate::router::{Route, navigate};
 
@@ -782,15 +783,12 @@ pub fn render_welcome(_msg: &Message, ctx: &RowCtx) -> AnyElement {
         } => {
             col = col
                 .child(welcome_icon_circle(
-                    if private {
-                        Icon::new(IconName::ThreadIconLocker)
-                            .size_10()
-                            .text_color(icon_fill)
-                    } else {
-                        Icon::new(IconName::ThreadIcon)
-                            .size_10()
-                            .text_color(icon_fill)
-                    },
+                    render_channel_icon(
+                        channel_icon(ChannelType::Thread, private),
+                        px(40.),
+                        icon_fill.into(),
+                        theme.tokens.bg_icon_theme_active.into(),
+                    ),
                     Some(theme.tokens.bg_active_member_channel),
                 ))
                 .child(

--- a/crates/mezon-ui/src/chat/stream.rs
+++ b/crates/mezon-ui/src/chat/stream.rs
@@ -64,7 +64,7 @@ pub fn render_stream_channel(
             theme,
             locale,
             channel,
-            &store,
+            store,
             &members,
             show_chat,
             stream_entity.clone(),

--- a/crates/mezon-ui/src/components/compositions/channel_row.rs
+++ b/crates/mezon-ui/src/components/compositions/channel_row.rs
@@ -1,6 +1,7 @@
+use gpui::{AnyElement, Hsla, IntoElement, ParentElement, Pixels, Styled, div};
 use mezon_store::ChannelType;
 
-use crate::components::primitives::IconName;
+use crate::components::primitives::{Icon, IconName};
 
 pub(crate) fn shows_left_unread_nub(channel_type: ChannelType) -> bool {
     !matches!(
@@ -16,11 +17,162 @@ pub(crate) fn channel_type_icon(channel_type: ChannelType, private: bool) -> Ico
         (ChannelType::Voice, false) => IconName::Speaker,
         (ChannelType::Voice, true) => IconName::SpeakerLocked,
         (ChannelType::Stream, _) => IconName::Stream,
-        (ChannelType::Thread, _) => IconName::ThreadIcon,
+        (ChannelType::Thread, false) => IconName::ThreadIcon,
+        (ChannelType::Thread, true) => IconName::ThreadIconLocker,
         (ChannelType::Forum, _) => IconName::Forum,
         (ChannelType::Announcement, _) => IconName::Announcement,
         (ChannelType::App, false) => IconName::AppChannelIcon,
         (ChannelType::App, true) => IconName::PrivateAppChannelIcon,
         (ChannelType::Unknown(_), _) => IconName::Hashtag,
+    }
+}
+
+/// React draws the padlock of a private channel in `--bg-icon-theme-active`, one
+/// shade brighter than the glyph under it. GPUI tints a whole SVG a single
+/// colour, so the padlock has to be a second element stacked on the glyph.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ChannelIcon {
+    pub base: IconName,
+    pub lock: Option<IconName>,
+}
+
+pub(crate) fn channel_icon(channel_type: ChannelType, private: bool) -> ChannelIcon {
+    match (channel_type, private) {
+        (ChannelType::Thread, true) => ChannelIcon {
+            base: IconName::ThreadIcon,
+            lock: Some(IconName::ThreadLock),
+        },
+        (ChannelType::Text, true) => ChannelIcon {
+            base: IconName::Hashtag,
+            lock: Some(IconName::HashtagLock),
+        },
+        _ => ChannelIcon {
+            base: channel_type_icon(channel_type, private),
+            lock: None,
+        },
+    }
+}
+
+pub(crate) fn render_channel_icon(
+    icon: ChannelIcon,
+    size: Pixels,
+    color: Hsla,
+    lock_color: Hsla,
+) -> AnyElement {
+    let Some(lock) = icon.lock else {
+        return Icon::new(icon.base)
+            .size(size)
+            .text_color(color)
+            .into_any_element();
+    };
+    div()
+        .relative()
+        .size(size)
+        .flex_shrink_0()
+        .child(Icon::new(icon.base).size(size).text_color(color))
+        .child(
+            div()
+                .absolute()
+                .top_0()
+                .left_0()
+                .child(Icon::new(lock).size(size).text_color(lock_color)),
+        )
+        .into_any_element()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn icon_path(channel_type: ChannelType, private: bool) -> &'static str {
+        channel_type_icon(channel_type, private).path()
+    }
+
+    #[test]
+    fn private_channels_get_the_locked_variant() {
+        assert_eq!(
+            icon_path(ChannelType::Thread, true),
+            IconName::ThreadIconLocker.path()
+        );
+        assert_eq!(
+            icon_path(ChannelType::Text, true),
+            IconName::HashtagLocked.path()
+        );
+        assert_eq!(
+            icon_path(ChannelType::Voice, true),
+            IconName::SpeakerLocked.path()
+        );
+        assert_eq!(
+            icon_path(ChannelType::App, true),
+            IconName::PrivateAppChannelIcon.path()
+        );
+    }
+
+    #[test]
+    fn public_channels_get_the_plain_variant() {
+        assert_eq!(
+            icon_path(ChannelType::Thread, false),
+            IconName::ThreadIcon.path()
+        );
+        assert_eq!(
+            icon_path(ChannelType::Text, false),
+            IconName::Hashtag.path()
+        );
+        assert_eq!(
+            icon_path(ChannelType::Voice, false),
+            IconName::Speaker.path()
+        );
+    }
+
+    #[test]
+    fn private_threads_and_channels_stack_a_separate_lock() {
+        let thread = channel_icon(ChannelType::Thread, true);
+        assert_eq!(thread.base.path(), IconName::ThreadIcon.path());
+        assert_eq!(
+            thread.lock.map(IconName::path),
+            Some(IconName::ThreadLock.path())
+        );
+
+        let text = channel_icon(ChannelType::Text, true);
+        assert_eq!(text.base.path(), IconName::Hashtag.path());
+        assert_eq!(
+            text.lock.map(IconName::path),
+            Some(IconName::HashtagLock.path())
+        );
+    }
+
+    #[test]
+    fn public_channels_need_no_lock_overlay() {
+        for channel_type in [ChannelType::Thread, ChannelType::Text, ChannelType::Voice] {
+            let icon = channel_icon(channel_type, false);
+            assert!(icon.lock.is_none());
+            assert_eq!(
+                icon.base.path(),
+                channel_type_icon(channel_type, false).path()
+            );
+        }
+    }
+
+    #[test]
+    fn types_with_a_combined_locked_glyph_keep_it() {
+        let voice = channel_icon(ChannelType::Voice, true);
+        assert_eq!(voice.base.path(), IconName::SpeakerLocked.path());
+        assert!(voice.lock.is_none());
+
+        let app = channel_icon(ChannelType::App, true);
+        assert_eq!(app.base.path(), IconName::PrivateAppChannelIcon.path());
+        assert!(app.lock.is_none());
+    }
+
+    #[test]
+    fn streams_ignore_the_private_flag() {
+        assert_eq!(
+            icon_path(ChannelType::Stream, true),
+            IconName::Stream.path()
+        );
+        assert_eq!(
+            icon_path(ChannelType::Stream, false),
+            IconName::Stream.path()
+        );
     }
 }

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/menu.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/menu.rs
@@ -421,10 +421,13 @@ pub(super) fn build_channel_menu(
             show_notification,
         );
         if !permissions.is_channel_creator {
-            menu = menu.danger_item(
-                leave_label.clone(),
-                coming_soon_modal(leave_label, locale_owned.clone()),
-            );
+            let leave_locale = locale_owned.clone();
+            menu = menu.danger_item(leave_label, move |window: &mut Window, cx: &mut App| {
+                let locale = leave_locale.clone();
+                Shell::global(cx).update(cx, |shell, cx| {
+                    shell.confirm_leave_thread(clan_id, channel_id, &locale, window, cx);
+                });
+            });
         }
         if permissions.has_manage_thread {
             menu = menu

--- a/crates/mezon-ui/src/sidebar/direct_sidebar.rs
+++ b/crates/mezon-ui/src/sidebar/direct_sidebar.rs
@@ -515,7 +515,7 @@ impl Render for DirectSidebar {
                     .relative()
                     .child(list)
                     .custom_scrollbars(
-                        Scrollbars::new(ScrollAxes::Vertical)
+                        Scrollbars::always_visible(ScrollAxes::Vertical)
                             .tracked_scroll_handle(&self.list_scroll),
                         window,
                         cx,


### PR DESCRIPTION
## Summary
- Add leave-thread confirmation modal and hook it from the channel context menu.
- Render private thread lock icons in channel headers, welcome rows, and sidebar rows.
- Seed unread state when the current user is added to a thread (`channel.rs`).
- Preserve hashtag/emoji entities on topic presigned sends; simplify stream mute logic.
- Minor UI polish: direct sidebar scrollbar visibility and small channel-settings fixes.

## Test plan
- [ ] Open a joined thread → channel menu → Leave thread → confirm removes the thread from the private list.
- [ ] Private thread shows lock overlay on header and welcome screen icon.
- [ ] Get added to a thread — unread badge appears as expected.
- [ ] Send a topic message with emoji/hashtag attachments — entities survive presigned upload.
- [ ] Direct messages sidebar keeps a visible vertical scrollbar while scrolling.

