### PR TITLE
fix(emoji): defer recent fetch until connected and cache freshness

### DIFF
--- a/crates/mezon-store/src/emoji.rs
+++ b/crates/mezon-store/src/emoji.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU16, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Task};
 use image::ImageEncoder as _;
@@ -15,6 +15,8 @@ use crate::ids::ClanId;
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
 
 const RECENT_EMOJI_CAP: usize = 20;
+const RECENT_FETCH_ATTEMPTS: u32 = 3;
+const RECENT_FETCH_RETRY_DELAY: Duration = Duration::from_secs(1);
 const EMOJI_ACTION_CREATED: i32 = 1;
 const EMOJI_ACTION_UPDATE: i32 = 2;
 const EMOJI_ACTION_DELETE: i32 = 3;
@@ -52,6 +54,7 @@ pub struct EmojiStore {
     recent_freshness: Freshness,
     loading: bool,
     loading_recent: bool,
+    reset_generation: u32,
     api: Arc<AppApi>,
     _conn_watch: Task<()>,
 }
@@ -84,6 +87,7 @@ impl EmojiStore {
         self.recent_freshness.mark_stale();
         self.loading = false;
         self.loading_recent = false;
+        self.reset_generation = self.reset_generation.wrapping_add(1);
         cx.notify();
     }
 
@@ -100,6 +104,7 @@ impl EmojiStore {
             recent_freshness: Freshness::new(),
             loading: false,
             loading_recent: false,
+            reset_generation: 0,
             api,
             _conn_watch: conn_watch,
         }
@@ -154,7 +159,7 @@ impl EmojiStore {
         self.fetch(cx)
     }
 
