### PR TITLE
fix: adjustment ui of clan setting page

### DIFF
--- a/crates/mezon-ui/src/clan/settings/emoji_sticker_picker.rs
+++ b/crates/mezon-ui/src/clan/settings/emoji_sticker_picker.rs
@@ -711,7 +711,7 @@ fn preview_image(preview: Option<&EmoticonPreview>) -> gpui::AnyElement {
             .object_fit(gpui::ObjectFit::Contain)
             .rounded_md()
             .into_any_element(),
-        None => Icon::new(IconName::ImageUploadIcon)
+        None => Icon::new(IconName::UploadImage)
             .size(px(32.))
             .text_color(gpui::rgb(0x80848e))
             .into_any_element(),

--- a/crates/mezon-ui/src/clan/settings/overview_setting_page.rs
+++ b/crates/mezon-ui/src/clan/settings/overview_setting_page.rs
@@ -3,8 +3,8 @@ use gpui::{
     Task, Window, deferred, div, img, prelude::*, px,
 };
 use mezon_store::{
-    ChannelId, ChannelList, ChannelType, ClanId, ClanImageMimeType, ClanList, ClanOverviewDraft,
-    ClanSystemMessage, MAX_CLAN_BANNER_BYTES, MAX_CLAN_LOGO_BYTES, Settings,
+    AppConfig, ChannelId, ChannelList, ChannelType, ClanId, ClanImageMimeType, ClanList,
+    ClanOverviewDraft, ClanSystemMessage, MAX_CLAN_BANNER_BYTES, MAX_CLAN_LOGO_BYTES, Settings,
 };
 
 use crate::app::shell::Shell;
@@ -194,7 +194,6 @@ impl OverviewSettingPage {
                 .placeholder(placeholder)
                 .height(px(40.0))
                 .text_size(px(16.0))
-                .borderless()
                 .bg(input_bg)
         });
         name_input.update(cx, |input, cx| {
@@ -662,6 +661,9 @@ impl OverviewSettingPage {
     ) -> impl IntoElement {
         let logo = self.draft.logo.clone();
         let has_logo = !logo.is_empty();
+        let logo_preview = AppConfig::try_global(cx)
+            .map(|config| config.imgproxy_url(&logo, 200, 200, "fill"))
+            .unwrap_or(logo);
 
         let avatar = div()
             .absolute()
@@ -677,7 +679,7 @@ impl OverviewSettingPage {
             .justify_center()
             .when(has_logo, |el| {
                 el.child(
-                    img(logo)
+                    img(logo_preview)
                         .size_full()
                         .rounded_full()
                         .object_fit(gpui::ObjectFit::Cover),
@@ -689,7 +691,15 @@ impl OverviewSettingPage {
                         .size(px(32.0))
                         .text_color(theme.text_secondary),
                 )
-            });
+            })
+            .child(
+                div()
+                    .absolute()
+                    .inset_0()
+                    .rounded_full()
+                    .border_1()
+                    .border_color(theme.border),
+            );
 
         div()
             .relative()

--- a/crates/mezon-ui/src/clan/settings/sticker_setting_page.rs
+++ b/crates/mezon-ui/src/clan/settings/sticker_setting_page.rs
@@ -533,7 +533,7 @@ fn render_add_card(theme: &Theme, entity: Entity<StickerSettingPage>) -> impl In
         .rounded_lg()
         .border_1()
         .border_dashed()
-        .border_color(theme.tokens.bg_tertiary)
+        .border_color(theme.border)
         .flex()
         .flex_col()
         .items_center()
@@ -543,9 +543,44 @@ fn render_add_card(theme: &Theme, entity: Entity<StickerSettingPage>) -> impl In
             entity.update(cx, |this, cx| this.open_create_modal(window, cx));
         })
         .child(
-            Icon::new(IconName::ImageUploadIcon)
-                .size(px(28.0))
-                .text_color(theme.text_secondary),
+            div()
+                .relative()
+                .size(px(36.0))
+                .child(
+                    div()
+                        .absolute()
+                        .top_0()
+                        .left_0()
+                        .size(px(30.0))
+                        .rounded(px(10.0))
+                        .bg(theme.text_secondary)
+                        .child(
+                            div().absolute().top(px(3.0)).left(px(3.0)).child(
+                                Icon::new(IconName::EmojiCatStar)
+                                    .size(px(15.0))
+                                    .text_color(gpui::white()),
+                            ),
+                        ),
+                )
+                .child(
+                    div()
+                        .absolute()
+                        .right_0()
+                        .bottom_0()
+                        .size(px(20.0))
+                        .rounded_full()
+                        .border(px(3.0))
+                        .border_color(theme.tokens.theme_setting_primary)
+                        .bg(theme.brand)
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .child(
+                            Icon::new(IconName::Plus)
+                                .size(px(11.0))
+                                .text_color(gpui::white()),
+                        ),
+                ),
         )
 }
 

--- a/crates/mezon-ui/src/settings/profile_page.rs
+++ b/crates/mezon-ui/src/settings/profile_page.rs
@@ -645,16 +645,21 @@ impl Render for ProfilePage {
                     // Delete Account button (only for user profile tab)
                     .when(!is_clan, |el| {
                         el.child(
-                            GpuiButton::new("delete-account-btn")
-                                .label(mezon_i18n::t(&locale, "setting.profile.deleteAccount"))
-                                .danger()
-                                .on_click(cx.listener(|this, _, _, cx| {
-                                    let locale = this.settings.read(cx).language.clone();
-                                    this.show_toast(
-                                        mezon_i18n::t(&locale, "setting.profile.deleteComingSoon"),
-                                        cx,
-                                    );
-                                })),
+                            h_flex().child(
+                                GpuiButton::new("delete-account-btn")
+                                    .label(mezon_i18n::t(&locale, "setting.profile.deleteAccount"))
+                                    .danger()
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        let locale = this.settings.read(cx).language.clone();
+                                        this.show_toast(
+                                            mezon_i18n::t(
+                                                &locale,
+                                                "setting.profile.deleteComingSoon",
+                                            ),
+                                            cx,
+                                        );
+                                    })),
+                            ),
                         )
                     }),
             )


### PR DESCRIPTION
> `Description:`

**env development:** window
- fix ui of clan setting page
- fix img of logo clan overflowed out of bound
- fix icons of uploadimage and sticker icon.

<img width="1545" height="237" alt="image" src="https://github.com/user-attachments/assets/0c56e89a-a12b-4fea-b0f9-932acef42cfd" />

<img width="666" height="527" alt="image" src="https://github.com/user-attachments/assets/02e979dc-90d5-4314-bf43-666d36e035aa" />

<img width="1360" height="405" alt="image" src="https://github.com/user-attachments/assets/48e9f38e-4ccd-4d1a-b5e3-1ff8f71bcb8f" />










