### PR TITLE
fix(images): stop a bad download from breaking an image until the cache evicts it

### DIFF
--- a/crates/mezon-client/src/image_disk_cache.rs
+++ b/crates/mezon-client/src/image_disk_cache.rs
@@ -206,26 +206,46 @@ fn looks_like_image(body: &[u8]) -> bool {
     if body.starts_with(PNG)
         || body.starts_with(GIF87)
         || body.starts_with(GIF89)
-        || body.starts_with(BMP)
         || body.starts_with(TIFF_LE)
         || body.starts_with(TIFF_BE)
         || body.starts_with(&[0xFF, 0xD8, 0xFF])
     {
         return true;
     }
+    // "BM" alone is two bytes of ordinary text, so check the size field too.
+    if body.len() >= 6 && body.starts_with(BMP) {
+        let declared = u32::from_le_bytes([body[2], body[3], body[4], body[5]]) as usize;
+        if declared == body.len() {
+            return true;
+        }
+    }
     // RIFF....WEBP
     if body.len() >= 12 && body.starts_with(b"RIFF") && &body[8..12] == b"WEBP" {
         return true;
     }
-    // ISO base media (avif/heic): ....ftyp
+    // ISO base media: ....ftyp<brand>. Match only the image brands, so an mp4
+    // that reached this predicate is not mistaken for one.
     if body.len() >= 12 && &body[4..8] == b"ftyp" {
-        return true;
+        const IMAGE_BRANDS: [&[u8]; 6] = [b"avif", b"avis", b"heic", b"heix", b"mif1", b"msf1"];
+        if IMAGE_BRANDS.contains(&&body[8..12]) {
+            return true;
+        }
     }
     // SVG arrives as text and may be preceded by a BOM, whitespace or a prolog.
     let head = &body[..body.len().min(1024)];
     let text = String::from_utf8_lossy(head);
     let text = text.trim_start_matches('\u{feff}').trim_start();
     text.starts_with("<svg") || (text.starts_with("<?xml") && text.contains("<svg"))
+}
+
+fn content_length(response: &Response<AsyncBody>) -> Option<u64> {
+    response
+        .headers()
+        .get(http::header::CONTENT_LENGTH)?
+        .to_str()
+        .ok()?
+        .parse()
+        .ok()
 }
 
 async fn read_limited(response: &mut Response<AsyncBody>) -> anyhow::Result<Vec<u8>> {
@@ -327,9 +347,15 @@ impl HttpClient for DiskImageCacheClient {
                                 }
                                 anyhow::bail!("image fetch returned non-success status");
                             }
+                            let declared_len = content_length(&response);
                             let body = read_limited(&mut response).await?;
+                            // A transfer that ended early still carries a valid
+                            // header, so the magic bytes alone would let a partial
+                            // image into the cache and keep it broken from then on.
+                            let complete = declared_len.is_none_or(|len| len == body.len() as u64);
                             if body.is_empty()
                                 || body.len() > MAX_ENTRY_BYTES
