### PR TITLE
fix(attachments): gate every CDN an upload can land on, and expire pending ones on time

### DIFF
--- a/crates/mezon-store/src/inbox.rs
+++ b/crates/mezon-store/src/inbox.rs
@@ -267,12 +267,12 @@ impl InboxStore {
         if bucket.items.iter().any(|n| n.id == notification.id) {
             return;
         }
-        if let Some(message_id) = notification.effective_message_id() {
-            if bucket.items.iter().any(|existing| {
+        if let Some(message_id) = notification.effective_message_id()
+            && bucket.items.iter().any(|existing| {
                 existing.effective_message_id().as_deref() == Some(message_id.as_str())
-            }) {
-                return;
-            }
+            })
+        {
+            return;
         }
         bucket.items.insert(0, notification);
         if bucket.items.len() > REALTIME_BUCKET_CAP {

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -534,6 +534,7 @@ pub struct MessagesStore {
     embed_form: HashMap<MessageId, HashMap<SharedString, SharedString>>,
     forward_task: Option<Task<()>>,
     forward_in_flight: bool,
+    presign_expiry_task: Option<Task<()>>,
     pending_send_payloads: HashMap<MessageId, PendingSendPayload>,
     anonymous_clans: HashSet<ClanId>,
     topic_anonymous_mode: bool,
@@ -948,6 +949,7 @@ impl MessagesStore {
             select_ui: HashMap::new(),
             embed_form: HashMap::new(),
             forward_task: None,
+            presign_expiry_task: None,
             forward_in_flight: false,
             pending_send_payloads: HashMap::new(),
             anonymous_clans: HashSet::new(),
@@ -2856,7 +2858,7 @@ impl MessagesStore {
             async move |_this, cx| match api.create_message_2_inbox(request).await {
                 Ok(()) => {
                     let notification = inbox_notification_from_marked_message_local(&marked);
-                    let _ = cx.update(|cx| {
+                    cx.update(|cx| {
                         InboxStore::global(cx).update(cx, |store, cx| {
                             store.prepend_local(
                                 GLOBAL_INBOX_BUCKET_CLAN_ID,
@@ -3105,6 +3107,61 @@ impl MessagesStore {
         });
         self.forward_task = Some(task);
         true
+    }
+
+    /// Re-run the presign gate so attachments whose upload never completed are
+    /// dropped once they pass their expiry, then arm the next deadline. Without
+    /// this the placeholder would sit there until some unrelated update for that
+    /// channel happened to arrive.
+    fn sweep_expired_presign(&mut self, cx: &mut Context<Self>) {
+        let base_img = AppConfig::try_global(cx)
+            .map(|c| c.base_img_url.clone())
+            .unwrap_or_default();
+        let now = now_unix_seconds();
+        let mut changed = false;
+        for channel in self.cache.values_mut() {
+            for message in channel.messages.items.iter_mut() {
+                if !message.attachments.iter().any(|a| a.presign_pending) {
+                    continue;
+                }
+                let Some(keys) = presign::parse_presign_finish_keys(&message.content) else {
+                    continue;
+                };
+                let before = message.attachments.len();
+                apply_presign_gate_at(
+                    &mut message.attachments,
+                    &keys,
+                    &base_img,
+                    message.create_time,
+                    now,
+                );
+                changed |= message.attachments.len() != before;
+            }
+        }
+        if changed {
+            cx.notify();
+        }
+        self.schedule_presign_expiry(cx);
+    }
+
+    fn schedule_presign_expiry(&mut self, cx: &mut Context<Self>) {
+        let now = now_unix_seconds();
+        let pending = self.cache.values_mut().flat_map(|channel| {
+            channel.messages.items.iter().map(|message| {
+                (
+                    message.create_time,
+                    message.attachments.iter().any(|a| a.presign_pending),
+                )
+            })
+        });
+        let Some(delay) = next_presign_expiry_in(pending, now) else {
+            self.presign_expiry_task = None;
+            return;
+        };
+        self.presign_expiry_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(delay).await;
+            let _ = this.update(cx, |this, cx| this.sweep_expired_presign(cx));
+        }));
     }
 
     pub fn share_contact(
@@ -4244,6 +4301,7 @@ impl MessagesStore {
                 let messages =
                     prepare_messages(page.messages, AppConfig::try_global(cx), viewer_user_id(cx));
                 self.set_channel(channel_id, messages);
+                self.schedule_presign_expiry(cx);
                 if is_current {
                     self.loading = false;
                     let count = self.messages().len();
@@ -4467,6 +4525,7 @@ impl MessagesStore {
             );
         }
         patch_reply_previews_after_update(&mut channel.messages, message_id, &preview);
+        self.schedule_presign_expiry(cx);
         if self.active_topic_id == Some(storage_id) {
             cx.emit(MessagesEvent::TopicUpdated {
                 topic_id: storage_id.get(),
@@ -6054,6 +6113,21 @@ fn apply_presign_gate(
     create_time: i64,
 ) {
     apply_presign_gate_at(attachments, keys, base_img, create_time, now_unix_seconds());
+}
+
+/// When the earliest still-pending attachment reaches its expiry, relative to
+/// `now`. `None` when nothing is waiting.
+fn next_presign_expiry_in(
+    messages: impl Iterator<Item = (i64, bool)>,
+    now: i64,
+) -> Option<std::time::Duration> {
+    messages
+        .filter(|(create_time, pending)| *pending && *create_time > 0)
+        .map(|(create_time, _)| {
+            let deadline = create_time + presign::PRESIGN_PENDING_MAX_AGE_SEC;
+            std::time::Duration::from_secs((deadline - now).max(0) as u64)
+        })
+        .min()
 }
 
 fn apply_presign_gate_at(
@@ -9080,6 +9154,34 @@ mod tests {
         assert!(
             attachments.is_empty(),
             "a stale never-uploaded attachment is dropped instead of rendering broken forever"
+        );
+    }
+
+    #[test]
+    fn expiry_is_scheduled_for_the_earliest_pending_message() {
+        let now = 1000;
+        let max = presign::PRESIGN_PENDING_MAX_AGE_SEC;
+        let delay = next_presign_expiry_in(
+            [(now - 60, true), (now - 300, true), (now, false)].into_iter(),
+            now,
+        )
+        .expect("a pending attachment arms the timer");
+        assert_eq!(
+            delay.as_secs() as i64,
+            max - 300,
+            "the timer follows the message closest to its expiry"
+        );
+
+        assert!(
+            next_presign_expiry_in([(now, false)].into_iter(), now).is_none(),
+            "nothing pending leaves the timer disarmed"
+        );
+        assert_eq!(
+            next_presign_expiry_in([(now - max - 60, true)].into_iter(), now)
+                .expect("an overdue message still fires")
+                .as_secs(),
+            0,
+            "an already expired attachment sweeps immediately instead of waiting"
         );
     }
 

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -3146,15 +3146,14 @@ impl MessagesStore {
 
     fn schedule_presign_expiry(&mut self, cx: &mut Context<Self>) {
         let now = now_unix_seconds();
-        let pending = self.cache.values_mut().flat_map(|channel| {
-            channel.messages.items.iter().map(|message| {
-                (
-                    message.create_time,
-                    message.attachments.iter().any(|a| a.presign_pending),
-                )
-            })
+        let deadlines = self.cache.values_mut().flat_map(|channel| {
+            channel
+                .messages
+                .items
+                .iter()
+                .filter_map(presign_expiry_deadline)
         });
-        let Some(delay) = next_presign_expiry_in(pending, now) else {
+        let Some(delay) = next_presign_expiry_in(deadlines, now) else {
             self.presign_expiry_task = None;
             return;
         };
@@ -4476,6 +4475,7 @@ impl MessagesStore {
         };
         let last_id = channel.messages.last().map(|m| m.id).unwrap_or(tail_id);
         self.set_last_message(storage_id, last_id);
+        self.schedule_presign_expiry(cx);
         if is_buzz && appended {
             self.play_buzz_sound(cx);
         }
@@ -6115,19 +6115,27 @@ fn apply_presign_gate(
     apply_presign_gate_at(attachments, keys, base_img, create_time, now_unix_seconds());
 }
 
-/// When the earliest still-pending attachment reaches its expiry, relative to
-/// `now`. `None` when nothing is waiting.
+/// When this message's pending attachments become droppable, or `None` when the
+/// sweep would not touch it. It must agree with `sweep_expired_presign`: a
+/// message the sweep skips but this counts would be rescheduled at zero delay
+/// forever.
+fn presign_expiry_deadline(message: &Message) -> Option<i64> {
+    if message.create_time <= 0 || !message.attachments.iter().any(|a| a.presign_pending) {
+        return None;
+    }
+    presign::parse_presign_finish_keys(&message.content)?;
+    Some(message.create_time + presign::PRESIGN_PENDING_MAX_AGE_SEC)
+}
+
+/// How long until the earliest deadline, relative to `now`. `None` when nothing
+/// is waiting.
 fn next_presign_expiry_in(
-    messages: impl Iterator<Item = (i64, bool)>,
+    deadlines: impl Iterator<Item = i64>,
     now: i64,
 ) -> Option<std::time::Duration> {
-    messages
-        .filter(|(create_time, pending)| *pending && *create_time > 0)
-        .map(|(create_time, _)| {
-            let deadline = create_time + presign::PRESIGN_PENDING_MAX_AGE_SEC;
-            std::time::Duration::from_secs((deadline - now).max(0) as u64)
-        })
+    deadlines
         .min()
+        .map(|deadline| std::time::Duration::from_secs((deadline - now).max(0) as u64))
 }
 
 fn apply_presign_gate_at(
@@ -9161,11 +9169,8 @@ mod tests {
     fn expiry_is_scheduled_for_the_earliest_pending_message() {
         let now = 1000;
         let max = presign::PRESIGN_PENDING_MAX_AGE_SEC;
-        let delay = next_presign_expiry_in(
-            [(now - 60, true), (now - 300, true), (now, false)].into_iter(),
-            now,
-        )
-        .expect("a pending attachment arms the timer");
+        let delay = next_presign_expiry_in([now - 60 + max, now - 300 + max].into_iter(), now)
+            .expect("a pending attachment arms the timer");
         assert_eq!(
             delay.as_secs() as i64,
             max - 300,
@@ -9173,16 +9178,36 @@ mod tests {
         );
 
         assert!(
-            next_presign_expiry_in([(now, false)].into_iter(), now).is_none(),
+            next_presign_expiry_in(std::iter::empty(), now).is_none(),
             "nothing pending leaves the timer disarmed"
         );
         assert_eq!(
-            next_presign_expiry_in([(now - max - 60, true)].into_iter(), now)
+            next_presign_expiry_in([now - 60].into_iter(), now)
                 .expect("an overdue message still fires")
                 .as_secs(),
             0,
             "an already expired attachment sweeps immediately instead of waiting"
         );
+    }
+
+    #[test]
+    fn a_message_the_sweep_cannot_clear_is_never_scheduled() {
+        let mut pending = Message::new(MessageId(1), "hi".to_string(), "5".to_string(), "me", 1000);
+        pending.create_time = 1000;
+        pending.attachments = vec![cdn_attachment("https://cdn.example/uploads/photo.png")];
+        pending.attachments[0].presign_pending = true;
+
+        pending.content = r#"{"t":"hi","presign_finish":[]}"#.to_string();
+        assert_eq!(
+            presign_expiry_deadline(&pending),
+            Some(1000 + presign::PRESIGN_PENDING_MAX_AGE_SEC),
+            "a pending message the sweep can act on arms the timer"
+        );
+
+        // The sweep skips a message whose content no longer carries the field, so
+        // counting it here would re-arm the timer at zero delay forever.
+        pending.content = r#"{"t":"hi"}"#.to_string();
+        assert_eq!(presign_expiry_deadline(&pending), None);
     }
 
     #[test]

--- a/crates/mezon-store/src/presign.rs
+++ b/crates/mezon-store/src/presign.rs
@@ -25,11 +25,28 @@ pub fn parse_presign_finish_keys(content: &str) -> Option<Vec<String>> {
     )
 }
 
+/// Every CDN an attachment can be presigned onto, mirroring the web client
+/// (`isMezonCdnUrl`). The configured `base_img_url` is only one of them, and a
+/// message can carry an attachment uploaded by a client pointed at another one —
+/// gating solely on our own host would let those through to imgproxy before the
+/// upload is confirmed, which caches a not-found for the real object.
+const PRESIGN_CDN_HOSTS: [&str; 3] = ["cdn.komu.vn", "cdn.komu.ai", "cdn.mezon.ai"];
+
+fn host_matches(host: &str, allowed: &str) -> bool {
+    host == allowed || host.ends_with(&format!(".{allowed}"))
+}
+
 pub fn is_mezon_cdn(url: &str, base_img_url: &str) -> bool {
-    let (Some(host), Some(allowed)) = (url_host(url), url_host(base_img_url)) else {
+    let Some(host) = url_host(url) else {
         return false;
     };
-    host == allowed || host.ends_with(&format!(".{allowed}"))
+    if PRESIGN_CDN_HOSTS
+        .iter()
+        .any(|allowed| host_matches(&host, allowed))
+    {
+        return true;
+    }
+    url_host(base_img_url).is_some_and(|allowed| host_matches(&host, &allowed))
 }
 
 pub fn presign_pending(url: &str, keys: Option<&[String]>, base_img_url: &str) -> bool {
@@ -115,6 +132,21 @@ mod tests {
         assert!(is_mezon_cdn("https://media.cdn.example/x/photo.png", CDN));
         assert!(!is_mezon_cdn("https://example.com/x/photo.png", CDN));
         assert!(!is_mezon_cdn("blob:https://cdn.example/uuid", CDN));
+    }
+
+    #[test]
+    fn every_mezon_cdn_is_gated_even_when_it_is_not_our_configured_host() {
+        for url in [
+            "https://cdn.mezon.ai/uploads/photo.png",
+            "https://cdn.komu.vn/uploads/photo.png",
+            "https://cdn.komu.ai/uploads/photo.png",
+        ] {
+            assert!(is_mezon_cdn(url, CDN), "{url} must be gated");
+            assert!(
+                presign_pending(url, Some(&["other".to_string()]), CDN),
+                "{url} must stay pending until its key arrives"
+            );
+        }
     }
 
     #[test]

--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -1194,7 +1194,11 @@ fn render_video_poster(
     let theme = ctx.theme;
     let url = SharedString::from(att.url.clone());
     let filename = SharedString::from(att.filename.clone());
-    let thumbnail = att.thumbnail_proxied.clone();
+    let thumbnail = if att.presign_pending {
+        SharedString::default()
+    } else {
+        att.thumbnail_proxied.clone()
+    };
     let width = att.display_width;
     let height = att.display_height;
     let host = ctx.video_host.clone();
@@ -1227,6 +1231,9 @@ fn render_video_poster(
         return container
             .child(attachment_sending_overlay(theme))
             .into_any_element();
+    }
+    if att.presign_pending {
+        return presign_child(container, att, theme).into_any_element();
     }
     let overlay = div()
         .absolute()


### PR DESCRIPTION
## Why this matters

We post a message with attachments **before** their uploads finish, so each CDN url is addressable while the object still does not exist. Loading one early makes imgproxy cache a not-found, and that cached miss outlives the upload — the image then stays broken for everyone.

`presign_pending` is the gate that prevents it. Three ways it fell short.

## What was wrong

**1. The gate only recognised our own configured CDN.** `is_mezon_cdn` compared against `base_img_url` alone, while `imgproxy_url` happily proxies anything in `media_origins` — which includes `cdn.mezon.ai`. An attachment uploaded by a client pointed at another mezon CDN (Android in particular) therefore slipped past the gate and went straight to imgproxy while still uploading. Web gates all three hosts; we gated one.

**2. A video poster was still built through imgproxy while its upload was pending**, and the tile stayed clickable — so the poster url could be fetched, and the video could be opened, before either existed.

**3. Expiry was only re-evaluated when an update for that channel happened to arrive.** A sender that died mid-upload left the placeholder on screen indefinitely: nothing ever came back to drop it. Web arms a one-shot timer, Android ticks every 30s; we did neither.

## What changed

- `is_mezon_cdn` covers every mezon CDN an upload can land on, and still honours `base_img_url` for custom deployments.
- The video poster is not proxied while pending, and the tile renders the pending placeholder instead of the play control.
- A single timer is armed for the earliest pending deadline (`create_time + 600s`), re-armed after each sweep — no polling. Hooked into channel load, message update, and socket arrival.

Also included: the two pre-existing clippy failures on develop (`inbox.rs` collapsible_if, `messages.rs` let_unit_value) that make the lint gate red.

## A note on the timer

The first version of it had two defects, both caught in review and fixed here:

- the sweep skips a message whose content no longer carries `presign_finish`, but the scheduler still counted it as pending — once past its deadline the timer re-armed at zero delay and span. Both sides now share `presign_expiry_deadline`, with a test pinning that exact case.
- a message arriving over the socket never armed the timer, which is precisely the case the timer exists for.

## Verification

`cargo test -p mezon-store` 776 passing, `cargo clippy --all-targets -D warnings` clean, fmt clean.
