### PR TITLE
fix(chat): resolve invite links via real clan lookup instead of gener…

### DIFF
--- a/crates/mezon-client/src/lib.rs
+++ b/crates/mezon-client/src/lib.rs
@@ -51,7 +51,7 @@ pub use network_probe::{
 };
 pub use notification_setting::ChannelNotificationSetting;
 pub use notification_setting::NotificationOverride;
-pub use ogp::{OgpResult, fetch_ogp};
+pub use ogp::{OgpResult, fetch_invite_preview, fetch_ogp};
 pub use search_message::{
     SEARCH_PAGE_SIZE, SearchDropdownMode, SearchPageToken, active_search_trigger,
     autocomplete_needle, build_clan_channel_content_search, build_direct_content_search,

--- a/crates/mezon-client/src/ogp.rs
+++ b/crates/mezon-client/src/ogp.rs
@@ -2,8 +2,10 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::Result;
+use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
 use futures::AsyncReadExt as _;
 use http_client::{AsyncBody, HttpClient, http};
+use prost::Message as _;
 use url::Url;
 
 use crate::transport_runtime::{http_client, runtime};
@@ -13,6 +15,7 @@ const OGP_MAX_HTML_BYTES: usize = 512 * 1024;
 const OGP_MAX_DECOMPRESSED: usize = 4 * 1024 * 1024;
 const OGP_USER_AGENT: &str =
     "Mozilla/5.0 (compatible; MezonDesktop/1.0; +https://mezon.ai) OpenGraphPreview";
+const INVITE_PREVIEW_MAX_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct OgpResult {
@@ -21,6 +24,10 @@ pub struct OgpResult {
     pub description: String,
     pub image: String,
     pub is_image: bool,
+    pub banner: String,
+    pub member_count: Option<i64>,
+    pub is_community: bool,
+    pub clan_id: Option<String>,
 }
 
 impl OgpResult {
@@ -30,8 +37,76 @@ impl OgpResult {
             title: self.title.clone(),
             description: self.description.clone(),
             image: self.image.clone(),
+            banner: self.banner.clone(),
+            member_count: self.member_count,
+            is_community: self.is_community,
+            clan_id: self.clan_id.clone(),
         }
     }
+}
+
+pub async fn fetch_invite_preview(
+    gw_host: &str,
+    gw_port: u16,
+    secure: bool,
+    server_key: &str,
+    url: &str,
+    invite_id: &str,
+) -> Result<OgpResult> {
+    let scheme = if secure { "https" } else { "http" };
+    let request_url = format!("{scheme}://{gw_host}:{gw_port}/v2/invite/{invite_id}");
+    let auth_header = format!("Basic {}", B64.encode(format!("{server_key}:")));
+    let page_url = url.to_string();
+    runtime()
+        .spawn(async move {
+            let request = http::Request::builder()
+                .method(http::Method::GET)
+                .uri(&request_url)
+                .header(http::header::AUTHORIZATION, auth_header)
+                .header(http::header::ACCEPT, "application/x-protobuf")
+                .body(AsyncBody::empty())?;
+            let outcome = tokio::time::timeout(OGP_TIMEOUT, async move {
+                let mut response = http_client().send(request).await?;
+                if !response.status().is_success() {
+                    anyhow::bail!("HTTP GET failed with status {}", response.status());
+                }
+                let content_encoding = response
+                    .headers()
+                    .get(http::header::CONTENT_ENCODING)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or("")
+                    .trim()
+                    .to_ascii_lowercase();
+                let mut bytes = Vec::new();
+                let mut limited = response.body_mut().take(INVITE_PREVIEW_MAX_BYTES as u64);
+                limited.read_to_end(&mut bytes).await?;
+                let decoded = decompress_body(&bytes, &content_encoding);
+                let payload = decoded.as_deref().unwrap_or(&bytes);
+                let res = mezon_proto::api::InviteUserRes::decode(payload)?;
+                Ok(OgpResult {
+                    url: page_url,
+                    title: res.clan_name,
+                    image: res.clan_logo,
+                    banner: res.banner,
+                    member_count: Some(res.member_count as i64),
+                    is_community: res.is_community,
+                    clan_id: (res.clan_id != 0).then(|| res.clan_id.to_string()),
+                    ..Default::default()
+                })
+            })
+            .await;
+            match outcome {
+                Ok(inner) => inner,
+                Err(_) => {
+                    anyhow::bail!(
+                        "invite preview fetch timed out after {}s",
+                        OGP_TIMEOUT.as_secs()
+                    )
+                }
+            }
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("invite preview fetch task failed: {e}"))?
 }
 
 pub async fn fetch_ogp(url: &str) -> Result<OgpResult> {

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -2380,6 +2380,10 @@ pub struct OutgoingOgp {
     pub title: String,
     pub description: String,
     pub image: String,
+    pub banner: String,
+    pub member_count: Option<i64>,
+    pub is_community: bool,
+    pub clan_id: Option<String>,
 }
 
 pub const OGP_MARKDOWN_KIND: &str = "lk_ogp";
@@ -2396,6 +2400,10 @@ impl OutgoingOgp {
             description: (!self.description.is_empty())
                 .then(|| self.description.chars().take(OGP_DESCRIPTION_MAX).collect()),
             image: (!self.image.is_empty()).then(|| self.image.clone()),
+            banner: (!self.banner.is_empty()).then(|| self.banner.clone()),
+            member_count: self.member_count,
+            is_community: self.is_community,
+            clan_id: self.clan_id.clone(),
             ..Default::default()
         }
     }
@@ -2820,6 +2828,18 @@ fn with_ogp_token(content_json: String, ogp: &OutgoingOgp) -> String {
     }
     if !ogp.image.is_empty() {
         token.insert("image".into(), ogp.image.clone().into());
+    }
+    if !ogp.banner.is_empty() {
+        token.insert("banner".into(), ogp.banner.clone().into());
+    }
+    if let Some(member_count) = ogp.member_count {
+        token.insert("member_count".into(), member_count.into());
+    }
+    if ogp.is_community {
+        token.insert("is_community".into(), ogp.is_community.into());
+    }
+    if let Some(clan_id) = &ogp.clan_id {
+        token.insert("clanId".into(), clan_id.clone().into());
     }
     let entry = obj
         .entry("mk")
@@ -9189,6 +9209,38 @@ mod tests {
         let tokens = parse_message_content_tokens(raw);
         assert!(tokens.t.is_empty());
         assert!(tokens.embed.is_empty());
+    }
+
+    #[test]
+    fn with_ogp_token_includes_invite_fields_on_the_wire() {
+        let ogp = OutgoingOgp {
+            url: "https://mezon.ai/invite/1840670747886882816".into(),
+            title: "KOMU".into(),
+            image: "https://cdn.mezon.ai/logo.png".into(),
+            banner: "https://cdn.mezon.ai/banner.png".into(),
+            member_count: Some(374),
+            is_community: true,
+            clan_id: Some("123456".into()),
+            ..Default::default()
+        };
+        let content_json = with_ogp_token(
+            r#"{"t":"https://mezon.ai/invite/1840670747886882816"}"#.into(),
+            &ogp,
+        );
+        let tokens = parse_message_content_tokens(&content_json);
+        let token = tokens
+            .mk
+            .iter()
+            .find(|t| t.kind.as_deref() == Some(OGP_MARKDOWN_KIND))
+            .expect("lk_ogp token present");
+        assert_eq!(token.title.as_deref(), Some("KOMU"));
+        assert_eq!(token.member_count, Some(374));
+        assert!(token.is_community);
+        assert_eq!(token.clan_id.as_deref(), Some("123456"));
+        assert_eq!(
+            token.banner.as_deref(),
+            Some("https://cdn.mezon.ai/banner.png")
+        );
     }
 
     #[test]

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -163,7 +163,10 @@ pub use mezon_client::{
 pub use mmn_client::{DECIMAL_FACTOR as TOKEN_DECIMAL_FACTOR, DECIMALS as TOKEN_DECIMALS};
 pub use notification_push::NotificationPushStore;
 pub use notification_setting::{NotificationSettingEvent, NotificationSettingStore};
-pub use ogp::{OgpResult, OutgoingOgp, fetch_ogp, first_previewable_url};
+pub use ogp::{
+    OgpResult, OutgoingOgp, fetch_invite_preview, fetch_ogp, first_previewable_url,
+    invite_id_from_url,
+};
 pub use permissions::{
     ClanSettingsPermissions, PERMISSION_ADMINISTRATOR, PERMISSION_CLAN_OWNER,
     PERMISSION_MANAGE_CHANNEL, PERMISSION_MANAGE_CLAN, PERMISSION_SCOPE_CHANNEL,

--- a/crates/mezon-store/src/ogp.rs
+++ b/crates/mezon-store/src/ogp.rs
@@ -1,5 +1,5 @@
 pub use mezon_client::transport::OutgoingOgp;
-pub use mezon_client::{OgpResult, fetch_ogp};
+pub use mezon_client::{OgpResult, fetch_invite_preview, fetch_ogp};
 
 const EXCLUDED_HOSTS: &[&str] = &[
     "youtube.com",
@@ -11,6 +11,20 @@ const EXCLUDED_HOSTS: &[&str] = &[
 ];
 
 const TRAILING_PUNCTUATION: &[char] = &['.', ',', ';', ':', '!', '?', ')', ']', '}', '\'', '"'];
+
+pub fn invite_id_from_url(url: &str) -> Option<String> {
+    const NEEDLE: &[u8] = b"/invite/";
+    let idx = url
+        .as_bytes()
+        .windows(NEEDLE.len())
+        .position(|window| window.eq_ignore_ascii_case(NEEDLE))?;
+    let rest = &url[idx + NEEDLE.len()..];
+    let end = rest
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '-'))
+        .unwrap_or(rest.len());
+    let id = &rest[..end];
+    (!id.is_empty()).then(|| id.to_string())
+}
 
 /// The first URL in `text` eligible for an OGP link preview, or `None`.
 ///
@@ -134,5 +148,25 @@ mod tests {
     #[test]
     fn none_when_no_url() {
         assert_eq!(first_previewable_url("just some text", None), None);
+    }
+
+    #[test]
+    fn extracts_invite_id() {
+        assert_eq!(
+            invite_id_from_url("https://mezon.ai/invite/1840670747886882816").as_deref(),
+            Some("1840670747886882816")
+        );
+        assert_eq!(
+            invite_id_from_url("https://mezon.ai/invite/abc-DEF_123?ref=x").as_deref(),
+            Some("abc-DEF_123")
+        );
+        assert_eq!(
+            invite_id_from_url("https://mezon.ai/channels/1").as_deref(),
+            None
+        );
+        assert_eq!(
+            invite_id_from_url("https://mezon.ai/invite/").as_deref(),
+            None
+        );
     }
 }

--- a/crates/mezon-ui/src/chat/input_bar.rs
+++ b/crates/mezon-ui/src/chat/input_bar.rs
@@ -1,12 +1,15 @@
+use crate::chat::message::invite_card::member_count_label;
 use crate::chat::{MentionInput, ReplyTarget};
 use crate::components::primitives::{Icon, IconName};
 use crate::image_cache::LruImageCache;
 use crate::theme::{ActiveTheme, Theme};
 use gpui::{
     Context, Entity, FontWeight, ObjectFit, Render, SharedString, Subscription, Window, div, img,
-    prelude::*, px, radians,
+    prelude::*, px, radians, rgb,
 };
 use mezon_store::{MessagesEvent, MessagesStore, OgpResult, Settings, TopicsStore};
+
+const OGP_PREVIEW_MEMBER_DOT: u32 = 0x22_c5_5e;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ReplyClearSource {
@@ -166,6 +169,24 @@ impl InputBar {
                     .text_size(px(13.))
                     .text_color(theme.text_muted)
                     .child(SharedString::from(preview.description.clone())),
+            );
+        }
+        if let Some(count) = preview.member_count {
+            text_col = text_col.child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_1()
+                    .text_size(px(13.))
+                    .text_color(theme.text_muted)
+                    .child(
+                        div()
+                            .w(px(6.))
+                            .h(px(6.))
+                            .rounded_full()
+                            .bg(rgb(OGP_PREVIEW_MEMBER_DOT)),
+                    )
+                    .child(member_count_label(&self.locale, count)),
             );
         }
         div()

--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -17,13 +17,14 @@ use gpui::{
 };
 use mezon_client::transport::QUICK_MENU_TYPE_FLASH;
 use mezon_store::{
-    AccountEvent, AccountStore, AudioStore, BadgeService, Channel, ChannelEvent, ChannelId,
-    ChannelList, ChannelMembersEvent, ChannelMembersStore, ClanList, ClanMembersEvent,
+    AccountEvent, AccountStore, AppConfig, AudioStore, BadgeService, Channel, ChannelEvent,
+    ChannelId, ChannelList, ChannelMembersEvent, ChannelMembersStore, ClanList, ClanMembersEvent,
     ClanMembersStore, ComposeDraft, ComposeStore, ComposeToken, ComposeTokenKind, DirectEvent,
     DirectMessageStore, Emoji, EmojiEvent, EmojiStore, GroupMembersEvent, GroupMembersStore,
     MENTION_HERE_ID, MessageSpan, MessagesStore, OgpResult, OutgoingAttachment, OutgoingContent,
     OutgoingEmoji, OutgoingHashtag, OutgoingMention, OutgoingOgp, QuickMenuStore, RolesEvent,
-    RolesStore, Settings, fetch_ogp, first_previewable_url,
+    RolesStore, Settings, fetch_invite_preview, fetch_ogp, first_previewable_url,
+    invite_id_from_url,
 };
 use std::time::Duration;
 
@@ -1385,6 +1386,20 @@ impl MentionInput {
         self.ogp_generation += 1;
         let generation = self.ogp_generation;
         cx.notify();
+        let invite_id = invite_id_from_url(&url);
+        let invite_gateway = invite_id
+            .is_some()
+            .then(|| {
+                AppConfig::try_global(cx).map(|cfg| {
+                    (
+                        cfg.api_gw_host.clone(),
+                        cfg.api_gw_port,
+                        cfg.api_secure,
+                        cfg.api_key.clone(),
+                    )
+                })
+            })
+            .flatten();
         self._ogp_task = Some(cx.spawn(async move |this, cx| {
             cx.background_executor()
                 .timer(Duration::from_millis(300))
@@ -1395,7 +1410,12 @@ impl MentionInput {
             if !current {
                 return;
             }
-            let result = fetch_ogp(&url).await;
+            let result = match (&invite_id, &invite_gateway) {
+                (Some(invite_id), Some((host, port, secure, key))) => {
+                    fetch_invite_preview(host, *port, *secure, key, &url, invite_id).await
+                }
+                _ => fetch_ogp(&url).await,
+            };
             let _ = this.update(cx, |this, cx| {
                 if this.ogp_generation != generation {
                     return;

--- a/crates/mezon-ui/src/chat/message/invite_card.rs
+++ b/crates/mezon-ui/src/chat/message/invite_card.rs
@@ -317,7 +317,7 @@ fn handle_join_or_goto(joined_clan: Option<ClanId>, url: &str, cx: &mut App) {
     }
 }
 
-fn member_count_label(locale: &str, count: i64) -> SharedString {
+pub(crate) fn member_count_label(locale: &str, count: i64) -> SharedString {
     let key = if count == 1 {
         "linkMessageInvite.memberCount"
     } else {

--- a/crates/mezon-ui/src/chat/message/mod.rs
+++ b/crates/mezon-ui/src/chat/message/mod.rs
@@ -11,7 +11,7 @@ mod embed_fields;
 mod forward_modal;
 mod gif_video;
 pub mod inline_content;
-mod invite_card;
+pub(crate) mod invite_card;
 mod message_actions_panel;
 mod message_buzz_modal;
 mod message_context_menu;


### PR DESCRIPTION
…ic OGP scrape

Composing a message with a mezon.ai/invite/<id> link now looks up the real clan (title/logo/banner/member_count/is_community) through the same unauthenticated invite-preview endpoint mezon-react uses, instead of falling back to a generic HTML scrape of the invite landing page (which only carries generic site-wide OG tags, not clan-specific ones).

Also fixes the outgoing wire-token builder (with_ogp_token), which was missing banner/member_count/is_community/clanId — a sent invite message always echoed back with 0 members after a reload since the server never stored those fields in the first place.