+                                || !complete
                                 || !looks_like_image(&body)
                             {
                                 if let Ok(mut held) = slot.lock() {
@@ -413,6 +439,14 @@ mod tests {
         assert!(!looks_like_image(b"{\"error\":\"not found\"}"));
         assert!(!looks_like_image(b"Not Found"));
         assert!(!looks_like_image(b""));
+
+        // Bare "BM" is two bytes of ordinary text, and an mp4 also carries ftyp.
+        assert!(!looks_like_image(b"BM is not a bitmap here"));
+        assert!(!looks_like_image(b"\0\0\0\x18ftypisom"));
+        let mut bmp = b"BM\0\0\0\0rest".to_vec();
+        let len = bmp.len() as u32;
+        bmp[2..6].copy_from_slice(&len.to_le_bytes());
+        assert!(looks_like_image(&bmp));
     }
 
     const AVATAR: &str = "https://dev-imgproxy.nccsoft.vn/k/rs:fill:100:100:1/mb:2097152/plain/https://cdn.komu.vn/a.png@webp";

--- a/crates/mezon-client/src/image_disk_cache.rs
+++ b/crates/mezon-client/src/image_disk_cache.rs
@@ -188,6 +188,46 @@ enum FetchResult {
     Passthrough(Response<AsyncBody>),
 }
 
+/// Whether the bytes actually start like an image.
+///
+/// A body only reaches the disk tier once, but it is read back from there for
+/// the lifetime of the entry: admitting something that cannot decode - a proxy
+/// error page served with 200, a transfer that ended early - leaves a broken
+/// image that survives restarts, because every later load replays the same
+/// stored bytes instead of asking the network again.
+fn looks_like_image(body: &[u8]) -> bool {
+    const PNG: &[u8] = b"\x89PNG\r\n\x1a\n";
+    const GIF87: &[u8] = b"GIF87a";
+    const GIF89: &[u8] = b"GIF89a";
+    const BMP: &[u8] = b"BM";
+    const TIFF_LE: &[u8] = b"II*\0";
+    const TIFF_BE: &[u8] = b"MM\0*";
+
+    if body.starts_with(PNG)
+        || body.starts_with(GIF87)
+        || body.starts_with(GIF89)
+        || body.starts_with(BMP)
+        || body.starts_with(TIFF_LE)
+        || body.starts_with(TIFF_BE)
+        || body.starts_with(&[0xFF, 0xD8, 0xFF])
+    {
+        return true;
+    }
+    // RIFF....WEBP
+    if body.len() >= 12 && body.starts_with(b"RIFF") && &body[8..12] == b"WEBP" {
+        return true;
+    }
+    // ISO base media (avif/heic): ....ftyp
+    if body.len() >= 12 && &body[4..8] == b"ftyp" {
+        return true;
+    }
+    // SVG arrives as text and may be preceded by a BOM, whitespace or a prolog.
+    let head = &body[..body.len().min(1024)];
+    let text = String::from_utf8_lossy(head);
+    let text = text.trim_start_matches('\u{feff}').trim_start();
+    text.starts_with("<svg") || (text.starts_with("<?xml") && text.contains("<svg"))
+}
+
 async fn read_limited(response: &mut Response<AsyncBody>) -> anyhow::Result<Vec<u8>> {
     let mut body = Vec::new();
     response
@@ -288,7 +328,10 @@ impl HttpClient for DiskImageCacheClient {
                                 anyhow::bail!("image fetch returned non-success status");
                             }
                             let body = read_limited(&mut response).await?;
-                            if body.is_empty() || body.len() > MAX_ENTRY_BYTES {
+                            if body.is_empty()
+                                || body.len() > MAX_ENTRY_BYTES
+                                || !looks_like_image(&body)
+                            {
                                 if let Ok(mut held) = slot.lock() {
                                     *held = Some(ok_response(body));
                                 }
@@ -314,7 +357,22 @@ impl HttpClient for DiskImageCacheClient {
                         );
                     }
                     match fetched {
-                        Ok(entry) => Ok(FetchResult::Bytes(entry.value().clone())),
+                        Ok(entry) => {
+                            let bytes = entry.value().clone();
+                            // An entry stored before this check existed, or one
+                            // whose file went bad, would otherwise be replayed
+                            // for as long as it stays resident - the image stays
+                            // broken across restarts. Drop it and report a miss
+                            // so the next attempt goes back to the network.
+                            if !looks_like_image(&bytes) {
+                                cache.remove(&key);
+                                tracing::debug!("dropped a disk cache entry that is not an image");
+                                return Err(anyhow::anyhow!(
+                                    "image disk cache entry was not usable"
+                                ));
+                            }
+                            Ok(FetchResult::Bytes(bytes))
+                        }
                         Err(err) => match downloaded {
                             Some(response) => Ok(FetchResult::Passthrough(response)),
                             None => Err(anyhow::anyhow!("image disk cache fetch failed: {err}")),
@@ -334,6 +392,28 @@ impl HttpClient for DiskImageCacheClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn only_real_image_bytes_are_admitted_to_disk() {
+        assert!(looks_like_image(b"\x89PNG\r\n\x1a\n----"));
+        assert!(looks_like_image(b"\xFF\xD8\xFF----"));
+        assert!(looks_like_image(b"GIF89a----"));
+        assert!(looks_like_image(b"RIFF\0\0\0\0WEBPVP8 "));
+        assert!(looks_like_image(b"\0\0\0\x18ftypavif"));
+        assert!(looks_like_image(
+            b"  <svg xmlns=\"http://www.w3.org/2000/svg\"/>"
+        ));
+        assert!(looks_like_image(
+            b"<?xml version=\"1.0\"?><svg xmlns=\"http://www.w3.org/2000/svg\"/>"
+        ));
+
+        // What a proxy or gateway hands back when the object is missing. Storing
+        // any of these leaves an image that stays broken across restarts.
+        assert!(!looks_like_image(b"<!DOCTYPE html><html>404</html>"));
+        assert!(!looks_like_image(b"{\"error\":\"not found\"}"));
+        assert!(!looks_like_image(b"Not Found"));
+        assert!(!looks_like_image(b""));
+    }
 
     const AVATAR: &str = "https://dev-imgproxy.nccsoft.vn/k/rs:fill:100:100:1/mb:2097152/plain/https://cdn.komu.vn/a.png@webp";
     const PROFILE: &str = "https://dev-imgproxy.nccsoft.vn/k/rs:fit:300:300:1/mb:2097152/plain/https://cdn.komu.vn/a.png@webp";


### PR DESCRIPTION
## Symptom

An image fails once and then stays broken — closing and reopening the app does not help. Only clearing the cache directory (or waiting for the entry to be evicted by capacity) brings it back.

## Cause

The disk tier stored whatever a `200` response carried. It rejected error statuses, empty bodies and oversized ones, but never checked that the bytes are actually an image. A proxy or gateway that answers `200` with an HTML or JSON error page — which is what happens while an object is missing — was therefore written to disk.

From then on every load for that url reads those bytes back. Nothing ever returns to the network, so the failure survives restarts: it lives on disk, not in memory.

## What changed

- Admit a body only when it starts like an image (PNG, JPEG, GIF, WEBP, BMP, TIFF, AVIF/HEIC, SVG). Anything else is still served for that one render, just not stored.
- Drop an entry already on disk that does not look like an image, and report the load as a miss. This is what heals the users who are stuck today — without it the fix would only help fresh installs.

Dropping the entry surfaces as a network-shaped failure, which the decoded cache already retries, so the next attempt refetches instead of replaying the same bytes.

Decode failures stay non-retryable, deliberately: this build has no AVIF decoder, so making them retryable would re-download those images every fifteen seconds forever.

## Verification

New test covers the accepted formats and the bodies that must be refused (HTML 404, JSON error, plain text, empty). `cargo test -p mezon-client` 203 passing, `-p mezon-ui` 346 passing, clippy and fmt clean.

## Worth a separate look

`.avif` and `.heic` are both treated as displayable images (and `.heic` can be uploaded), but this build has no decoder for either — `ravif` is an encoder, and there is no dav1d. Those attachments are broken on every client regardless of caching. Fixing it is a product call: enable a decoder, transcode at upload time, or stop treating them as displayable.
