### PR TITLE
feat(store,ui): thread membership, compose drafts, and message parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5186,10 +5186,15 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "814b44c24cd2cb236c3b8a41c7f08237b452a8e76ecaa81f1cec40b5b678215b"
 dependencies = [
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "futures-channel",
+ "futures-lite 2.6.1",
  "futures-util",
  "pastey 0.2.3",
  "serde",
- "tokio",
+ "task-local",
  "zbus 5.16.0",
 ]
 
@@ -10477,6 +10482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "task-local"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2972044a9e5e448a506a7ff6f0d03b566d8ef4cd6918a58fc59835a0f8666626"
+dependencies = [
+ "pin-project-lite",
+]
+
+[[package]]
 name = "tauri-winrt-notification"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10714,7 +10728,6 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -13214,7 +13227,6 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_repr",
- "tokio",
  "tracing",
  "uds_windows",
  "uuid",

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -1708,11 +1708,11 @@ pub struct ApiEmbed {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ApiSelectOption {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "string_flex::deserialize")]
     pub label: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "string_flex::deserialize")]
     pub value: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "opt_string_flex::deserialize")]
     pub description: Option<String>,
     #[serde(default, deserialize_with = "bool_flex::deserialize")]
     pub default: bool,
@@ -1740,9 +1740,9 @@ pub struct ApiSelectComponent {
         deserialize_with = "opt_i32_flex::deserialize"
     )]
     pub select_type: Option<i32>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "select_options::deserialize")]
     pub options: Vec<ApiSelectOption>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "opt_string_flex::deserialize")]
     pub placeholder: Option<String>,
     #[serde(default, deserialize_with = "opt_i32_flex::deserialize")]
     pub min_options: Option<i32>,
@@ -1750,8 +1750,96 @@ pub struct ApiSelectComponent {
     pub max_options: Option<i32>,
     #[serde(default, deserialize_with = "bool_flex::deserialize")]
     pub disabled: bool,
-    #[serde(default, rename = "valueSelected")]
+    #[serde(
+        default,
+        rename = "valueSelected",
+        deserialize_with = "opt_select_option::deserialize"
+    )]
     pub value_selected: Option<ApiSelectOption>,
+}
+
+fn flex_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+fn parse_select_option(value: &serde_json::Value) -> Option<ApiSelectOption> {
+    if value.is_object() {
+        return serde_json::from_value(value.clone()).ok();
+    }
+    let text = flex_string(value)?;
+    Some(ApiSelectOption {
+        label: text.clone(),
+        value: text,
+        description: None,
+        default: false,
+    })
+}
+
+mod string_flex {
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<String, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Option::<serde_json::Value>::deserialize(deserializer)?
+            .as_ref()
+            .and_then(super::flex_string)
+            .unwrap_or_default())
+    }
+}
+
+mod opt_string_flex {
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Option::<serde_json::Value>::deserialize(deserializer)?
+            .as_ref()
+            .and_then(super::flex_string)
+            .filter(|text| !text.is_empty()))
+    }
+}
+
+mod select_options {
+    use super::ApiSelectOption;
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<ApiSelectOption>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let Some(serde_json::Value::Array(items)) =
+            Option::<serde_json::Value>::deserialize(deserializer)?
+        else {
+            return Ok(Vec::new());
+        };
+        Ok(items
+            .iter()
+            .filter_map(super::parse_select_option)
+            .collect())
+    }
+}
+
+mod opt_select_option {
+    use super::ApiSelectOption;
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<ApiSelectOption>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Option::<serde_json::Value>::deserialize(deserializer)?
+            .as_ref()
+            .and_then(super::parse_select_option))
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/mezon-mcp/src/tools.rs
+++ b/crates/mezon-mcp/src/tools.rs
@@ -986,6 +986,8 @@ impl McpBackend {
                 sent.message_id,
                 content,
                 Vec::new(),
+                Vec::new(),
+                Vec::new(),
                 vec![key],
                 sent.create_time.max(0) as u32,
                 mode,

--- a/crates/mezon-native/Cargo.toml
+++ b/crates/mezon-native/Cargo.toml
@@ -14,13 +14,15 @@ thiserror.workspace = true
 tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-libc.workspace = true
 flume.workspace = true
 cpal.workspace = true
 open = "5"
 dirs = { workspace = true }
 image = { workspace = true }
 auto-launch = "0.5"
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
 tray-icon = { version = "0.19", features = ["common-controls-v6"] }
@@ -35,4 +37,4 @@ windows.workspace = true
 [target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]
 notify-rust = "4"
 zbus = "4"
-ksni = { version = "0.3", features = ["blocking"] }
+ksni = { version = "0.3", default-features = false, features = ["blocking", "async-io"] }

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -1984,13 +1984,6 @@ impl ChannelList {
                 let Some(cats) = self.cache.get_mut(&clan_id) else {
                     return;
                 };
-                let already_exists = cats
-                    .iter()
-                    .flat_map(|c| &c.channels)
-                    .any(|ch| ch.id == channel_id);
-                if already_exists {
-                    return;
-                }
                 let last_sent = desc.last_sent_message.as_ref();
                 let (last_sent_message_id, last_sent_timestamp) = match last_sent {
                     Some(header) => (
@@ -4580,6 +4573,25 @@ mod tests {
                      which is only fetched once per session"
                 );
                 assert!(channels.user_channels().any(|ch| ch.id == ChannelId(42)));
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn being_added_to_an_already_visible_channel_still_lists_it(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_authenticated_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                assert!(channels.user_channel(ChannelId(9)).is_none());
+
+                channels.handle_event(&added_to_channel(9, 1, &[REMOVED_SELF]), cx);
+
+                assert!(
+                    channels.user_channel(ChannelId(9)).is_some(),
+                    "react dispatches listChannelsByUserActions.add unconditionally, so a public \
+                     thread already in the clan structure must still reach user_channels"
+                );
             });
         });
     }

