### PR TITLE
fix(attachments,ci): follow-ups to #219 and a green test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,13 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # Building the tests compiles the vendored Linux crates (libspa, zed-scap,
+    # gpui_linux), and the repo rule is to never lint vendored code - a path
+    # dependency gets no cap-lints, so the workflow-wide `-D warnings` turns
+    # their upstream warnings into build failures. Owned-crate lints are covered
+    # by the macOS `lint` job, same as the `windows-check` job below.
+    env:
+      RUSTFLAGS: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/crates/mezon-mcp/src/router.rs
+++ b/crates/mezon-mcp/src/router.rs
@@ -48,14 +48,14 @@ pub fn tool_count(read_only: bool) -> usize {
         .count()
 }
 
-pub fn build_tool_router<S, F, Fut>(_read_only: bool, invoke: F) -> ToolRouter<S>
+pub fn build_tool_router<S, F, Fut>(read_only: bool, invoke: F) -> ToolRouter<S>
 where
     S: Send + Sync + 'static,
     F: Fn(String, Value) -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = anyhow::Result<Value>> + Send + 'static,
 {
     let mut router = ToolRouter::<S>::new();
-    for spec in TOOL_SPECS {
+    for spec in TOOL_SPECS.iter().filter(|spec| !read_only || !spec.write) {
         let tool_name = spec.name.to_string();
         let invoke = invoke.clone();
         router.add_route(ToolRoute::new_dyn(

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -4457,6 +4457,9 @@ impl MessagesStore {
             return;
         }
         let tail_id = msg.id;
+        // Arming the expiry timer walks every cached message, so only pay for it
+        // when this message can actually be waiting on an upload.
+        let arms_expiry = msg.attachments.iter().any(|a| a.presign_pending);
         let old_len = channel.messages.len();
         let appended = match channel
             .messages
@@ -4475,7 +4478,9 @@ impl MessagesStore {
         };
         let last_id = channel.messages.last().map(|m| m.id).unwrap_or(tail_id);
         self.set_last_message(storage_id, last_id);
-        self.schedule_presign_expiry(cx);
+        if arms_expiry {
+            self.schedule_presign_expiry(cx);
+        }
         if is_buzz && appended {
             self.play_buzz_sound(cx);
         }
@@ -4524,8 +4529,11 @@ impl MessagesStore {
                 existing.create_time,
             );
         }
+        let arms_expiry = existing.attachments.iter().any(|a| a.presign_pending);
         patch_reply_previews_after_update(&mut channel.messages, message_id, &preview);
-        self.schedule_presign_expiry(cx);
+        if arms_expiry {
+            self.schedule_presign_expiry(cx);
+        }
         if self.active_topic_id == Some(storage_id) {
             cx.emit(MessagesEvent::TopicUpdated {
                 topic_id: storage_id.get(),
@@ -9187,6 +9195,23 @@ mod tests {
                 .as_secs(),
             0,
             "an already expired attachment sweeps immediately instead of waiting"
+        );
+    }
+
+    #[test]
+    fn an_ordinary_message_does_not_arm_the_expiry_timer() {
+        // Arming walks every cached message, and this runs on every socket
+        // arrival, so a message with nothing pending must not trigger it.
+        let mut plain = Message::new(MessageId(9), "hi".to_string(), "5".to_string(), "me", 1000);
+        plain.create_time = 1000;
+        assert_eq!(presign_expiry_deadline(&plain), None);
+
+        plain.attachments = vec![cdn_attachment("https://cdn.example/uploads/photo.png")];
+        plain.content = r#"{"t":"hi","presign_finish":["photo"]}"#.to_string();
+        assert_eq!(
+            presign_expiry_deadline(&plain),
+            None,
+            "a finished attachment has nothing left to expire"
         );
     }
 

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -3114,7 +3114,9 @@ impl MessagesStore {
     /// this the placeholder would sit there until some unrelated update for that
     /// channel happened to arrive.
     fn sweep_expired_presign(&mut self, cx: &mut Context<Self>) {
-        let base_img = AppConfig::try_global(cx)
+        let config = AppConfig::try_global(cx).cloned();
+        let base_img = config
+            .as_ref()
             .map(|c| c.base_img_url.clone())
             .unwrap_or_default();
         let now = now_unix_seconds();
@@ -3135,7 +3137,16 @@ impl MessagesStore {
                     message.create_time,
                     now,
                 );
-                changed |= message.attachments.len() != before;
+                if message.attachments.len() != before {
+                    // The album layout and the viewer list are built from the
+                    // attachments, so dropping one leaves them describing tiles
+                    // that are no longer there.
+                    let (album_layout, viewer_media) =
+                        build_media_presentation(&message.attachments, config.as_ref());
+                    message.album_layout = album_layout;
+                    message.viewer_media = viewer_media;
+                    changed = true;
+                }
             }
         }
         if changed {


### PR DESCRIPTION
Follow-up to #219, which merged while the first two of these were still in review. Everything here applies to what is on `develop` right now.

## 1. The expiry timer walks the whole cache on every socket message

`schedule_presign_expiry` iterates every cached message — up to 30 channels × 200 — and #219 calls it from `apply_incoming_message` and `apply_message_update`, i.e. **on every arriving message and every update**, whether or not anything is pending. That is ~6000 iterations per socket message on a busy account, for a timer that almost always has nothing to arm.

Guard both hot paths on the message at hand. A newly arrived message can never have an earlier deadline than one already waiting, so nothing needs re-arming unless that message itself is pending. A test pins that an ordinary message — and one whose attachment has already finished — does not arm the timer.

## 2. The album layout was not rebuilt when expiry dropped an attachment

The layout and the viewer list are derived from the attachments and built once, so removing an expired one left them describing a tile that is no longer rendered — a three-up album kept three-up geometry while showing two. No crash, since the render zips the two lists, but the wrong shape. Rebuild both for any message the sweep actually changed.

## 3. The Test job was red on every PR, and not because of the PR

Building the tests compiles the vendored Linux crates, and a path dependency gets no `cap-lints`, so the workflow-wide `RUSTFLAGS: -D warnings` turned their upstream warnings into build failures: `libspa` fails on a deprecated `cc` call plus four elided-lifetime warnings, with `zed-scap` and `gpui_linux` queued behind it. #209 tried removing the `cc` call and the job still failed on the next warning — it is whack-a-mole, and it contradicts the repo rule of never linting vendored code.

Clear `RUSTFLAGS` for that job, exactly as `windows-check` already does and documents. Owned crates keep their `-D warnings` enforcement in the macOS `lint` job, which runs `--all-targets --all-features`.

This unblocks #209 and #220 as well.

## 4. `mcp --read-only` advertised and served the write tools

With the job finally getting past compilation, it immediately caught a real failure that has been sitting on `develop`: `build_tool_router` ignored its `read_only` argument, and the stdio proxy has no second check at call time — so read-only mode registered all 44 tools instead of the 22 read ones, and would happily run them. Filter where the routes are built, matching what `list_tools_json` and `tool_count` already do.

(The same one-line fix rides along in #209. If that merges first, this hunk becomes a no-op.)

## Verification

`cargo test -p mezon-store` 777 passing, `-p mezon-cli`/`-p mezon-mcp` green, clippy `--all-targets -D warnings` clean on the owned crates, fmt clean.
