### PR TITLE
fix(friends): stop the activity sidebar from overflowing and rebuilding

### DIFF
--- a/crates/mezon-store/src/activity.rs
+++ b/crates/mezon-store/src/activity.rs
@@ -121,6 +121,16 @@ impl ActivityStore {
         &self.activities
     }
 
+    fn apply_activities(&mut self, next: Vec<UserActivity>, cx: &mut Context<Self>) {
+        self.freshness.mark_fetched();
+        if next == self.activities {
+            return;
+        }
+        self.activities = next;
+        cx.emit(ActivityEvent::Changed);
+        cx.notify();
+    }
+
     pub fn refresh(&mut self, cx: &mut Context<Self>) {
         self.fetch(cx);
     }
@@ -146,13 +156,10 @@ impl ActivityStore {
                 }
                 this.loading = false;
                 match result {
-                    Ok(list) => {
-                        this.activities =
-                            list.activities.into_iter().map(activity_from_api).collect();
-                        this.freshness.mark_fetched();
-                        cx.emit(ActivityEvent::Changed);
-                        cx.notify();
-                    }
+                    Ok(list) => this.apply_activities(
+                        list.activities.into_iter().map(activity_from_api).collect(),
+                        cx,
+                    ),
                     Err(e) => tracing::error!("list_activity failed: {e}"),
                 }
             });
