### PR TITLE
fix(linux): auto-detect software GPU and use opaque X11 visual

### DIFF
--- a/crates/vendor/gpui_linux/src/linux/x11/window.rs
+++ b/crates/vendor/gpui_linux/src/linux/x11/window.rs
@@ -440,11 +440,25 @@ impl X11WindowState {
 
         // mezon vendor edit: opt-out from the 32-bit ARGB visual. Mesa's software
         // rasterizer (llvmpipe/lavapipe) presents nothing to an ARGB32 X window —
-        // the window stays pure black while the render loop runs normally — so
-        // running the app under software rendering (containers, VMs, CI) needs the
-        // plain opaque visual. Real GPU drivers are unaffected; this is off unless
-        // GPUI_X11_OPAQUE_VISUAL is set.
-        let visual = if std::env::var_os("GPUI_X11_OPAQUE_VISUAL").is_some() {
+        // the window stays pure black while the render loop runs normally — which
+        // is exactly what remote X11 sessions (xrdp/VNC) and GPU-less VMs get, so
+        // auto-detect software-only rendering and fall back to the plain opaque
+        // visual. Real GPU drivers are unaffected. GPUI_X11_OPAQUE_VISUAL forces
+        // the choice either way (0/empty = transparent, anything else = opaque).
+        let use_opaque = match std::env::var("GPUI_X11_OPAQUE_VISUAL").ok().as_deref() {
+            Some("0") | Some("") => false,
+            Some(_) => true,
+            None => {
+                let software = gpui_wgpu::gpu_is_software(&gpu_context);
+                if software {
+                    eprintln!(
+                        "[x11] software-only rendering detected; using the opaque visual"
+                    );
+                }
+                software
+            }
+        };
+        let visual = if use_opaque {
             visual_set.inherit
         } else {
             match visual_set.transparent {

--- a/crates/vendor/gpui_wgpu/src/gpui_wgpu.rs
+++ b/crates/vendor/gpui_wgpu/src/gpui_wgpu.rs
@@ -7,4 +7,4 @@ pub use cosmic_text_system::*;
 pub use wgpu;
 pub use wgpu_atlas::*;
 pub use wgpu_context::*;
-pub use wgpu_renderer::{GpuContext, WgpuRenderer, WgpuSurfaceConfig};
+pub use wgpu_renderer::{GpuContext, WgpuRenderer, WgpuSurfaceConfig, gpu_is_software};

--- a/crates/vendor/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/vendor/gpui_wgpu/src/wgpu_renderer.rs
@@ -104,6 +104,38 @@ struct WgpuBindGroupLayouts {
 /// Shared GPU context reference, used to coordinate device recovery across multiple windows.
 pub type GpuContext = Rc<RefCell<Option<WgpuContext>>>;
 
+// mezon vendor edit: X11 must know BEFORE creating a window whether rendering
+// will land on a software rasterizer (llvmpipe/lavapipe/SwiftShader) — Mesa's
+// software WSI presents nothing into a 32-bit ARGB visual, so remote X11
+// sessions (xrdp/VNC) and GPU-less VMs need the opaque visual instead.
+// Uses the already-selected adapter when the shared context exists; otherwise
+// enumerates adapters headlessly (no surface required) and caches the result.
+#[cfg(not(target_family = "wasm"))]
+pub fn gpu_is_software(gpu_context: &GpuContext) -> bool {
+    if let Some(context) = gpu_context.borrow().as_ref() {
+        return context.adapter.get_info().device_type == wgpu::DeviceType::Cpu;
+    }
+    static PROBE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *PROBE.get_or_init(|| {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::VULKAN | wgpu::Backends::GL,
+            flags: wgpu::InstanceFlags::default(),
+            backend_options: wgpu::BackendOptions::default(),
+            memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+            display: None,
+        });
+        let adapters = gpui::block_on(instance.enumerate_adapters(wgpu::Backends::all()));
+        let software_only = !adapters.is_empty()
+            && adapters
+                .iter()
+                .all(|adapter| adapter.get_info().device_type == wgpu::DeviceType::Cpu);
+        if software_only {
+            log::info!("GPU probe: only software adapters available");
+        }
+        software_only
+    })
+}
+
 /// GPU resources that must be dropped together during device recovery.
 struct WgpuResources {
     device: Arc<wgpu::Device>,


### PR DESCRIPTION
## Summary
- Auto-detect software-only GPU adapters (llvmpipe/lavapipe/SwiftShader) before X11 window creation and select the opaque visual so remote sessions (xrdp/VNC) and GPU-less VMs are not stuck with a black window.
- Add `gpu_is_software()` in vendored `gpui_wgpu` (adapter probe with headless fallback when no shared context exists yet).
- `GPUI_X11_OPAQUE_VISUAL` still forces the choice: `0`/empty → transparent, any other value → opaque.

## Test plan
- [ ] CI passes
- [ ] Linux with real GPU: window still uses transparent visual (unchanged)
- [ ] Linux xrdp/VNC or software-only VM: window renders content instead of black
- [ ] `GPUI_X11_OPAQUE_VISUAL=1` forces opaque; `GPUI_X11_OPAQUE_VISUAL=0` forces transparent