--- a/crates/mezon-store/src/channel_members.rs
+++ b/crates/mezon-store/src/channel_members.rs
@@ -168,6 +168,24 @@ impl ChannelMembersStore {
         self.cache.contains(&channel_id)
     }
 
+    /// Seed a channel's roster from a `ListChannelUsers` response fetched outside
+    /// this store, so a caller that had to look the members up itself does not
+    /// leave the cache cold for the next reader.
+    pub fn apply_members_loaded(
+        &mut self,
+        channel_id: ChannelId,
+        users: &[api::channel_user_list::ChannelUser],
+        cx: &mut Context<Self>,
+    ) {
+        let mut bucket = ChannelBucket::default();
+        for cu in users {
+            bucket.upsert(channel_member_from_proto(cu));
+        }
+        self.cache.insert(channel_id, bucket, None);
+        cx.emit(ChannelMembersEvent::Changed { channel_id });
+        cx.notify();
+    }
+
     pub fn apply_members_added(
         &mut self,
         channel_id: ChannelId,
@@ -239,15 +257,7 @@ impl ChannelMembersStore {
             let _ = this.update(cx, |this, cx| {
                 this.loading.remove(&channel_id);
                 match result {
-                    Ok(users) => {
-                        let mut bucket = ChannelBucket::default();
-                        for cu in users {
-                            bucket.upsert(channel_member_from_proto(&cu));
-                        }
-                        this.cache.insert(channel_id, bucket, None);
-                        cx.emit(ChannelMembersEvent::Changed { channel_id });
-                        cx.notify();
-                    }
+                    Ok(users) => this.apply_members_loaded(channel_id, &users, cx),
                     Err(e) => {
                         tracing::error!("list_channel_users failed for {channel_id}: {e}");
                         cx.emit(ChannelMembersEvent::Changed { channel_id });

--- a/crates/mezon-store/src/compose.rs
+++ b/crates/mezon-store/src/compose.rs
@@ -6,6 +6,7 @@ use gpui::{App, AppContext, Entity, Global};
 use crate::ids::ChannelId;
 
 pub const MAX_DRAFT_CHANNELS: usize = 50;
+pub const MAX_DRAFT_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ComposeTokenKind {
@@ -123,12 +124,27 @@ impl ComposeStore {
         self.recent.push(channel_id);
     }
 
+    fn total_bytes(&self) -> usize {
+        self.by_channel.values().map(draft_bytes).sum()
+    }
+
     fn evict_oldest(&mut self) {
-        while self.recent.len() > MAX_DRAFT_CHANNELS {
+        while self.recent.len() > MAX_DRAFT_CHANNELS
+            || (self.recent.len() > 1 && self.total_bytes() > MAX_DRAFT_BYTES)
+        {
             let oldest = self.recent.remove(0);
             self.by_channel.remove(&oldest);
         }
     }
+}
+
+fn draft_bytes(draft: &ComposeDraft) -> usize {
+    draft.text.len()
+        + draft
+            .attachments
+            .iter()
+            .map(|attachment| attachment.poster_jpeg.as_ref().map_or(0, Vec::len))
+            .sum::<usize>()
 }
 
 #[cfg(test)]
@@ -260,6 +276,43 @@ mod tests {
             store.draft(ChannelId(999)).map(|d| d.text.as_str()),
             Some("newest")
         );
+    }
+
+    #[test]
+    fn evicts_until_the_byte_budget_holds() {
+        let mut store = ComposeStore::new();
+        let heavy = || ComposeDraft {
+            text: String::new(),
+            tokens: Vec::new(),
+            attachments: vec![PendingAttachment {
+                poster_jpeg: Some(vec![0; MAX_DRAFT_BYTES / 2 + 1]),
+                ..attachment()
+            }],
+        };
+        store.set_draft(ChannelId(1), heavy());
+        store.set_draft(ChannelId(2), heavy());
+
+        assert_eq!(store.len(), 1);
+        assert!(store.draft(ChannelId(1)).is_none());
+        assert!(store.draft(ChannelId(2)).is_some());
+    }
+
+    #[test]
+    fn a_lone_oversized_draft_is_not_dropped() {
+        let mut store = ComposeStore::new();
+        store.set_draft(
+            ChannelId(1),
+            ComposeDraft {
+                text: String::new(),
+                tokens: Vec::new(),
+                attachments: vec![PendingAttachment {
+                    poster_jpeg: Some(vec![0; MAX_DRAFT_BYTES + 1]),
+                    ..attachment()
+                }],
+            },
+        );
+
+        assert!(store.draft(ChannelId(1)).is_some());
     }
 
     #[test]

--- a/crates/mezon-store/src/login.rs
+++ b/crates/mezon-store/src/login.rs
@@ -108,6 +108,9 @@ impl LoginStore {
         if let Some(e) = crate::clan_load::ClanLoadScheduler::try_global(cx) {
             e.update(cx, |s, cx| s.reset(cx));
         }
+        if let Some(e) = crate::compose::ComposeStore::try_global(cx) {
+            e.update(cx, |s, _cx| s.clear_all());
+        }
         if let Some(e) = crate::account::AccountStore::try_global(cx) {
             e.update(cx, |s, cx| s.reset(cx));
         }

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -4528,20 +4528,22 @@ impl MessagesStore {
         };
         let message = message_id.get();
         let storage_for_rollback = storage_id;
-        if let Some(reaction_clan_id) = self.active_clan_id {
-            let users = plan_thread_membership_for_reaction(
-                parent_channel_id,
-                reaction_clan_id,
-                current_uid,
-                cx,
-            );
-            if !users.is_empty() {
-                let join_api = api.clone();
-                cx.spawn(async move |this, cx| {
-                    add_thread_members(&join_api, &this, parent_channel_id, users, cx).await;
-                })
-                .detach();
-            }
+        if let Some(reaction_clan_id) = self.active_clan_id
+            && is_thread_channel(parent_channel_id, reaction_clan_id, cx)
+        {
+            let join_api = api.clone();
+            cx.spawn(async move |this, cx| {
+                ensure_thread_membership_for_reaction(
+                    &join_api,
+                    &this,
+                    parent_channel_id,
+                    reaction_clan_id,
+                    current_uid,
+                    cx,
+                )
+                .await;
+            })
+            .detach();
         }
         cx.spawn(async move |this, cx| {
             if let Err(e) = api
@@ -5003,9 +5005,13 @@ fn mentioned_thread_candidates(
 
 struct ThreadSendContext {
     parent_id: ChannelId,
+    channel_type: Option<i32>,
     parent_channel_type: Option<i32>,
     self_id: Option<UserId>,
-    thread_members: Vec<UserId>,
+    /// `None` when the store holds no roster for the channel. Distinguishing that
+    /// from an empty roster matters: an unloaded thread would otherwise read as
+    /// "nobody is a member" and re-add people who are already in it.
+    thread_members: Option<Vec<UserId>>,
     parent_members: Option<Vec<UserId>>,
     mentioned: Vec<UserId>,
 }
@@ -5018,10 +5024,9 @@ fn thread_send_context(
 ) -> Option<ThreadSendContext> {
     let channels = ChannelList::global(cx);
     let channels = channels.read(cx);
-    let parent_id = channels
-        .channel(clan_id, channel_id)
-        .and_then(|channel| channel.parent_id)
-        .filter(|parent_id| !parent_id.is_zero())?;
+    let channel = channels.channel(clan_id, channel_id)?;
+    let channel_type = Some(channel.channel_type.as_raw() as i32);
+    let parent_id = channel.parent_id.filter(|parent_id| !parent_id.is_zero())?;
     let parent_channel_type = channels
         .channel(clan_id, parent_id)
         .map(|channel| channel.channel_type.as_raw() as i32);
@@ -5029,9 +5034,12 @@ fn thread_send_context(
     let members = members.read(cx);
     Some(ThreadSendContext {
         parent_id,
+        channel_type,
         parent_channel_type,
         self_id: viewer_user_id(cx),
-        thread_members: members.member_ids(channel_id),
+        thread_members: members
+            .has_channel(channel_id)
+            .then(|| members.member_ids(channel_id)),
         parent_members: members
             .has_channel(parent_id)
             .then(|| members.member_ids(parent_id)),
@@ -5039,17 +5047,105 @@ fn thread_send_context(
     })
 }
 
-fn plan_thread_membership_for_reaction(
+fn is_thread_channel(channel_id: ChannelId, clan_id: ClanId, cx: &App) -> bool {
+    ChannelList::global(cx)
+        .read(cx)
+        .channel(clan_id, channel_id)
+        .and_then(|channel| channel.parent_id)
+        .is_some_and(|parent_id| !parent_id.is_zero())
+}
+
+/// Member ids for `channel_id`, falling back to a `ListChannelUsers` round-trip
+/// when the store has no roster yet. The response is written back into
+/// `ChannelMembersStore` so the next send reads it from cache. `None` means the
+/// roster is genuinely unknown — callers must not treat that as "no members".
+async fn resolve_channel_members(
+    api: &AppApi,
+    this: &WeakEntity<MessagesStore>,
+    clan_id: ClanId,
+    channel_id: ChannelId,
+    channel_type: Option<i32>,
+    cached: Option<Vec<UserId>>,
+    cx: &mut AsyncApp,
+) -> Option<Vec<UserId>> {
+    if let Some(members) = cached {
+        return Some(members);
+    }
+    let users = match api
+        .list_channel_users(clan_id.get(), channel_id.get(), channel_type?)
+        .await
+    {
+        Ok(users) => users,
+        Err(e) => {
+            tracing::error!("list_channel_users for {channel_id} failed: {e}");
+            return None;
+        }
+    };
+    let member_ids = users.iter().map(|user| UserId(user.user_id)).collect();
+    let _ = this.update(cx, |_this, cx| {
+        if let Some(members) = ChannelMembersStore::try_global(cx) {
+            members.update(cx, |members, cx| {
+                members.apply_members_loaded(channel_id, &users, cx);
+            });
+        }
+    });
+    Some(member_ids)
+}
+
+/// Users that must join `channel_id` before the caller's action lands, or an
+/// empty plan when nothing is needed (or the thread roster could not be read).
+async fn resolve_thread_membership_plan(
+    api: &AppApi,
+    this: &WeakEntity<MessagesStore>,
     channel_id: ChannelId,
     clan_id: ClanId,
-    user_id: UserId,
-    cx: &App,
+    mentions: &[TransportMention],
+    join_self: bool,
+    extra_candidates: &[UserId],
+    cx: &mut AsyncApp,
 ) -> Vec<UserId> {
-    let Some(ctx) = thread_send_context(channel_id, clan_id, &[], cx) else {
+    let Ok(Some(ctx)) = this.update(cx, |_this, cx| {
+        thread_send_context(channel_id, clan_id, mentions, cx)
+    }) else {
         return Vec::new();
     };
-    let parent_members = ctx.parent_members.unwrap_or_default();
-    plan_thread_membership(None, &ctx.thread_members, &parent_members, &[user_id])
+    let Some(thread_members) = resolve_channel_members(
+        api,
+        this,
+        clan_id,
+        channel_id,
+        ctx.channel_type,
+        ctx.thread_members,
+        cx,
+    )
+    .await
+    else {
+        return Vec::new();
+    };
+    let mut candidates = ctx.mentioned;
+    candidates.extend_from_slice(extra_candidates);
+    // Parent membership only gates the candidates; a self-join never consults it.
+    let parent_members = if needs_parent_lookup(&thread_members, &candidates) {
+        resolve_channel_members(
+            api,
+            this,
+            clan_id,
+            ctx.parent_id,
+            ctx.parent_channel_type,
+            ctx.parent_members,
+            cx,
+        )
+        .await
+        .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    plan_thread_membership(
+        if join_self { ctx.self_id } else { None },
+        &thread_members,
+        &parent_members,
+        &candidates,
+    )
 }
 
 async fn add_thread_members(
@@ -5089,38 +5185,26 @@ async fn ensure_thread_membership_for_send(
     mentions: &[TransportMention],
     cx: &mut AsyncApp,
 ) {
-    let Ok(Some(ctx)) = this.update(cx, |_this, cx| {
-        thread_send_context(channel_id, clan_id, mentions, cx)
-    }) else {
+    let users =
+        resolve_thread_membership_plan(api, this, channel_id, clan_id, mentions, true, &[], cx)
+            .await;
+    if users.is_empty() {
         return;
-    };
-    let parent_members = match (ctx.parent_members, ctx.parent_channel_type) {
-        (Some(members), _) => members,
-        (None, Some(parent_channel_type))
-            if needs_parent_lookup(&ctx.thread_members, &ctx.mentioned) =>
-        {
-            match api
-                .list_channel_users(clan_id.get(), ctx.parent_id.get(), parent_channel_type)
-                .await
-            {
-                Ok(users) => users.iter().map(|user| UserId(user.user_id)).collect(),
-                Err(e) => {
-                    tracing::error!(
-                        "list_channel_users for thread parent {} failed: {e}",
-                        ctx.parent_id
-                    );
-                    Vec::new()
-                }
-            }
-        }
-        (None, _) => Vec::new(),
-    };
-    let users = plan_thread_membership(
-        ctx.self_id,
-        &ctx.thread_members,
-        &parent_members,
-        &ctx.mentioned,
-    );
+    }
+    add_thread_members(api, this, channel_id, users, cx).await;
+}
+
+async fn ensure_thread_membership_for_reaction(
+    api: &AppApi,
+    this: &WeakEntity<MessagesStore>,
+    channel_id: ChannelId,
+    clan_id: ClanId,
+    user_id: UserId,
+    cx: &mut AsyncApp,
+) {
+    let users =
+        resolve_thread_membership_plan(api, this, channel_id, clan_id, &[], false, &[user_id], cx)
+            .await;
     if users.is_empty() {
         return;
     }
@@ -7215,6 +7299,48 @@ mod tests {
         assert_eq!(select.id.as_deref(), Some("typeOfWork"));
         assert_eq!(select.options.len(), 2);
         assert_eq!(select.options[0].value.as_ref(), "code");
+    }
+
+    #[test]
+    fn parse_embed_input_keeps_select_options_with_non_string_values() {
+        let value = serde_json::json!({
+            "type": 2,
+            "id": "typeOfWork",
+            "component": {
+                "type": 1,
+                "options": [
+                    { "label": "Normal Time", "value": 1, "description": 0 },
+                    { "label": "Overtime", "value": 2 },
+                    "Weekend"
+                ],
+                "valueSelected": { "label": "Normal Time", "value": 1 }
+            }
+        });
+        let EmbedInput::Select(select) =
+            parse_embed_input(Some(&value)).expect("select component should parse")
+        else {
+            panic!("expected a select");
+        };
+        assert_eq!(select.options.len(), 3);
+        assert_eq!(select.options[0].value.as_ref(), "1");
+        assert_eq!(select.options[2].label.as_ref(), "Weekend");
+        assert_eq!(select.value_selected.as_deref(), Some("1"));
+    }
+
+    #[test]
+    fn parse_embed_input_keeps_select_with_null_options() {
+        let value = serde_json::json!({
+            "type": 2,
+            "id": "typeOfWork",
+            "component": { "options": null, "placeholder": "Pick one" }
+        });
+        let EmbedInput::Select(select) =
+            parse_embed_input(Some(&value)).expect("select component should parse")
+        else {
+            panic!("expected a select");
+        };
+        assert!(select.options.is_empty());
+        assert_eq!(select.placeholder.as_deref(), Some("Pick one"));
     }
 
     #[test]

--- a/crates/mezon-store/src/threads.rs
+++ b/crates/mezon-store/src/threads.rs
@@ -228,7 +228,7 @@ impl ThreadsStore {
         let Some(desc) = ev.channel_desc.as_ref() else {
             return;
         };
-        if desc.r#type != CHANNEL_TYPE_THREAD as i32 || desc.parent_id == 0 {
+        if !is_thread_membership_event(desc.r#type, desc.parent_id) {
             return;
         }
         let Some(me) = crate::badge::BadgeService::try_global(cx)
@@ -242,8 +242,11 @@ impl ThreadsStore {
         let channel_id = desc.channel_id.to_string();
         self.set_thread_active(&channel_id, THREAD_STATUS_JOINED, cx);
         let parent_id = desc.parent_id.to_string();
-        if desc.channel_private == 0 || self.list_channel_id.as_deref() != Some(parent_id.as_str())
-        {
+        if !joins_private_thread_list(
+            desc.channel_private,
+            &parent_id,
+            self.list_channel_id.as_deref(),
+        ) {
             return;
         }
         let summary = ThreadSummary {
@@ -265,8 +268,14 @@ impl ThreadsStore {
             member_count: desc.member_count.max(0),
         };
         let before = self.threads.len();
-        merge_threads(&mut self.threads, vec![summary]);
-        if self.threads.len() != before {
+        merge_threads(&mut self.threads, vec![summary.clone()]);
+        let mut changed = self.threads.len() != before;
+        if let Some(results) = self.search_results.as_mut() {
+            let results_before = results.len();
+            merge_threads(results, vec![summary]);
+            changed |= results.len() != results_before;
+        }
+        if changed {
             cx.notify();
         }
     }
@@ -295,14 +304,21 @@ impl ThreadsStore {
     }
 
     fn is_private_thread(&self, channel_id: &str) -> bool {
-        self.threads
-            .iter()
-            .chain(self.search_results.iter().flatten())
-            .any(|thread| thread.channel_id == channel_id && thread.channel_private != 0)
+        contains_private_thread(
+            self.threads
+                .iter()
+                .chain(self.search_results.iter().flatten()),
+            channel_id,
+        )
     }
 
     pub fn leave_thread(&mut self, clan_id: ClanId, channel_id: ChannelId, cx: &mut Context<Self>) {
         let api = self.api.clone();
+        let is_private = ChannelList::global(cx)
+            .read(cx)
+            .channel(clan_id, channel_id)
+            .map(|channel| channel.private)
+            .unwrap_or_else(|| self.is_private_thread(&channel_id.to_string()));
         cx.spawn(async move |this, cx| {
             if let Err(e) = api.leave_thread(clan_id.get(), channel_id.get()).await {
                 tracing::error!("leave_thread failed for {channel_id}: {e}");
@@ -317,9 +333,8 @@ impl ThreadsStore {
                 ChannelList::global(cx).update(cx, |list, cx| {
                     list.apply_self_removed_from_channel(channel_id, cx);
                 });
-                let id = channel_id.to_string();
-                if this.is_private_thread(&id) {
-                    this.apply_thread_deleted(&id, cx);
+                if is_private {
+                    this.apply_thread_deleted(&channel_id.to_string(), cx);
                 }
             });
         })
@@ -1013,6 +1028,30 @@ fn page_has_more(batch_len: usize) -> bool {
     batch_len >= THREAD_LIST_LIMIT as usize
 }
 
+/// A `UserChannelAdded`/`UserChannelRemoved` payload only concerns the thread
+/// list when it describes a thread hanging off a real parent channel.
+fn is_thread_membership_event(channel_type: i32, parent_id: i64) -> bool {
+    channel_type == CHANNEL_TYPE_THREAD as i32 && parent_id != 0
+}
+
+/// Being added is the only signal that can surface a *private* thread, so it is
+/// the only case that inserts a row. Public threads already arrive through
+/// `ChannelCreated`, and only the list currently showing the parent can grow.
+fn joins_private_thread_list(
+    channel_private: i32,
+    parent_id: &str,
+    list_channel_id: Option<&str>,
+) -> bool {
+    channel_private != 0 && list_channel_id == Some(parent_id)
+}
+
+fn contains_private_thread<'a>(
+    mut threads: impl Iterator<Item = &'a ThreadSummary>,
+    channel_id: &str,
+) -> bool {
+    threads.any(|thread| thread.channel_id == channel_id && thread.channel_private != 0)
+}
+
 fn merge_threads(into: &mut Vec<ThreadSummary>, batch: Vec<ThreadSummary>) {
     for thread in batch {
         if !into
@@ -1167,6 +1206,64 @@ mod tests {
     #[test]
     fn page_has_more_false_when_batch_partial() {
         assert!(!page_has_more(10));
+    }
+
+    fn summary(channel_id: &str, channel_private: i32) -> ThreadSummary {
+        ThreadSummary {
+            channel_id: channel_id.into(),
+            channel_label: "t".into(),
+            clan_id: "c".into(),
+            parent_id: "p".into(),
+            channel_private,
+            active: THREAD_STATUS_JOINED,
+            creator_id: String::new(),
+            last_message_content: String::new(),
+            last_message_sender_id: String::new(),
+            last_message_sender_name: String::new(),
+            last_message_sender_avatar: String::new(),
+            last_sent_timestamp: 0,
+            member_count: 0,
+        }
+    }
+
+    #[test]
+    fn membership_events_only_match_threads_with_a_parent() {
+        assert!(is_thread_membership_event(CHANNEL_TYPE_THREAD as i32, 77));
+        assert!(!is_thread_membership_event(CHANNEL_TYPE_THREAD as i32, 0));
+        assert!(!is_thread_membership_event(
+            CHANNEL_TYPE_THREAD as i32 + 1,
+            77
+        ));
+    }
+
+    #[test]
+    fn only_a_private_thread_under_the_open_parent_joins_the_list() {
+        assert!(joins_private_thread_list(1, "77", Some("77")));
+        // Public threads arrive via ChannelCreated instead.
+        assert!(!joins_private_thread_list(0, "77", Some("77")));
+        // A different parent's list must not grow.
+        assert!(!joins_private_thread_list(1, "77", Some("88")));
+        assert!(!joins_private_thread_list(1, "77", None));
+    }
+
+    #[test]
+    fn private_thread_lookup_spans_the_list_and_search_results() {
+        let threads = [summary("1", 0)];
+        let results = [summary("2", 1)];
+
+        assert!(contains_private_thread(
+            threads.iter().chain(results.iter()),
+            "2"
+        ));
+        // Public threads are left alone: removal must not delete their row.
+        assert!(!contains_private_thread(
+            threads.iter().chain(results.iter()),
+            "1"
+        ));
+        assert!(!contains_private_thread(
+            threads.iter().chain(results.iter()),
+            "9"
+        ));
     }
 
     #[test]

--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -635,13 +635,15 @@ impl MentionInput {
         }
         let Some(store) = ComposeStore::try_global(cx) else {
             self.draft_channel = channel_id;
+            self.apply_draft(ComposeDraft::default(), window, cx);
             return;
         };
-        let leaving = self.draft_channel;
-        let outgoing = self.take_draft(cx);
+        let outgoing = self
+            .draft_channel
+            .map(|leaving| (leaving, self.take_draft(cx)));
         let incoming = store.update(cx, |store, _| {
-            if let Some(leaving) = leaving {
-                match outgoing {
+            if let Some((leaving, draft)) = outgoing {
+                match draft {
                     Some(draft) => store.set_draft(leaving, draft),
                     None => store.clear_draft(leaving),
                 }
@@ -687,6 +689,7 @@ impl MentionInput {
         self.suppress_typing = true;
         self.last_content = SharedString::from(text.clone());
         self.input.update(cx, |input, cx| {
+            input.prepare_channel_switch();
             input.set_mention_spans(Vec::new(), cx);
             input.set_value(text, window, cx);
         });

--- a/crates/mezon-ui/src/chat/mention_input/text_field.rs
+++ b/crates/mezon-ui/src/chat/mention_input/text_field.rs
@@ -295,6 +295,7 @@ pub(crate) struct MentionInputState {
     selected_range: Range<usize>,
     selection_reversed: bool,
     marked_range: Option<Range<usize>>,
+    discard_ime_commit: Option<String>,
     last_lines: Vec<DocLine>,
     last_bounds: Option<Bounds<Pixels>>,
     line_height: Pixels,
@@ -331,6 +332,7 @@ impl MentionInputState {
             selected_range: 0..0,
             selection_reversed: false,
             marked_range: None,
+            discard_ime_commit: None,
             last_lines: Vec::new(),
             last_bounds: None,
             line_height: px(20.),
@@ -426,6 +428,12 @@ impl MentionInputState {
         self.pause_caret_blink(cx);
         cx.notify();
         cx.emit(MentionFieldEvent::Change);
+    }
+
+    pub(crate) fn prepare_channel_switch(&mut self) {
+        if let Some(marked) = self.marked_range.take() {
+            self.discard_ime_commit = self.content.get(marked).map(str::to_string);
+        }
     }
 
     pub fn set_value(
@@ -1088,6 +1096,11 @@ impl EntityInputHandler for MentionInputState {
     }
 
     fn unmark_text(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {
+        #[cfg(target_os = "linux")]
+        if let Some(marked) = self.marked_range.clone() {
+            let marked = self.clamp_range(marked);
+            self.discard_ime_commit = self.content.get(marked).map(str::to_string);
+        }
         self.marked_range = None;
     }
 
@@ -1098,6 +1111,18 @@ impl EntityInputHandler for MentionInputState {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if range_utf16.is_none()
+            && self.marked_range.is_none()
+            && let Some(expected) = self.discard_ime_commit.as_deref()
+        {
+            if new_text == expected {
+                self.discard_ime_commit = None;
+                return;
+            }
+            if !new_text.is_empty() {
+                self.discard_ime_commit = None;
+            }
+        }
         let range = range_utf16
             .as_ref()
             .map(|range_utf16| self.range_from_utf16(range_utf16))
@@ -1133,6 +1158,18 @@ impl EntityInputHandler for MentionInputState {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if range_utf16.is_none()
+            && self.marked_range.is_none()
+            && let Some(expected) = self.discard_ime_commit.as_deref()
+        {
+            if new_text == expected {
+                self.discard_ime_commit = None;
+                return;
+            }
+            if !new_text.is_empty() {
+                self.discard_ime_commit = None;
+            }
+        }
         let range = range_utf16
             .as_ref()
             .map(|range_utf16| self.range_from_utf16(range_utf16))

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -1203,6 +1203,7 @@ pub struct ChannelMessages {
     _skeleton_timer: Option<Task<()>>,
     hovered_row: Option<MessageId>,
     raw_hover: Option<MessageId>,
+    overlay_hover: Option<MessageId>,
     _hover_show_task: Option<Task<()>>,
     _hover_hide_task: Option<Task<()>>,
     scroll_relief_armed: bool,
@@ -1425,6 +1426,7 @@ impl ChannelMessages {
                     this.context_menu_target = None;
                     this.hovered_row = None;
                     this.raw_hover = None;
+                    this.overlay_hover = None;
                     this._hover_show_task = None;
                     this._hover_hide_task = None;
                     this.edit_input = None;
@@ -1763,11 +1765,13 @@ impl ChannelMessages {
                 }
                 if this.hovered_row.is_some()
                     || this.raw_hover.is_some()
+                    || this.overlay_hover.is_some()
                     || this._hover_show_task.is_some()
                     || this._hover_hide_task.is_some()
                 {
                     this.hovered_row = None;
                     this.raw_hover = None;
+                    this.overlay_hover = None;
                     this._hover_show_task = None;
                     this._hover_hide_task = None;
                 }
@@ -1892,6 +1896,7 @@ impl ChannelMessages {
             _skeleton_timer: None,
             hovered_row: None,
             raw_hover: None,
+            overlay_hover: None,
             _hover_show_task: None,
             _hover_hide_task: None,
             scroll_relief_armed: false,
@@ -2431,6 +2436,7 @@ impl ChannelMessages {
         self._hover_hide_task = None;
         self.hovered_row = None;
         self.raw_hover = None;
+        self.overlay_hover = None;
         self.reaction_submenu_open = false;
         self.context_menu_target = Some((message_id, position));
         cx.notify();
@@ -2439,7 +2445,7 @@ impl ChannelMessages {
     pub(crate) fn close_context_menu(&mut self, cx: &mut Context<Self>) {
         if self.context_menu_target.take().is_some() {
             self.reaction_submenu_open = false;
-            if self.raw_hover.is_none() {
+            if self.hover_target().is_none() {
                 self.hovered_row = None;
             }
             cx.notify();
@@ -2453,6 +2459,10 @@ impl ChannelMessages {
         }
     }
 
+    fn hover_target(&self) -> Option<MessageId> {
+        self.raw_hover.or(self.overlay_hover)
+    }
+
     pub(crate) fn set_row_hover(
         &mut self,
         message_id: MessageId,
@@ -2462,10 +2472,31 @@ impl ChannelMessages {
         if entered {
             self.ensure_topic_create_permissions(cx);
             self.raw_hover = Some(message_id);
+            if self.overlay_hover != Some(message_id) {
+                self.overlay_hover = None;
+            }
         } else if self.raw_hover == Some(message_id) {
             self.raw_hover = None;
         }
-        let raw = self.raw_hover;
+        self.sync_hover_tasks(cx);
+    }
+
+    pub(crate) fn set_overlay_hover(
+        &mut self,
+        message_id: MessageId,
+        entered: bool,
+        cx: &mut Context<Self>,
+    ) {
+        if entered {
+            self.overlay_hover = Some(message_id);
+        } else if self.overlay_hover == Some(message_id) {
+            self.overlay_hover = None;
+        }
+        self.sync_hover_tasks(cx);
+    }
+
+    fn sync_hover_tasks(&mut self, cx: &mut Context<Self>) {
+        let raw = self.hover_target();
 
         match raw {
             Some(target) if self.hovered_row != Some(target) => {
@@ -2474,7 +2505,7 @@ impl ChannelMessages {
                         .timer(Duration::from_millis(HOVER_SHOW_DELAY_MS))
                         .await;
                     let _ = this.update(cx, |this, cx| {
-                        if this.raw_hover == Some(target) && this.hovered_row != Some(target) {
+                        if this.hover_target() == Some(target) && this.hovered_row != Some(target) {
                             this.hovered_row = Some(target);
                             cx.notify();
                         }
@@ -2494,7 +2525,7 @@ impl ChannelMessages {
                         .timer(Duration::from_millis(HOVER_HIDE_DELAY_MS))
                         .await;
                     let _ = this.update(cx, |this, cx| {
-                        if this.raw_hover != Some(shown) && this.hovered_row == Some(shown) {
+                        if this.hover_target() != Some(shown) && this.hovered_row == Some(shown) {
                             this.hovered_row = None;
                             cx.notify();
                         }

--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -1,6 +1,7 @@
 use std::cell::Cell;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Duration;
 
 use gpui::{
     Anchor, AnyElement, App, ClickEvent, Entity, FontWeight, Hsla, MouseButton, ObjectFit, Pixels,
@@ -1567,6 +1568,7 @@ fn add_reaction_button(message_id: MessageId, ctx: &RowCtx) -> AnyElement {
         .into_any_element()
 }
 
+const REACTION_TOOLTIP_DELAY: Duration = Duration::from_millis(200);
 const REACTION_EMOJI_PX: f32 = 16.;
 const REACTION_EMOJI_SOURCE_PX: u32 = 32;
 const RECENT_EMOJI_PX: f32 = 20.;
@@ -1645,7 +1647,8 @@ fn reaction_pill(reaction: &Reaction, message_id: MessageId, ctx: &RowCtx) -> An
                     )
                 })
                 .into()
-            });
+            })
+            .tooltip_show_delay(REACTION_TOOLTIP_DELAY);
     }
     if reacted {
         pill = pill
@@ -1805,11 +1808,21 @@ pub fn render_hover_actions(
         )
     });
 
+    let overlay_host = ctx.video_host.clone();
+    let overlay_id = msg.id;
+
     div()
         .id(SharedString::from(format!(
             "hover-actions-{}",
             msg.row_anchor_id.0
         )))
+        .occlude()
+        .on_hover(move |hovered: &bool, _window, cx| {
+            let entered = *hovered;
+            let _ = overlay_host.update(cx, |this, cx| {
+                this.set_overlay_hover(overlay_id, entered, cx)
+            });
+        })
         .absolute()
         .right(px(24.))
         .top(px(top))

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
@@ -409,7 +409,8 @@ impl ChannelSidebar {
                             .filter(|ch| ch.visible_in_sidebar())
                             .collect();
                         let active_parent_id = active_channel_id.and_then(|id| {
-                            ch_slice
+                            category
+                                .channels
                                 .iter()
                                 .find(|ch| ch.id == id)
                                 .and_then(|ch| ch.parent_id)


### PR DESCRIPTION
## Summary
- **Threads**: handle private thread membership events, sync search results on add, and fix leave flow for private threads.
- **Compose**: per-channel draft persistence improvements in `ComposeStore`.
- **Messages**: extended fetch/handling and channel message list rendering parity.
- **Client**: new transport APIs for thread/channel operations.
- **UI**: mention input text field updates and sidebar tweaks.
- **Native**: dedupe `libc` dep (unix-only target).

## Test plan
- [ ] CI lint/test pass
- [ ] Open a channel with threads — private thread appears when added to membership
- [ ] Leave a private thread — thread row removed from list
- [ ] Switch channels — compose draft restored per channel
- [ ] Message list loads and displays correctly after navigation
