### PR TITLE
fix(chat): colour role mentions with the everyone token and send @here

### DIFF
--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -1192,21 +1192,19 @@ pub fn enrich_content_tokens(tokens: &mut ApiMessageContent, entity_mentions: &[
         }
         let user_id = (m.user_id != 0).then(|| m.user_id.to_string());
         let role_id = (m.role_id != 0).then(|| m.role_id.to_string());
-        let duplicate = tokens.mentions.iter().any(|tok| {
-            tok.s == Some(i64::from(m.s))
-                && tok.e == Some(i64::from(m.e))
-                && tok.user_id == user_id
-                && tok.role_id == role_id
-        });
-        if duplicate {
+        let already_described = tokens
+            .mentions
+            .iter()
+            .any(|tok| tok.s == Some(i64::from(m.s)) && tok.e == Some(i64::from(m.e)));
+        if already_described {
             continue;
         }
         tokens.mentions.push(ContentToken {
             s: Some(i64::from(m.s)),
             e: Some(i64::from(m.e)),
+            username: (role_id.is_none() && !m.username.is_empty()).then(|| m.username.clone()),
             user_id,
             role_id,
-            username: (!m.username.is_empty()).then(|| m.username.clone()),
             ..Default::default()
         });
     }
@@ -2228,14 +2226,23 @@ pub struct OutgoingMention {
 
 impl OutgoingMention {
     fn is_here(&self) -> bool {
-        self.user_id == MENTION_HERE_ID
+        is_here_user_id(&self.user_id)
+    }
+
+    fn wire_user_id(&self) -> &str {
+        if self.is_here() {
+            MENTION_HERE_USER_ID
+        } else {
+            &self.user_id
+        }
     }
 
     fn to_content_token(&self) -> ContentToken {
+        let user_id = self.wire_user_id();
         ContentToken {
             s: Some(i64::from(self.s)),
             e: Some(i64::from(self.e)),
-            user_id: (!self.user_id.is_empty()).then(|| self.user_id.clone()),
+            user_id: (!user_id.is_empty()).then(|| user_id.to_string()),
             role_id: (!self.role_id.is_empty()).then(|| self.role_id.clone()),
             username: (!self.username.is_empty()).then(|| self.username.clone()),
             ..Default::default()
@@ -2243,10 +2250,7 @@ impl OutgoingMention {
     }
 
     fn to_proto(&self) -> Option<api::MessageMention> {
-        if self.is_here() {
-            return None;
-        }
-        let user_id = match self.user_id.as_str() {
+        let user_id = match self.wire_user_id() {
             "" => 0,
             raw => match raw.parse::<i64>() {
                 Ok(id) => id,
@@ -9067,7 +9071,7 @@ mod tests {
 
     fn here_mention(s: i32, e: i32) -> OutgoingMention {
         OutgoingMention {
-            user_id: MENTION_HERE_ID.into(),
+            user_id: MENTION_HERE_USER_ID.into(),
             role_id: String::new(),
             username: "@here".into(),
             s,
@@ -9076,7 +9080,7 @@ mod tests {
     }
 
     #[test]
-    fn here_mention_sets_everyone_and_is_excluded_from_proto() {
+    fn here_mention_sets_everyone_and_is_sent_in_the_proto() {
         let mentions = [user_mention("42", 0, 4), here_mention(5, 10)];
         let everyone = mentions.iter().any(OutgoingMention::is_here);
         let proto: Vec<_> = mentions
@@ -9084,11 +9088,36 @@ mod tests {
             .filter_map(OutgoingMention::to_proto)
             .collect();
         assert!(everyone);
-        assert_eq!(proto.len(), 1);
+        assert_eq!(proto.len(), 2);
         assert_eq!(proto[0].user_id, 42);
-        assert_eq!(proto[0].s, 0);
-        assert_eq!(proto[0].e, 4);
         assert_eq!(proto[0].username, "@bob");
+        assert_eq!(
+            proto[1].user_id,
+            MENTION_HERE_USER_ID
+                .parse::<i64>()
+                .expect("numeric here id")
+        );
+        assert_eq!(proto[1].s, 5);
+        assert_eq!(proto[1].e, 10);
+    }
+
+    #[test]
+    fn legacy_here_sentinel_is_normalised_to_the_numeric_id() {
+        let legacy = OutgoingMention {
+            user_id: MENTION_HERE_ID.into(),
+            ..here_mention(0, 5)
+        };
+        assert!(legacy.is_here());
+        assert_eq!(
+            legacy.to_proto().expect("here mention is sent").user_id,
+            MENTION_HERE_USER_ID
+                .parse::<i64>()
+                .expect("numeric here id")
+        );
+        assert_eq!(
+            legacy.to_content_token().user_id.as_deref(),
+            Some(MENTION_HERE_USER_ID)
+        );
     }
 
     #[test]
@@ -9335,11 +9364,61 @@ mod tests {
     }
 
     #[test]
+    fn enrich_never_adds_a_username_to_a_role_mention() {
+        let mut tokens = ApiMessageContent {
+            t: "@Everyone".into(),
+            ..Default::default()
+        };
+        enrich_content_tokens(
+            &mut tokens,
+            &[ApiEntityMention {
+                user_id: 0,
+                role_id: 9,
+                username: "@Everyone".into(),
+                s: 0,
+                e: 9,
+            }],
+        );
+        assert_eq!(tokens.mentions.len(), 1);
+        assert_eq!(tokens.mentions[0].role_id.as_deref(), Some("9"));
+        assert_eq!(tokens.mentions[0].username.as_deref(), None);
+    }
+
+    #[test]
+    fn enrich_leaves_a_span_the_content_json_already_describes() {
+        let mut tokens = ApiMessageContent {
+            t: "@Everyone".into(),
+            mentions: vec![ContentToken {
+                s: Some(0),
+                e: Some(9),
+                role_id: Some("9".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        enrich_content_tokens(
+            &mut tokens,
+            &[ApiEntityMention {
+                user_id: 0,
+                role_id: 9,
+                username: "@Everyone".into(),
+                s: 0,
+                e: 9,
+            }],
+        );
+        assert_eq!(tokens.mentions.len(), 1);
+        assert_eq!(tokens.mentions[0].username.as_deref(), None);
+    }
+
+    #[test]
     fn content_json_keeps_here_mention_for_receive_colouring() {
         let json = build_message_content_json("@here", &[here_mention(0, 5)], &[], &[], &[]);
         let parsed: ApiMessageContent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.mentions.len(), 1);
-        assert_eq!(parsed.mentions[0].user_id.as_deref(), Some("here"));
+        assert_eq!(
+            parsed.mentions[0].user_id.as_deref(),
+            Some(MENTION_HERE_USER_ID)
+        );
     }
 
     fn role_mention(role_id: &str, s: i32, e: i32) -> OutgoingMention {

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -2873,8 +2873,9 @@ fn build_message_content_json(
             .iter()
             .map(|m| {
                 let mut o = serde_json::Map::new();
-                if !m.user_id.is_empty() {
-                    o.insert("user_id".into(), m.user_id.clone().into());
+                let user_id = m.wire_user_id();
+                if !user_id.is_empty() {
+                    o.insert("user_id".into(), user_id.into());
                 }
                 if !m.role_id.is_empty() {
                     o.insert("role_id".into(), m.role_id.clone().into());
@@ -9116,6 +9117,13 @@ mod tests {
         );
         assert_eq!(
             legacy.to_content_token().user_id.as_deref(),
+            Some(MENTION_HERE_USER_ID)
+        );
+        let sent = build_send_content("@here", std::slice::from_ref(&legacy), &[], &[]);
+        let parsed: ApiMessageContent =
+            serde_json::from_str(&sent.json).expect("wire content json");
+        assert_eq!(
+            parsed.mentions[0].user_id.as_deref(),
             Some(MENTION_HERE_USER_ID)
         );
     }

--- a/crates/mezon-store/src/message.rs
+++ b/crates/mezon-store/src/message.rs
@@ -555,6 +555,7 @@ pub enum RichRunKind {
     Code,
     Link,
     Mention,
+    RoleMention,
     Hashtag,
 }
 
@@ -914,18 +915,19 @@ pub fn parse_spans(content: &ApiMessageContent) -> Vec<MessageSpan> {
         let inner = slice(s, e);
         match kind {
             Kind::Mention => {
-                let is_user = tok
+                let has_user = tok
                     .user_id
                     .as_deref()
-                    .is_some_and(|u| u != "0" && !u.is_empty())
-                    || tok.username.is_some();
-                if is_user {
+                    .is_some_and(|u| u != "0" && !u.is_empty());
+                let has_role = tok.role_id.as_deref().is_some_and(|r| !r.is_empty());
+                let has_username = tok.username.as_deref().is_some_and(|u| !u.is_empty());
+                if has_user || has_username {
                     spans.push(MessageSpan::Mention {
                         display: inner.into(),
                         user_id: tok.user_id.clone(),
                         role_id: None,
                     });
-                } else if tok.role_id.as_deref().is_some_and(|r| !r.is_empty()) {
+                } else if has_role {
                     spans.push(MessageSpan::Mention {
                         display: inner.into(),
                         user_id: None,
@@ -1316,19 +1318,24 @@ pub fn build_rich_layout(spans: &[MessageSpan]) -> Option<Arc<RichLayout>> {
             } => {
                 let start = text.len();
                 text.push_str(display);
-                let click = if role_id.as_deref().is_none_or(str::is_empty) {
+                let is_role = role_id.as_deref().is_some_and(|r| !r.is_empty());
+                let click = if is_role {
+                    None
+                } else {
                     user_id
                         .as_deref()
                         .filter(|u| !u.is_empty() && *u != "0" && !is_here_user_id(u))
                         .and_then(|u| u.parse::<i64>().ok())
                         .map(UserId)
                         .map(RichClick::Mention)
-                } else {
-                    None
                 };
                 runs.push(RichRun {
                     range: start..text.len(),
-                    kind: RichRunKind::Mention,
+                    kind: if is_role {
+                        RichRunKind::RoleMention
+                    } else {
+                        RichRunKind::Mention
+                    },
                     click,
                 });
             }
@@ -1780,6 +1787,115 @@ mod tests {
                     role_id: None,
                 },
                 MessageSpan::Text(" !".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_spans_keeps_role_id_when_token_carries_an_empty_username() {
+        let content = ApiMessageContent {
+            t: "hi @Admin".into(),
+            mentions: vec![ContentToken {
+                role_id: Some("9".into()),
+                username: Some(String::new()),
+                ..token(3, 9)
+            }],
+            ..Default::default()
+        };
+        assert_eq!(
+            parse_spans(&content),
+            vec![
+                MessageSpan::Text("hi ".into()),
+                MessageSpan::Mention {
+                    display: "@Admin".into(),
+                    user_id: None,
+                    role_id: Some("9".into()),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_spans_prefers_user_when_a_role_token_carries_a_real_username() {
+        let content = ApiMessageContent {
+            t: "hi @Admin".into(),
+            mentions: vec![ContentToken {
+                role_id: Some("9".into()),
+                username: Some("@Admin".into()),
+                ..token(3, 9)
+            }],
+            ..Default::default()
+        };
+        assert_eq!(
+            parse_spans(&content),
+            vec![
+                MessageSpan::Text("hi ".into()),
+                MessageSpan::Mention {
+                    display: "@Admin".into(),
+                    user_id: None,
+                    role_id: None,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_spans_reads_role_token_without_username() {
+        let content: ApiMessageContent =
+            serde_json::from_str(r#"{"t":"hi @Admin","mentions":[{"s":3,"e":9,"role_id":9}]}"#)
+                .expect("role mention token json");
+        assert_eq!(
+            parse_spans(&content),
+            vec![
+                MessageSpan::Text("hi ".into()),
+                MessageSpan::Mention {
+                    display: "@Admin".into(),
+                    user_id: None,
+                    role_id: Some("9".into()),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_spans_keeps_username_only_mention_as_user() {
+        let content = ApiMessageContent {
+            t: "hi @bob".into(),
+            mentions: vec![ContentToken {
+                username: Some("bob".into()),
+                ..token(3, 7)
+            }],
+            ..Default::default()
+        };
+        assert_eq!(
+            parse_spans(&content),
+            vec![
+                MessageSpan::Text("hi ".into()),
+                MessageSpan::Mention {
+                    display: "@bob".into(),
+                    user_id: None,
+                    role_id: None,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_spans_treats_idless_empty_username_mention_as_plain_text() {
+        let content = ApiMessageContent {
+            t: "hi @here".into(),
+            mentions: vec![ContentToken {
+                user_id: Some("0".into()),
+                username: Some(String::new()),
+                ..token(3, 8)
+            }],
+            ..Default::default()
+        };
+        assert_eq!(
+            parse_spans(&content),
+            vec![
+                MessageSpan::Text("hi ".into()),
+                MessageSpan::Text("@here".into())
             ]
         );
     }
@@ -2321,6 +2437,19 @@ mod tests {
         assert_eq!(run.range, 3..7);
         assert_eq!(&layout.text[run.range.clone()], "@bob");
         assert_eq!(run.click, Some(RichClick::Mention(UserId(42))));
+    }
+
+    #[test]
+    fn rich_layout_tags_role_mentions_apart_from_user_mentions() {
+        let spans = vec![MessageSpan::Mention {
+            display: "@Everyone".into(),
+            user_id: None,
+            role_id: Some("1841396057137745920".into()),
+        }];
+        let layout = build_rich_layout(&spans).expect("rich layout");
+        assert_eq!(layout.runs.len(), 1);
+        assert_eq!(layout.runs[0].kind, RichRunKind::RoleMention);
+        assert_eq!(layout.runs[0].click, None);
     }
 
     #[test]

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -182,10 +182,11 @@ pub struct OutgoingMention {
 
 impl OutgoingMention {
     pub(crate) fn into_transport(self) -> TransportMention {
+        let is_role = self.user_id.is_empty() && !self.role_id.is_empty();
         TransportMention {
+            username: if is_role { String::new() } else { self.display },
             user_id: self.user_id,
             role_id: self.role_id,
-            username: self.display,
             s: self.s,
             e: self.e,
         }
@@ -7941,6 +7942,67 @@ mod tests {
                     display: "@bob".into(),
                     user_id: Some("42".into()),
                     role_id: None,
+                },
+                MessageSpan::Text(" hi".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn role_mention_survives_the_full_send_wire_json() {
+        let transport: Vec<TransportMention> = vec![OutgoingMention {
+            user_id: String::new(),
+            role_id: "9".into(),
+            display: "@Everyone".into(),
+            s: 0,
+            e: 9,
+        }]
+        .into_iter()
+        .map(OutgoingMention::into_transport)
+        .collect();
+        let sent =
+            mezon_client::transport::build_send_content("@Everyone hi", &transport, &[], &[]);
+        let parsed: ApiMessageContent =
+            serde_json::from_str(&sent.json).expect("wire content json");
+        assert_eq!(parsed.mentions.len(), 1);
+        assert_eq!(parsed.mentions[0].role_id.as_deref(), Some("9"));
+        assert_eq!(parsed.mentions[0].username.as_deref(), None);
+        assert_eq!(
+            parse_spans(&parsed)[0],
+            MessageSpan::Mention {
+                display: "@Everyone".into(),
+                user_id: None,
+                role_id: Some("9".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn role_mention_tokens_round_trip_without_a_username() {
+        let mentions = vec![OutgoingMention {
+            user_id: String::new(),
+            role_id: "9".into(),
+            display: "@Admin".into(),
+            s: 0,
+            e: 6,
+        }];
+        let transport: Vec<TransportMention> = mentions
+            .into_iter()
+            .map(OutgoingMention::into_transport)
+            .collect();
+        assert_eq!(transport[0].username, "");
+        let tokens = ApiMessageContent {
+            t: "@Admin hi".into(),
+            mentions: mention_content_tokens(&transport),
+            ..Default::default()
+        };
+        assert_eq!(
+            parse_spans(&tokens),
+            vec![
+                MessageSpan::Mention {
+                    display: "@Admin".into(),
+                    user_id: None,
+                    role_id: Some("9".into()),
                 },
                 MessageSpan::Text(" hi".into()),
             ]

--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -10,10 +10,10 @@ use std::rc::Rc;
 use crate::router::{Route, Router};
 use gpui::{
     AnyElement, App, Bounds, Context, DismissEvent, Div, Entity, EventEmitter, Focusable,
-    FontWeight, Image, ImageFormat, IntoElement, KeyBinding, MouseButton, PathPromptOptions,
-    Pixels, Rgba, ScrollStrategy, SharedString, Stateful, Subscription, Task,
-    UniformListScrollHandle, Window, actions, canvas, deferred, div, img, prelude::*, px,
-    uniform_list,
+    FontWeight, HighlightStyle, Hsla, Image, ImageFormat, IntoElement, KeyBinding, MouseButton,
+    PathPromptOptions, Pixels, Rgba, ScrollStrategy, SharedString, Stateful, StyledText,
+    Subscription, Task, UniformListScrollHandle, Window, actions, canvas, deferred, div, img,
+    prelude::*, px, uniform_list,
 };
 use mezon_client::transport::QUICK_MENU_TYPE_FLASH;
 use mezon_store::{
@@ -21,9 +21,9 @@ use mezon_store::{
     ChannelId, ChannelList, ChannelMembersEvent, ChannelMembersStore, ClanList, ClanMembersEvent,
     ClanMembersStore, ComposeDraft, ComposeStore, ComposeToken, ComposeTokenKind, DirectEvent,
     DirectMessageStore, Emoji, EmojiEvent, EmojiStore, GroupMembersEvent, GroupMembersStore,
-    MENTION_HERE_ID, MessageSpan, MessagesStore, OgpResult, OutgoingAttachment, OutgoingContent,
-    OutgoingEmoji, OutgoingHashtag, OutgoingMention, OutgoingOgp, QuickMenuStore, RolesEvent,
-    RolesStore, Settings, fetch_invite_preview, fetch_ogp, first_previewable_url,
+    MENTION_HERE_USER_ID, MessageSpan, MessagesStore, OgpResult, OutgoingAttachment,
+    OutgoingContent, OutgoingEmoji, OutgoingHashtag, OutgoingMention, OutgoingOgp, QuickMenuStore,
+    RolesEvent, RolesStore, Settings, fetch_invite_preview, fetch_ogp, first_previewable_url,
     invite_id_from_url,
 };
 use std::time::Duration;
@@ -43,12 +43,13 @@ use crate::chat::member_list::{
 use crate::chat::message::CreatePollModal;
 use crate::chat::message::MessageBuzzModal;
 use crate::chat::message::ShareLocationModal;
+use crate::chat::role_style::role_fallback_color;
 use crate::components::primitives::{Avatar, Icon, IconName, ToastKind};
 use crate::image_cache::{
     AVATAR_ENTRY_MAX_BYTES, AVATAR_IMAGE_CACHE_BYTES, AVATAR_IMAGE_CACHE_CAPACITY, LruImageCache,
 };
 use crate::theme::{ActiveTheme, Theme};
-use crate::util::text_utils::normalize_search_string;
+use crate::util::text_utils::{normalize_search_string, push_search_normalized};
 use text_field::{
     MentionFieldEvent, MentionInputField, MentionInputState, MentionSpan, MentionSpanKind,
     byte_offset_to_utf16,
@@ -68,8 +69,8 @@ const MENTION_HERE_NORM: &str = "@HERE";
 const CONVERT_TO_FILE_THRESHOLD: usize = 3700;
 const CONVERT_PREFIX_LEN: usize = 8;
 const STREAM_MODE_DM: i32 = 4;
-const MENTION_ROW_PX: f32 = 36.;
-const MENTION_POPUP_MAX_PX: f32 = MENTION_ROW_PX * 6.;
+const MENTION_ROW_PX: f32 = 40.;
+const MENTION_POPUP_MAX_PX: f32 = MENTION_ROW_PX * MAX_SUGGESTIONS as f32;
 
 actions!(
     mezon_mention,
@@ -155,6 +156,16 @@ impl Sigil {
             Sigil::Colon => 2,
             Sigil::Slash => 3,
         }
+    }
+
+    fn category_title(self, locale: &str) -> SharedString {
+        let key = match self {
+            Sigil::At => "messageBox.mentionCategories.members",
+            Sigil::Hash => "messageBox.mentionCategories.textChannels",
+            Sigil::Colon => "messageBox.mentionCategories.emojiMatching",
+            Sigil::Slash => "messageBox.mentionCategories.commands",
+        };
+        SharedString::from(mezon_i18n::t(locale, key).to_uppercase())
     }
 
     fn from_byte(b: u8) -> Option<Self> {
@@ -249,6 +260,7 @@ struct RoleSuggestRaw {
     title_lc: String,
     title_norm: String,
     icon_src: SharedString,
+    color: Hsla,
 }
 
 #[derive(Clone)]
@@ -280,12 +292,12 @@ enum Suggestion {
 impl Suggestion {
     fn group_order(&self) -> u8 {
         match self {
+            Suggestion::Role(_) => 0,
             Suggestion::Member(..)
             | Suggestion::Channel(_)
             | Suggestion::Emoji(..)
-            | Suggestion::SlashCommand(_) => 0,
-            Suggestion::Role(_) => 1,
-            Suggestion::Here => 2,
+            | Suggestion::SlashCommand(_)
+            | Suggestion::Here => 1,
         }
     }
 
@@ -344,6 +356,45 @@ fn resolve_suggestion_media(items: &mut [Suggestion], cx: &App) {
     }
 }
 
+fn normalized_with_offsets(text: &str) -> (String, Vec<(usize, usize)>) {
+    let mut normalized = String::with_capacity(text.len());
+    let mut spans: Vec<(usize, usize)> = Vec::with_capacity(text.len());
+    for (byte_ix, ch) in text.char_indices() {
+        push_search_normalized(ch, &mut normalized);
+        spans.resize(normalized.len(), (byte_ix, byte_ix + ch.len_utf8()));
+    }
+    (normalized, spans)
+}
+
+fn highlight_match_range(text: &str, query: &str) -> Option<std::ops::Range<usize>> {
+    if text.is_empty() {
+        return None;
+    }
+    let needle = normalize_search_string(query);
+    if needle.is_empty() {
+        return None;
+    }
+    let (haystack, spans) = normalized_with_offsets(text);
+    let start = haystack.find(&needle)?;
+    let end = start + needle.len();
+    let from = spans.get(start)?.0;
+    let to = spans.get(end - 1)?.1;
+    Some(from..to)
+}
+
+fn highlighted_label(text: SharedString, query: &str) -> StyledText {
+    match highlight_match_range(&text, query) {
+        Some(range) => StyledText::new(text).with_highlights(vec![(
+            range,
+            HighlightStyle {
+                font_weight: Some(FontWeight::BOLD),
+                ..Default::default()
+            },
+        )]),
+        None => StyledText::new(text),
+    }
+}
+
 fn prioritize_and_limit(mut items: Vec<Suggestion>, query: &str) -> Vec<Suggestion> {
     let query_lc = query.to_lowercase();
     items.sort_by_cached_key(|item| (item.group_order(), item.match_rank(&query_lc)));
@@ -378,6 +429,7 @@ pub struct MentionInput {
     active_sigil: Sigil,
     pooled: [Option<MentionScope>; 4],
     query_len: usize,
+    active_query: SharedString,
     suggestions: Vec<Suggestion>,
     selected: usize,
     suggestion_scroll: UniformListScrollHandle,
@@ -568,6 +620,7 @@ impl MentionInput {
             active_sigil: Sigil::At,
             pooled: [None; 4],
             query_len: 0,
+            active_query: SharedString::default(),
             suggestions: Vec::new(),
             selected: 0,
             suggestion_scroll: UniformListScrollHandle::new(),
@@ -1259,6 +1312,7 @@ impl MentionInput {
     fn close_suggestions(&mut self) {
         self.active_at = None;
         self.query_len = 0;
+        self.active_query = SharedString::default();
         self.suggestions.clear();
         self.selected = 0;
     }
@@ -1580,6 +1634,7 @@ impl MentionInput {
         self.active_at = Some(at);
         self.active_sigil = sigil;
         self.query_len = query.len() + 1;
+        self.active_query = SharedString::from(query.to_string());
         self.build_suggestions(query, cx);
         if self.suggestions.is_empty() {
             self.clear_suggestions(cx);
@@ -1879,7 +1934,7 @@ impl MentionInput {
             Suggestion::Here => (
                 "@here".to_string(),
                 TokenKind::Mention {
-                    user_id: MENTION_HERE_ID.to_string(),
+                    user_id: MENTION_HERE_USER_ID.to_string(),
                     role_id: String::new(),
                 },
             ),
@@ -2114,11 +2169,13 @@ impl MentionInput {
         suggestion: &Suggestion,
         entity: &Entity<MentionInput>,
     ) -> AnyElement {
-        let text_primary = theme.text_primary;
+        let text_primary = theme.tokens.text_theme_primary;
         let text_muted = theme.text_muted;
         let selected_bg = theme.tokens.bg_active_member_channel;
         let is_selected = index == self.selected;
+        let query = self.active_query.clone();
 
+        let mut display_color = Hsla::from(text_primary);
         let (leading, display, secondary): (Option<AnyElement>, SharedString, SharedString) =
             match suggestion {
                 Suggestion::Here => (
@@ -2129,7 +2186,7 @@ impl MentionInput {
                 Suggestion::Member(member, avatar_src) => {
                     let mut avatar = Avatar::new()
                         .name(member.display.clone())
-                        .size_px(px(24.))
+                        .size_px(px(20.))
                         .image_cache(self.avatar_cache.clone());
                     if !avatar_src.is_empty() {
                         avatar = avatar
@@ -2139,19 +2196,26 @@ impl MentionInput {
                     (
                         Some(avatar.into_any_element()),
                         member.display.clone().into(),
-                        format!("@{}", member.username).into(),
+                        format!("@{}", member.username.to_lowercase()).into(),
                     )
                 }
                 Suggestion::Role(role) => {
-                    let mut avatar = Avatar::new()
-                        .name(role.title.clone())
-                        .size_px(px(24.))
-                        .image_cache(self.avatar_cache.clone());
-                    if !role.icon_src.is_empty() {
-                        avatar = avatar.src(role.icon_src.clone());
-                    }
+                    display_color = role.color;
+                    let leading = if role.icon_src.is_empty() {
+                        Icon::new(IconName::RoleIcon)
+                            .size(px(20.))
+                            .flex_shrink_0()
+                            .text_color(role.color)
+                            .into_any_element()
+                    } else {
+                        img(role.icon_src.clone())
+                            .size(px(20.))
+                            .flex_shrink_0()
+                            .rounded(px(4.))
+                            .into_any_element()
+                    };
                     (
-                        Some(avatar.into_any_element()),
+                        Some(leading),
                         role.title.clone().into(),
                         SharedString::default(),
                     )
@@ -2162,7 +2226,7 @@ impl MentionInput {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .size(px(24.))
+                            .size(px(20.))
                             .text_size(px(16.))
                             .font_weight(FontWeight::SEMIBOLD)
                             .text_color(text_muted)
@@ -2190,7 +2254,7 @@ impl MentionInput {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .size(px(24.))
+                            .size(px(20.))
                             .text_size(px(16.))
                             .font_weight(FontWeight::SEMIBOLD)
                             .text_color(text_muted)
@@ -2212,8 +2276,8 @@ impl MentionInput {
             .gap_2()
             .w_full()
             .px_3()
-            .py(px(6.))
-            .rounded(px(6.))
+            .py_2()
+            .rounded(px(8.))
             .cursor_pointer()
             .when(is_selected, |row| row.bg(selected_bg))
             .on_hover({
@@ -2247,8 +2311,8 @@ impl MentionInput {
                         div()
                             .text_size(px(15.))
                             .font_weight(FontWeight::MEDIUM)
-                            .text_color(text_primary)
-                            .child(display),
+                            .text_color(display_color)
+                            .child(highlighted_label(display, &query)),
                     ),
             )
             .when(!secondary.is_empty(), |row| {
@@ -2257,8 +2321,8 @@ impl MentionInput {
                         .flex_shrink_0()
                         .text_size(px(12.))
                         .font_weight(FontWeight::SEMIBOLD)
-                        .text_color(text_muted)
-                        .child(secondary),
+                        .text_color(text_primary)
+                        .child(highlighted_label(secondary, &query)),
                 )
             })
             .into_any_element()
@@ -2302,6 +2366,7 @@ impl MentionInput {
         let count = self.suggestions.len();
         let list_h = (count as f32 * MENTION_ROW_PX).min(MENTION_POPUP_MAX_PX);
         let locale = self.locale(cx);
+        let header_title = self.active_sigil.category_title(&locale);
         let list = uniform_list(
             "mention-suggestion-list",
             count,
@@ -2321,6 +2386,19 @@ impl MentionInput {
         .track_scroll(&self.suggestion_scroll)
         .h(px(list_h))
         .w_full();
+        let header = div()
+            .flex()
+            .items_center()
+            .justify_between()
+            .p_2()
+            .h(px(40.))
+            .child(
+                div()
+                    .text_size(px(12.))
+                    .font_weight(FontWeight::BOLD)
+                    .text_color(theme.tokens.text_theme_primary)
+                    .child(header_title),
+            );
         deferred(
             div()
                 .image_cache(self.avatar_cache.clone())
@@ -2330,7 +2408,6 @@ impl MentionInput {
                 .left_0()
                 .right_0()
                 .mb(px(8.))
-                .p(px(4.))
                 .rounded(px(8.))
                 .border_1()
                 .border_color(border)
@@ -2338,6 +2415,7 @@ impl MentionInput {
                 .shadow_lg()
                 .occlude()
                 .on_mouse_down_out(cx.listener(|this, _event, _window, cx| this.hide(cx)))
+                .child(header)
                 .child(list),
         )
         .into_any_element()
@@ -2426,7 +2504,11 @@ fn role_suggest_pool(cx: &App) -> Vec<RoleSuggestRaw> {
             icon_src: if role.icon.is_empty() {
                 SharedString::default()
             } else {
-                SharedString::from(crate::util::imgproxy::avatar_url(cx, &role.icon))
+                SharedString::from(crate::util::imgproxy::role_icon_url(cx, &role.icon))
+            },
+            color: match mezon_store::parse_role_color(&role.color) {
+                Some(rgba) => Hsla::from(rgba),
+                None => role_fallback_color(),
             },
         })
         .collect()
@@ -2803,6 +2885,94 @@ mod suggest_tests {
     fn sale_id_is_empty_without_extension() {
         assert_eq!(sale_item_id_from_source("https://cdn.example/emojis"), "");
         assert_eq!(sale_item_id_from_source(""), "");
+    }
+}
+
+#[cfg(test)]
+mod suggestion_order_tests {
+    use super::{
+        MentionMemberRaw, RoleSuggestRaw, Suggestion, highlight_match_range, prioritize_and_limit,
+        role_fallback_color,
+    };
+    use gpui::SharedString;
+    use std::rc::Rc;
+
+    fn member(display: &str) -> Suggestion {
+        Suggestion::Member(
+            Rc::new(MentionMemberRaw {
+                user_id: display.to_string(),
+                display: display.to_string(),
+                username: display.to_lowercase(),
+                avatar_raw: String::new(),
+                display_lc: display.to_lowercase(),
+                username_lc: display.to_lowercase(),
+                display_norm: display.to_uppercase(),
+                username_norm: display.to_uppercase(),
+            }),
+            SharedString::default(),
+        )
+    }
+
+    fn role(title: &str) -> Suggestion {
+        Suggestion::Role(Rc::new(RoleSuggestRaw {
+            role_id: title.to_string(),
+            title: title.to_string(),
+            title_lc: title.to_lowercase(),
+            title_norm: title.to_uppercase(),
+            icon_src: SharedString::default(),
+            color: role_fallback_color(),
+        }))
+    }
+
+    fn labels(items: &[Suggestion]) -> Vec<String> {
+        items
+            .iter()
+            .map(|item| match item {
+                Suggestion::Member(m, _) => m.display.clone(),
+                Suggestion::Role(r) => r.title.clone(),
+                Suggestion::Here => "@here".to_string(),
+                _ => String::new(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn roles_rank_above_members_and_here() {
+        let items = vec![
+            member("alice"),
+            member("bob"),
+            Suggestion::Here,
+            role("admin"),
+            role("mod"),
+        ];
+        assert_eq!(
+            labels(&prioritize_and_limit(items, "")),
+            vec!["admin", "mod", "alice", "bob", "@here"]
+        );
+    }
+
+    #[test]
+    fn relevance_orders_within_the_member_group() {
+        let items = vec![member("zeta"), Suggestion::Here, member("here-bot")];
+        assert_eq!(
+            labels(&prioritize_and_limit(items, "here")),
+            vec!["here-bot", "zeta", "@here"]
+        );
+    }
+
+    #[test]
+    fn highlight_spans_the_query_inside_the_label() {
+        assert_eq!(highlight_match_range("Moderator", "der"), Some(2..5));
+        assert_eq!(highlight_match_range("Moderator", "MOD"), Some(0..3));
+        assert_eq!(highlight_match_range("Moderator", "zz"), None);
+        assert_eq!(highlight_match_range("Moderator", ""), None);
+    }
+
+    #[test]
+    fn highlight_range_is_byte_safe_for_accented_labels() {
+        let label = "Quản trị viên";
+        let range = highlight_match_range(label, "tri").expect("accent-insensitive match");
+        assert_eq!(&label[range], "trị");
     }
 }
 

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -248,7 +248,7 @@ fn render_deleted_placeholder(msg: &Message, ctx: &RowCtx, theme: &Theme) -> Any
 fn rich_text_plan_matches(
     plan: &RichTextRenderPlan,
     layout: &std::sync::Arc<mezon_store::RichLayout>,
-    colors: [Hsla; 5],
+    colors: [Hsla; 7],
     edited: bool,
 ) -> bool {
     std::sync::Arc::ptr_eq(&plan.layout, layout) && plan.colors == colors && plan.edited == edited
@@ -258,11 +258,15 @@ fn render_rich_styled(msg: &Message, ctx: &RowCtx, body_color: gpui::Rgba) -> An
     let theme = ctx.theme;
     let mention_color: Hsla = theme.tokens.mention_color.into();
     let mention_bg: Hsla = theme.tokens.mention_primary.into();
+    let role_color: Hsla = theme.tokens.color_mention_evryone.into();
+    let role_bg: Hsla = theme.tokens.bg_mention_evryone.into();
     let code_bg: Hsla = theme.tokens.bg_markdown_code.into();
     let link_color: Hsla = theme.tokens.mention_color.into();
     let colors = [
         mention_color,
         mention_bg,
+        role_color,
+        role_bg,
         code_bg,
         link_color,
         theme.text_muted.into(),
@@ -315,6 +319,14 @@ fn render_rich_styled(msg: &Message, ctx: &RowCtx, body_color: gpui::Rgba) -> An
                         HighlightStyle {
                             color: Some(mention_color),
                             background_color: Some(mention_bg),
+                            ..Default::default()
+                        },
+                    )),
+                    RichRunKind::RoleMention => highlights.push((
+                        run.range.clone(),
+                        HighlightStyle {
+                            color: Some(role_color),
+                            background_color: Some(role_bg),
                             ..Default::default()
                         },
                     )),
@@ -2387,6 +2399,8 @@ pub(crate) fn text_wrap_children(text: &str, color: gpui::Rgba) -> Vec<AnyElemen
 pub(crate) fn render_pin_rich_layout_element(layout: &RichLayout, theme: &Theme) -> AnyElement {
     let mention_color: Hsla = theme.tokens.mention_color.into();
     let mention_bg: Hsla = theme.tokens.mention_primary.into();
+    let role_color: Hsla = theme.tokens.color_mention_evryone.into();
+    let role_bg: Hsla = theme.tokens.bg_mention_evryone.into();
     let code_bg: Hsla = theme.tokens.bg_markdown_code.into();
     let link_color: Hsla = theme.tokens.mention_color.into();
     let body_color = theme.tokens.text_theme_message;
@@ -2440,6 +2454,14 @@ pub(crate) fn render_pin_rich_layout_element(layout: &RichLayout, theme: &Theme)
                 HighlightStyle {
                     color: Some(mention_color),
                     background_color: Some(mention_bg),
+                    ..Default::default()
+                },
+            )),
+            RichRunKind::RoleMention => highlights.push((
+                run.range.clone(),
+                HighlightStyle {
+                    color: Some(role_color),
+                    background_color: Some(role_bg),
                     ..Default::default()
                 },
             )),
@@ -2695,7 +2717,7 @@ mod tests {
     #[test]
     fn rich_text_plan_reuses_only_the_same_layout_and_style() {
         let layout = build_rich_layout(&[MessageSpan::Bold("hello".into())]).unwrap();
-        let colors = [Hsla::default(); 5];
+        let colors = [Hsla::default(); 7];
         let plan = RichTextRenderPlan {
             layout: layout.clone(),
             colors,

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -254,23 +254,77 @@ fn rich_text_plan_matches(
     std::sync::Arc::ptr_eq(&plan.layout, layout) && plan.colors == colors && plan.edited == edited
 }
 
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) struct RichRunPalette {
+    pub mention: Hsla,
+    pub mention_bg: Hsla,
+    pub role: Hsla,
+    pub role_bg: Hsla,
+    pub code_bg: Hsla,
+    pub link: Hsla,
+}
+
+impl RichRunPalette {
+    pub(crate) fn from_theme(theme: &Theme) -> Self {
+        Self {
+            mention: theme.tokens.mention_color.into(),
+            mention_bg: theme.tokens.mention_primary.into(),
+            role: theme.tokens.color_mention_evryone.into(),
+            role_bg: theme.tokens.bg_mention_evryone.into(),
+            code_bg: theme.tokens.bg_markdown_code.into(),
+            link: theme.tokens.mention_color.into(),
+        }
+    }
+
+    pub(crate) fn memo_key(&self, text_muted: Hsla) -> [Hsla; 7] {
+        [
+            self.mention,
+            self.mention_bg,
+            self.role,
+            self.role_bg,
+            self.code_bg,
+            self.link,
+            text_muted,
+        ]
+    }
+}
+
+pub(crate) fn rich_run_highlight(kind: RichRunKind, palette: &RichRunPalette) -> HighlightStyle {
+    match kind {
+        RichRunKind::Bold => HighlightStyle {
+            font_weight: Some(FontWeight::BOLD),
+            ..Default::default()
+        },
+        RichRunKind::Code => HighlightStyle {
+            background_color: Some(palette.code_bg),
+            ..Default::default()
+        },
+        RichRunKind::Link => HighlightStyle {
+            color: Some(palette.link),
+            underline: Some(UnderlineStyle {
+                thickness: px(1.),
+                color: Some(palette.link),
+                wavy: false,
+            }),
+            ..Default::default()
+        },
+        RichRunKind::Mention | RichRunKind::Hashtag => HighlightStyle {
+            color: Some(palette.mention),
+            background_color: Some(palette.mention_bg),
+            ..Default::default()
+        },
+        RichRunKind::RoleMention => HighlightStyle {
+            color: Some(palette.role),
+            background_color: Some(palette.role_bg),
+            ..Default::default()
+        },
+    }
+}
+
 fn render_rich_styled(msg: &Message, ctx: &RowCtx, body_color: gpui::Rgba) -> AnyElement {
     let theme = ctx.theme;
-    let mention_color: Hsla = theme.tokens.mention_color.into();
-    let mention_bg: Hsla = theme.tokens.mention_primary.into();
-    let role_color: Hsla = theme.tokens.color_mention_evryone.into();
-    let role_bg: Hsla = theme.tokens.bg_mention_evryone.into();
-    let code_bg: Hsla = theme.tokens.bg_markdown_code.into();
-    let link_color: Hsla = theme.tokens.mention_color.into();
-    let colors = [
-        mention_color,
-        mention_bg,
-        role_color,
-        role_bg,
-        code_bg,
-        link_color,
-        theme.text_muted.into(),
-    ];
+    let palette = RichRunPalette::from_theme(theme);
+    let colors = palette.memo_key(theme.text_muted.into());
     let Some(layout) = msg.rich_layout.as_ref() else {
         return div().into_any_element();
     };
@@ -284,52 +338,9 @@ fn render_rich_styled(msg: &Message, ctx: &RowCtx, body_color: gpui::Rgba) -> An
             let mut click_ranges: Vec<Range<usize>> = Vec::new();
             let mut actions: Vec<RichClick> = Vec::new();
             for run in layout.runs.iter() {
-                match run.kind {
-                    RichRunKind::Bold => highlights.push((
-                        run.range.clone(),
-                        HighlightStyle {
-                            font_weight: Some(FontWeight::BOLD),
-                            ..Default::default()
-                        },
-                    )),
-                    RichRunKind::Code => {
-                        highlights.push((
-                            run.range.clone(),
-                            HighlightStyle {
-                                background_color: Some(code_bg),
-                                ..Default::default()
-                            },
-                        ));
-                        font_overrides.push((run.range.clone(), "monospace".into()));
-                    }
-                    RichRunKind::Link => highlights.push((
-                        run.range.clone(),
-                        HighlightStyle {
-                            color: Some(link_color),
-                            underline: Some(UnderlineStyle {
-                                thickness: px(1.),
-                                color: Some(link_color),
-                                wavy: false,
-                            }),
-                            ..Default::default()
-                        },
-                    )),
-                    RichRunKind::Mention | RichRunKind::Hashtag => highlights.push((
-                        run.range.clone(),
-                        HighlightStyle {
-                            color: Some(mention_color),
-                            background_color: Some(mention_bg),
-                            ..Default::default()
-                        },
-                    )),
-                    RichRunKind::RoleMention => highlights.push((
-                        run.range.clone(),
-                        HighlightStyle {
-                            color: Some(role_color),
-                            background_color: Some(role_bg),
-                            ..Default::default()
-                        },
-                    )),
+                highlights.push((run.range.clone(), rich_run_highlight(run.kind, &palette)));
+                if run.kind == RichRunKind::Code {
+                    font_overrides.push((run.range.clone(), "monospace".into()));
                 }
                 if let Some(click) = run.click.clone() {
                     click_ranges.push(run.range.clone());
@@ -2397,12 +2408,7 @@ pub(crate) fn text_wrap_children(text: &str, color: gpui::Rgba) -> Vec<AnyElemen
 }
 
 pub(crate) fn render_pin_rich_layout_element(layout: &RichLayout, theme: &Theme) -> AnyElement {
-    let mention_color: Hsla = theme.tokens.mention_color.into();
-    let mention_bg: Hsla = theme.tokens.mention_primary.into();
-    let role_color: Hsla = theme.tokens.color_mention_evryone.into();
-    let role_bg: Hsla = theme.tokens.bg_mention_evryone.into();
-    let code_bg: Hsla = theme.tokens.bg_markdown_code.into();
-    let link_color: Hsla = theme.tokens.mention_color.into();
+    let palette = RichRunPalette::from_theme(theme);
     let body_color = theme.tokens.text_theme_message;
 
     if layout.runs.is_empty() {
@@ -2422,50 +2428,7 @@ pub(crate) fn render_pin_rich_layout_element(layout: &RichLayout, theme: &Theme)
     let mut click_ranges: Vec<Range<usize>> = Vec::new();
     let mut actions: Vec<RichClick> = Vec::new();
     for run in layout.runs.iter() {
-        match run.kind {
-            RichRunKind::Bold => highlights.push((
-                run.range.clone(),
-                HighlightStyle {
-                    font_weight: Some(FontWeight::BOLD),
-                    ..Default::default()
-                },
-            )),
-            RichRunKind::Code => highlights.push((
-                run.range.clone(),
-                HighlightStyle {
-                    background_color: Some(code_bg),
-                    ..Default::default()
-                },
-            )),
-            RichRunKind::Link => highlights.push((
-                run.range.clone(),
-                HighlightStyle {
-                    color: Some(link_color),
-                    underline: Some(UnderlineStyle {
-                        thickness: px(1.),
-                        color: Some(link_color),
-                        wavy: false,
-                    }),
-                    ..Default::default()
-                },
-            )),
-            RichRunKind::Mention | RichRunKind::Hashtag => highlights.push((
-                run.range.clone(),
-                HighlightStyle {
-                    color: Some(mention_color),
-                    background_color: Some(mention_bg),
-                    ..Default::default()
-                },
-            )),
-            RichRunKind::RoleMention => highlights.push((
-                run.range.clone(),
-                HighlightStyle {
-                    color: Some(role_color),
-                    background_color: Some(role_bg),
-                    ..Default::default()
-                },
-            )),
-        }
+        highlights.push((run.range.clone(), rich_run_highlight(run.kind, &palette)));
         if let Some(click) = run.click.clone() {
             click_ranges.push(run.range.clone());
             actions.push(click);
@@ -2702,16 +2665,58 @@ fn split_unbreakable(text: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        RichTextRenderPlan, SelectableSectionCursor, parse_channel_id, rich_text_plan_matches,
-        selectable_message_layout_identity, selectable_text_chunks,
+        RichRunPalette, RichTextRenderPlan, SelectableSectionCursor, parse_channel_id,
+        rich_run_highlight, rich_text_plan_matches, selectable_message_layout_identity,
+        selectable_text_chunks,
     };
     use gpui::{Hsla, SharedString};
-    use mezon_store::{ChannelId, Message, MessageId, MessageSpan, build_rich_layout};
+    use mezon_store::{ChannelId, Message, MessageId, MessageSpan, RichRunKind, build_rich_layout};
 
     #[test]
     fn parse_channel_id_rejects_zero() {
         assert_eq!(parse_channel_id("0"), None);
         assert_eq!(parse_channel_id("12345"), Some(ChannelId(12345)));
+    }
+
+    fn test_palette() -> RichRunPalette {
+        RichRunPalette {
+            mention: gpui::rgb(0x3298ff).into(),
+            mention_bg: gpui::rgb(0x4361ee).into(),
+            role: gpui::rgb(0x2eb08c).into(),
+            role_bg: gpui::rgb(0x2eb08b).into(),
+            code_bg: gpui::rgb(0x111111).into(),
+            link: gpui::rgb(0x3298ff).into(),
+        }
+    }
+
+    #[test]
+    fn role_mention_runs_use_the_everyone_palette() {
+        let palette = test_palette();
+        let role = rich_run_highlight(RichRunKind::RoleMention, &palette);
+        assert_eq!(role.color, Some(palette.role));
+        assert_eq!(role.background_color, Some(palette.role_bg));
+    }
+
+    #[test]
+    fn role_and_user_mention_runs_never_share_a_colour() {
+        let palette = test_palette();
+        let role = rich_run_highlight(RichRunKind::RoleMention, &palette);
+        let user = rich_run_highlight(RichRunKind::Mention, &palette);
+        let hashtag = rich_run_highlight(RichRunKind::Hashtag, &palette);
+        assert_eq!(user.color, Some(palette.mention));
+        assert_eq!(user.background_color, Some(palette.mention_bg));
+        assert_eq!(hashtag.color, user.color);
+        assert_ne!(role.color, user.color);
+        assert_ne!(role.background_color, user.background_color);
+    }
+
+    #[test]
+    fn palette_memo_key_changes_when_a_role_colour_changes() {
+        let palette = test_palette();
+        let muted: Hsla = gpui::rgb(0x808080).into();
+        let mut recoloured = palette;
+        recoloured.role = gpui::rgb(0x3d8bff).into();
+        assert_ne!(palette.memo_key(muted), recoloured.memo_key(muted));
     }
 
     #[test]

--- a/crates/mezon-ui/src/chat/message/context.rs
+++ b/crates/mezon-ui/src/chat/message/context.rs
@@ -160,7 +160,7 @@ impl RowMemo {
 #[derive(Clone)]
 pub struct RichTextRenderPlan {
     pub layout: Arc<RichLayout>,
-    pub colors: [Hsla; 5],
+    pub colors: [Hsla; 7],
     pub edited: bool,
     pub text: SharedString,
     pub highlights: Arc<[(Range<usize>, HighlightStyle)]>,

--- a/crates/mezon-ui/src/chat/message/mod.rs
+++ b/crates/mezon-ui/src/chat/message/mod.rs
@@ -39,6 +39,7 @@ mod video_player;
 
 pub use channel_messages::{ChannelMessages, ChannelMessagesEvent};
 pub(crate) use content::open_message_link;
+pub(crate) use content::{RichRunPalette, rich_run_highlight};
 pub(crate) use content::{heading_line_height, heading_size};
 pub(crate) use content::{
     pin_link_element, render_pin_rich_layout_element, resolve_message_link_url, text_wrap_children,

--- a/crates/mezon-ui/src/chat/message_search.rs
+++ b/crates/mezon-ui/src/chat/message_search.rs
@@ -11,7 +11,7 @@ use gpui::{
 };
 use mezon_store::{
     ChannelId, ChannelList, ChannelType, ClanId, MessageSearchStore, MessageSpan, MessagesStore,
-    RichLayout, RichRunKind, SearchDropdownMode, SearchHit, SearchPageToken, autocomplete_needle,
+    RichLayout, SearchDropdownMode, SearchHit, SearchPageToken, autocomplete_needle,
     has_filter_options, resolve_search_hit_ogp, search_content_highlight_terms,
     search_dropdown_mode, search_page_count, search_page_numbers, should_show_search_dropdown,
 };
@@ -21,7 +21,9 @@ use ui::WithScrollbar;
 
 use crate::chat::layout::ChatLayout;
 use crate::chat::member_list::{MentionMemberRaw, mention_member_pool};
-use crate::chat::message::{format_message_time, open_message_link, render_ogp_preview};
+use crate::chat::message::{
+    RichRunPalette, format_message_time, open_message_link, render_ogp_preview, rich_run_highlight,
+};
 use crate::chat::role_style::message_sender_color;
 use crate::components::primitives::{Icon, IconName, Input, InputState, Sizable, Size, Spinner};
 use crate::image_cache::{
@@ -1103,10 +1105,7 @@ fn render_rich_search_content(
     terms: &[String],
     theme: &Theme,
 ) -> gpui::AnyElement {
-    let mention_color: gpui::Hsla = theme.tokens.mention_color.into();
-    let mention_bg: gpui::Hsla = theme.tokens.mention_primary.into();
-    let code_bg: gpui::Hsla = theme.tokens.bg_markdown_code.into();
-    let link_color: gpui::Hsla = theme.tokens.mention_color.into();
+    let palette = RichRunPalette::from_theme(theme);
     let search_bg: gpui::Hsla = theme.tokens.bg_item_theme_hover.into();
     let text = layout.text.clone();
     let mut highlights: Vec<(Range<usize>, HighlightStyle)> = Vec::new();
@@ -1123,36 +1122,7 @@ fn render_rich_search_content(
     }
 
     for run in layout.runs.iter() {
-        let style = match run.kind {
-            RichRunKind::Bold => HighlightStyle {
-                font_weight: Some(FontWeight::BOLD),
-                ..Default::default()
-            },
-            RichRunKind::Code => HighlightStyle {
-                background_color: Some(code_bg),
-                ..Default::default()
-            },
-            RichRunKind::Link => HighlightStyle {
-                color: Some(link_color),
-                underline: Some(gpui::UnderlineStyle {
-                    thickness: px(1.),
-                    color: Some(link_color),
-                    wavy: false,
-                }),
-                ..Default::default()
-            },
-            RichRunKind::Mention | RichRunKind::Hashtag => HighlightStyle {
-                color: Some(mention_color),
-                background_color: Some(mention_bg),
-                ..Default::default()
-            },
-            RichRunKind::RoleMention => HighlightStyle {
-                color: Some(theme.tokens.color_mention_evryone.into()),
-                background_color: Some(theme.tokens.bg_mention_evryone.into()),
-                ..Default::default()
-            },
-        };
-        highlights.push((run.range.clone(), style));
+        highlights.push((run.range.clone(), rich_run_highlight(run.kind, &palette)));
     }
 
     div()

--- a/crates/mezon-ui/src/chat/message_search.rs
+++ b/crates/mezon-ui/src/chat/message_search.rs
@@ -1146,6 +1146,11 @@ fn render_rich_search_content(
                 background_color: Some(mention_bg),
                 ..Default::default()
             },
+            RichRunKind::RoleMention => HighlightStyle {
+                color: Some(theme.tokens.color_mention_evryone.into()),
+                background_color: Some(theme.tokens.bg_mention_evryone.into()),
+                ..Default::default()
+            },
         };
         highlights.push((run.range.clone(), style));
     }

--- a/crates/mezon-ui/src/util/text_utils.rs
+++ b/crates/mezon-ui/src/util/text_utils.rs
@@ -14,19 +14,29 @@ pub(crate) fn normalize_string(value: &str) -> String {
     out
 }
 
+fn push_search_normalized_part(part: char, out: &mut String) {
+    if ('\u{0300}'..='\u{036f}').contains(&part) {
+        return;
+    }
+    match part {
+        '-' | '_' | '+' => out.push(' '),
+        _ => out.extend(part.to_uppercase()),
+    }
+}
+
+pub(crate) fn push_search_normalized(ch: char, out: &mut String) {
+    for part in ch.nfd() {
+        push_search_normalized_part(part, out);
+    }
+}
+
 pub(crate) fn normalize_search_string(value: &str) -> String {
     if value.is_empty() {
         return String::new();
     }
     let mut out = String::with_capacity(value.len());
-    for ch in value.nfd() {
-        if ('\u{0300}'..='\u{036f}').contains(&ch) {
-            continue;
-        }
-        match ch {
-            '-' | '_' | '+' => out.push(' '),
-            _ => out.extend(ch.to_uppercase()),
-        }
+    for part in value.nfd() {
+        push_search_normalized_part(part, &mut out);
     }
     out
 }


### PR DESCRIPTION
Role mention chips rendered with the blue user-mention colour instead of the teal everyone colour. Message text goes through three render paths and only two of them branched on role_id. The third -- the memoized msg.rich_layout path -- styles by RichRunKind, which had no role variant, so build_rich_layout read role_id only to suppress the click handler and then discarded it.