### PR TITLE
chore: bump to 0.1.31 and sync release CI prod env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
       NX_CHAT_APP_MMN_API_URL: https://dong.mezon.ai/mmn-api/
       NX_CHAT_APP_ZK_API_URL: https://dong.mezon.ai/zk-api/
       NX_CHAT_APP_INDEXER_API_URL: https://dong.mezon.ai/indexer-api/
+      NX_CHAT_APP_DONG_SERVICE_API_URL: ${{ secrets.NX_CHAT_APP_DONG_SERVICE_API_URL }}
       NX_WEBRTC_ICESERVERS_URL: turn:relay.mezon.ai:5349
       NX_WEBRTC_ICESERVERS_USERNAME: turnmezon
       NX_WEBRTC_ICESERVERS_CREDENTIAL: ${{ secrets.NX_WEBRTC_ICESERVERS_CREDENTIAL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ env:
   NX_CHAT_APP_API_KEY: ${{ secrets.NX_CHAT_APP_API_KEY }}
   NX_CHAT_APP_API_GW_HOST: ${{ secrets.NX_CHAT_APP_API_GW_HOST || 'gw.mezon.ai' }}
   NX_CHAT_APP_API_GW_PORT: ${{ secrets.NX_CHAT_APP_API_GW_PORT || '443' }}
-  NX_CHAT_APP_TCP_PORT: ${{ secrets.NX_CHAT_APP_TCP_PORT }}
+  NX_CHAT_APP_TCP_PORT: ${{ secrets.NX_CHAT_APP_TCP_PORT || '' }}
   NX_CHAT_APP_STREAM_WS_URL: ${{ secrets.NX_CHAT_APP_STREAM_WS_URL || 'wss://stn.mezon.ai' }}
   NX_CHAT_APP_MEET_WS_URL: ${{ secrets.NX_CHAT_APP_MEET_WS_URL || 'wss://meet.mezon.ai' }}
   NX_CHAT_APP_NOTIFICATION_WS_URL: ${{ secrets.NX_CHAT_APP_NOTIFICATION_WS_URL || 'wss://gotify.mezon.ai' }}
   NX_CHAT_APP_OAUTH2_AUTHORIZE_URL: https://oauth2.mezon.ai/oauth2/auth
-  NX_CHAT_APP_OAUTH2_CLIENT_ID: ${{ secrets.NX_CHAT_APP_OAUTH2_CLIENT_ID || '25f63a1f-16b8-488b-8b14-68520eeab77f' }}
-  NX_CHAT_APP_OAUTH2_REDIRECT_URI: ${{ secrets.NX_CHAT_APP_OAUTH2_REDIRECT_URI || 'http://127.0.0.1:4200/login/callback' }}
+  NX_CHAT_APP_OAUTH2_CLIENT_ID: ${{ secrets.NX_CHAT_APP_OAUTH2_CLIENT_ID || 'f049f29e-12a9-464c-938f-0a2f60c3210b' }}
+  NX_CHAT_APP_OAUTH2_REDIRECT_URI: ${{ secrets.NX_CHAT_APP_OAUTH2_REDIRECT_URI || 'https://mezon.ai/login/callback' }}
   NX_CHAT_APP_OAUTH2_RESPONSE_TYPE: code
   NX_CHAT_APP_OAUTH2_SCOPE: openid+offline
   NX_CHAT_APP_OAUTH2_CODE_CHALLENGE_METHOD: S256
@@ -31,8 +31,9 @@ env:
   NX_CHAT_APP_GOOGLE_CLIENT_ID: 391688022389-1k9kb377ea6dccpqii7m5pifjj0agsjc.apps.googleusercontent.com
   NX_DOMAIN_URL: https://mezon.ai
   NX_CHAT_APP_REDIRECT_URI: https://mezon.ai
-  NX_LOGO_MEZON: https://cdn.mezon.ai/images/mezon_logo.png
+  NX_LOGO_MEZON: https://cdn.komu.vn/images/mezon_logo.png
   NX_BASE_IMG_URL: ${{ secrets.NX_BASE_IMG_URL || 'https://cdn.komu.vn' }}
+  NX_UPLOAD_IMG_URL: https://cdn-api.mezon.ai
   NX_PROFILE_IMG_URL: https://profile.mezon.ai
   NX_IMGPROXY_BASE_URL: ${{ secrets.NX_IMGPROXY_BASE_URL || 'https://imgproxy.komu.vn' }}
   NX_IMGPROXY_KEY: ${{ secrets.NX_IMGPROXY_KEY }}
@@ -42,6 +43,10 @@ env:
   NX_CHAT_APP_API_MEZONTREASURY_KEY: ${{ secrets.NX_CHAT_APP_API_MEZONTREASURY_KEY }}
   NX_CHAT_APP_CONTRACT_ADDRESS: "0x4F17a94dD6E1B2D6241C4D1956C6c7a07ba2Ec50"
   NX_CHAT_APP_MEZON_TREASURY_URL_NETWORK: https://sepolia.etherscan.io
+  NX_CHAT_APP_MMN_API_URL: https://dong.mezon.ai/mmn-api/
+  NX_CHAT_APP_ZK_API_URL: https://dong.mezon.ai/zk-api/
+  NX_CHAT_APP_INDEXER_API_URL: https://dong.mezon.ai/indexer-api/
+  NX_CHAT_APP_DONG_SERVICE_API_URL: ${{ secrets.NX_CHAT_APP_DONG_SERVICE_API_URL }}
   NX_WEBRTC_ICESERVERS_URL: ${{ secrets.NX_WEBRTC_ICESERVERS_URL || 'turn:relay.mezon.ai:5349' }}
   NX_WEBRTC_ICESERVERS_USERNAME: turnmezon
   NX_WEBRTC_ICESERVERS_CREDENTIAL: ${{ secrets.NX_WEBRTC_ICESERVERS_CREDENTIAL }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5919,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-app"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -5951,7 +5951,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-audio"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "flume",
@@ -5966,7 +5966,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-canvas"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-cli"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "clap",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-client"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6039,14 +6039,14 @@ dependencies = [
 
 [[package]]
 name = "mezon-i18n"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mezon-mcp"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "axum",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-native"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "auto-launch",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-proto"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "prost 0.13.5",
  "prost-build 0.13.5",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-store"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-stream"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "flume",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-theme"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "gpui",
  "theme",
@@ -6160,7 +6160,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-ui"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6202,7 +6202,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-updater"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-video"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "core-foundation 0.10.0",
@@ -6242,7 +6242,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-voice"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "block",
@@ -6271,7 +6271,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-webview"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "gtk",
@@ -6284,7 +6284,7 @@ dependencies = [
 
 [[package]]
 name = "mezon-widgets"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "gpui",
  "mezon-store",
@@ -6348,7 +6348,7 @@ dependencies = [
 
 [[package]]
 name = "mmn-client"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "base64 0.22.1",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.30"
+version = "0.1.31"
 edition = "2024"
 authors = ["Mezon Team"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary
- Bump workspace version `0.1.30` → `0.1.31` for the next release tag (`v0.1.31`).
- Sync `release.yml` baked `NX_*` env with prod defaults already used in `build.yml`: OAuth client/redirect, logo/upload URLs, MMN/ZK/indexer APIs.
- Add `NX_CHAT_APP_DONG_SERVICE_API_URL` secret to both `build.yml` and `release.yml`.

## Test plan
- [ ] CI lint/test/build workflows pass on this PR
- [ ] After merge to `develop`, tag `v0.1.31` to trigger release workflow
