### PR TITLE
fix(native): repair Windows toast notifications on real installs

### DIFF
--- a/crates/mezon-native/src/notifications.rs
+++ b/crates/mezon-native/src/notifications.rs
@@ -470,9 +470,6 @@ fn ensure_start_menu_shortcut() -> anyhow::Result<()> {
         .join("Start Menu")
         .join("Programs")
         .join("Mezon.lnk");
-    if shortcut.exists() {
-        return Ok(());
-    }
     if let Some(parent) = shortcut.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -498,7 +495,7 @@ fn ensure_start_menu_shortcut() -> anyhow::Result<()> {
         file.Save(&HSTRING::from(shortcut.as_os_str()), true)?;
     }
 
-    tracing::info!("created Start Menu shortcut for toast notifications");
+    tracing::info!("wrote Start Menu shortcut with AppUserModelID for toast notifications");
     Ok(())
 }
 
@@ -510,8 +507,18 @@ fn show_windows(n: &Notification) {
     let icon_path = n.icon_path.clone();
 
     std::thread::spawn(move || {
+        use windows::Win32::System::Com::{
+            COINIT_APARTMENTTHREADED, CoInitializeEx, CoUninitialize,
+        };
+
+        unsafe {
+            let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+        }
         if let Err(e) = try_show_toast(&title, &body, tag.as_deref(), icon_path.as_deref()) {
             tracing::warn!("Windows toast notification failed: {e}");
+        }
+        unsafe {
+            CoUninitialize();
         }
     });
 }

--- a/packaging/windows/mezon.iss
+++ b/packaging/windows/mezon.iss
@@ -35,8 +35,8 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; Flags: unchecked
 Source: "{#SourceExe}"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
-Name: "{userprograms}\Mezon"; Filename: "{app}\mezon.exe"
-Name: "{userdesktop}\Mezon"; Filename: "{app}\mezon.exe"; Tasks: desktopicon
+Name: "{userprograms}\Mezon"; Filename: "{app}\mezon.exe"; AppUserModelID: "ai.mezon.Mezon"
+Name: "{userdesktop}\Mezon"; Filename: "{app}\mezon.exe"; Tasks: desktopicon; AppUserModelID: "ai.mezon.Mezon"
 
 [Run]
 Filename: "{app}\mezon.exe"; Description: "{cm:LaunchProgram,Mezon}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
Toast notifications require the process AppUserModelID (AUMID) to match a Start Menu shortcut carrying the same AUMID, or Windows silently drops every toast. Two things broke that on installed builds (dev runs worked, since no prior shortcut existed for the app to skip past):

- packaging/windows/mezon.iss created both shortcuts without an AppUserModelID, so the installer always shipped a shortcut Windows won't route toasts through.
- ensure_start_menu_shortcut() only wrote the shortcut `if !shortcut.exists()`, so once the installer had already created one (without the AUMID), the app's own remediation was skipped on every launch.

Fixes: mezon.iss now sets AppUserModelID on both shortcuts, and ensure_start_menu_shortcut() always (re)writes the shortcut so existing installs self-heal on next launch instead of needing a reinstall.

Also added CoInitializeEx/CoUninitialize around the toast-sending thread in show_windows() — it was calling WinRT toast APIs with no COM apartment initialized on that thread, unlike the other Windows call sites in this crate (badge.rs), which likely made toasts fail regardless of the AUMID fix.