-    pub fn ensure_recent_loaded(&mut self, cx: &mut Context<Self>) {
+    fn ensure_recent_loaded(&mut self, cx: &mut Context<Self>) {
         if self.recent_freshness.is_fresh(crate::CACHE_TTL) {
             return;
         }
@@ -162,6 +167,7 @@ impl EmojiStore {
     }
 
     pub fn refresh(&mut self, cx: &mut Context<Self>) {
+        self.freshness.mark_stale();
         self.fetch(cx).detach();
         self.recent_freshness.mark_stale();
         self.fetch_recent(cx);
@@ -173,9 +179,13 @@ impl EmojiStore {
         }
         self.loading = true;
         let api = self.api.clone();
+        let generation = self.reset_generation;
         cx.spawn(async move |this, cx| {
             let result = api.list_emojis_by_user_id().await;
             let _ = this.update(cx, |this, cx| {
+                if this.reset_generation != generation {
+                    return;
+                }
                 this.loading = false;
                 match result.map(|emojis| {
                     emojis
@@ -200,30 +210,62 @@ impl EmojiStore {
         })
     }
 
+    fn apply_recents_if_current(
+        &mut self,
+        generation: u32,
+        recents: Vec<api::EmojiRecent>,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.reset_generation != generation {
+            return false;
+        }
+        let mut seen = HashSet::new();
+        self.recent_ids = recents
+            .into_iter()
+            .map(|r| r.emoji_id.to_string())
+            .filter(|id| seen.insert(id.clone()))
+            .take(RECENT_EMOJI_CAP)
+            .collect();
+        self.recent_freshness.mark_fetched();
+        cx.emit(EmojiEvent::Changed);
+        cx.notify();
+        true
+    }
+
     fn fetch_recent(&mut self, cx: &mut Context<Self>) {
         if self.loading_recent {
             return;
         }
         self.loading_recent = true;
         let api = self.api.clone();
+        let generation = self.reset_generation;
         cx.spawn(async move |this, cx| {
-            let result = api.emoji_recent_list().await;
-            let _ = this.update(cx, |this, cx| {
-                this.loading_recent = false;
-                match result {
+            let mut delay = RECENT_FETCH_RETRY_DELAY;
+            for attempt in 1..=RECENT_FETCH_ATTEMPTS {
+                match api.emoji_recent_list().await {
                     Ok(recents) => {
-                        let mut seen = HashSet::new();
-                        this.recent_ids = recents
-                            .into_iter()
-                            .map(|r| r.emoji_id.to_string())
-                            .filter(|id| seen.insert(id.clone()))
-                            .take(RECENT_EMOJI_CAP)
-                            .collect();
-                        this.recent_freshness.mark_fetched();
-                        cx.emit(EmojiEvent::Changed);
-                        cx.notify();
+                        let _ = this.update(cx, |this, cx| {
+                            if this.apply_recents_if_current(generation, recents, cx) {
+                                this.loading_recent = false;
+                            }
+                        });
+                        return;
                     }
-                    Err(e) => tracing::error!("emoji_recent_list failed: {e}"),
+                    Err(e) => {
+                        tracing::error!(
+                            "emoji_recent_list failed (attempt {attempt}/{RECENT_FETCH_ATTEMPTS}): {e}"
+                        );
+                        if attempt == RECENT_FETCH_ATTEMPTS {
+                            break;
+                        }
+                        cx.background_executor().timer(delay).await;
+                        delay *= 2;
+                    }
+                }
+            }
+            let _ = this.update(cx, |this, _| {
+                if this.reset_generation == generation {
+                    this.loading_recent = false;
                 }
             });
         })
@@ -818,6 +860,44 @@ pub async fn upload_emoticon_file(
 mod tests {
     use super::*;
 
+    fn init_emoji_store(cx: &mut gpui::TestAppContext) -> (Arc<AppApi>, Entity<EmojiStore>) {
+        cx.update(|cx| {
+            let api = Arc::new(mezon_client::AppApi::new(
+                Arc::new(mezon_client::TransportClient::new(String::new())),
+                String::new(),
+            ));
+            RealtimeDispatch::init(api.clone(), cx);
+            let store = cx.new(|cx| EmojiStore::new(api.clone(), cx));
+            (api, store)
+        })
+    }
+
+    fn connect(api: &Arc<AppApi>, cx: &mut gpui::TestAppContext) {
+        api.set_status(ConnectionStatus::Disconnected);
+        cx.run_until_parked();
+        api.set_status(ConnectionStatus::Connected);
+        cx.run_until_parked();
+    }
+
+    fn recent_fetch_in_flight(store: &Entity<EmojiStore>, cx: &gpui::TestAppContext) -> bool {
+        store.read_with(cx, |store, _| store.loading_recent)
+    }
+
+    fn settle_recent_fetch_with_success(store: &Entity<EmojiStore>, cx: &mut gpui::TestAppContext) {
+        store.update(cx, |store, cx| {
+            let generation = store.reset_generation;
+            store.loading_recent = false;
+            store.apply_recents_if_current(generation, Vec::new(), cx);
+        });
+    }
+
+    fn recent(emoji_id: i64) -> api::EmojiRecent {
+        api::EmojiRecent {
+            emoji_id,
+            ..Default::default()
+        }
+    }
+
     fn proto(
         id: i64,
         shortname: &str,
@@ -943,45 +1023,64 @@ mod tests {
         assert!(!recent.contains(&(RECENT_EMOJI_CAP - 1).to_string()));
     }
 
-    fn init_emoji_store(cx: &mut App) -> Entity<EmojiStore> {
-        let api = Arc::new(mezon_client::AppApi::new(
-            Arc::new(mezon_client::TransportClient::new(String::new())),
-            String::new(),
-        ));
-        RealtimeDispatch::init(api.clone(), cx);
-        cx.new(|cx| EmojiStore::new(api, cx))
-    }
-
     #[gpui::test]
     fn construction_does_not_fetch_recents(cx: &mut gpui::TestAppContext) {
-        cx.update(|cx| {
-            let store = init_emoji_store(cx);
-            store.update(cx, |store, _| {
-                assert!(
-                    !store.loading_recent,
-                    "recents must wait for the socket, not fire while disconnected"
-                );
-            });
-        });
+        let (_api, store) = init_emoji_store(cx);
+        cx.run_until_parked();
+        assert!(
+            !recent_fetch_in_flight(&store, cx),
+            "recents must wait for the socket, not fire while disconnected"
+        );
     }
 
     #[gpui::test]
-    fn ensure_recent_loaded_fetches_once_then_gates_on_freshness(cx: &mut gpui::TestAppContext) {
-        cx.update(|cx| {
-            let store = init_emoji_store(cx);
-            store.update(cx, |store, cx| {
-                store.ensure_recent_loaded(cx);
-                assert!(store.loading_recent, "first connect must fetch recents");
+    fn connecting_fetches_recents_and_a_fresh_reconnect_does_not(cx: &mut gpui::TestAppContext) {
+        let (api, store) = init_emoji_store(cx);
 
-                store.loading_recent = false;
-                store.recent_freshness.mark_fetched();
-                store.ensure_recent_loaded(cx);
-                assert!(!store.loading_recent, "a fresh list must not refetch");
+        connect(&api, cx);
+        assert!(
+            recent_fetch_in_flight(&store, cx),
+            "the first connect must fetch recents"
+        );
 
-                store.reset(cx);
-                store.ensure_recent_loaded(cx);
-                assert!(store.loading_recent, "logout must force a refetch");
-            });
+        settle_recent_fetch_with_success(&store, cx);
+        connect(&api, cx);
+        assert!(
+            !recent_fetch_in_flight(&store, cx),
+            "a reconnect within the TTL must not refetch"
+        );
+    }
+
+    #[gpui::test]
+    fn logout_forces_a_refetch_on_the_next_connect(cx: &mut gpui::TestAppContext) {
+        let (api, store) = init_emoji_store(cx);
+        connect(&api, cx);
+        settle_recent_fetch_with_success(&store, cx);
+
+        store.update(cx, |store, cx| store.reset(cx));
+        connect(&api, cx);
+
+        assert!(
+            recent_fetch_in_flight(&store, cx),
+            "logout must invalidate recents so the next connect refetches"
+        );
+    }
+
+    #[gpui::test]
+    fn a_response_that_outlives_a_logout_is_dropped(cx: &mut gpui::TestAppContext) {
+        let (api, store) = init_emoji_store(cx);
+        connect(&api, cx);
+
+        store.update(cx, |store, cx| {
+            let in_flight = store.reset_generation;
+            store.reset(cx);
+
+            assert!(
+                !store.apply_recents_if_current(in_flight, vec![recent(1), recent(2)], cx),
+                "a response issued for the previous account must be dropped"
+            );
+            assert!(store.recent_ids.is_empty());
+            assert!(!store.recent_freshness.is_fresh(crate::CACHE_TTL));
         });
     }
 

--- a/crates/mezon-store/src/emoji.rs
+++ b/crates/mezon-store/src/emoji.rs
@@ -17,6 +17,7 @@ use crate::realtime::{RealtimeDispatch, RealtimeKind};
 const RECENT_EMOJI_CAP: usize = 20;
 const RECENT_FETCH_ATTEMPTS: u32 = 3;
 const RECENT_FETCH_RETRY_DELAY: Duration = Duration::from_secs(1);
+const LAG_REFRESH_MIN_INTERVAL: Duration = Duration::from_secs(30);
 const EMOJI_ACTION_CREATED: i32 = 1;
 const EMOJI_ACTION_UPDATE: i32 = 2;
 const EMOJI_ACTION_DELETE: i32 = 3;
@@ -52,6 +53,7 @@ pub struct EmojiStore {
     recent_ids: Vec<String>,
     freshness: Freshness,
     recent_freshness: Freshness,
+    lag_refresh: Freshness,
     loading: bool,
     loading_recent: bool,
     reset_generation: u32,
@@ -85,6 +87,7 @@ impl EmojiStore {
         self.recent_ids.clear();
         self.freshness.mark_stale();
         self.recent_freshness.mark_stale();
+        self.lag_refresh.mark_stale();
         self.loading = false;
         self.loading_recent = false;
         self.reset_generation = self.reset_generation.wrapping_add(1);
@@ -102,6 +105,7 @@ impl EmojiStore {
             recent_ids: Vec::new(),
             freshness: Freshness::new(),
             recent_freshness: Freshness::new(),
+            lag_refresh: Freshness::new(),
             loading: false,
             loading_recent: false,
             reset_generation: 0,
@@ -119,7 +123,7 @@ impl EmojiStore {
             dispatch.on(RealtimeKind::MessageReaction, &entity, |this, event, cx| {
                 this.handle_reaction_echo(event, cx)
             });
-            dispatch.on_lagged(&entity, |this, cx| this.refresh(cx));
+            dispatch.on_lagged(&entity, |this, cx| this.refresh_after_lag(cx));
         });
     }
 
@@ -173,6 +177,14 @@ impl EmojiStore {
         self.fetch_recent(cx);
     }
 
+    fn refresh_after_lag(&mut self, cx: &mut Context<Self>) {
+        if self.lag_refresh.is_fresh(LAG_REFRESH_MIN_INTERVAL) {
+            return;
+        }
+        self.lag_refresh.mark_fetched();
+        self.refresh(cx);
+    }
+
     fn fetch(&mut self, cx: &mut Context<Self>) -> Task<()> {
         if self.loading {
             return Task::ready(());
@@ -193,21 +205,24 @@ impl EmojiStore {
                         .filter_map(emoji_from_proto)
                         .collect::<Vec<_>>()
                 }) {
-                    Ok(emojis) => {
-                        this.by_id.clear();
-                        this.order.clear();
-                        for emoji in emojis {
-                            this.insert(emoji);
-                        }
-                        this.freshness.mark_fetched();
-                        tracing::info!("EmojiStore: fetched {} emojis", this.order.len());
-                        cx.emit(EmojiEvent::Changed);
-                        cx.notify();
-                    }
+                    Ok(emojis) => this.apply_catalog(emojis, cx),
                     Err(e) => tracing::error!("list_emojis_by_user_id failed: {e}"),
                 }
             });
         })
+    }
+
+    fn apply_catalog(&mut self, emojis: Vec<Emoji>, cx: &mut Context<Self>) {
+        let (by_id, order) = index_emojis(emojis);
+        self.freshness.mark_fetched();
+        if by_id == self.by_id && order == self.order {
+            return;
+        }
+        self.by_id = by_id;
+        self.order = order;
+        tracing::info!("EmojiStore: fetched {} emojis", self.order.len());
+        cx.emit(EmojiEvent::Changed);
+        cx.notify();
     }
 
     fn apply_recents_if_current(
@@ -220,13 +235,17 @@ impl EmojiStore {
             return false;
         }
         let mut seen = HashSet::new();
-        self.recent_ids = recents
+        let recent_ids: Vec<String> = recents
             .into_iter()
             .map(|r| r.emoji_id.to_string())
             .filter(|id| seen.insert(id.clone()))
             .take(RECENT_EMOJI_CAP)
             .collect();
         self.recent_freshness.mark_fetched();
+        if recent_ids == self.recent_ids {
+            return true;
+        }
+        self.recent_ids = recent_ids;
         cx.emit(EmojiEvent::Changed);
         cx.notify();
         true
@@ -255,7 +274,9 @@ impl EmojiStore {
                         tracing::error!(
                             "emoji_recent_list failed (attempt {attempt}/{RECENT_FETCH_ATTEMPTS}): {e}"
                         );
-                        if attempt == RECENT_FETCH_ATTEMPTS {
+                        if attempt == RECENT_FETCH_ATTEMPTS
+                            || api.connection_status() != ConnectionStatus::Connected
+                        {
                             break;
                         }
                         cx.background_executor().timer(delay).await;
@@ -472,6 +493,18 @@ impl EmojiStore {
             cx.notify();
         }
     }
+}
+
+fn index_emojis(emojis: Vec<Emoji>) -> (HashMap<String, Emoji>, Vec<String>) {
+    let mut by_id = HashMap::with_capacity(emojis.len());
+    let mut order = Vec::with_capacity(emojis.len());
+    for emoji in emojis {
+        let id = emoji.id.clone();
+        if by_id.insert(id.clone(), emoji).is_none() {
+            order.push(id);
+        }
+    }
+    (by_id, order)
 }
 
 fn push_recent(recent_ids: &mut Vec<String>, id: String) {
@@ -883,6 +916,21 @@ mod tests {
         store.read_with(cx, |store, _| store.loading_recent)
     }
 
+    fn count_changed_events(
+        store: &Entity<EmojiStore>,
+        cx: &mut gpui::TestAppContext,
+    ) -> std::rc::Rc<std::cell::Cell<usize>> {
+        let seen = std::rc::Rc::new(std::cell::Cell::new(0));
+        let sink = seen.clone();
+        cx.update(|cx| {
+            cx.subscribe(store, move |_, _: &EmojiEvent, _| {
+                sink.set(sink.get() + 1);
+            })
+            .detach();
+        });
+        seen
+    }
+
     fn settle_recent_fetch_with_success(store: &Entity<EmojiStore>, cx: &mut gpui::TestAppContext) {
         store.update(cx, |store, cx| {
             let generation = store.reset_generation;
@@ -1081,6 +1129,68 @@ mod tests {
             );
             assert!(store.recent_ids.is_empty());
             assert!(!store.recent_freshness.is_fresh(crate::CACHE_TTL));
+        });
+    }
+
+    #[gpui::test]
+    fn an_unchanged_recent_list_does_not_wake_the_pickers(cx: &mut gpui::TestAppContext) {
+        let (_api, store) = init_emoji_store(cx);
+        let changed = count_changed_events(&store, cx);
+
+        store.update(cx, |store, cx| {
+            let generation = store.reset_generation;
+            store.apply_recents_if_current(generation, vec![recent(1), recent(2)], cx);
+            store.apply_recents_if_current(generation, vec![recent(1), recent(2)], cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            changed.get(),
+            1,
+            "an identical response must refresh the TTL without rebuilding every picker"
+        );
+        assert!(
+            store.read_with(cx, |store, _| store
+                .recent_freshness
+                .is_fresh(crate::CACHE_TTL)),
+            "the TTL must still be refreshed on the second response"
+        );
+    }
+
+    #[gpui::test]
+    fn an_unchanged_catalog_does_not_wake_the_pickers(cx: &mut gpui::TestAppContext) {
+        let (_api, store) = init_emoji_store(cx);
+        let changed = count_changed_events(&store, cx);
+        let catalog = vec![emoji("1", "smile", "Faces", "A")];
+
+        store.update(cx, |store, cx| {
+            store.apply_catalog(catalog.clone(), cx);
+            store.apply_catalog(catalog.clone(), cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(changed.get(), 1, "an identical catalog must not re-emit");
+    }
+
+    #[gpui::test]
+    fn a_lag_storm_refreshes_at_most_once_per_interval(cx: &mut gpui::TestAppContext) {
+        let (_api, store) = init_emoji_store(cx);
+
+        store.update(cx, |store, cx| {
+            store.refresh_after_lag(cx);
+            assert!(store.loading, "the first lag must refresh the catalog");
+
+            store.loading = false;
+            store.loading_recent = false;
+            store.refresh_after_lag(cx);
+            assert!(
+                !store.loading,
+                "a second lag inside the interval must not refetch the catalog"
+            );
+
+            store.lag_refresh.mark_stale();
+            store.refresh_after_lag(cx);
+            assert!(store.loading, "a lag past the interval must refresh again");
         });
     }
 

--- a/crates/mezon-store/src/emoji.rs
+++ b/crates/mezon-store/src/emoji.rs
@@ -49,7 +49,9 @@ pub struct EmojiStore {
     order: Vec<String>,
     recent_ids: Vec<String>,
     freshness: Freshness,
+    recent_freshness: Freshness,
     loading: bool,
+    loading_recent: bool,
     api: Arc<AppApi>,
     _conn_watch: Task<()>,
 }
@@ -79,7 +81,9 @@ impl EmojiStore {
         self.order.clear();
         self.recent_ids.clear();
         self.freshness.mark_stale();
+        self.recent_freshness.mark_stale();
         self.loading = false;
+        self.loading_recent = false;
         cx.notify();
     }
 
@@ -88,17 +92,17 @@ impl EmojiStore {
 
         let conn_watch = Self::spawn_connection_watch(api.clone(), cx);
 
-        let mut store = Self {
+        Self {
             by_id: HashMap::new(),
             order: Vec::new(),
             recent_ids: Vec::new(),
             freshness: Freshness::new(),
+            recent_freshness: Freshness::new(),
             loading: false,
+            loading_recent: false,
             api,
             _conn_watch: conn_watch,
-        };
-        store.fetch_recent(cx);
-        store
+        }
     }
 
     fn register_realtime(cx: &mut Context<Self>) {
@@ -125,7 +129,11 @@ impl EmojiStore {
                 let connected = *status_rx.borrow() == ConnectionStatus::Connected;
                 if connected && !was_connected {
                     was_connected = true;
-                    if this.update(cx, |this, cx| this.ensure_loaded(cx)).is_err() {
+                    let updated = this.update(cx, |this, cx| {
+                        this.ensure_loaded(cx);
+                        this.ensure_recent_loaded(cx);
+                    });
+                    if updated.is_err() {
                         break;
                     }
                 } else if !connected {
@@ -146,8 +154,17 @@ impl EmojiStore {
         self.fetch(cx)
     }
 
+    pub fn ensure_recent_loaded(&mut self, cx: &mut Context<Self>) {
+        if self.recent_freshness.is_fresh(crate::CACHE_TTL) {
+            return;
+        }
+        self.fetch_recent(cx);
+    }
+
     pub fn refresh(&mut self, cx: &mut Context<Self>) {
         self.fetch(cx).detach();
+        self.recent_freshness.mark_stale();
+        self.fetch_recent(cx);
     }
 
     fn fetch(&mut self, cx: &mut Context<Self>) -> Task<()> {
@@ -184,22 +201,30 @@ impl EmojiStore {
     }
 
     fn fetch_recent(&mut self, cx: &mut Context<Self>) {
+        if self.loading_recent {
+            return;
+        }
+        self.loading_recent = true;
         let api = self.api.clone();
         cx.spawn(async move |this, cx| {
             let result = api.emoji_recent_list().await;
-            let _ = this.update(cx, |this, cx| match result {
-                Ok(recents) => {
-                    let mut seen = HashSet::new();
-                    this.recent_ids = recents
-                        .into_iter()
-                        .map(|r| r.emoji_id.to_string())
-                        .filter(|id| seen.insert(id.clone()))
-                        .take(RECENT_EMOJI_CAP)
-                        .collect();
-                    cx.emit(EmojiEvent::Changed);
-                    cx.notify();
+            let _ = this.update(cx, |this, cx| {
+                this.loading_recent = false;
+                match result {
+                    Ok(recents) => {
+                        let mut seen = HashSet::new();
+                        this.recent_ids = recents
+                            .into_iter()
+                            .map(|r| r.emoji_id.to_string())
+                            .filter(|id| seen.insert(id.clone()))
+                            .take(RECENT_EMOJI_CAP)
+                            .collect();
+                        this.recent_freshness.mark_fetched();
+                        cx.emit(EmojiEvent::Changed);
+                        cx.notify();
+                    }
+                    Err(e) => tracing::error!("emoji_recent_list failed: {e}"),
                 }
-                Err(e) => tracing::error!("emoji_recent_list failed: {e}"),
             });
         })
         .detach();
@@ -916,6 +941,48 @@ mod tests {
         assert_eq!(recent.len(), RECENT_EMOJI_CAP);
         assert_eq!(recent[0], "new");
         assert!(!recent.contains(&(RECENT_EMOJI_CAP - 1).to_string()));
+    }
+
+    fn init_emoji_store(cx: &mut App) -> Entity<EmojiStore> {
+        let api = Arc::new(mezon_client::AppApi::new(
+            Arc::new(mezon_client::TransportClient::new(String::new())),
+            String::new(),
+        ));
+        RealtimeDispatch::init(api.clone(), cx);
+        cx.new(|cx| EmojiStore::new(api, cx))
+    }
+
+    #[gpui::test]
+    fn construction_does_not_fetch_recents(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let store = init_emoji_store(cx);
+            store.update(cx, |store, _| {
+                assert!(
+                    !store.loading_recent,
+                    "recents must wait for the socket, not fire while disconnected"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn ensure_recent_loaded_fetches_once_then_gates_on_freshness(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let store = init_emoji_store(cx);
+            store.update(cx, |store, cx| {
+                store.ensure_recent_loaded(cx);
+                assert!(store.loading_recent, "first connect must fetch recents");
+
+                store.loading_recent = false;
+                store.recent_freshness.mark_fetched();
+                store.ensure_recent_loaded(cx);
+                assert!(!store.loading_recent, "a fresh list must not refetch");
+
+                store.reset(cx);
+                store.ensure_recent_loaded(cx);
+                assert!(store.loading_recent, "logout must force a refetch");
+            });
+        });
     }
 
     #[test]

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -733,6 +733,21 @@ fn pagination_direction(
     }
 }
 
+fn hover_show_target(pointer: Option<MessageId>, shown: Option<MessageId>) -> Option<MessageId> {
+    pointer.filter(|target| shown != Some(*target))
+}
+
+fn hover_hide_target(
+    pointer: Option<MessageId>,
+    shown: Option<MessageId>,
+    menu_latched: bool,
+) -> Option<MessageId> {
+    if menu_latched {
+        return None;
+    }
+    shown.filter(|shown| pointer != Some(*shown))
+}
+
 fn deadline_remaining(last_activity: Instant, now: Instant, delay: Duration) -> Option<Duration> {
     let elapsed = now.saturating_duration_since(last_activity);
     if elapsed < delay {
@@ -1133,6 +1148,49 @@ mod pagination_tests {
 }
 
 #[cfg(test)]
+mod hover_schedule_tests {
+    use super::*;
+
+    const A: MessageId = MessageId(1);
+    const B: MessageId = MessageId(2);
+
+    #[test]
+    fn pointing_at_an_unshown_row_schedules_a_show() {
+        assert_eq!(hover_show_target(Some(A), None), Some(A));
+        assert_eq!(hover_show_target(Some(B), Some(A)), Some(B));
+    }
+
+    #[test]
+    fn the_already_shown_row_schedules_nothing() {
+        assert_eq!(hover_show_target(Some(A), Some(A)), None);
+        assert_eq!(hover_hide_target(Some(A), Some(A), false), None);
+    }
+
+    #[test]
+    fn leaving_the_shown_row_schedules_a_hide() {
+        assert_eq!(hover_hide_target(None, Some(A), false), Some(A));
+        assert_eq!(hover_hide_target(Some(B), Some(A), false), Some(A));
+    }
+
+    #[test]
+    fn sweeping_across_rows_keeps_one_hide_target_so_the_timer_is_not_restarted() {
+        let shown = Some(A);
+        let first = hover_hide_target(Some(B), shown, false);
+        let then = hover_hide_target(Some(MessageId(3)), shown, false);
+        assert_eq!(first, Some(A));
+        assert_eq!(
+            first, then,
+            "an unchanged hide target must not respawn the timer"
+        );
+    }
+
+    #[test]
+    fn an_open_context_menu_keeps_its_row_latched() {
+        assert_eq!(hover_hide_target(None, Some(A), true), None);
+    }
+}
+
+#[cfg(test)]
 mod scroll_idle_tests {
     use super::*;
 
@@ -1211,6 +1269,8 @@ pub struct ChannelMessages {
     overlay_hover: Option<MessageId>,
     _hover_show_task: Option<Task<()>>,
     _hover_hide_task: Option<Task<()>>,
+    pending_show: Option<MessageId>,
+    pending_hide: Option<MessageId>,
     scroll_relief_armed: bool,
     paginate_armed_top: bool,
     paginate_armed_bottom: bool,
@@ -1432,8 +1492,7 @@ impl ChannelMessages {
                     this.hovered_row = None;
                     this.raw_hover = None;
                     this.overlay_hover = None;
-                    this._hover_show_task = None;
-                    this._hover_hide_task = None;
+                    this.clear_hover_tasks();
                     this.edit_input = None;
                     this._edit_input_sub = None;
                     Rc::make_mut(&mut this.active_videos).clear();
@@ -1768,18 +1827,6 @@ impl ChannelMessages {
                 if visible_range_changed {
                     this.schedule_pagination_check(window, cx);
                 }
-                if this.hovered_row.is_some()
-                    || this.raw_hover.is_some()
-                    || this.overlay_hover.is_some()
-                    || this._hover_show_task.is_some()
-                    || this._hover_hide_task.is_some()
-                {
-                    this.hovered_row = None;
-                    this.raw_hover = None;
-                    this.overlay_hover = None;
-                    this._hover_show_task = None;
-                    this._hover_hide_task = None;
-                }
             });
         });
 
@@ -1904,6 +1951,8 @@ impl ChannelMessages {
             overlay_hover: None,
             _hover_show_task: None,
             _hover_hide_task: None,
+            pending_show: None,
+            pending_hide: None,
             scroll_relief_armed: false,
             paginate_armed_top: true,
             paginate_armed_bottom: true,
@@ -2480,11 +2529,8 @@ impl ChannelMessages {
             _ => false,
         };
         self.ensure_topic_create_permissions(cx);
-        self._hover_show_task = None;
-        self._hover_hide_task = None;
+        self.clear_hover_tasks();
         self.hovered_row = None;
-        self.raw_hover = None;
-        self.overlay_hover = None;
         self.reaction_submenu_open = false;
         self.context_menu_target = Some((message_id, position));
         cx.notify();
@@ -2496,6 +2542,7 @@ impl ChannelMessages {
             if self.hover_target().is_none() {
                 self.hovered_row = None;
             }
+            self.sync_hover_tasks(cx);
             cx.notify();
         }
     }
@@ -2543,44 +2590,55 @@ impl ChannelMessages {
         self.sync_hover_tasks(cx);
     }
 
+    fn clear_hover_tasks(&mut self) {
+        self._hover_show_task = None;
+        self._hover_hide_task = None;
+        self.pending_show = None;
+        self.pending_hide = None;
+    }
+
     fn sync_hover_tasks(&mut self, cx: &mut Context<Self>) {
         let raw = self.hover_target();
+        let shown = self.hovered_row;
+        let menu_latched =
+            shown.is_some_and(|shown| self.context_menu_target.is_some_and(|(id, _)| id == shown));
 
-        match raw {
-            Some(target) if self.hovered_row != Some(target) => {
-                self._hover_show_task = Some(cx.spawn(async move |this, cx| {
+        let show = hover_show_target(raw, shown);
+        if self.pending_show != show {
+            self.pending_show = show;
+            self._hover_show_task = show.map(|target| {
+                cx.spawn(async move |this, cx| {
                     cx.background_executor()
                         .timer(Duration::from_millis(HOVER_SHOW_DELAY_MS))
                         .await;
                     let _ = this.update(cx, |this, cx| {
+                        this.pending_show = None;
                         if this.hover_target() == Some(target) && this.hovered_row != Some(target) {
                             this.hovered_row = Some(target);
                             cx.notify();
                         }
                     });
-                }));
-            }
-            _ => self._hover_show_task = None,
+                })
+            });
         }
 
-        match self.hovered_row {
-            Some(shown) if raw != Some(shown) => {
-                if self.context_menu_target.is_some_and(|(id, _)| id == shown) {
-                    return;
-                }
-                self._hover_hide_task = Some(cx.spawn(async move |this, cx| {
+        let hide = hover_hide_target(raw, shown, menu_latched);
+        if self.pending_hide != hide {
+            self.pending_hide = hide;
+            self._hover_hide_task = hide.map(|shown| {
+                cx.spawn(async move |this, cx| {
                     cx.background_executor()
                         .timer(Duration::from_millis(HOVER_HIDE_DELAY_MS))
                         .await;
                     let _ = this.update(cx, |this, cx| {
+                        this.pending_hide = None;
                         if this.hover_target() != Some(shown) && this.hovered_row == Some(shown) {
                             this.hovered_row = None;
                             cx.notify();
                         }
                     });
-                }));
-            }
-            _ => self._hover_hide_task = None,
+                })
+            });
         }
     }
 

--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -1573,6 +1573,8 @@ const REACTION_EMOJI_PX: f32 = 16.;
 const REACTION_EMOJI_SOURCE_PX: u32 = 32;
 const RECENT_EMOJI_PX: f32 = 20.;
 const RECENT_EMOJI_SOURCE_PX: u32 = 40;
+const HOVER_ACTIONS_TOP: f32 = -32.;
+const HOVER_ACTIONS_MARGIN_TOP_DIFFERENT_DAY: f32 = 4.;
 
 pub fn recent_emoji_cells(emojis: &[Emoji], cx: &App) -> Vec<RecentEmojiCell> {
     emojis
@@ -1690,19 +1692,13 @@ fn reaction_pill(reaction: &Reaction, message_id: MessageId, ctx: &RowCtx) -> An
     pill.child(emoji_el).child(count_label).into_any_element()
 }
 
-pub fn render_hover_actions(
-    msg: &Message,
-    combined: bool,
-    has_reply: bool,
-    is_different_day: bool,
-    ctx: &RowCtx,
-) -> AnyElement {
-    if ctx.suppress_hover
-        || ctx.context_menu_message == Some(msg.id)
-        || ctx.hovered_row != Some(msg.id)
-    {
-        return div().into_any_element();
-    }
+pub fn hover_actions_visible(msg: &Message, ctx: &RowCtx) -> bool {
+    !ctx.suppress_hover
+        && ctx.context_menu_message != Some(msg.id)
+        && ctx.hovered_row == Some(msg.id)
+}
+
+pub fn render_hover_actions(msg: &Message, is_different_day: bool, ctx: &RowCtx) -> AnyElement {
     let theme = ctx.theme;
     let bg_hover = theme.bg_hover;
     let action = move |id: &'static str, icon: IconName, size: f32| {
@@ -1724,12 +1720,10 @@ pub fn render_hover_actions(
             .child(svg_icon)
     };
 
-    let (top, margin_top) = if is_different_day {
-        (-8., 4.)
-    } else if combined || has_reply {
-        (-8., 0.)
+    let margin_top = if is_different_day {
+        HOVER_ACTIONS_MARGIN_TOP_DIFFERENT_DAY
     } else {
-        (16., 0.)
+        0.
     };
 
     let reply_id = msg.id;
@@ -1825,7 +1819,7 @@ pub fn render_hover_actions(
         })
         .absolute()
         .right(px(24.))
-        .top(px(top))
+        .top(px(HOVER_ACTIONS_TOP))
         .mt(px(margin_top))
         .flex()
         .flex_row()

--- a/crates/mezon-ui/src/chat/message/reaction_picker.rs
+++ b/crates/mezon-ui/src/chat/message/reaction_picker.rs
@@ -79,6 +79,7 @@ pub struct ReactionPicker {
     search: Entity<InputState>,
     query: String,
     snapshot: Vec<CategorySnapshot>,
+    snapshot_stale: bool,
     rows: Vec<PickerRow>,
     nav: Vec<NavCategory>,
     collapsed: HashSet<String>,
@@ -143,7 +144,7 @@ impl ReactionPicker {
         });
         let emoji_sub = EmojiStore::try_global(cx).map(|store| {
             cx.subscribe(&store, |this, _store, _event: &EmojiEvent, cx| {
-                this.rebuild_snapshot(cx);
+                this.snapshot_stale = true;
                 cx.notify();
             })
         });
@@ -161,6 +162,7 @@ impl ReactionPicker {
             search,
             query: String::new(),
             snapshot: Vec::new(),
+            snapshot_stale: false,
             rows: Vec::new(),
             nav: Vec::new(),
             collapsed: HashSet::new(),
@@ -178,6 +180,7 @@ impl ReactionPicker {
     }
 
     fn rebuild_snapshot(&mut self, cx: &mut Context<Self>) {
+        self.snapshot_stale = false;
         let active = ClanList::global(cx)
             .read(cx)
             .active_clan_id
@@ -327,6 +330,9 @@ impl ReactionPicker {
 
 impl Render for ReactionPicker {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if self.snapshot_stale {
+            self.rebuild_snapshot(cx);
+        }
         let theme = cx.theme();
         let bg_tertiary = theme.bg_tertiary;
         let text_muted = theme.text_muted;

--- a/crates/mezon-ui/src/chat/message/user_row.rs
+++ b/crates/mezon-ui/src/chat/message/user_row.rs
@@ -10,8 +10,8 @@ use super::embed_card::render_embeds;
 use super::message_actions_panel::render_actions_panel;
 use super::ogp_embed::render_ogp_embed;
 use super::parts::{
-    avatar_element, render_attachments, render_head, render_hover_actions, render_reactions,
-    render_reply,
+    avatar_element, hover_actions_visible, render_attachments, render_head, render_hover_actions,
+    render_reactions, render_reply,
 };
 use super::poll_card::render_poll_card;
 use super::token_transaction_card::render_token_transaction_card;
@@ -312,14 +312,8 @@ pub fn render_user_message(
             d.child(render_reply(&msg.references[0], ctx))
         })
         .child(body)
-        .when(interactive, |d| {
-            d.child(render_hover_actions(
-                msg,
-                combined,
-                has_reply,
-                is_different_day,
-                ctx,
-            ))
+        .when(interactive && hover_actions_visible(msg, ctx), |d| {
+            d.child(render_hover_actions(msg, is_different_day, ctx))
         })
         .when(
             !ctx.is_topic_box && msg.is_card && !ephemeral && msg.code != MessageCode::Topic,


### PR DESCRIPTION
## Summary
- Do not fetch recent emoji during `EmojiStore::new` while disconnected
- Load recents on socket connect via `ensure_recent_loaded` with TTL freshness and in-flight guard
- Mark recent freshness stale on refresh/reset so logout forces a refetch
- Add GPUI tests for construction and freshness gating

## Test plan
- [ ] Cold start with no socket — no `emoji_recent_list` until connected
- [ ] After connect — recents load once; reconnect while fresh does not spam refetch
- [ ] Logout / reset — next connect fetches recents again
- [ ] `just test -p mezon-store construction_does_not_fetch_recents ensure_recent_loaded`