@@ -163,7 +170,61 @@ impl ActivityStore {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
+
+    fn init_store(cx: &mut App) -> Entity<ActivityStore> {
+        let api = Arc::new(mezon_client::AppApi::new(
+            Arc::new(mezon_client::TransportClient::new(String::new())),
+            String::new(),
+        ));
+        cx.new(|cx| ActivityStore::new(api, cx))
+    }
+
+    fn work(user_id: i64, name: &str) -> UserActivity {
+        UserActivity {
+            user_id: UserId(user_id),
+            activity_type: ACTIVITY_TYPE_WORK,
+            activity_name: name.into(),
+            activity_description: String::new(),
+        }
+    }
+
+    #[gpui::test]
+    fn an_identical_refetch_emits_nothing(cx: &mut gpui::TestAppContext) {
+        let emitted = Arc::new(AtomicUsize::new(0));
+        let (store, _sub) = cx.update(|cx| {
+            let store = init_store(cx);
+            let counter = emitted.clone();
+            let sub = cx.subscribe(&store, move |_, _: &ActivityEvent, _| {
+                counter.fetch_add(1, Ordering::SeqCst);
+            });
+            (store, sub)
+        });
+
+        for _ in 0..2 {
+            cx.update(|cx| {
+                store.update(cx, |store, cx| {
+                    store.apply_activities(vec![work(1, "Visual Studio Code")], cx);
+                });
+            });
+        }
+
+        assert_eq!(emitted.load(Ordering::SeqCst), 1);
+    }
+
+    #[gpui::test]
+    fn a_changed_refetch_emits_and_replaces(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let store = init_store(cx);
+            store.update(cx, |store, cx| {
+                store.apply_activities(vec![work(1, "Visual Studio Code")], cx);
+                store.apply_activities(vec![work(1, "Spotify")], cx);
+                assert_eq!(store.activities(), &[work(1, "Spotify")]);
+            });
+        });
+    }
 
     #[test]
     fn activity_from_api_maps_fields() {

--- a/crates/mezon-ui/src/chat/friends_page.rs
+++ b/crates/mezon-ui/src/chat/friends_page.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use gpui::{
     App, ClickEvent, Context, Entity, InteractiveElement, IntoElement, ParentElement, Pixels,
     Point, SharedString, StatefulInteractiveElement, Styled, Subscription, UniformListScrollHandle,
@@ -178,7 +180,7 @@ impl FriendsPage {
             |this, _, event, cx| match event {
                 PresenceEvent::ChannelPresenceChanged { .. } | PresenceEvent::StatusChanged => {
                     if on_friends_route(cx) {
-                        this.rebuild(cx);
+                        this.apply_presence(cx);
                     }
                 }
                 PresenceEvent::TypingChanged { .. } => {}
@@ -189,7 +191,7 @@ impl FriendsPage {
             |this, _, event, cx| match event {
                 ActivityEvent::Changed => {
                     if on_friends_route(cx) {
-                        this.rebuild(cx);
+                        this.rebuild_activity_rows(cx);
                     }
                 }
             },
@@ -250,7 +252,7 @@ impl FriendsPage {
             self._subs
                 .push(cx.subscribe(&search, |this, _, event: &InputEvent, cx| {
                     if matches!(event, InputEvent::Change) {
-                        this.rebuild(cx);
+                        this.rebuild_friend_rows(cx);
                     }
                 }));
             self.search = Some(search);
@@ -296,6 +298,44 @@ impl FriendsPage {
     }
 
     fn rebuild(&mut self, cx: &mut Context<Self>) {
+        self.rebuild_friend_rows(cx);
+        self.rebuild_activity_rows(cx);
+    }
+
+    fn rebuild_activity_rows(&mut self, cx: &mut Context<Self>) {
+        let store = FriendStore::global(cx);
+        let locale = self.settings.read(cx).language.clone();
+        self.activity_rows =
+            build_activity_rows(&locale, store.read(cx), ActivityStore::global(cx), cx);
+        cx.notify();
+    }
+
+    fn apply_presence(&mut self, cx: &mut Context<Self>) {
+        if self.selected_tab == FriendsTab::Online {
+            self.rebuild_friend_rows(cx);
+            return;
+        }
+        let store = PresenceStore::global(cx);
+        let presence = store.read(cx);
+        let mut changed = false;
+        for row in &mut self.rows {
+            let online = presence.is_online(row.id);
+            if row.online != online {
+                row.online = online;
+                changed = true;
+            }
+            let status = presence.user_status(row.id).unwrap_or("");
+            if row.user_status.as_ref() != status {
+                row.user_status = SharedString::from(status.to_string());
+                changed = true;
+            }
+        }
+        if changed {
+            cx.notify();
+        }
+    }
+
+    fn rebuild_friend_rows(&mut self, cx: &mut Context<Self>) {
         let store = FriendStore::global(cx);
         let presence = PresenceStore::global(cx);
         let me = Self::current_user_id(cx);
@@ -348,8 +388,6 @@ impl FriendsPage {
             })
             .collect();
 
-        self.activity_rows = build_activity_rows(&locale, friends, ActivityStore::global(cx), cx);
-
         self.pending_count = pending;
         self.list_header = SharedString::from(format!(
             "{} - {}",
@@ -376,7 +414,7 @@ impl FriendsPage {
     fn select_tab(&mut self, tab: FriendsTab, cx: &mut Context<Self>) {
         self.selected_tab = tab;
         self.add_friend_open = false;
-        self.rebuild(cx);
+        self.rebuild_friend_rows(cx);
     }
 
     fn submit_add_friend(&mut self, cx: &mut Context<Self>) {
@@ -531,26 +569,21 @@ fn build_activity_rows(
     cx: &App,
 ) -> Vec<ActivityRow> {
     let activities = activities.read(cx);
+    let by_id: HashMap<UserId, &Friend> = friends.friends().iter().map(|f| (f.id, f)).collect();
     let mut rows = Vec::new();
     for (activity_type, key) in ACTIVITY_SECTIONS {
-        let group: Vec<&UserActivity> = activities
+        let group: Vec<(&UserActivity, &Friend)> = activities
             .activities()
             .iter()
-            .filter(|a| {
-                a.activity_type == activity_type
-                    && a.user_id != UserId(0)
-                    && friends.friend(a.user_id).is_some()
-            })
+            .filter(|a| a.activity_type == activity_type && a.user_id != UserId(0))
+            .filter_map(|a| by_id.get(&a.user_id).map(|f| (a, *f)))
             .collect();
         rows.push(ActivityRow::Header(SharedString::from(format!(
             "{} - {}",
             mezon_i18n::t(locale, key).to_uppercase(),
             group.len()
         ))));
-        for a in group {
-            let Some(f) = friends.friend(a.user_id) else {
-                continue;
-            };
+        for (a, f) in group {
             let description = if a.activity_description.is_empty() {
                 a.activity_name.clone()
             } else {
@@ -830,7 +863,7 @@ impl FriendsPage {
                             if let Some(search) = this.search.clone() {
                                 search.update(cx, |input, cx| input.clear(cx));
                             }
-                            this.rebuild(cx);
+                            this.rebuild_friend_rows(cx);
                         }))
                         .child("×"),
                 )
@@ -903,6 +936,7 @@ impl FriendsPage {
                 })
                 .collect::<Vec<_>>()
         })
+        .suppress_hover_while_scrolling()
         .track_scroll(&self.list_scroll)
         .flex_1()
         .min_h_0();
@@ -1264,8 +1298,10 @@ fn render_activity_row(
         ActivityRow::Header(title) => div()
             .flex()
             .items_center()
+            .w_full()
             .px_4()
             .h(px(48.))
+            .truncate()
             .text_size(px(14.))
             .font_weight(gpui::FontWeight::SEMIBOLD)
             .text_color(theme.tokens.text_theme_primary)
@@ -1296,9 +1332,11 @@ fn render_activity_row(
             div()
                 .flex()
                 .items_center()
+                .w_full()
                 .gap(px(9.))
                 .px_4()
                 .h(px(48.))
+                .overflow_hidden()
                 .child(div().flex_shrink_0().size(px(AVATAR_SIZE)).child(avatar))
                 .child(
                     div()


### PR DESCRIPTION
Each row of the activity list is laid out by `uniform_list` as a taffy root with the list width as available space, but the row itself had no width, so taffy sized it to the sum of its items instead of clamping it. With the container width unknown, `flex_1`'s `flex-basis: 0%` could not resolve either, and the text column fell back to a max-content measurement -- leaving no free space to shrink into, so `truncate()` never had a bounded width to cut against and long labels ran past the panel. Give the row `w_full`, which is what the friend row above it already does, and `overflow_hidden` so a description carrying a newline is clipped to the 48px row instead of bleeding into its neighbour. The section headers get the same treatment.

The rest is rebuild scope. `rebuild` recomputed both lists, so every presence packet also rebuilt the activity sidebar -- which presence never affects -- and every activity event re-filtered, re-sorted and reallocated the whole friend list. Split it in two and route each subscription to the half it owns. Presence now patches `online` and `user_status` in place and only notifies when something changed, falling back to a full rebuild on the Online tab, whose row set really does depend on presence.

`build_activity_rows` called `FriendStore::friend` -- a linear scan -- twice per activity across three sections; it now builds one lookup map and keeps the `&Friend` from the filter. `ActivityStore` skips the emit when a refetch returns the list it already holds, which is the common case on reconnect and on re-entering the route after the TTL.

Also suppress hover while the friend list is scrolling, matching the member list.