### PR TITLE
feat(store,ui): ensure channel detail on route and DM mark-as-read

### DIFF
--- a/crates/mezon-client/src/app_api.rs
+++ b/crates/mezon-client/src/app_api.rs
@@ -226,6 +226,10 @@ impl AppApi {
         self.transport.list_channel_by_user_id().await
     }
 
+    pub async fn list_channel_detail(&self, channel_id: i64) -> Result<ApiChannelDesc> {
+        self.transport.list_channel_detail(channel_id).await
+    }
+
     pub async fn list_dm_channels(&self, page: i32) -> Result<Vec<ApiDirectChannel>> {
         self.transport.list_dm_channel_descs(page).await
     }

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -4696,7 +4696,7 @@ impl MezonTransport {
     }
 
     /// List channel description detail.
-    pub async fn list_channel_detail(&self, channel_id: i64) -> Result<api::ChannelDescription> {
+    pub async fn list_channel_detail(&self, channel_id: i64) -> Result<ApiChannelDesc> {
         let cid = self.generate_cid();
         let body = api::ListChannelDetailRequest { channel_id }.encode_to_vec();
         let (code, response) = self
@@ -4705,7 +4705,8 @@ impl MezonTransport {
         if code != 0 {
             return Err(anyhow::anyhow!("API error: code={}", code));
         }
-        Ok(api::ChannelDescription::decode(response.as_slice())?)
+        let channel = api::ChannelDescription::decode(response.as_slice())?;
+        Ok(Self::channel_desc_from_proto(channel))
     }
 
     /// List thread descriptions for a parent channel.

--- a/crates/mezon-client/src/transport_runtime.rs
+++ b/crates/mezon-client/src/transport_runtime.rs
@@ -497,6 +497,18 @@ impl TransportClient {
             .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
     }
 
+    pub async fn list_channel_detail(
+        &self,
+        channel_id: i64,
+    ) -> Result<crate::transport::ApiChannelDesc> {
+        let transport = self.inner.clone();
+
+        runtime()
+            .spawn(async move { transport.list_channel_detail(channel_id).await })
+            .await
+            .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
+    }
+
     pub async fn list_archived_channel_descs(
         &self,
         clan_id: i64,

--- a/crates/mezon-store/src/badge.rs
+++ b/crates/mezon-store/src/badge.rs
@@ -353,21 +353,21 @@ impl BadgeService {
                     DirectMessageStore::global(cx).update(cx, |dm, cx| {
                         dm.note_read(channel_id, cx);
                     });
-                } else if e.category_id == 0 {
-                    ChannelList::global(cx).update(cx, |cl, cx| {
-                        cl.apply_mark_as_read_clan(clan_id, cx);
-                    });
-                    ClanList::global(cx).update(cx, |cls, cx| cls.apply_badge_read(clan_id, cx));
-                } else if e.channel_id == 0 {
-                    ChannelList::global(cx).update(cx, |cl, cx| {
-                        cl.apply_mark_as_read_category(clan_id, e.category_id, cx);
-                    });
-                } else {
+                } else if e.channel_id != 0 {
                     let channel_id = ChannelId(e.channel_id);
                     ChannelList::global(cx).update(cx, |cl, cx| {
                         cl.apply_read(clan_id, channel_id, cx);
                         cl.apply_topic_read(channel_id, cx);
                     });
+                } else if e.category_id != 0 {
+                    ChannelList::global(cx).update(cx, |cl, cx| {
+                        cl.apply_mark_as_read_category(clan_id, e.category_id, cx);
+                    });
+                } else {
+                    ChannelList::global(cx).update(cx, |cl, cx| {
+                        cl.apply_mark_as_read_clan(clan_id, cx);
+                    });
+                    ClanList::global(cx).update(cx, |cls, cx| cls.apply_badge_read(clan_id, cx));
                 }
             }
             RealtimeEvent::LastSeenUpdated(e) => {

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -28,6 +28,8 @@ const CATEGORY_EVENT_UPDATED: i32 = 2;
 const PREVIOUS_CHANNELS_PERSIST_DEBOUNCE: Duration = Duration::from_millis(500);
 const BADGE_SEED_MAX_ATTEMPTS: u32 = 3;
 const BADGE_SEED_RETRY_BACKOFF: Duration = Duration::from_millis(400);
+const CHANNEL_DETAIL_MAX_ATTEMPTS: u32 = 3;
+const CHANNEL_DETAIL_RETRY_BACKOFF: Duration = Duration::from_secs(1);
 const THREAD_ARCHIVE_DURATION_SECONDS: i64 = 7 * 24 * 60 * 60;
 const ADDED_THREAD_UNREAD_WINDOW_SECONDS: i64 = 1000;
 
@@ -293,6 +295,8 @@ pub struct ChannelList {
     channel_index: RefCell<ChannelLocationCache>,
     reset_generation: u64,
     reactivating: HashSet<ChannelId>,
+    channel_detail_pending: HashSet<ChannelId>,
+    channel_detail_failed: HashSet<ChannelId>,
     _previous_channels_persist: Task<()>,
     _clan_sub: Subscription,
     _conn_watch: Task<()>,
@@ -442,6 +446,8 @@ impl ChannelList {
         self.persist_previous_channels(cx);
         self.invalidate_channel_index_all();
         self.reactivating.clear();
+        self.channel_detail_pending.clear();
+        self.channel_detail_failed.clear();
         self.active_clan_id = None;
         if self.active_channel_id.take().is_some() {
             cx.emit(ChannelEvent::ActiveChannelChanged(None));
@@ -523,6 +529,8 @@ impl ChannelList {
             channel_index: RefCell::new(ChannelLocationCache::default()),
             reset_generation: 0,
             reactivating: HashSet::new(),
+            channel_detail_pending: HashSet::new(),
+            channel_detail_failed: HashSet::new(),
             _previous_channels_persist: Task::ready(()),
             _clan_sub: clan_sub,
             _conn_watch: conn_watch,
@@ -818,6 +826,7 @@ impl ChannelList {
         }
         self.cache.insert(clan_id, categories, None);
         self.invalidate_channel_index(clan_id);
+        self.channel_detail_failed.clear();
         cx.emit(ChannelEvent::ClanChannelsLoaded(clan_id));
         cx.notify();
         if self.want_extras.contains(&clan_id) {
@@ -911,6 +920,86 @@ impl ChannelList {
     pub fn ensure_user_channels_loaded(&mut self, cx: &mut Context<Self>) {
         if !self.user_channels_loaded && !self.user_channels_loading {
             self.fetch_user_channels(cx);
+        }
+    }
+
+    /// Mirrors mezon-react's `addThreadToChannels` (channelLoader): when a route targets a
+    /// channel/thread absent from the clan structure, fetch its detail and insert it. Returns
+    /// `true` while the channel is present or still being resolved (caller should wait), and
+    /// `false` once the fetch has definitively failed (caller may fall back).
+    pub fn ensure_channel_in_clan(
+        &mut self,
+        clan_id: ClanId,
+        channel_id: ChannelId,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.channel_in_clan(clan_id, channel_id) {
+            return true;
+        }
+        if !self.cache.contains(&clan_id) {
+            return true;
+        }
+        if self.channel_detail_failed.remove(&channel_id) {
+            return false;
+        }
+        if !self.channel_detail_pending.insert(channel_id) {
+            return true;
+        }
+        let api = self.api.clone();
+        let generation = self.reset_generation;
+        cx.spawn(async move |this, cx| {
+            let mut attempt = 0u32;
+            let desc = loop {
+                match api.list_channel_detail(channel_id.get()).await {
+                    Ok(desc) => break Some(desc),
+                    Err(e) => {
+                        attempt += 1;
+                        if attempt >= CHANNEL_DETAIL_MAX_ATTEMPTS {
+                            tracing::warn!(
+                                "list_channel_detail failed for {channel_id} after {attempt} attempts: {e}"
+                            );
+                            break None;
+                        }
+                        cx.background_executor()
+                            .timer(CHANNEL_DETAIL_RETRY_BACKOFF * attempt)
+                            .await;
+                    }
+                }
+            };
+            let _ = this.update(cx, |this, cx| {
+                this.channel_detail_pending.remove(&channel_id);
+                if this.reset_generation != generation {
+                    return;
+                }
+                match desc {
+                    Some(desc) => this.apply_channel_detail(clan_id, desc, cx),
+                    None => {
+                        this.channel_detail_failed.insert(channel_id);
+                        cx.notify();
+                    }
+                }
+            });
+        })
+        .detach();
+        true
+    }
+
+    fn apply_channel_detail(
+        &mut self,
+        clan_id: ClanId,
+        desc: ApiChannelDesc,
+        cx: &mut Context<Self>,
+    ) {
+        let badge = desc.badge_count.max(0) as u32;
+        let mut channel = channel_from_desc(desc, badge, Vec::new(), false);
+        channel.clan_id = clan_id;
+        let Some(categories) = self.cache.get_mut(&clan_id) else {
+            return;
+        };
+        if insert_channel(categories, channel) {
+            self.invalidate_channel_index(clan_id);
+            cx.emit(ChannelEvent::ClanChannelsLoaded(clan_id));
+            cx.notify();
         }
     }
 
@@ -1463,6 +1552,57 @@ impl ChannelList {
             if let Err(e) = api.mark_as_read(0, 0, id).await {
                 tracing::error!("mark clan as read failed for clan {id}: {e}");
             }
+        })
+        .detach();
+    }
+
+    fn apply_channel_read_with_threads(
+        &mut self,
+        clan_id: ClanId,
+        channel_id: ChannelId,
+        cx: &mut Context<Self>,
+    ) {
+        let thread_ids = self
+            .cache
+            .get(&clan_id)
+            .map(|categories| thread_ids_of(categories, channel_id))
+            .unwrap_or_default();
+        self.apply_read(clan_id, channel_id, cx);
+        for thread_id in thread_ids {
+            self.apply_read(clan_id, thread_id, cx);
+        }
+    }
+
+    pub fn mark_channel_as_read(
+        &mut self,
+        clan_id: ClanId,
+        channel_id: ChannelId,
+        cx: &mut Context<Self>,
+    ) {
+        if channel_id.is_zero() {
+            return;
+        }
+        let category_id = self
+            .cache
+            .get(&clan_id)
+            .map(|categories| mark_as_read_category_id(categories, channel_id))
+            .unwrap_or(0);
+        let api = self.api.clone();
+        let generation = self.reset_generation;
+        cx.spawn(async move |this, cx| {
+            if let Err(e) = api
+                .mark_as_read(channel_id.get(), category_id, clan_id.get())
+                .await
+            {
+                tracing::error!("mark channel as read failed for channel {channel_id}: {e}");
+                return;
+            }
+            let _ = this.update(cx, |this, cx| {
+                if this.reset_generation != generation {
+                    return;
+                }
+                this.apply_channel_read_with_threads(clan_id, channel_id, cx);
+            });
         })
         .detach();
     }
@@ -3431,6 +3571,47 @@ fn record_topic_parent_badge(
     entry.count = entry.count.saturating_add(1);
 }
 
+fn find_channel_in(categories: &[Category], channel_id: ChannelId) -> Option<&Channel> {
+    categories
+        .iter()
+        .flat_map(|category| category.channels.iter())
+        .find(|channel| channel.id == channel_id)
+}
+
+fn numeric_category_id(channel: &Channel) -> Option<i64> {
+    channel
+        .category_id
+        .as_deref()
+        .and_then(|id| id.parse::<i64>().ok())
+        .filter(|id| *id != 0)
+}
+
+fn mark_as_read_category_id(categories: &[Category], channel_id: ChannelId) -> i64 {
+    let Some(channel) = find_channel_in(categories, channel_id) else {
+        return 0;
+    };
+    numeric_category_id(channel)
+        .or_else(|| {
+            channel
+                .parent_id
+                .and_then(|parent_id| find_channel_in(categories, parent_id))
+                .and_then(numeric_category_id)
+        })
+        .unwrap_or(0)
+}
+
+fn thread_ids_of(categories: &[Category], parent_id: ChannelId) -> Vec<ChannelId> {
+    let mut ids: Vec<ChannelId> = categories
+        .iter()
+        .flat_map(|category| category.channels.iter())
+        .filter(|channel| channel.parent_id == Some(parent_id))
+        .map(|channel| channel.id)
+        .collect();
+    ids.sort_unstable();
+    ids.dedup();
+    ids
+}
+
 fn clear_topic_badges_for_parent(
     topic_badges: &mut HashMap<ChannelId, TopicParentBadge>,
     parent_id: ChannelId,
@@ -3714,6 +3895,77 @@ mod tests {
         assert_eq!(index.get(&ChannelId(999)), None);
     }
 
+    fn category(id: &str, channels: Vec<Channel>) -> Category {
+        Category {
+            id: id.into(),
+            clan_id: ClanId(1),
+            name: "General".into(),
+            order: 0,
+            channels,
+        }
+    }
+
+    fn favorites_category(channels: Vec<Channel>) -> Category {
+        let mut cat = category(FAVOR_CATE_ID, channels);
+        cat.name = "favoriteChannel".into();
+        cat.order = i32::MIN;
+        cat
+    }
+
+    #[test]
+    fn mark_as_read_category_id_resolves_through_the_favorites_copy() {
+        let mut favorited = make_channel(10, "alpha", "77");
+        favorited.is_favorite = true;
+        let cats = assemble_with_favorites(vec![category("77", vec![favorited])], ClanId(1));
+        assert_eq!(cats[0].id, FAVOR_CATE_ID);
+        assert_eq!(mark_as_read_category_id(&cats, ChannelId(10)), 77);
+    }
+
+    #[test]
+    fn mark_as_read_category_id_falls_back_to_the_parent_channel() {
+        let mut thread = make_thread(500, 10, "77");
+        thread.category_id = None;
+        let cats = vec![category(
+            "77",
+            vec![make_channel(10, "alpha", "77"), thread],
+        )];
+        assert_eq!(mark_as_read_category_id(&cats, ChannelId(500)), 77);
+    }
+
+    #[test]
+    fn mark_as_read_category_id_is_zero_when_unresolvable() {
+        let cats = categories();
+        assert_eq!(mark_as_read_category_id(&cats, ChannelId(999)), 0);
+        assert_eq!(mark_as_read_category_id(&cats, ChannelId(10)), 0);
+    }
+
+    #[test]
+    fn mark_as_read_of_a_zero_channel_would_request_a_clan_wide_read() {
+        let cats = vec![category("77", vec![make_channel(10, "alpha", "77")])];
+        assert_eq!(mark_as_read_category_id(&cats, ChannelId(0)), 0);
+    }
+
+    #[test]
+    fn thread_ids_of_collects_each_child_once() {
+        let cats = vec![
+            category(
+                "77",
+                vec![
+                    make_channel(10, "alpha", "77"),
+                    make_thread(501, 10, "77"),
+                    make_thread(500, 10, "77"),
+                    make_thread(600, 11, "77"),
+                ],
+            ),
+            favorites_category(vec![make_thread(500, 10, "77")]),
+        ];
+        assert_eq!(
+            thread_ids_of(&cats, ChannelId(10)),
+            vec![ChannelId(500), ChannelId(501)]
+        );
+        assert!(thread_ids_of(&cats, ChannelId(999)).is_empty());
+    }
+
     #[test]
     fn clan_channel_index_lookup_matches_linear_scan() {
         let cats = categories();
@@ -3768,6 +4020,49 @@ mod tests {
             .find(|c| c.id == ChannelId(500))
             .unwrap();
         assert_eq!(inserted.channel_type, ChannelType::Thread);
+        assert_eq!(inserted.parent_id, Some(ChannelId(10)));
+    }
+
+    #[test]
+    fn channel_detail_desc_inserts_thread_under_parent() {
+        let mut cats = categories();
+        let desc = ApiChannelDesc {
+            channel_id: 500,
+            channel_label: "my-thread".into(),
+            channel_type: 7,
+            clan_id: 0,
+            category_name: String::new(),
+            category_id: 0,
+            channel_private: 0,
+            count_mess_unread: 0,
+            member_count: 0,
+            parent_id: 10,
+            is_mute: false,
+            last_seen_message_id: 0,
+            last_seen_timestamp: 0,
+            last_sent_message_id: 0,
+            last_sent_timestamp: 0,
+            badge_count: 2,
+            active: CHANNEL_ACTIVE_JOINED,
+            creator_id: 0,
+            clan_name: String::new(),
+            channel_avatar: String::new(),
+        };
+        let badge = desc.badge_count.max(0) as u32;
+        let mut channel = channel_from_desc(desc, badge, Vec::new(), false);
+        channel.clan_id = ClanId(1);
+        assert!(insert_channel(&mut cats, channel));
+        let ids: Vec<ChannelId> = cats[0].channels.iter().map(|c| c.id).collect();
+        let parent_pos = ids.iter().position(|id| *id == ChannelId(10)).unwrap();
+        assert_eq!(ids[parent_pos + 1], ChannelId(500));
+        let inserted = cats
+            .iter()
+            .flat_map(|c| &c.channels)
+            .find(|c| c.id == ChannelId(500))
+            .unwrap();
+        assert_eq!(inserted.channel_type, ChannelType::Thread);
+        assert_eq!(inserted.clan_id, ClanId(1));
+        assert_eq!(inserted.badge_count, 2);
         assert_eq!(inserted.parent_id, Some(ChannelId(10)));
     }
 

--- a/crates/mezon-store/src/direct.rs
+++ b/crates/mezon-store/src/direct.rs
@@ -792,6 +792,21 @@ impl DirectMessageStore {
         true
     }
 
+    pub fn mark_as_read(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
+        if channel_id.is_zero() {
+            return;
+        }
+        self.note_read(channel_id, cx);
+        let api = self.api.clone();
+        let id = channel_id.get();
+        cx.spawn(async move |_, _| {
+            if let Err(e) = api.mark_as_read(id, 0, 0).await {
+                tracing::error!("mark dm as read failed for channel {id}: {e}");
+            }
+        })
+        .detach();
+    }
+
     fn schedule_changed_notify(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
         if !self.pending_changed.contains(&channel_id) {
             self.pending_changed.push(channel_id);

--- a/crates/mezon-ui/src/chat/area.rs
+++ b/crates/mezon-ui/src/chat/area.rs
@@ -21,7 +21,7 @@ use crate::chat::input_bar::{InputBar, ReplyClearSource};
 use crate::chat::media_channel::MediaChannelPanel;
 use crate::chat::member_list::{MemberListPanel, MemberSource};
 use crate::chat::mention_input::{MentionInput, MentionInputEvent};
-use crate::chat::message::ChannelMessages;
+use crate::chat::message::{ChannelMessages, ChannelMessagesEvent};
 use crate::chat::message_search::{MESSAGE_SEARCH_PANEL_WIDTH, MessageSearchPanel};
 use crate::chat::pinned_popover::PinnedPopoverPanel;
 use crate::components::compositions::channel_row::ChannelIcon;
@@ -48,6 +48,7 @@ pub struct ChatArea {
     no_permission_label: Option<(SharedString, SharedString)>,
     _submit_sub: Option<Subscription>,
     _reply_sub: Option<Subscription>,
+    _edit_closed_sub: Option<Subscription>,
     _send_permission_sub: Subscription,
     _send_permission_channel_sub: Subscription,
     _send_permission_debounce: Option<Task<()>>,
@@ -100,6 +101,7 @@ impl ChatArea {
             no_permission_label: None,
             _submit_sub: None,
             _reply_sub: None,
+            _edit_closed_sub: None,
             _send_permission_sub: send_permission_sub,
             _send_permission_channel_sub: send_permission_channel_sub,
             _send_permission_debounce: None,
@@ -216,6 +218,12 @@ impl ChatArea {
                     MentionInputEvent::SendSound { url, filename } => {
                         this.send_sound(url.clone(), filename.clone(), cx)
                     }
+                    MentionInputEvent::EditLastMessage => {
+                        let timeline = this.chat_area.timeline.clone();
+                        timeline.update(cx, |timeline, cx| {
+                            timeline.edit_last_own_message(window, cx)
+                        });
+                    }
                 },
             );
             self._submit_sub = Some(submit_sub);
@@ -256,6 +264,23 @@ impl ChatArea {
                 },
             );
             self._reply_sub = Some(reply_sub);
+
+            let edit_closed_sub = cx.subscribe_in(
+                &self.timeline,
+                window,
+                |this: &mut crate::ChatLayout, _, event: &ChannelMessagesEvent, window, cx| {
+                    let ChannelMessagesEvent::EditClosed = event;
+                    if this.chat_area.can_send_message == Some(false) {
+                        return;
+                    }
+                    if let Some(input) = this.chat_area.mention_input.clone() {
+                        window.defer(cx, move |window, cx| {
+                            input.update(cx, |input, cx| input.focus_input(window, cx));
+                        });
+                    }
+                },
+            );
+            self._edit_closed_sub = Some(edit_closed_sub);
         }
     }
 

--- a/crates/mezon-ui/src/chat/create_topic_panel.rs
+++ b/crates/mezon-ui/src/chat/create_topic_panel.rs
@@ -9,7 +9,7 @@ use crate::chat::ReplyTarget;
 use crate::chat::channel_typing::ChannelTyping;
 use crate::chat::input_bar::{InputBar, ReplyClearSource};
 use crate::chat::mention_input::{MentionInput, MentionInputEvent};
-use crate::chat::message::ChannelMessages;
+use crate::chat::message::{ChannelMessages, ChannelMessagesEvent};
 use crate::components::primitives::{Icon, IconName, h_flex, v_flex};
 use crate::theme::ActiveTheme;
 
@@ -92,6 +92,23 @@ impl TopicPanel {
                 MentionInputEvent::Cancel => {
                     TopicsStore::global(cx).update(cx, |store, cx| store.close_panel(cx));
                 }
+                MentionInputEvent::EditLastMessage => {
+                    let timeline = this.topic_timeline.clone();
+                    timeline.update(cx, |timeline, cx| {
+                        timeline.edit_last_own_message(window, cx)
+                    });
+                }
+            },
+        ));
+        subs.push(cx.subscribe_in(
+            &topic_timeline,
+            window,
+            |this, _, event: &ChannelMessagesEvent, window, cx| {
+                let ChannelMessagesEvent::EditClosed = event;
+                let input = this.mention_input.clone();
+                window.defer(cx, move |window, cx| {
+                    input.update(cx, |input, cx| input.focus_input(window, cx));
+                });
             },
         ));
 

--- a/crates/mezon-ui/src/chat/layout.rs
+++ b/crates/mezon-ui/src/chat/layout.rs
@@ -1107,11 +1107,19 @@ impl ChatLayout {
         else {
             return;
         };
-        let channel_list = self.channel_list.read(cx);
-        if !channel_list.is_clan_cache_loaded(clan_id) {
-            return;
+        {
+            let channel_list = self.channel_list.read(cx);
+            if !channel_list.is_clan_cache_loaded(clan_id) {
+                return;
+            }
+            if channel_list.channel_in_clan(clan_id, thread_id) {
+                return;
+            }
         }
-        if channel_list.channel_in_clan(clan_id, thread_id) {
+        let resolving = self.channel_list.update(cx, |store, cx| {
+            store.ensure_channel_in_clan(clan_id, thread_id, cx)
+        });
+        if resolving {
             return;
         }
         crate::router::replace(
@@ -1139,12 +1147,20 @@ impl ChatLayout {
             channel_id,
         } = Router::global(cx).read(cx).route()
             && route_clan == clan_id
-            && self
+        {
+            if self
                 .channel_list
                 .read(cx)
                 .channel_in_clan(clan_id, channel_id)
-        {
-            return;
+            {
+                return;
+            }
+            let resolving = self.channel_list.update(cx, |store, cx| {
+                store.ensure_channel_in_clan(clan_id, channel_id, cx)
+            });
+            if resolving {
+                return;
+            }
         }
 
         let welcome = self.clan_list.read(cx).welcome_channel_id(clan_id);

--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -367,6 +367,7 @@ pub enum MentionInputEvent {
         url: String,
         filename: String,
     },
+    EditLastMessage,
 }
 
 pub struct MentionInput {
@@ -2036,10 +2037,14 @@ impl MentionInput {
             self.suggestion_scroll
                 .scroll_to_item(self.selected, ScrollStrategy::Nearest);
             cx.notify();
-        } else {
-            self.input
-                .update(cx, |input, cx| input.move_caret_line(-1, cx));
+            return;
         }
+        if self.input.read(cx).value().is_empty() {
+            cx.emit(MentionInputEvent::EditLastMessage);
+            return;
+        }
+        self.input
+            .update(cx, |input, cx| input.move_caret_line(-1, cx));
     }
 
     fn on_nav_down(&mut self, cx: &mut Context<Self>) {

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -6,11 +6,11 @@ use std::time::{Duration, Instant};
 
 use gpui::{
     Anchor, Animation, AnimationExt as _, AnyElement, App, ClipboardItem, Context, DismissEvent,
-    DispatchPhase, Element, ElementId, Entity, FocusHandle, Focusable, GlobalElementId, Hitbox,
-    HitboxBehavior, InspectorElementId, KeyDownEvent, LayoutId, ListAlignment, ListState,
-    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, SharedString,
-    Subscription, Task, TextLayout, WeakEntity, Window, anchored, deferred, div, ease_in_out, list,
-    prelude::*, px,
+    DispatchPhase, Element, ElementId, Entity, EventEmitter, FocusHandle, Focusable,
+    GlobalElementId, Hitbox, HitboxBehavior, InspectorElementId, KeyDownEvent, LayoutId,
+    ListAlignment, ListState, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels,
+    Point, SharedString, Subscription, Task, TextLayout, WeakEntity, Window, anchored, deferred,
+    div, ease_in_out, list, prelude::*, px,
 };
 use ui::{ScrollAxes, Scrollbars, WithScrollbar};
 
@@ -1173,6 +1173,11 @@ mod scroll_idle_tests {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ChannelMessagesEvent {
+    EditClosed,
+}
+
 pub struct ChannelMessages {
     pub(crate) list_state: ListState,
     focus_handle: FocusHandle,
@@ -2306,6 +2311,45 @@ impl ChannelMessages {
         cx.notify();
     }
 
+    fn last_editable_own_message(&self, cx: &App) -> Option<(MessageId, usize)> {
+        let me = self.cached_current_user_id.as_ref();
+        if me.is_empty() {
+            return None;
+        }
+        let last_editable = |messages: &[Message]| {
+            messages
+                .iter()
+                .enumerate()
+                .rev()
+                .find(|(_, m)| message_context_menu::message_is_editable(m, me))
+                .map(|(pos, m)| (m.id, pos))
+        };
+        if self.is_topic_box {
+            last_editable(&self.topic_messages)
+        } else {
+            last_editable(MessagesStore::global(cx).read(cx).viewport_messages())
+        }
+    }
+
+    fn row_is_offscreen(&self, pos: usize) -> bool {
+        let ix = usize::from(self.header_shown) + pos;
+        self.list_state.item_is_above_viewport(ix) == Some(true)
+            || self.list_state.item_is_below_viewport(ix) == Some(true)
+    }
+
+    pub(crate) fn edit_last_own_message(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.edit_input.is_some() {
+            return;
+        }
+        let Some((message_id, pos)) = self.last_editable_own_message(cx) else {
+            return;
+        };
+        if !self.is_topic_box && self.row_is_offscreen(pos) {
+            self.pending_jump = Some(message_id);
+        }
+        self.begin_edit(message_id, window, cx);
+    }
+
     /// Enter inline-edit mode for a message (Discord-style: in the row, not the composer).
     pub(crate) fn begin_edit(
         &mut self,
@@ -2352,7 +2396,8 @@ impl ChannelMessages {
                 MentionInputEvent::Cancel => this.cancel_edit(cx),
                 MentionInputEvent::SendSticker { .. }
                 | MentionInputEvent::SendGif { .. }
-                | MentionInputEvent::SendSound { .. } => {}
+                | MentionInputEvent::SendSound { .. }
+                | MentionInputEvent::EditLastMessage => {}
             },
         ));
         self.edit_input = Some((message_id, input));
@@ -2364,6 +2409,7 @@ impl ChannelMessages {
         self.edit_input = None;
         self._edit_input_sub = None;
         MessagesStore::global(cx).update(cx, |store, cx| store.cancel_edit(cx));
+        cx.emit(ChannelMessagesEvent::EditClosed);
         cx.notify();
     }
 
@@ -2391,6 +2437,7 @@ impl ChannelMessages {
 
         if original.as_deref() == Some(text.as_str()) {
             store.update(cx, |store, cx| store.cancel_edit(cx));
+            cx.emit(ChannelMessagesEvent::EditClosed);
             cx.notify();
             return;
         }
@@ -2398,6 +2445,7 @@ impl ChannelMessages {
         store.update(cx, |store, cx| {
             store.edit_message(message_id, text, content_tokens, cx)
         });
+        cx.emit(ChannelMessagesEvent::EditClosed);
         cx.notify();
     }
 
@@ -4276,6 +4324,8 @@ impl ChannelMessages {
             .into_any_element()
     }
 }
+
+impl EventEmitter<ChannelMessagesEvent> for ChannelMessages {}
 
 impl Render for ChannelMessages {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {

--- a/crates/mezon-ui/src/chat/message/message_context_menu.rs
+++ b/crates/mezon-ui/src/chat/message/message_context_menu.rs
@@ -156,6 +156,29 @@ fn active_group_dm_owner(cx: &App) -> (bool, bool) {
     (true, me.is_some() && direct.creator_id == me)
 }
 
+pub(crate) fn edit_message_allowed(
+    is_my_message: bool,
+    code: MessageCode,
+    is_forwarded: bool,
+    send_failed: bool,
+) -> bool {
+    is_my_message
+        && !send_failed
+        && !is_forwarded
+        && code != MessageCode::SendToken
+        && code != MessageCode::Poll
+        && code.is_user_timeline()
+}
+
+pub(crate) fn message_is_editable(msg: &Message, current_user_id: &str) -> bool {
+    edit_message_allowed(
+        current_user_id == msg.sender_id.as_str(),
+        msg.code,
+        msg.is_forwarded,
+        msg.send_failed,
+    )
+}
+
 fn can_delete_message(msg: &Message, current_user_id: &str, is_topic_box: bool, cx: &App) -> bool {
     if is_topic_box {
         if is_first_topic_message(msg.id, cx) {
@@ -381,11 +404,7 @@ fn build_topic_menu(
         );
     }
 
-    let show_edit = is_own_message
-        && msg.code != MessageCode::SendToken
-        && msg.code.is_user_timeline()
-        && !is_poll
-        && !msg.is_forwarded;
+    let show_edit = message_is_editable(msg, current_user_id);
     if show_edit {
         let host = host.clone();
         let message_id = msg.id;
@@ -566,11 +585,7 @@ fn build_channel_menu(
         );
     }
 
-    let show_edit = is_own_message
-        && msg.code != MessageCode::SendToken
-        && msg.code.is_user_timeline()
-        && !is_poll
-        && !msg.is_forwarded;
+    let show_edit = message_is_editable(msg, current_user_id);
     if show_edit {
         let host = host.clone();
         let message_id = msg.id;
@@ -856,5 +871,45 @@ mod delete_permission_tests {
     #[test]
     fn clan_owner_has_no_bypass() {
         assert!(!delete_message_allowed(false, false, true, true, false));
+    }
+}
+
+#[cfg(test)]
+mod edit_permission_tests {
+    use super::edit_message_allowed;
+    use mezon_store::MessageCode;
+
+    #[test]
+    fn edit_allowed_only_for_own_plain_message() {
+        assert!(edit_message_allowed(true, MessageCode::Chat, false, false));
+        assert!(!edit_message_allowed(
+            false,
+            MessageCode::Chat,
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn edit_rejects_message_kinds_without_editable_content() {
+        for code in [
+            MessageCode::SendToken,
+            MessageCode::Poll,
+            MessageCode::Welcome,
+            MessageCode::AuditLog,
+            MessageCode::CreateThread,
+            MessageCode::Indicator,
+        ] {
+            assert!(
+                !edit_message_allowed(true, code, false, false),
+                "{code:?} must not be editable"
+            );
+        }
+    }
+
+    #[test]
+    fn edit_rejects_forwarded_and_unsent_messages() {
+        assert!(!edit_message_allowed(true, MessageCode::Chat, true, false));
+        assert!(!edit_message_allowed(true, MessageCode::Chat, false, true));
     }
 }

--- a/crates/mezon-ui/src/chat/message/mod.rs
+++ b/crates/mezon-ui/src/chat/message/mod.rs
@@ -37,7 +37,7 @@ mod transaction_history_modal;
 mod user_row;
 mod video_player;
 
-pub use channel_messages::ChannelMessages;
+pub use channel_messages::{ChannelMessages, ChannelMessagesEvent};
 pub(crate) use content::open_message_link;
 pub(crate) use content::{heading_line_height, heading_size};
 pub(crate) use content::{

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/menu.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/menu.rs
@@ -111,6 +111,7 @@ pub(super) struct OpenMenu {
     pub(super) position: Point<Pixels>,
     pub(super) channel_id: ChannelId,
     pub(super) clan_id: ClanId,
+    pub(super) in_favorites: bool,
     pub(super) mute_sub_open: bool,
     pub(super) noti_sub_open: bool,
 }
@@ -128,6 +129,17 @@ fn coming_soon_modal(title: String, locale: String) -> impl Fn(&mut Window, &mut
         let locale = locale.clone();
         Shell::global(cx).update(cx, |shell, cx| {
             shell.show_coming_soon(title, &locale, window, cx);
+        });
+    }
+}
+
+fn mark_channel_read(
+    clan_id: ClanId,
+    channel_id: ChannelId,
+) -> impl Fn(&mut Window, &mut App) + 'static {
+    move |_window: &mut Window, cx: &mut App| {
+        ChannelList::global(cx).update(cx, |channels, cx| {
+            channels.mark_channel_as_read(clan_id, channel_id, cx);
         });
     }
 }
@@ -363,6 +375,7 @@ pub(super) fn build_channel_menu(
     mute_sub_open: bool,
     noti_sub_open: bool,
     clan_default: Option<i32>,
+    in_favorites: bool,
     permissions: ChannelMenuPermissions,
 ) -> ContextMenu {
     let t = |key: &'static str| mezon_i18n::t(locale, key).to_string();
@@ -380,12 +393,16 @@ pub(super) fn build_channel_menu(
         }
     });
 
+    if !in_favorites {
+        menu = menu
+            .item(
+                t("channelMenu.menu.watchMenu.markAsRead"),
+                mark_channel_read(clan_id, channel_id),
+            )
+            .separator();
+    }
+
     menu = menu
-        .item(
-            t("channelMenu.menu.watchMenu.markAsRead"),
-            coming_soon_toast(coming_soon.clone()),
-        )
-        .separator()
         .item(
             t("channelMenu.menu.inviteMenu.copyLink"),
             coming_soon_toast(coming_soon.clone()),

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
@@ -732,6 +732,7 @@ impl Render for ChannelSidebar {
                 menu.noti_sub_open,
                 mezon_store::NotificationSettingStore::try_global(cx)
                     .and_then(|store| store.read(cx).clan_default(menu.clan_id)),
+                menu.in_favorites,
                 ChannelMenuPermissions::resolve(menu.clan_id, menu.channel_id, cx),
             )
         });
@@ -1023,6 +1024,7 @@ impl Render for ChannelSidebar {
                     mute_sub_open,
                     noti_sub_open,
                     clan_default,
+                    in_favorites,
                     channel_permissions,
                 )| {
                     el.child(context_menu_at(
@@ -1040,6 +1042,7 @@ impl Render for ChannelSidebar {
                             mute_sub_open,
                             noti_sub_open,
                             clan_default,
+                            in_favorites,
                             channel_permissions,
                         ),
                     ))
@@ -1769,7 +1772,7 @@ fn render_sidebar_item(
                 let click_clan = clan_id_inner;
                 let menu_sidebar = sidebar.clone();
                 let reveal_sidebar = sidebar.clone();
-                let reveal_favorite = *is_favorite;
+                let in_favorites = *is_favorite;
                 let menu_channel_type = *channel_type;
                 let menu_is_thread = *is_thread;
                 return element
@@ -1786,7 +1789,7 @@ fn render_sidebar_item(
                                 },
                             );
                         }
-                        if reveal_favorite {
+                        if in_favorites {
                             let _ = reveal_sidebar.update(cx, |this, cx| {
                                 this.reveal_original_channel(&click_id, cx);
                             });
@@ -1801,6 +1804,7 @@ fn render_sidebar_item(
                                     position,
                                     channel_id: menu_channel_id,
                                     clan_id: menu_clan_id,
+                                    in_favorites,
                                     mute_sub_open: false,
                                     noti_sub_open: false,
                                 });
@@ -1918,6 +1922,7 @@ fn render_sidebar_item(
             let mut channel_col = channel_col.on_mouse_down(MouseButton::Right, {
                 let channel_type = *channel_type;
                 let is_thread = *is_thread;
+                let in_favorites = *is_favorite;
                 move |event: &MouseDownEvent, _window, cx| {
                     let position = event.position;
                     if let Some(view) = sidebar.upgrade() {
@@ -1928,6 +1933,7 @@ fn render_sidebar_item(
                                 position,
                                 channel_id: menu_channel_id,
                                 clan_id: menu_clan_id,
+                                in_favorites,
                                 mute_sub_open: false,
                                 noti_sub_open: false,
                             });

--- a/crates/mezon-ui/src/sidebar/direct_sidebar.rs
+++ b/crates/mezon-ui/src/sidebar/direct_sidebar.rs
@@ -144,7 +144,6 @@ fn build_dm_menu(
     mute_sub_open: bool,
 ) -> ContextMenu {
     let t = |key: &'static str| mezon_i18n::t(locale, key).to_string();
-    let coming_soon = t("common.comingSoon");
     let sidebar_dismiss = sidebar.clone();
     let mut menu = ContextMenu::new()
         .on_dismiss(move |_window, cx| {
@@ -153,14 +152,14 @@ fn build_dm_menu(
                 cx.notify();
             });
         })
-        .item(t("channelMenu.menu.watchMenu.markAsRead"), {
-            let message = coming_soon.clone();
+        .item(
+            t("channelMenu.menu.watchMenu.markAsRead"),
             move |_window: &mut Window, cx: &mut App| {
-                let message = message.clone();
-                crate::app::shell::Shell::global(cx)
-                    .update(cx, move |shell, cx| shell.info(message, cx));
-            }
-        })
+                DirectMessageStore::global(cx).update(cx, |store, cx| {
+                    store.mark_as_read(channel_id, cx);
+                });
+            },
+        )
         .separator();
     if muted {
         let label = match muted_until {


### PR DESCRIPTION
## Summary
- Add `list_channel_detail` transport/AppApi and `ChannelList::ensure_channel_in_clan` to fetch and insert missing channels/threads when routing (React `addThreadToChannels` parity).
- Wire DM sidebar **Mark as read** via `DirectMessageStore::mark_as_read`.
- Chat layout, context menu, badge, and sidebar updates to support the new flows.

## Test plan
- [ ] CI lint/test pass
- [ ] Open deep link to thread not in sidebar — channel appears after fetch
- [ ] DM sidebar → Mark as read clears unread badge
- [ ] Failed channel detail fetch (invalid id) falls back without wedging navigation
