### PR TITLE
feat(store): DM unread from gotify push and stranger message insert

### DIFF
--- a/crates/mezon-client/src/gotify.rs
+++ b/crates/mezon-client/src/gotify.rs
@@ -26,6 +26,8 @@ pub struct GotifyNotification {
     #[serde(default, deserialize_with = "de_id")]
     pub sender_id: String,
     #[serde(default)]
+    pub date: String,
+    #[serde(default)]
     pub extras: GotifyExtras,
 }
 

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -95,6 +95,60 @@ pub enum RealtimeEvent {
     Unhandled(realtime::envelope::Message),
 }
 
+impl RealtimeEvent {
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            Self::ChannelMessage(_) => "ChannelMessage",
+            Self::MessageTyping(_) => "MessageTyping",
+            Self::ChannelPresence(_) => "ChannelPresence",
+            Self::StatusPresence(_) => "StatusPresence",
+            Self::CustomStatus(_) => "CustomStatus",
+            Self::UserStatus(_) => "UserStatus",
+            Self::MessageReaction(_) => "MessageReaction",
+            Self::MarkAsRead(_) => "MarkAsRead",
+            Self::LastSeenUpdated(_) => "LastSeenUpdated",
+            Self::Notifications(_) => "Notifications",
+            Self::ChannelCreated(_) => "ChannelCreated",
+            Self::ChannelUpdated(_) => "ChannelUpdated",
+            Self::ChannelDeleted(_) => "ChannelDeleted",
+            Self::ChannelArchive(_) => "ChannelArchive",
+            Self::CategoryEvent(_) => "CategoryEvent",
+            Self::Unmute(_) => "Unmute",
+            Self::StreamingJoined(_) => "StreamingJoined",
+            Self::StreamingLeaved(_) => "StreamingLeaved",
+            Self::StreamingStarted(_) => "StreamingStarted",
+            Self::StreamingEnded(_) => "StreamingEnded",
+            Self::VoiceStarted(_) => "VoiceStarted",
+            Self::VoiceEnded(_) => "VoiceEnded",
+            Self::VoiceJoined(_) => "VoiceJoined",
+            Self::VoiceLeaved(_) => "VoiceLeaved",
+            Self::VoiceReaction(_) => "VoiceReaction",
+            Self::UserChannelAdded(_) => "UserChannelAdded",
+            Self::UserChannelRemoved(_) => "UserChannelRemoved",
+            Self::NotifUserChannel(_) => "NotifUserChannel",
+            Self::AddClanUser(_) => "AddClanUser",
+            Self::ClanEventCreated(_) => "ClanEventCreated",
+            Self::UserClanRemoved(_) => "UserClanRemoved",
+            Self::ClanUpdated(_) => "ClanUpdated",
+            Self::ClanProfileUpdated(_) => "ClanProfileUpdated",
+            Self::ClanDeleted(_) => "ClanDeleted",
+            Self::ClanEmoji(_) => "ClanEmoji",
+            Self::AddFriend(_) => "AddFriend",
+            Self::RemoveFriend(_) => "RemoveFriend",
+            Self::BlockFriend(_) => "BlockFriend",
+            Self::UnblockFriend(_) => "UnblockFriend",
+            Self::SessionRefreshed(_) => "SessionRefreshed",
+            Self::LastPinMessage(_) => "LastPinMessage",
+            Self::UnpinMessage(_) => "UnpinMessage",
+            Self::SdTopicEvent(_) => "SdTopicEvent",
+            Self::TopicInMessageEvent(_) => "TopicInMessageEvent",
+            Self::TokenSent(_) => "TokenSent",
+            Self::GiveCoffee(_) => "GiveCoffee",
+            Self::Unhandled(_) => "Unhandled",
+        }
+    }
+}
+
 impl TryFrom<realtime::envelope::Message> for RealtimeEvent {
     type Error = &'static str;
 
@@ -163,8 +217,15 @@ fn dispatch_realtime_push(
     match realtime::Envelope::decode(payload) {
         Ok(envelope) => match envelope.message {
             Some(msg) => {
-                tracing::trace!("server push (cid={cid}) -> publishing realtime event");
                 if let Ok(event) = RealtimeEvent::try_from(msg) {
+                    if !matches!(
+                        event,
+                        RealtimeEvent::MessageTyping(_)
+                            | RealtimeEvent::ChannelPresence(_)
+                            | RealtimeEvent::StatusPresence(_)
+                    ) {
+                        tracing::debug!("server push (cid={cid}): {}", event.kind_name());
+                    }
                     on_event(event);
                 }
             }

--- a/crates/mezon-store/src/badge.rs
+++ b/crates/mezon-store/src/badge.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::time::{Duration, Instant};
 
 use gpui::{App, AppContext, Context, Entity, Global};
 use mezon_client::RealtimeEvent;
@@ -17,6 +18,7 @@ use crate::realtime::{RealtimeDispatch, RealtimeKind};
 const STREAM_MODE_GROUP: i32 = 3;
 const STREAM_MODE_DM: i32 = 4;
 const MAX_BADGE_DEDUP: usize = 500;
+const DM_GOTIFY_DEDUP_WINDOW: Duration = Duration::from_secs(1);
 const NOTIFICATION_USER_MENTIONED: i32 = -9;
 const NOTIFICATION_USER_REPLIED: i32 = -11;
 const NOTIFICATION_CHANNEL_TYPE_THREAD: i32 = 7;
@@ -142,6 +144,8 @@ pub struct BadgeService {
     auth_state: Entity<AuthState>,
     processed_badge_messages: HashSet<(ChannelId, MessageId)>,
     processed_badge_order: VecDeque<(ChannelId, MessageId)>,
+    dm_push_channels: HashSet<ChannelId>,
+    dm_gotify_counted: HashMap<ChannelId, Instant>,
 }
 
 struct GlobalBadgeService(Entity<BadgeService>);
@@ -165,11 +169,50 @@ impl BadgeService {
     pub fn reset(&mut self, cx: &mut Context<Self>) {
         self.processed_badge_messages.clear();
         self.processed_badge_order.clear();
+        self.dm_push_channels.clear();
+        self.dm_gotify_counted.clear();
         cx.notify();
     }
 
     pub fn current_user_id(&self, cx: &App) -> Option<UserId> {
         self.current_user_id_raw(cx).map(UserId)
+    }
+
+    /// Count a DM message delivered only through the notification push stream — the server's
+    /// `ChannelMessage` socket push for fresh/unopened DMs is unreliable (sometimes absent).
+    /// The notification payload carries no message id, so dedup against the socket path is by
+    /// delivery channel: once a socket push has been seen for a DM the socket owns its
+    /// counting, and a race between the near-simultaneous pair is absorbed by a short window.
+    /// A late-arriving notification for a message the user already read is dropped by
+    /// comparing the notification date against the conversation's last-seen timestamp,
+    /// mirroring the web `isAlreadySeen` guard.
+    pub fn note_dm_notification(&mut self, channel_id: ChannelId, ts: i64, cx: &mut Context<Self>) {
+        let Some(last_seen) = DirectMessageStore::global(cx)
+            .read(cx)
+            .find(channel_id)
+            .map(|channel| channel.last_seen_timestamp)
+        else {
+            return;
+        };
+        if self.dm_push_channels.contains(&channel_id) {
+            tracing::debug!("note_dm_notification: channel {channel_id} counted via socket push");
+            return;
+        }
+        if ts > 0 && last_seen >= ts {
+            tracing::debug!(
+                "note_dm_notification: channel {channel_id} already seen, not counting"
+            );
+            return;
+        }
+        if !should_increment_dm_unread(cx, channel_id, false) {
+            tracing::debug!("note_dm_notification: viewing channel {channel_id}, not counting");
+            return;
+        }
+        self.dm_gotify_counted.insert(channel_id, Instant::now());
+        tracing::debug!("note_dm_notification: unread +1 for channel {channel_id}");
+        DirectMessageStore::global(cx).update(cx, |dm, cx| {
+            dm.note_message(channel_id, ts, false, true, cx);
+        });
     }
 
     fn new(auth_state: Entity<AuthState>, cx: &mut Context<Self>) -> Self {
@@ -190,6 +233,8 @@ impl BadgeService {
             auth_state,
             processed_badge_messages: HashSet::new(),
             processed_badge_order: VecDeque::new(),
+            dm_push_channels: HashSet::new(),
+            dm_gotify_counted: HashMap::new(),
         }
     }
 
@@ -234,6 +279,15 @@ impl BadgeService {
     fn handle_event(&mut self, event: &RealtimeEvent, cx: &mut Context<Self>) {
         match event {
             RealtimeEvent::ChannelMessage(m) => {
+                tracing::debug!(
+                    "channel_message push: channel={} clan={} mode={} code={} topic={} sender={}",
+                    m.channel_id,
+                    m.clan_id,
+                    m.mode,
+                    m.code,
+                    m.topic_id,
+                    m.sender_id
+                );
                 let channel_id = badge_channel_id(m);
                 let ts = if m.create_time_seconds > 0 {
                     i64::from(m.create_time_seconds)
@@ -246,9 +300,28 @@ impl BadgeService {
 
                 if is_dm_message(m) {
                     if !is_content_mutation(m) {
-                        let increment_unread = should_increment_dm_unread(cx, channel_id, from_me);
+                        self.dm_push_channels.insert(channel_id);
+                        let gotify_counted = self
+                            .dm_gotify_counted
+                            .get(&channel_id)
+                            .is_some_and(|at| at.elapsed() < DM_GOTIFY_DEDUP_WINDOW);
+                        let fresh = message_id.is_zero()
+                            || mark_badge_processed(
+                                &mut self.processed_badge_messages,
+                                &mut self.processed_badge_order,
+                                (channel_id, message_id),
+                            );
+                        let increment_unread = fresh
+                            && !gotify_counted
+                            && should_increment_dm_unread(cx, channel_id, from_me);
                         DirectMessageStore::global(cx).update(cx, |dm, cx| {
-                            dm.note_message(channel_id, ts, from_me, increment_unread, cx);
+                            if !dm.note_message(channel_id, ts, from_me, increment_unread, cx) {
+                                let inserted = dm.insert_from_message(m, from_me, increment_unread, cx);
+                                tracing::info!(
+                                    "dm message for unknown channel {}: synthesized entry inserted={inserted}",
+                                    m.channel_id
+                                );
+                            }
                         });
                         ChannelList::global(cx).update(cx, |cl, cx| {
                             cl.note_user_channel_dm_message(

--- a/crates/mezon-store/src/direct.rs
+++ b/crates/mezon-store/src/direct.rs
@@ -11,6 +11,8 @@ use crate::Freshness;
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
 use crate::users_by_user::UsersByUserStore;
 
+const STREAM_MODE_GROUP: i32 = 3;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DirectKind {
     Dm,
@@ -742,8 +744,20 @@ impl DirectMessageStore {
                 if channel_type != 2 && channel_type != 3 {
                     return;
                 }
-                let api_ch = direct_from_channel_desc(desc);
-                if !self.channels.push_new(direct_from_api(api_ch)) {
+                let mut api_ch = direct_from_channel_desc(desc);
+                if e.create_time_seconds > 0 {
+                    api_ch.last_sent_timestamp = i64::from(e.create_time_seconds);
+                }
+                let mut channel = direct_from_api(api_ch);
+                let self_id = crate::badge::BadgeService::try_global(cx)
+                    .and_then(|badge| badge.read(cx).current_user_id(cx));
+                enrich_direct_from_event_users(&mut channel, &e.users, self_id);
+                let inserted = self.channels.push_new(channel);
+                tracing::info!(
+                    "user_channel_added: direct channel {} inserted={inserted}",
+                    desc.channel_id
+                );
+                if !inserted {
                     return;
                 }
                 cx.emit(DirectEvent::Changed { channel_id: None });
@@ -764,11 +778,11 @@ impl DirectMessageStore {
         let Some(channel) = self.channels.find_mut(channel_id) else {
             return false;
         };
-        if ts > 0 {
+        if ts > channel.last_sent_timestamp {
             channel.last_sent_timestamp = ts;
         }
         if from_me {
-            if ts > 0 {
+            if ts > channel.last_seen_timestamp {
                 channel.last_seen_timestamp = ts;
             }
         } else if increment_unread {
@@ -776,6 +790,28 @@ impl DirectMessageStore {
         }
         self.channels.resort_after_bump(channel_id);
         self.schedule_changed_notify(channel_id, cx);
+        true
+    }
+
+    /// Mirrors mezon-react's `addDirectByMessageWS`: a DM/group message arriving for a
+    /// conversation not in the list (stranger DM, first message ever) synthesizes the entry
+    /// from the message itself so the conversation shows up immediately. The next full fetch
+    /// replaces it with the server record.
+    pub fn insert_from_message(
+        &mut self,
+        m: &mezon_proto::api::ChannelMessage,
+        from_me: bool,
+        increment_unread: bool,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if !self
+            .channels
+            .push_new(direct_from_message(m, from_me, increment_unread))
+        {
+            return false;
+        }
+        cx.emit(DirectEvent::Changed { channel_id: None });
+        cx.notify();
         true
     }
 
@@ -1006,6 +1042,96 @@ fn group_desc_payload(
     (label, avatar)
 }
 
+fn enrich_direct_from_event_users(
+    channel: &mut DirectChannel,
+    users: &[mezon_proto::realtime::UserProfileRedis],
+    self_id: Option<UserId>,
+) {
+    let others: Vec<&mezon_proto::realtime::UserProfileRedis> = users
+        .iter()
+        .filter(|u| u.user_id != 0)
+        .filter(|u| self_id.is_none_or(|me| UserId(u.user_id) != me))
+        .collect();
+    let others_label = others
+        .iter()
+        .map(|u| {
+            if u.display_name.is_empty() {
+                u.username.clone()
+            } else {
+                u.display_name.clone()
+            }
+        })
+        .filter(|name| !name.is_empty())
+        .collect::<Vec<_>>()
+        .join(", ");
+    match channel.kind {
+        DirectKind::Dm => {
+            if !others_label.is_empty() {
+                channel.label = others_label;
+            }
+            if let Some(peer) = others.first() {
+                channel.peer_user_id = Some(UserId(peer.user_id));
+                channel.peer_username = peer.username.clone();
+                if !peer.avatar.is_empty() {
+                    channel.avatar = peer.avatar.clone();
+                }
+                channel.online = channel.online || peer.online;
+            }
+        }
+        DirectKind::Group => {
+            if channel.label.is_empty() {
+                channel.label = others_label;
+            }
+        }
+    }
+    if channel.member_count == 0 {
+        channel.member_count = users.len() as u32;
+    }
+}
+
+fn direct_from_message(
+    m: &mezon_proto::api::ChannelMessage,
+    from_me: bool,
+    increment_unread: bool,
+) -> DirectChannel {
+    let kind = if m.mode == STREAM_MODE_GROUP {
+        DirectKind::Group
+    } else {
+        DirectKind::Dm
+    };
+    let label = if !m.display_name.is_empty() {
+        m.display_name.clone()
+    } else {
+        m.username.clone()
+    };
+    let ts = if m.create_time_seconds > 0 {
+        i64::from(m.create_time_seconds)
+    } else {
+        0
+    };
+    let (peer_user_id, peer_username) = match kind {
+        DirectKind::Dm => (
+            (m.sender_id != 0).then_some(UserId(m.sender_id)),
+            m.username.clone(),
+        ),
+        DirectKind::Group => (None, String::new()),
+    };
+    DirectChannel {
+        id: ChannelId(m.channel_id),
+        label,
+        kind,
+        avatar: m.avatar.clone(),
+        peer_user_id,
+        peer_username,
+        creator_id: (m.sender_id != 0).then_some(UserId(m.sender_id)),
+        online: true,
+        member_count: 0,
+        unread_count: u32::from(increment_unread),
+        last_sent_timestamp: ts,
+        last_seen_timestamp: if from_me { ts } else { ts.saturating_sub(1) },
+    }
+}
+
 fn direct_from_api(c: ApiDirectChannel) -> DirectChannel {
     let kind = DirectKind::from_raw(c.channel_type);
     let (avatar, peer_user_id, peer_username, online) = match kind {
@@ -1125,6 +1251,127 @@ mod tests {
     fn direct_from_api_zero_creator_is_none() {
         let api = api_dm(1, "Group", 2);
         assert_eq!(direct_from_api(api).creator_id, None);
+    }
+
+    fn incoming_dm_message() -> mezon_proto::api::ChannelMessage {
+        mezon_proto::api::ChannelMessage {
+            channel_id: 77,
+            sender_id: 42,
+            username: "stranger".into(),
+            display_name: "Stranger Danger".into(),
+            avatar: "stranger.png".into(),
+            mode: 4,
+            create_time_seconds: 1000,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn stranger_dm_message_synthesizes_unread_conversation() {
+        let dm = direct_from_message(&incoming_dm_message(), false, true);
+        assert_eq!(dm.id, ChannelId(77));
+        assert_eq!(dm.kind, DirectKind::Dm);
+        assert_eq!(dm.label, "Stranger Danger");
+        assert_eq!(dm.avatar, "stranger.png");
+        assert_eq!(dm.peer_user_id, Some(UserId(42)));
+        assert_eq!(dm.peer_username, "stranger");
+        assert_eq!(dm.unread_count, 1);
+        assert_eq!(dm.last_sent_timestamp, 1000);
+        assert!(dm.is_unread());
+    }
+
+    #[test]
+    fn own_message_synthesizes_seen_conversation() {
+        let dm = direct_from_message(&incoming_dm_message(), true, false);
+        assert_eq!(dm.unread_count, 0);
+        assert_eq!(dm.last_seen_timestamp, dm.last_sent_timestamp);
+        assert!(!dm.is_unread());
+    }
+
+    #[test]
+    fn user_channel_added_dm_label_overrides_server_garbage() {
+        let mut channel = DirectChannel {
+            id: ChannelId(9),
+            label: "dev.mezon".into(),
+            kind: DirectKind::Dm,
+            avatar: String::new(),
+            peer_user_id: Some(UserId(999)),
+            peer_username: "wrong".into(),
+            creator_id: None,
+            online: false,
+            member_count: 0,
+            unread_count: 0,
+            last_sent_timestamp: 100,
+            last_seen_timestamp: 0,
+        };
+        let users = vec![
+            mezon_proto::realtime::UserProfileRedis {
+                user_id: 1,
+                username: "me".into(),
+                ..Default::default()
+            },
+            mezon_proto::realtime::UserProfileRedis {
+                user_id: 2,
+                username: "potinoc605".into(),
+                ..Default::default()
+            },
+        ];
+        enrich_direct_from_event_users(&mut channel, &users, Some(UserId(1)));
+        assert_eq!(channel.label, "potinoc605");
+        assert_eq!(channel.peer_user_id, Some(UserId(2)));
+        assert_eq!(channel.peer_username, "potinoc605");
+    }
+
+    #[test]
+    fn user_channel_added_enriches_blank_dm_from_event_users() {
+        let mut channel = DirectChannel {
+            id: ChannelId(9),
+            label: String::new(),
+            kind: DirectKind::Dm,
+            avatar: String::new(),
+            peer_user_id: None,
+            peer_username: String::new(),
+            creator_id: None,
+            online: false,
+            member_count: 0,
+            unread_count: 0,
+            last_sent_timestamp: 100,
+            last_seen_timestamp: 0,
+        };
+        let users = vec![
+            mezon_proto::realtime::UserProfileRedis {
+                user_id: 1,
+                username: "me".into(),
+                display_name: "Me".into(),
+                ..Default::default()
+            },
+            mezon_proto::realtime::UserProfileRedis {
+                user_id: 2,
+                username: "newbie".into(),
+                display_name: "New Bie".into(),
+                avatar: "newbie.png".into(),
+                online: true,
+                ..Default::default()
+            },
+        ];
+        enrich_direct_from_event_users(&mut channel, &users, Some(UserId(1)));
+        assert_eq!(channel.label, "New Bie");
+        assert_eq!(channel.peer_user_id, Some(UserId(2)));
+        assert_eq!(channel.peer_username, "newbie");
+        assert_eq!(channel.avatar, "newbie.png");
+        assert!(channel.online);
+        assert_eq!(channel.member_count, 2);
+    }
+
+    #[test]
+    fn group_message_synthesizes_group_conversation() {
+        let mut m = incoming_dm_message();
+        m.mode = 3;
+        m.display_name = String::new();
+        let dm = direct_from_message(&m, false, true);
+        assert_eq!(dm.kind, DirectKind::Group);
+        assert_eq!(dm.label, "stranger");
+        assert_eq!(dm.peer_user_id, None);
     }
 
     #[test]

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -5600,7 +5600,10 @@ fn merge_message_update(existing: &mut Message, incoming: &Message) {
         }
         existing.attachments = new_attachments;
     }
-    existing.references = incoming.references.clone();
+    let kept_prior_references = incoming.references.is_empty();
+    if !kept_prior_references {
+        existing.references = incoming.references.clone();
+    }
     existing.update_time = incoming.update_time;
     existing.is_edited = incoming.is_edited;
     existing.ogp = incoming.ogp.clone();
@@ -5613,7 +5616,8 @@ fn merge_message_update(existing: &mut Message, incoming: &Message) {
     existing.is_deleted_placeholder = incoming.is_deleted_placeholder;
     existing.topic_id = incoming.topic_id;
     existing.topic_creator_id = incoming.topic_creator_id;
-    existing.highlights_viewer_direct = incoming.highlights_viewer_direct;
+    existing.highlights_viewer_direct = incoming.highlights_viewer_direct
+        || (kept_prior_references && existing.highlights_viewer_direct);
     existing.raw_content = incoming.raw_content.clone();
     existing.mention_targets = incoming.mention_targets.clone();
     if incoming.poll.is_some() {
@@ -7906,6 +7910,92 @@ mod tests {
             !existing.attachments[0].presign_pending,
             "recompute against the arrived presign_finish flips the gate"
         );
+    }
+
+    #[test]
+    fn presign_finish_update_keeps_the_reply_reference() {
+        let mut existing = Message::new(MessageId(1), "hi", "u1", "U1", 100)
+            .with_references(vec![MessageReference {
+                message_ref_id: MessageId(7),
+                sender_name: "Alice".into(),
+                content: "original".into(),
+                ..Default::default()
+            }])
+            .with_attachments(vec![MessageAttachment {
+                url: "https://cdn.example/uploads/photo.png".into(),
+                ..Default::default()
+            }]);
+
+        let incoming = Message::new(MessageId(1), "hi", "u1", "U1", 100);
+        assert!(incoming.references.is_empty());
+        assert!(incoming.attachments.is_empty());
+        merge_message_update(&mut existing, &incoming);
+
+        assert_eq!(
+            existing.references.len(),
+            1,
+            "a content-only presign_finish echo must not drop the reply reference"
+        );
+        assert_eq!(existing.references[0].message_ref_id, MessageId(7));
+        assert_eq!(existing.attachments.len(), 1);
+    }
+
+    #[test]
+    fn presign_finish_update_keeps_the_reply_row_highlight() {
+        let mut existing = Message::new(MessageId(1), "hi", "u1", "U1", 100)
+            .with_references(vec![MessageReference {
+                message_ref_id: MessageId(7),
+                sender_id: UserId(42),
+                ..Default::default()
+            }])
+            .with_viewer_highlight(true);
+
+        let incoming = Message::new(MessageId(1), "hi", "u1", "U1", 100);
+        assert!(!incoming.highlights_viewer_direct);
+        merge_message_update(&mut existing, &incoming);
+
+        assert!(
+            existing.highlights_viewer_direct,
+            "the highlight is derived from references, so keeping them must keep it"
+        );
+    }
+
+    #[test]
+    fn update_that_carries_references_recomputes_the_highlight() {
+        let mut existing = Message::new(MessageId(1), "hi", "u1", "U1", 100)
+            .with_references(vec![MessageReference {
+                message_ref_id: MessageId(7),
+                sender_id: UserId(42),
+                ..Default::default()
+            }])
+            .with_viewer_highlight(true);
+        let incoming = Message::new(MessageId(1), "hi", "u1", "U1", 100).with_references(vec![
+            MessageReference {
+                message_ref_id: MessageId(9),
+                sender_id: UserId(7),
+                ..Default::default()
+            },
+        ]);
+        merge_message_update(&mut existing, &incoming);
+        assert!(!existing.highlights_viewer_direct);
+    }
+
+    #[test]
+    fn update_that_carries_references_replaces_them() {
+        let mut existing = Message::new(MessageId(1), "hi", "u1", "U1", 100).with_references(vec![
+            MessageReference {
+                message_ref_id: MessageId(7),
+                ..Default::default()
+            },
+        ]);
+        let incoming = Message::new(MessageId(1), "hi", "u1", "U1", 100).with_references(vec![
+            MessageReference {
+                message_ref_id: MessageId(9),
+                ..Default::default()
+            },
+        ]);
+        merge_message_update(&mut existing, &incoming);
+        assert_eq!(existing.references[0].message_ref_id, MessageId(9));
     }
 
     fn plain_api_message(

--- a/crates/mezon-store/src/notification_push.rs
+++ b/crates/mezon-store/src/notification_push.rs
@@ -125,7 +125,10 @@ impl NotificationPushStore {
             let mut rx = api.spawn_gotify_stream(ws_base, token);
             while let Some(notification) = rx.recv().await {
                 let prepared = this
-                    .update(cx, |_, cx| prepare(cx, &user_id, &notification))
+                    .update(cx, |_, cx| {
+                        note_dm_unread(cx, &user_id, &notification);
+                        prepare(cx, &user_id, &notification)
+                    })
                     .ok()
                     .flatten();
                 let Some(prepared) = prepared else {
@@ -158,6 +161,26 @@ struct PreparedNotification {
     clan_id: Option<String>,
     link: Option<String>,
     icon_url: Option<String>,
+}
+
+fn note_dm_unread(cx: &mut App, user_id: &str, n: &GotifyNotification) {
+    if n.sender_id == user_id {
+        return;
+    }
+    let Ok(channel_id) = n.channel_id.parse::<i64>() else {
+        return;
+    };
+    if channel_id == 0 {
+        return;
+    }
+    let ts = chrono::DateTime::parse_from_rfc3339(&n.date)
+        .map(|date| date.timestamp())
+        .unwrap_or(0);
+    if let Some(badge) = crate::badge::BadgeService::try_global(cx) {
+        badge.update(cx, |badge, cx| {
+            badge.note_dm_notification(ChannelId(channel_id), ts, cx);
+        });
+    }
 }
 
 const SENDER_AVATAR_PX: u32 = 64;

--- a/crates/mezon-ui/src/chat/layout.rs
+++ b/crates/mezon-ui/src/chat/layout.rs
@@ -1029,6 +1029,7 @@ impl ChatLayout {
                 self.direct_store
                     .update(cx, |store, cx| store.ensure_loaded(cx));
                 self.chat_area.clear_member_panel();
+                MessagesStore::global(cx).update(cx, |store, cx| store.close(cx));
             }
             Route::Chat => {
                 self.pending_channel_id = None;


### PR DESCRIPTION
## Summary
- **`DirectMessageStore`**: insert DM/group from first message (`insert_from_message`), enrich labels from `UserChannelAdded` users, fix last-seen/timestamp ordering.
- **`BadgeService`**: count unread from gotify notification push when socket `ChannelMessage` is missing, with dedup against socket path and already-read guard.
- **`notification_push` / `messages`**: wire notification path into DM store.
- **`transport`**: `RealtimeEvent::kind_name()` and debug logging for server pushes (excluding typing/presence floods).

## Test plan
- [ ] CI lint/test pass
- [ ] Stranger sends first DM — conversation appears in sidebar without refresh
- [ ] DM unread increments via gotify when socket push absent
- [ ] No double-count when both socket and gotify deliver same message
- [ ] Mark-as-read before notification arrives — badge not incremented

