### PR TITLE
fix(session): persist the Windows session with DPAPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5829,6 +5829,7 @@ dependencies = [
  "tracing",
  "url",
  "webpki-roots 1.0.8",
+ "windows 0.61.3",
 ]
 
 [[package]]

--- a/crates/mezon-client/Cargo.toml
+++ b/crates/mezon-client/Cargo.toml
@@ -39,3 +39,6 @@ tokio = { workspace = true, features = ["rt", "macros"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 system-configuration = "0.6"
 core-foundation = "0.9"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows.workspace = true

--- a/crates/mezon-client/src/keychain.rs
+++ b/crates/mezon-client/src/keychain.rs
@@ -90,6 +90,8 @@ mod dev_file {
 #[cfg(all(not(debug_assertions), target_os = "windows"))]
 mod dpapi_store {
     use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     use anyhow::{Context, bail};
     use windows::Win32::Foundation::{HLOCAL, LocalFree};
@@ -103,11 +105,19 @@ mod dpapi_store {
     const LEGACY_SERVICE: &str = "mezon-desktop";
     const LEGACY_USERNAME: &str = "session";
 
+    static COMMIT_LOCK: Mutex<()> = Mutex::new(());
+    static STAGED_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
     fn session_path() -> PathBuf {
         dirs::config_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join("mezon")
             .join("session.dat")
+    }
+
+    fn staged_path(path: &Path) -> PathBuf {
+        let sequence = STAGED_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        path.with_extension(format!("dat.{}.{sequence}.tmp", std::process::id()))
     }
 
     fn take_blob(blob: &mut CRYPT_INTEGER_BLOB) -> Vec<u8> {
@@ -200,17 +210,27 @@ mod dpapi_store {
         parse_session(&entry.get_password().ok()?)
     }
 
+    fn clear_legacy_credential() {
+        if let Ok(entry) = keyring::Entry::new(LEGACY_SERVICE, LEGACY_USERNAME) {
+            let _ = entry.delete_credential();
+        }
+    }
+
     pub fn save_session(session: &Session) -> Result<()> {
         let json = serde_json::to_string(session)?;
         let protected = protect(json.as_bytes())?;
         let path = session_path();
         let parent = path.parent().context("session path has no parent")?;
         std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
-        let staged = path.with_extension("dat.tmp");
+
+        let _commit = COMMIT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let staged = staged_path(&path);
         std::fs::write(&staged, &protected)
             .with_context(|| format!("write {}", staged.display()))?;
-        std::fs::rename(&staged, &path)
-            .with_context(|| format!("rename into {}", path.display()))?;
+        if let Err(e) = std::fs::rename(&staged, &path) {
+            let _ = std::fs::remove_file(&staged);
+            return Err(e).with_context(|| format!("rename into {}", path.display()));
+        }
         tracing::debug!(
             "Session saved to {} (user_id={})",
             path.display(),
@@ -226,8 +246,9 @@ mod dpapi_store {
         }
         let session = load_legacy_credential()?;
         tracing::info!("Migrating the stored session out of the credential store");
-        if let Err(e) = save_session(&session) {
-            tracing::warn!("Failed to migrate the stored session: {e:#}");
+        match save_session(&session) {
+            Ok(()) => clear_legacy_credential(),
+            Err(e) => tracing::warn!("Failed to migrate the stored session: {e:#}"),
         }
         Some(session)
     }
@@ -239,9 +260,7 @@ mod dpapi_store {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => return Err(e).with_context(|| format!("remove {}", path.display())),
         }
-        if let Ok(entry) = keyring::Entry::new(LEGACY_SERVICE, LEGACY_USERNAME) {
-            let _ = entry.delete_credential();
-        }
+        clear_legacy_credential();
         tracing::debug!("Session cleared from {}", path.display());
         Ok(())
     }

--- a/crates/mezon-client/src/keychain.rs
+++ b/crates/mezon-client/src/keychain.rs
@@ -87,7 +87,167 @@ mod dev_file {
     }
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(all(not(debug_assertions), target_os = "windows"))]
+mod dpapi_store {
+    use std::path::{Path, PathBuf};
+
+    use anyhow::{Context, bail};
+    use windows::Win32::Foundation::{HLOCAL, LocalFree};
+    use windows::Win32::Security::Cryptography::{
+        CRYPT_INTEGER_BLOB, CRYPTPROTECT_UI_FORBIDDEN, CryptProtectData, CryptUnprotectData,
+    };
+    use windows::core::PCWSTR;
+
+    use super::*;
+
+    const LEGACY_SERVICE: &str = "mezon-desktop";
+    const LEGACY_USERNAME: &str = "session";
+
+    fn session_path() -> PathBuf {
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("mezon")
+            .join("session.dat")
+    }
+
+    fn take_blob(blob: &mut CRYPT_INTEGER_BLOB) -> Vec<u8> {
+        if blob.pbData.is_null() {
+            return Vec::new();
+        }
+        let bytes =
+            unsafe { std::slice::from_raw_parts(blob.pbData, blob.cbData as usize) }.to_vec();
+        unsafe { LocalFree(Some(HLOCAL(blob.pbData.cast()))) };
+        blob.pbData = std::ptr::null_mut();
+        blob.cbData = 0;
+        bytes
+    }
+
+    fn protect(plain: &[u8]) -> Result<Vec<u8>> {
+        let input = CRYPT_INTEGER_BLOB {
+            cbData: u32::try_from(plain.len()).context("session is too large to encrypt")?,
+            pbData: plain.as_ptr().cast_mut(),
+        };
+        let mut output = CRYPT_INTEGER_BLOB::default();
+        unsafe {
+            CryptProtectData(
+                &input,
+                PCWSTR::null(),
+                None,
+                None,
+                None,
+                CRYPTPROTECT_UI_FORBIDDEN,
+                &mut output,
+            )
+        }
+        .context("CryptProtectData failed")?;
+        let protected = take_blob(&mut output);
+        if protected.is_empty() {
+            bail!("CryptProtectData returned an empty blob");
+        }
+        Ok(protected)
+    }
+
+    fn unprotect(cipher: &[u8]) -> Result<Vec<u8>> {
+        let input = CRYPT_INTEGER_BLOB {
+            cbData: u32::try_from(cipher.len())
+                .context("stored session is too large to decrypt")?,
+            pbData: cipher.as_ptr().cast_mut(),
+        };
+        let mut output = CRYPT_INTEGER_BLOB::default();
+        unsafe {
+            CryptUnprotectData(
+                &input,
+                None,
+                None,
+                None,
+                None,
+                CRYPTPROTECT_UI_FORBIDDEN,
+                &mut output,
+            )
+        }
+        .context("CryptUnprotectData failed")?;
+        Ok(take_blob(&mut output))
+    }
+
+    fn load_from_file(path: &Path) -> Option<Session> {
+        let cipher = match std::fs::read(path) {
+            Ok(cipher) => cipher,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => {
+                tracing::warn!("Failed to read {}: {e}", path.display());
+                return None;
+            }
+        };
+        let plain = match unprotect(&cipher) {
+            Ok(plain) => plain,
+            Err(e) => {
+                tracing::warn!("Failed to decrypt the stored session, ignoring: {e:#}");
+                return None;
+            }
+        };
+        let json = String::from_utf8(plain).ok()?;
+        parse_session(&json).inspect(|session| {
+            tracing::debug!(
+                "Session loaded from {} (user_id={})",
+                path.display(),
+                session.user_id
+            );
+        })
+    }
+
+    fn load_legacy_credential() -> Option<Session> {
+        let entry = keyring::Entry::new(LEGACY_SERVICE, LEGACY_USERNAME).ok()?;
+        parse_session(&entry.get_password().ok()?)
+    }
+
+    pub fn save_session(session: &Session) -> Result<()> {
+        let json = serde_json::to_string(session)?;
+        let protected = protect(json.as_bytes())?;
+        let path = session_path();
+        let parent = path.parent().context("session path has no parent")?;
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+        let staged = path.with_extension("dat.tmp");
+        std::fs::write(&staged, &protected)
+            .with_context(|| format!("write {}", staged.display()))?;
+        std::fs::rename(&staged, &path)
+            .with_context(|| format!("rename into {}", path.display()))?;
+        tracing::debug!(
+            "Session saved to {} (user_id={})",
+            path.display(),
+            session.user_id
+        );
+        Ok(())
+    }
+
+    pub fn load_session() -> Option<Session> {
+        let path = session_path();
+        if let Some(session) = load_from_file(&path) {
+            return Some(session);
+        }
+        let session = load_legacy_credential()?;
+        tracing::info!("Migrating the stored session out of the credential store");
+        if let Err(e) = save_session(&session) {
+            tracing::warn!("Failed to migrate the stored session: {e:#}");
+        }
+        Some(session)
+    }
+
+    pub fn clear_session() -> Result<()> {
+        let path = session_path();
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e).with_context(|| format!("remove {}", path.display())),
+        }
+        if let Ok(entry) = keyring::Entry::new(LEGACY_SERVICE, LEGACY_USERNAME) {
+            let _ = entry.delete_credential();
+        }
+        tracing::debug!("Session cleared from {}", path.display());
+        Ok(())
+    }
+}
+
+#[cfg(all(not(debug_assertions), not(target_os = "windows")))]
 mod keychain_store {
     use keyring::Entry;
 
@@ -123,5 +283,8 @@ mod keychain_store {
 #[cfg(debug_assertions)]
 pub use dev_file::{clear_session, load_session, save_session};
 
-#[cfg(not(debug_assertions))]
+#[cfg(all(not(debug_assertions), target_os = "windows"))]
+pub use dpapi_store::{clear_session, load_session, save_session};
+
+#[cfg(all(not(debug_assertions), not(target_os = "windows")))]
 pub use keychain_store::{clear_session, load_session, save_session};


### PR DESCRIPTION


Windows users were logged out every time they reopened the app. Windows Credential Manager caps a credential blob at CRED_MAX_CREDENTIAL_BLOB_SIZE (2560 bytes) and keyring stores the password as UTF-16, so the real ceiling is 1280 characters. A live session serialises to 1996 characters — 3992 bytes once encoded — with id_token alone accounting for 1019 of them. So keyring rejected the write before it ever reached the OS, every save_session call site only logged a warning, and the session was silently never stored.

macOS Keychain and the Linux Secret Service have no comparable limit, which is why only Windows lost the session.

Store the session on Windows as a DPAPI-encrypted file in %APPDATA%\mezon instead: user-scoped CryptProtectData, no size ceiling, written through a temporary file and renamed so a crash cannot leave a half-written blob. A session still sitting in the credential store from an older build is read once and migrated, and clear_session removes both.

Nothing changes on macOS or Linux — they keep the keyring path.

Note this module is #[cfg(not(debug_assertions))], so a debug build never compiles it and `just run` on Windows can never reproduce the bug. Verified with a release check on macOS and a Windows-target type-check of the DPAPI module.