### PR TITLE
fix: theme cisher in event list

### DIFF
--- a/crates/mezon-ui/src/chat/clan_events_page.rs
+++ b/crates/mezon-ui/src/chat/clan_events_page.rs
@@ -203,7 +203,7 @@ impl ClanEventsModal {
                             .px_2()
                             .py_1()
                             .rounded_full()
-                            .bg(theme.bg_secondary)
+                            .bg(theme.tokens.bg_secondary)
                             .child(interested.to_string())
                             .child(
                                 Icon::new(IconName::MemberList)

--- a/crates/mezon-ui/src/chat/clan_events_page.rs
+++ b/crates/mezon-ui/src/chat/clan_events_page.rs
@@ -254,7 +254,7 @@ impl ClanEventsModal {
                 .px_4()
                 .py_2()
                 .rounded_lg()
-                .bg(theme.bg_tertiary)
+                .bg(theme.tokens.bg_secondary)
                 .text_color(theme.text_secondary)
                 .child(Icon::new(icon).size_4().text_color(theme.text_secondary))
                 .child(div().text_color(theme.text_secondary).child(label))
@@ -277,7 +277,7 @@ impl ClanEventsModal {
             .rounded_lg()
             .border_1()
             .border_color(theme.border)
-            .bg(theme.bg_floating)
+            .bg(theme.tokens.bg_theme_direct_message)
             .overflow_hidden()
             .child(div().p_4().child(heading).child(details))
             .child(


### PR DESCRIPTION
> `Description:`

**env development:** window
- fix theme cisher in event list
<img width="1065" height="785" alt="image" src="https://github.com/user-attachments/assets/694e1111-8129-4212-b3c9-bbe201b0f760" />

===================================================================================

<img width="1915" height="1013" alt="image" src="https://github.com/user-attachments/assets/10604b8f-dc9d-45b2-a303-18efcac4ca71" />








