### PR TITLE
feat(input): unify text-input keymap and add standard editing shortcuts

### DIFF
--- a/crates/mezon-canvas/src/editor.rs
+++ b/crates/mezon-canvas/src/editor.rs
@@ -10,11 +10,12 @@ use gpui::{
     Anchor, App, Bounds, ClickEvent, ClipboardEntry, ClipboardItem, Context, CursorStyle,
     DispatchPhase, Div, Element, ElementId, ElementInputHandler, Entity, EntityInputHandler,
     FocusHandle, Focusable, FontStyle, FontWeight, GlobalElementId, Hsla, Image, ImageFormat,
-    InspectorElementId, InteractiveElement as _, IntoElement, KeyBinding, LayoutId, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point, Render, RenderOnce,
-    ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString, StrikethroughStyle,
-    Style, StyleRefinement, Styled, TextAlign, TextRun, UTF16Selection, UnderlineStyle, Window,
-    WrappedLine, actions, anchored, deferred, div, fill, point, prelude::*, px, size,
+    InspectorElementId, InteractiveElement as _, IntoElement, KeyBinding, KeyContext, LayoutId,
+    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point, Render,
+    RenderOnce, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString,
+    StrikethroughStyle, Style, StyleRefinement, Styled, TextAlign, TextRun, UTF16Selection,
+    UnderlineStyle, Window, WrappedLine, actions, anchored, deferred, div, fill, point, prelude::*,
+    px, size,
 };
 use mezon_store::{CanvasStore, PlatformStore};
 use serde_json::{Value, json};
@@ -31,11 +32,28 @@ use crate::view::{
     is_tiptap_content_empty, parse_tiptap_doc,
 };
 use mezon_theme::ActiveTheme;
+use mezon_widgets::text_actions::{
+    Backspace, Copy, Cut, Delete, Down, End, Enter, Home, Left, MoveToDocEnd, MoveToDocStart,
+    MoveToNextWordEnd, MoveToPreviousWordStart, Newline, Paste, Right, SelectAll, SelectDown,
+    SelectLeft, SelectRight, SelectToDocEnd, SelectToDocStart, SelectToLineEnd, SelectToLineStart,
+    SelectToNextWordEnd, SelectToPreviousWordStart, SelectUp, TEXT_INPUT_CONTEXT, Up,
+};
+use mezon_widgets::text_edit::{
+    SelectGranularity, extend_range_for_granularity, granularity_for_click, next_word_boundary,
+    previous_word_boundary, range_for_granularity,
+};
 use mezon_widgets::{
     Button, ButtonVariants, Icon, IconName, Input, InputState, Sizable, Size, h_flex, v_flex,
 };
 
-const KEY_CONTEXT: &str = "MezonCanvasEditor";
+const FORMAT_KEY_CONTEXT: &str = "MezonCanvasEditor";
+
+fn editor_key_context() -> KeyContext {
+    let mut context = KeyContext::default();
+    context.add(TEXT_INPUT_CONTEXT);
+    context.add(FORMAT_KEY_CONTEXT);
+    context
+}
 const CANVAS_IMAGE_MARGIN: Pixels = px(16.);
 const CANVAS_MIN_LAYOUT_WIDTH: Pixels = px(64.);
 const CANVAS_LAYOUT_WIDTH_FALLBACK: Pixels = px(480.);
@@ -74,62 +92,16 @@ fn apply_mark_font(run: &mut TextRun, block_weight: FontWeight, bold: bool, ital
 
 actions!(
     canvas_editor,
-    [
-        Backspace,
-        Delete,
-        Enter,
-        ShiftEnter,
-        Left,
-        Right,
-        Up,
-        Down,
-        SelectLeft,
-        SelectRight,
-        SelectUp,
-        SelectDown,
-        SelectHome,
-        SelectEnd,
-        SelectAll,
-        Home,
-        End,
-        Paste,
-        Cut,
-        Copy,
-        Bold,
-        Italic,
-        StrikeThrough,
-        CodeBlock,
-        Link,
-    ]
+    [Bold, Italic, StrikeThrough, CodeBlock, Link]
 );
 
 pub fn init(cx: &mut App) {
     cx.bind_keys([
-        KeyBinding::new("backspace", Backspace, Some(KEY_CONTEXT)),
-        KeyBinding::new("delete", Delete, Some(KEY_CONTEXT)),
-        KeyBinding::new("enter", Enter, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-enter", ShiftEnter, Some(KEY_CONTEXT)),
-        KeyBinding::new("left", Left, Some(KEY_CONTEXT)),
-        KeyBinding::new("right", Right, Some(KEY_CONTEXT)),
-        KeyBinding::new("up", Up, Some(KEY_CONTEXT)),
-        KeyBinding::new("down", Down, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-left", SelectLeft, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-right", SelectRight, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-up", SelectUp, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-down", SelectDown, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-home", SelectHome, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-end", SelectEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-a", SelectAll, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-v", Paste, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-c", Copy, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-x", Cut, Some(KEY_CONTEXT)),
-        KeyBinding::new("home", Home, Some(KEY_CONTEXT)),
-        KeyBinding::new("end", End, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-b", Bold, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-i", Italic, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-secondary-s", StrikeThrough, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-k", Link, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-alt-c", CodeBlock, Some(KEY_CONTEXT)),
+        KeyBinding::new("secondary-b", Bold, Some(FORMAT_KEY_CONTEXT)),
+        KeyBinding::new("secondary-i", Italic, Some(FORMAT_KEY_CONTEXT)),
+        KeyBinding::new("shift-secondary-s", StrikeThrough, Some(FORMAT_KEY_CONTEXT)),
+        KeyBinding::new("secondary-k", Link, Some(FORMAT_KEY_CONTEXT)),
+        KeyBinding::new("secondary-alt-c", CodeBlock, Some(FORMAT_KEY_CONTEXT)),
     ]);
 }
 
@@ -242,6 +214,8 @@ pub struct CanvasEditorState {
     link_menu_open: bool,
     link_input: Entity<InputState>,
     is_selecting: bool,
+    select_granularity: SelectGranularity,
+    select_anchor: Range<usize>,
     layout_generation: u64,
     layout_cache: RefCell<Option<Arc<EditorShapeCache>>>,
     doc_json_cache: RefCell<Option<String>>,
@@ -285,6 +259,8 @@ impl CanvasEditorState {
             link_menu_open: false,
             link_input,
             is_selecting: false,
+            select_granularity: SelectGranularity::Character,
+            select_anchor: 0..0,
             layout_generation: 0,
             layout_cache: RefCell::new(None),
             doc_json_cache: RefCell::new(None),
@@ -1178,11 +1154,26 @@ impl CanvasEditorState {
         self.caret_blink.sync_focused(cx);
         self.is_selecting = true;
         let offset = self.index_for_mouse_position(event.position);
+
         if event.modifiers.shift {
+            self.select_granularity = SelectGranularity::Character;
             self.select_to(offset, cx);
-        } else {
-            self.move_to(offset, cx);
+            return;
         }
+
+        self.select_granularity = granularity_for_click(event.click_count);
+        if self.select_granularity == SelectGranularity::Character {
+            self.select_anchor = offset..offset;
+            self.move_to(offset, cx);
+            return;
+        }
+
+        let range = range_for_granularity(&self.content, offset, self.select_granularity, true);
+        self.select_anchor = range.clone();
+        self.selection_reversed = false;
+        self.selected_range = range;
+        self.caret_blink.pause_blinking(cx);
+        cx.notify();
     }
 
     fn on_mouse_up(&mut self, event: &MouseUpEvent, _: &mut Window, cx: &mut Context<Self>) {
@@ -1196,9 +1187,28 @@ impl CanvasEditorState {
     }
 
     fn on_mouse_move(&mut self, event: &MouseMoveEvent, _: &mut Window, cx: &mut Context<Self>) {
-        if self.is_selecting {
-            self.select_to(self.index_for_mouse_position(event.position), cx);
+        if !self.is_selecting {
+            return;
         }
+        let offset = self.index_for_mouse_position(event.position);
+        if self.select_granularity == SelectGranularity::Character {
+            self.select_to(offset, cx);
+            return;
+        }
+        let (range, reversed) = extend_range_for_granularity(
+            &self.content,
+            &self.select_anchor,
+            offset,
+            self.select_granularity,
+            true,
+        );
+        if range == self.selected_range && reversed == self.selection_reversed {
+            return;
+        }
+        self.selected_range = range;
+        self.selection_reversed = reversed;
+        self.caret_blink.pause_blinking(cx);
+        cx.notify();
     }
 
     fn on_read_only_mouse_up(
@@ -1328,7 +1338,7 @@ impl CanvasEditorState {
         self.split_paragraph(cx);
     }
 
-    fn shift_enter(&mut self, _: &ShiftEnter, _: &mut Window, cx: &mut Context<Self>) {
+    fn shift_enter(&mut self, _: &Newline, _: &mut Window, cx: &mut Context<Self>) {
         self.insert_hard_break(cx);
     }
 
@@ -1396,12 +1406,12 @@ impl CanvasEditorState {
         self.select_to(self.line_col_to_offset(line + 1, col.min(next_len)), cx);
     }
 
-    fn select_home(&mut self, _: &SelectHome, _: &mut Window, cx: &mut Context<Self>) {
+    fn select_home(&mut self, _: &SelectToLineStart, _: &mut Window, cx: &mut Context<Self>) {
         let (line, _) = self.offset_to_line_col(self.cursor_offset());
         self.select_to(self.line_col_to_offset(line, 0), cx);
     }
 
-    fn select_end(&mut self, _: &SelectEnd, _: &mut Window, cx: &mut Context<Self>) {
+    fn select_end(&mut self, _: &SelectToLineEnd, _: &mut Window, cx: &mut Context<Self>) {
         let (line, _) = self.offset_to_line_col(self.cursor_offset());
         self.select_to(
             self.line_col_to_offset(line, self.lines[line].text.len()),
@@ -1421,6 +1431,77 @@ impl CanvasEditorState {
         self.selected_range = 0..self.content.len();
         self.selection_reversed = false;
         cx.notify();
+    }
+
+    fn previous_word_offset(&self) -> usize {
+        snap_offset(
+            &self.content,
+            previous_word_boundary(&self.content, self.cursor_offset()),
+        )
+    }
+
+    fn next_word_offset(&self) -> usize {
+        snap_offset(
+            &self.content,
+            next_word_boundary(&self.content, self.cursor_offset()),
+        )
+    }
+
+    fn move_to_previous_word_start(
+        &mut self,
+        _: &MoveToPreviousWordStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.move_to(self.previous_word_offset(), cx);
+    }
+
+    fn move_to_next_word_end(
+        &mut self,
+        _: &MoveToNextWordEnd,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.move_to(self.next_word_offset(), cx);
+    }
+
+    fn select_to_previous_word_start(
+        &mut self,
+        _: &SelectToPreviousWordStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(self.previous_word_offset(), cx);
+    }
+
+    fn select_to_next_word_end(
+        &mut self,
+        _: &SelectToNextWordEnd,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(self.next_word_offset(), cx);
+    }
+
+    fn move_to_doc_start(&mut self, _: &MoveToDocStart, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(0, cx);
+    }
+
+    fn move_to_doc_end(&mut self, _: &MoveToDocEnd, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(self.content.len(), cx);
+    }
+
+    fn select_to_doc_start(
+        &mut self,
+        _: &SelectToDocStart,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.select_to(0, cx);
+    }
+
+    fn select_to_doc_end(&mut self, _: &SelectToDocEnd, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(self.content.len(), cx);
     }
 
     fn home(&mut self, _: &Home, window: &mut Window, cx: &mut Context<Self>) {
@@ -1728,7 +1809,7 @@ impl Render for CanvasEditorState {
             .when(page_scroll, |el| el.h(layout_height))
             .when(!page_scroll, |el| el.flex_1().min_h_0())
             .when(!read_only, |el| {
-                el.key_context(KEY_CONTEXT)
+                el.key_context(editor_key_context())
                     .track_focus(&self.focus_handle)
                     .cursor(CursorStyle::IBeam)
                     .on_action(cx.listener(Self::backspace))
@@ -1748,6 +1829,14 @@ impl Render for CanvasEditorState {
                     .on_action(cx.listener(Self::select_all))
                     .on_action(cx.listener(Self::home))
                     .on_action(cx.listener(Self::end))
+                    .on_action(cx.listener(Self::move_to_previous_word_start))
+                    .on_action(cx.listener(Self::move_to_next_word_end))
+                    .on_action(cx.listener(Self::select_to_previous_word_start))
+                    .on_action(cx.listener(Self::select_to_next_word_end))
+                    .on_action(cx.listener(Self::move_to_doc_start))
+                    .on_action(cx.listener(Self::move_to_doc_end))
+                    .on_action(cx.listener(Self::select_to_doc_start))
+                    .on_action(cx.listener(Self::select_to_doc_end))
                     .on_action(cx.listener(Self::paste))
                     .on_action(cx.listener(Self::cut))
                     .on_action(cx.listener(Self::copy))

--- a/crates/mezon-canvas/src/editor.rs
+++ b/crates/mezon-canvas/src/editor.rs
@@ -1342,50 +1342,30 @@ impl CanvasEditorState {
         self.insert_hard_break(cx);
     }
 
-    fn left(&mut self, _: &Left, window: &mut Window, cx: &mut Context<Self>) {
-        let offset = self.previous_boundary(self.cursor_offset());
-        if window.modifiers().shift {
-            self.select_to(offset, cx);
-        } else {
-            self.move_to(offset, cx);
-        }
+    fn left(&mut self, _: &Left, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(self.previous_boundary(self.cursor_offset()), cx);
     }
 
-    fn right(&mut self, _: &Right, window: &mut Window, cx: &mut Context<Self>) {
-        let offset = self.next_boundary(self.cursor_offset());
-        if window.modifiers().shift {
-            self.select_to(offset, cx);
-        } else {
-            self.move_to(offset, cx);
-        }
+    fn right(&mut self, _: &Right, _: &mut Window, cx: &mut Context<Self>) {
+        self.move_to(self.next_boundary(self.cursor_offset()), cx);
     }
 
-    fn up(&mut self, _: &Up, window: &mut Window, cx: &mut Context<Self>) {
+    fn up(&mut self, _: &Up, _: &mut Window, cx: &mut Context<Self>) {
         let (line, col) = self.offset_to_line_col(self.cursor_offset());
         if line == 0 {
             return;
         }
         let prev_len = self.lines[line - 1].text.len();
-        let offset = self.line_col_to_offset(line - 1, col.min(prev_len));
-        if window.modifiers().shift {
-            self.select_to(offset, cx);
-        } else {
-            self.move_to(offset, cx);
-        }
+        self.move_to(self.line_col_to_offset(line - 1, col.min(prev_len)), cx);
     }
 
-    fn down(&mut self, _: &Down, window: &mut Window, cx: &mut Context<Self>) {
+    fn down(&mut self, _: &Down, _: &mut Window, cx: &mut Context<Self>) {
         let (line, col) = self.offset_to_line_col(self.cursor_offset());
         if line + 1 >= self.lines.len() {
             return;
         }
         let next_len = self.lines[line + 1].text.len();
-        let offset = self.line_col_to_offset(line + 1, col.min(next_len));
-        if window.modifiers().shift {
-            self.select_to(offset, cx);
-        } else {
-            self.move_to(offset, cx);
-        }
+        self.move_to(self.line_col_to_offset(line + 1, col.min(next_len)), cx);
     }
 
     fn select_up(&mut self, _: &SelectUp, _: &mut Window, cx: &mut Context<Self>) {
@@ -1504,24 +1484,17 @@ impl CanvasEditorState {
         self.select_to(self.content.len(), cx);
     }
 
-    fn home(&mut self, _: &Home, window: &mut Window, cx: &mut Context<Self>) {
+    fn home(&mut self, _: &Home, _: &mut Window, cx: &mut Context<Self>) {
         let (line, _) = self.offset_to_line_col(self.cursor_offset());
-        let offset = self.line_col_to_offset(line, 0);
-        if window.modifiers().shift {
-            self.select_to(offset, cx);
-        } else {
-            self.move_to(offset, cx);
-        }
+        self.move_to(self.line_col_to_offset(line, 0), cx);
     }
 
-    fn end(&mut self, _: &End, window: &mut Window, cx: &mut Context<Self>) {
+    fn end(&mut self, _: &End, _: &mut Window, cx: &mut Context<Self>) {
         let (line, _) = self.offset_to_line_col(self.cursor_offset());
-        let offset = self.line_col_to_offset(line, self.lines[line].text.len());
-        if window.modifiers().shift {
-            self.select_to(offset, cx);
-        } else {
-            self.move_to(offset, cx);
-        }
+        self.move_to(
+            self.line_col_to_offset(line, self.lines[line].text.len()),
+            cx,
+        );
     }
 
     fn paste(&mut self, _: &Paste, window: &mut Window, cx: &mut Context<Self>) {
@@ -1812,39 +1785,41 @@ impl Render for CanvasEditorState {
                 el.key_context(editor_key_context())
                     .track_focus(&self.focus_handle)
                     .cursor(CursorStyle::IBeam)
-                    .on_action(cx.listener(Self::backspace))
-                    .on_action(cx.listener(Self::delete))
-                    .on_action(cx.listener(Self::enter))
-                    .on_action(cx.listener(Self::shift_enter))
-                    .on_action(cx.listener(Self::left))
-                    .on_action(cx.listener(Self::right))
-                    .on_action(cx.listener(Self::up))
-                    .on_action(cx.listener(Self::down))
-                    .on_action(cx.listener(Self::select_left))
-                    .on_action(cx.listener(Self::select_right))
-                    .on_action(cx.listener(Self::select_up))
-                    .on_action(cx.listener(Self::select_down))
-                    .on_action(cx.listener(Self::select_home))
-                    .on_action(cx.listener(Self::select_end))
-                    .on_action(cx.listener(Self::select_all))
-                    .on_action(cx.listener(Self::home))
-                    .on_action(cx.listener(Self::end))
-                    .on_action(cx.listener(Self::move_to_previous_word_start))
-                    .on_action(cx.listener(Self::move_to_next_word_end))
-                    .on_action(cx.listener(Self::select_to_previous_word_start))
-                    .on_action(cx.listener(Self::select_to_next_word_end))
-                    .on_action(cx.listener(Self::move_to_doc_start))
-                    .on_action(cx.listener(Self::move_to_doc_end))
-                    .on_action(cx.listener(Self::select_to_doc_start))
-                    .on_action(cx.listener(Self::select_to_doc_end))
-                    .on_action(cx.listener(Self::paste))
-                    .on_action(cx.listener(Self::cut))
-                    .on_action(cx.listener(Self::copy))
-                    .on_action(cx.listener(Self::bold))
-                    .on_action(cx.listener(Self::italic))
-                    .on_action(cx.listener(Self::strike_through))
-                    .on_action(cx.listener(Self::code_block))
-                    .on_action(cx.listener(Self::link))
+                    .when(focused, |el| {
+                        el.on_action(cx.listener(Self::backspace))
+                            .on_action(cx.listener(Self::delete))
+                            .on_action(cx.listener(Self::enter))
+                            .on_action(cx.listener(Self::shift_enter))
+                            .on_action(cx.listener(Self::left))
+                            .on_action(cx.listener(Self::right))
+                            .on_action(cx.listener(Self::up))
+                            .on_action(cx.listener(Self::down))
+                            .on_action(cx.listener(Self::select_left))
+                            .on_action(cx.listener(Self::select_right))
+                            .on_action(cx.listener(Self::select_up))
+                            .on_action(cx.listener(Self::select_down))
+                            .on_action(cx.listener(Self::select_home))
+                            .on_action(cx.listener(Self::select_end))
+                            .on_action(cx.listener(Self::select_all))
+                            .on_action(cx.listener(Self::home))
+                            .on_action(cx.listener(Self::end))
+                            .on_action(cx.listener(Self::move_to_previous_word_start))
+                            .on_action(cx.listener(Self::move_to_next_word_end))
+                            .on_action(cx.listener(Self::select_to_previous_word_start))
+                            .on_action(cx.listener(Self::select_to_next_word_end))
+                            .on_action(cx.listener(Self::move_to_doc_start))
+                            .on_action(cx.listener(Self::move_to_doc_end))
+                            .on_action(cx.listener(Self::select_to_doc_start))
+                            .on_action(cx.listener(Self::select_to_doc_end))
+                            .on_action(cx.listener(Self::paste))
+                            .on_action(cx.listener(Self::cut))
+                            .on_action(cx.listener(Self::copy))
+                            .on_action(cx.listener(Self::bold))
+                            .on_action(cx.listener(Self::italic))
+                            .on_action(cx.listener(Self::strike_through))
+                            .on_action(cx.listener(Self::code_block))
+                            .on_action(cx.listener(Self::link))
+                    })
                     .on_mouse_down(MouseButton::Left, cx.listener(Self::on_mouse_down))
                     .on_mouse_up(MouseButton::Left, cx.listener(Self::on_mouse_up))
                     .on_mouse_up_out(MouseButton::Left, cx.listener(Self::on_mouse_up))

--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -83,7 +83,6 @@ actions!(
 );
 
 pub fn init(cx: &mut App) {
-    text_field::init(cx);
     cx.bind_keys([
         KeyBinding::new("tab", MentionAccept, Some(KEY_CONTEXT)),
         KeyBinding::new("escape", MentionDismiss, Some(KEY_CONTEXT)),

--- a/crates/mezon-ui/src/chat/mention_input/text_field.rs
+++ b/crates/mezon-ui/src/chat/mention_input/text_field.rs
@@ -11,22 +11,30 @@ use blink_manager::CaretBlink;
 use gpui::{
     App, Bounds, ClipboardEntry, ClipboardItem, Context, CursorStyle, Div, Element, ElementId,
     ElementInputHandler, Entity, EntityInputHandler, EventEmitter, FocusHandle, Focusable,
-    FontWeight, GlobalElementId, Hsla, Image, InspectorElementId, IntoElement, KeyBinding,
-    LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point,
-    Render, RenderOnce, ScrollWheelEvent, SharedString, Style, StyleRefinement, Styled,
-    Subscription, TextAlign, TextRun, UTF16Selection, UnderlineStyle, Window, WrappedLine, actions,
-    div, fill, point, prelude::*, px, rgb, size,
+    FontWeight, GlobalElementId, Hsla, Image, InspectorElementId, IntoElement, LayoutId,
+    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point, Render,
+    RenderOnce, ScrollWheelEvent, SharedString, Style, StyleRefinement, Styled, Subscription,
+    TextAlign, TextRun, UTF16Selection, UnderlineStyle, Window, WrappedLine, div, fill, point,
+    prelude::*, px, rgb, size,
 };
 use unicode_segmentation::UnicodeSegmentation;
 
+use crate::components::primitives::text_actions::{
+    Backspace, Copy, Cut, Delete, DeleteToLineEnd, DeleteToLineStart, DeleteToNextWordEnd,
+    DeleteToPreviousWordStart, Down, End, Enter, Home, Left, MoveToDocEnd, MoveToDocStart,
+    MoveToNextWordEnd, MoveToPreviousWordStart, Newline, Paste, Redo, Right, SelectAll, SelectDown,
+    SelectLeft, SelectRight, SelectToDocEnd, SelectToDocStart, SelectToLineEnd, SelectToLineStart,
+    SelectToNextWordEnd, SelectToPreviousWordStart, SelectUp, ShowCharacterPalette,
+    TEXT_INPUT_CONTEXT, Undo, Up,
+};
 use crate::theme::ActiveTheme;
 use crate::util::text_edit::{
-    EditKind, HistoryEntry, MAX_UNDO_HISTORY, home_target, line_end, line_start,
-    next_word_boundary, previous_word_boundary, should_coalesce,
+    EditKind, HistoryEntry, MAX_UNDO_HISTORY, SelectGranularity, extend_range_for_granularity,
+    granularity_for_click, home_target, line_end, line_start, next_word_boundary,
+    previous_word_boundary, range_for_granularity, should_coalesce,
 };
 
 const MASK: char = '\u{2022}';
-const KEY_CONTEXT: &str = "MezonMentionInput";
 const MAX_VISIBLE_LINES: usize = 10;
 
 struct DocLine {
@@ -157,124 +165,6 @@ fn build_text_runs(
         .collect()
 }
 
-actions!(
-    mezon_mention_input,
-    [
-        Backspace,
-        Delete,
-        Enter,
-        Newline,
-        Up,
-        Down,
-        Left,
-        Right,
-        SelectLeft,
-        SelectRight,
-        SelectAll,
-        Home,
-        End,
-        MoveToPreviousWordStart,
-        MoveToNextWordEnd,
-        SelectToPreviousWordStart,
-        SelectToNextWordEnd,
-        DeleteToPreviousWordStart,
-        DeleteToNextWordEnd,
-        SelectToLineStart,
-        SelectToLineEnd,
-        MoveToDocStart,
-        MoveToDocEnd,
-        SelectToDocStart,
-        SelectToDocEnd,
-        DeleteToLineStart,
-        DeleteToLineEnd,
-        Undo,
-        Redo,
-        ShowCharacterPalette,
-        Paste,
-        Cut,
-        Copy,
-    ]
-);
-
-pub(crate) fn init(cx: &mut App) {
-    let mut bindings = vec![
-        KeyBinding::new("backspace", Backspace, Some(KEY_CONTEXT)),
-        KeyBinding::new("delete", Delete, Some(KEY_CONTEXT)),
-        KeyBinding::new("enter", Enter, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-enter", Newline, Some(KEY_CONTEXT)),
-        KeyBinding::new("up", Up, Some(KEY_CONTEXT)),
-        KeyBinding::new("down", Down, Some(KEY_CONTEXT)),
-        KeyBinding::new("left", Left, Some(KEY_CONTEXT)),
-        KeyBinding::new("right", Right, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-left", SelectLeft, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-right", SelectRight, Some(KEY_CONTEXT)),
-        KeyBinding::new("home", Home, Some(KEY_CONTEXT)),
-        KeyBinding::new("end", End, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-home", SelectToLineStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-end", SelectToLineEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-a", SelectAll, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-v", Paste, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-c", Copy, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-x", Cut, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-z", Undo, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-shift-z", Redo, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-cmd-space", ShowCharacterPalette, Some(KEY_CONTEXT)),
-    ];
-
-    #[cfg(target_os = "macos")]
-    bindings.extend([
-        KeyBinding::new("alt-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("alt-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new(
-            "alt-shift-left",
-            SelectToPreviousWordStart,
-            Some(KEY_CONTEXT),
-        ),
-        KeyBinding::new("alt-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new(
-            "alt-backspace",
-            DeleteToPreviousWordStart,
-            Some(KEY_CONTEXT),
-        ),
-        KeyBinding::new("alt-delete", DeleteToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-left", Home, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-right", End, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-shift-left", SelectToLineStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-shift-right", SelectToLineEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-up", MoveToDocStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-down", MoveToDocEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-shift-up", SelectToDocStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-shift-down", SelectToDocEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-backspace", DeleteToLineStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-delete", DeleteToLineEnd, Some(KEY_CONTEXT)),
-    ]);
-
-    #[cfg(not(target_os = "macos"))]
-    bindings.extend([
-        KeyBinding::new("ctrl-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new(
-            "ctrl-shift-left",
-            SelectToPreviousWordStart,
-            Some(KEY_CONTEXT),
-        ),
-        KeyBinding::new("ctrl-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new(
-            "ctrl-backspace",
-            DeleteToPreviousWordStart,
-            Some(KEY_CONTEXT),
-        ),
-        KeyBinding::new("ctrl-delete", DeleteToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-home", MoveToDocStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-end", MoveToDocEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-shift-home", SelectToDocStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-shift-end", SelectToDocEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-y", Redo, Some(KEY_CONTEXT)),
-    ]);
-
-    cx.bind_keys(bindings);
-}
-
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) enum MentionFieldEvent {
     Change,
@@ -304,6 +194,8 @@ pub(crate) struct MentionInputState {
     content_height: Pixels,
     pending_caret_reveal: bool,
     is_selecting: bool,
+    select_granularity: SelectGranularity,
+    select_anchor: Range<usize>,
     masked: bool,
     compact: bool,
     mention_spans: Vec<MentionSpan>,
@@ -341,6 +233,8 @@ impl MentionInputState {
             content_height: px(0.),
             pending_caret_reveal: true,
             is_selecting: false,
+            select_granularity: SelectGranularity::Character,
+            select_anchor: 0..0,
             masked: false,
             compact: false,
             mention_spans: Vec::new(),
@@ -725,14 +619,9 @@ impl MentionInputState {
         cx.emit(MentionFieldEvent::NavDown);
     }
 
-    pub(crate) fn move_caret_line(&mut self, delta: isize, cx: &mut Context<Self>) {
+    fn caret_line_target(&self, delta: isize) -> usize {
         if self.last_lines.len() <= 1 {
-            if delta < 0 {
-                self.move_to(0, cx);
-            } else {
-                self.move_to(self.content.len(), cx);
-            }
-            return;
+            return if delta < 0 { 0 } else { self.content.len() };
         }
         let line_height = self.line_height;
         let display_cursor = self.to_display_offset(self.cursor_offset());
@@ -744,21 +633,28 @@ impl MentionInputState {
             .unwrap_or(Pixels::ZERO);
         let target_ix = line_ix as isize + delta;
         if target_ix < 0 {
-            self.move_to(0, cx);
-            return;
+            return 0;
         }
-        if target_ix as usize >= self.last_lines.len() {
-            self.move_to(self.content.len(), cx);
-            return;
-        }
-        let target = &self.last_lines[target_ix as usize];
+        let Some(target) = self.last_lines.get(target_ix as usize) else {
+            return self.content.len();
+        };
         let local_target = target
             .line
             .closest_index_for_position(point(caret_x, px(0.)), line_height)
             .unwrap_or_else(|ix| ix);
-        let display_offset = target.start + local_target;
-        let offset = self.display_to_content_offset(display_offset);
-        self.move_to(offset, cx);
+        self.display_to_content_offset(target.start + local_target)
+    }
+
+    pub(crate) fn move_caret_line(&mut self, delta: isize, cx: &mut Context<Self>) {
+        self.move_to(self.caret_line_target(delta), cx);
+    }
+
+    fn select_up(&mut self, _: &SelectUp, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(self.caret_line_target(-1), cx);
+    }
+
+    fn select_down(&mut self, _: &SelectDown, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(self.caret_line_target(1), cx);
     }
 
     fn delete(&mut self, _: &Delete, window: &mut Window, cx: &mut Context<Self>) {
@@ -782,11 +678,29 @@ impl MentionInputState {
         window.focus(&self.focus_handle, cx);
         self.caret_blink.sync_focused(cx);
         self.is_selecting = true;
+        let offset = self.index_for_mouse_position(event.position);
+
         if event.modifiers.shift {
-            self.select_to(self.index_for_mouse_position(event.position), cx);
-        } else {
-            self.move_to(self.index_for_mouse_position(event.position), cx)
+            self.select_granularity = SelectGranularity::Character;
+            self.select_to(offset, cx);
+            return;
         }
+
+        self.select_granularity = granularity_for_click(event.click_count);
+        if self.select_granularity == SelectGranularity::Character {
+            self.select_anchor = offset..offset;
+            self.move_to(offset, cx);
+            return;
+        }
+
+        let range = range_for_granularity(&self.content, offset, self.select_granularity, true);
+        self.select_anchor = range.clone();
+        self.selection_reversed = false;
+        self.selected_range = range;
+        self.last_edit_kind = None;
+        self.pending_caret_reveal = true;
+        self.caret_blink.pause_blinking(cx);
+        cx.notify();
     }
 
     fn on_mouse_up(&mut self, _: &MouseUpEvent, _: &mut Window, _: &mut Context<Self>) {
@@ -794,9 +708,30 @@ impl MentionInputState {
     }
 
     fn on_mouse_move(&mut self, event: &MouseMoveEvent, _: &mut Window, cx: &mut Context<Self>) {
-        if self.is_selecting {
-            self.select_to(self.index_for_mouse_position(event.position), cx);
+        if !self.is_selecting {
+            return;
         }
+        let offset = self.index_for_mouse_position(event.position);
+        if self.select_granularity == SelectGranularity::Character {
+            self.select_to(offset, cx);
+            return;
+        }
+        let (range, reversed) = extend_range_for_granularity(
+            &self.content,
+            &self.select_anchor,
+            offset,
+            self.select_granularity,
+            true,
+        );
+        if range == self.selected_range && reversed == self.selection_reversed {
+            return;
+        }
+        self.selected_range = range;
+        self.selection_reversed = reversed;
+        self.last_edit_kind = None;
+        self.pending_caret_reveal = true;
+        self.caret_blink.pause_blinking(cx);
+        cx.notify();
     }
 
     fn show_character_palette(
@@ -1307,7 +1242,7 @@ impl Render for MentionInputState {
         div()
             .relative()
             .when(!focused, |input| input.group("mention-input-scrollbar"))
-            .key_context(KEY_CONTEXT)
+            .key_context(TEXT_INPUT_CONTEXT)
             .track_focus(&self.focus_handle)
             .cursor(CursorStyle::IBeam)
             .on_action(cx.listener(Self::backspace))
@@ -1320,6 +1255,8 @@ impl Render for MentionInputState {
             .on_action(cx.listener(Self::right))
             .on_action(cx.listener(Self::select_left))
             .on_action(cx.listener(Self::select_right))
+            .on_action(cx.listener(Self::select_up))
+            .on_action(cx.listener(Self::select_down))
             .on_action(cx.listener(Self::select_all))
             .on_action(cx.listener(Self::home))
             .on_action(cx.listener(Self::end))

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -41,7 +41,7 @@ use super::video_player::{VideoActivation, VideoPlayerView};
 use crate::app::shell::Shell;
 use crate::chat::mention_input::{MentionInput, MentionInputEvent};
 use crate::chat::user_profile_popover::UserProfilePopover;
-use crate::components::primitives::input::Copy;
+use crate::components::primitives::text_actions::Copy;
 use crate::components::primitives::{Icon, IconName, TextArea, TextAreaEvent, context_menu_at};
 use crate::image_cache::{
     LruImageCache, MESSAGE_ENTRY_MAX_BYTES, MESSAGE_IMAGE_CACHE_BYTES, MESSAGE_IMAGE_CACHE_CAPACITY,

--- a/crates/mezon-ui/src/components/primitives/mod.rs
+++ b/crates/mezon-ui/src/components/primitives/mod.rs
@@ -29,6 +29,10 @@ pub mod input {
     pub use mezon_widgets::input::*;
 }
 
+pub mod text_actions {
+    pub use mezon_widgets::text_actions::*;
+}
+
 pub mod sizing {
     pub use mezon_widgets::{Sizable, Size};
 }
@@ -68,5 +72,4 @@ pub use sizing::{Sizable, Size};
 pub use spinner::Spinner;
 pub use stack::{h_flex, v_flex};
 
-pub use mezon_widgets::init_input;
-pub use textarea::init as init_textarea;
+pub use mezon_widgets::init_text_input;

--- a/crates/mezon-ui/src/components/primitives/textarea.rs
+++ b/crates/mezon-ui/src/components/primitives/textarea.rs
@@ -3,139 +3,31 @@ use std::ops::Range;
 use gpui::{
     App, Bounds, ClipboardItem, Context, CursorStyle, Div, Element, ElementId, ElementInputHandler,
     Entity, EntityInputHandler, EventEmitter, FocusHandle, Focusable, GlobalElementId, Hsla,
-    InspectorElementId, IntoElement, KeyBinding, LayoutId, MouseButton, MouseDownEvent,
-    MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point, Render, RenderOnce, SharedString,
-    Style, StyleRefinement, Styled, TextAlign, TextRun, UTF16Selection, UnderlineStyle, Window,
-    WrappedLine, actions, div, fill, point, prelude::*, px, size,
+    InspectorElementId, IntoElement, LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent,
+    MouseUpEvent, PaintQuad, Pixels, Point, Render, RenderOnce, SharedString, Style,
+    StyleRefinement, Styled, TextAlign, TextRun, UTF16Selection, UnderlineStyle, Window,
+    WrappedLine, div, fill, point, prelude::*, px, size,
 };
 use unicode_segmentation::UnicodeSegmentation;
 
 use mezon_theme::ActiveTheme;
 use mezon_widgets::blink_manager::{CaretBlink, HasCaretBlink};
 
+use crate::components::primitives::text_actions::{
+    Backspace, Copy, Cut, Delete, DeleteToLineEnd, DeleteToLineStart, DeleteToNextWordEnd,
+    DeleteToPreviousWordStart, Down, End, Enter, Home, Left, MoveToDocEnd, MoveToDocStart,
+    MoveToNextWordEnd, MoveToPreviousWordStart, Newline, Paste, Redo, Right, SelectAll, SelectDown,
+    SelectLeft, SelectRight, SelectToDocEnd, SelectToDocStart, SelectToLineEnd, SelectToLineStart,
+    SelectToNextWordEnd, SelectToPreviousWordStart, SelectUp, ShowCharacterPalette,
+    TEXT_INPUT_CONTEXT, Undo, Up,
+};
 use crate::util::text_edit::{
-    EditKind, HistoryEntry, MAX_UNDO_HISTORY, home_target, line_end, line_start,
-    next_word_boundary, previous_word_boundary, should_coalesce,
+    EditKind, HistoryEntry, MAX_UNDO_HISTORY, SelectGranularity, extend_range_for_granularity,
+    granularity_for_click, home_target, line_end, line_start, next_word_boundary,
+    previous_word_boundary, range_for_granularity, should_coalesce,
 };
 
-const KEY_CONTEXT: &str = "MezonTextArea";
 const DEFAULT_MAX_VISIBLE_LINES: usize = 8;
-
-actions!(
-    mezon_textarea,
-    [
-        Backspace,
-        Delete,
-        Enter,
-        Left,
-        Right,
-        Up,
-        Down,
-        SelectLeft,
-        SelectRight,
-        SelectAll,
-        Home,
-        End,
-        MoveToPreviousWordStart,
-        MoveToNextWordEnd,
-        SelectToPreviousWordStart,
-        SelectToNextWordEnd,
-        DeleteToPreviousWordStart,
-        DeleteToNextWordEnd,
-        SelectToLineStart,
-        SelectToLineEnd,
-        MoveToDocStart,
-        MoveToDocEnd,
-        SelectToDocStart,
-        SelectToDocEnd,
-        DeleteToLineStart,
-        DeleteToLineEnd,
-        Undo,
-        Redo,
-        ShowCharacterPalette,
-        Paste,
-        Cut,
-        Copy,
-    ]
-);
-
-pub fn init(cx: &mut App) {
-    let mut bindings = vec![
-        KeyBinding::new("backspace", Backspace, Some(KEY_CONTEXT)),
-        KeyBinding::new("delete", Delete, Some(KEY_CONTEXT)),
-        KeyBinding::new("enter", Enter, Some(KEY_CONTEXT)),
-        KeyBinding::new("up", Up, Some(KEY_CONTEXT)),
-        KeyBinding::new("down", Down, Some(KEY_CONTEXT)),
-        KeyBinding::new("left", Left, Some(KEY_CONTEXT)),
-        KeyBinding::new("right", Right, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-left", SelectLeft, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-right", SelectRight, Some(KEY_CONTEXT)),
-        KeyBinding::new("home", Home, Some(KEY_CONTEXT)),
-        KeyBinding::new("end", End, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-home", SelectToLineStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-end", SelectToLineEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-a", SelectAll, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-v", Paste, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-c", Copy, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-x", Cut, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-z", Undo, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-shift-z", Redo, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-cmd-space", ShowCharacterPalette, Some(KEY_CONTEXT)),
-    ];
-
-    #[cfg(target_os = "macos")]
-    bindings.extend([
-        KeyBinding::new("alt-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("alt-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new(
-            "alt-shift-left",
-            SelectToPreviousWordStart,
-            Some(KEY_CONTEXT),
-        ),
-        KeyBinding::new("alt-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new(
-            "alt-backspace",
-            DeleteToPreviousWordStart,
-            Some(KEY_CONTEXT),
-        ),
-        KeyBinding::new("alt-delete", DeleteToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-left", Home, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-right", End, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-shift-left", SelectToLineStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-shift-right", SelectToLineEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-up", MoveToDocStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-down", MoveToDocEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-shift-up", SelectToDocStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-shift-down", SelectToDocEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-backspace", DeleteToLineStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-delete", DeleteToLineEnd, Some(KEY_CONTEXT)),
-    ]);
-
-    #[cfg(not(target_os = "macos"))]
-    bindings.extend([
-        KeyBinding::new("ctrl-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new(
-            "ctrl-shift-left",
-            SelectToPreviousWordStart,
-            Some(KEY_CONTEXT),
-        ),
-        KeyBinding::new("ctrl-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new(
-            "ctrl-backspace",
-            DeleteToPreviousWordStart,
-            Some(KEY_CONTEXT),
-        ),
-        KeyBinding::new("ctrl-delete", DeleteToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-home", MoveToDocStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-end", MoveToDocEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-shift-home", SelectToDocStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-shift-end", SelectToDocEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-y", Redo, Some(KEY_CONTEXT)),
-    ]);
-
-    cx.bind_keys(bindings);
-}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum TextAreaEvent {
@@ -211,6 +103,8 @@ pub struct TextArea {
     content_height: Pixels,
     pending_caret_reveal: bool,
     is_selecting: bool,
+    select_granularity: SelectGranularity,
+    select_anchor: Range<usize>,
     single_line: bool,
     bg: Option<Hsla>,
     text_color: Option<Hsla>,
@@ -259,6 +153,8 @@ impl TextArea {
             content_height: px(0.),
             pending_caret_reveal: true,
             is_selecting: false,
+            select_granularity: SelectGranularity::Character,
+            select_anchor: 0..0,
             single_line: false,
             bg: None,
             text_color: None,
@@ -441,14 +337,9 @@ impl TextArea {
             .unwrap_or(self.content.len())
     }
 
-    fn move_caret_line(&mut self, delta: isize, cx: &mut Context<Self>) {
+    fn caret_line_target(&self, delta: isize) -> usize {
         if self.single_line || self.last_lines.len() <= 1 {
-            if delta < 0 {
-                self.move_to(0, cx);
-            } else {
-                self.move_to(self.content.len(), cx);
-            }
-            return;
+            return if delta < 0 { 0 } else { self.content.len() };
         }
         let line_height = self.line_height;
         let (line_ix, local) = locate_display_offset(&self.last_lines, self.cursor_offset());
@@ -459,19 +350,20 @@ impl TextArea {
             .unwrap_or(Pixels::ZERO);
         let target_ix = line_ix as isize + delta;
         if target_ix < 0 {
-            self.move_to(0, cx);
-            return;
+            return 0;
         }
-        if target_ix as usize >= self.last_lines.len() {
-            self.move_to(self.content.len(), cx);
-            return;
-        }
-        let target = &self.last_lines[target_ix as usize];
+        let Some(target) = self.last_lines.get(target_ix as usize) else {
+            return self.content.len();
+        };
         let local_target = target
             .line
             .closest_index_for_position(point(caret_x, px(0.)), line_height)
             .unwrap_or_else(|ix| ix);
-        self.move_to(target.start + local_target, cx);
+        target.start + local_target
+    }
+
+    fn move_caret_line(&mut self, delta: isize, cx: &mut Context<Self>) {
+        self.move_to(self.caret_line_target(delta), cx);
     }
 
     fn index_for_mouse_position(&self, position: Point<Pixels>) -> usize {
@@ -523,6 +415,22 @@ impl TextArea {
 
     fn down(&mut self, _: &Down, _: &mut Window, cx: &mut Context<Self>) {
         self.move_caret_line(1, cx);
+    }
+
+    fn select_up(&mut self, _: &SelectUp, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(self.caret_line_target(-1), cx);
+    }
+
+    fn select_down(&mut self, _: &SelectDown, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(self.caret_line_target(1), cx);
+    }
+
+    fn newline(&mut self, _: &Newline, window: &mut Window, cx: &mut Context<Self>) {
+        if self.single_line {
+            cx.propagate();
+            return;
+        }
+        self.replace_text_in_range(None, "\n", window, cx);
     }
 
     fn select_left(&mut self, _: &SelectLeft, _: &mut Window, cx: &mut Context<Self>) {
@@ -819,11 +727,34 @@ impl TextArea {
         window.focus(&self.focus_handle, cx);
         self.caret_blink.sync_focused(cx);
         self.is_selecting = true;
+        let offset = self.index_for_mouse_position(event.position);
+
         if event.modifiers.shift {
-            self.select_to(self.index_for_mouse_position(event.position), cx);
-        } else {
-            self.move_to(self.index_for_mouse_position(event.position), cx);
+            self.select_granularity = SelectGranularity::Character;
+            self.select_to(offset, cx);
+            return;
         }
+
+        self.select_granularity = granularity_for_click(event.click_count);
+        if self.select_granularity == SelectGranularity::Character {
+            self.select_anchor = offset..offset;
+            self.move_to(offset, cx);
+            return;
+        }
+
+        let range = range_for_granularity(
+            &self.content,
+            offset,
+            self.select_granularity,
+            !self.single_line,
+        );
+        self.select_anchor = range.clone();
+        self.selection_reversed = false;
+        self.selected_range = range;
+        self.last_edit_kind = None;
+        self.pending_caret_reveal = true;
+        self.caret_blink.pause_blinking(cx);
+        cx.notify();
     }
 
     fn on_mouse_up(&mut self, _: &MouseUpEvent, _: &mut Window, _: &mut Context<Self>) {
@@ -831,9 +762,30 @@ impl TextArea {
     }
 
     fn on_mouse_move(&mut self, event: &MouseMoveEvent, _: &mut Window, cx: &mut Context<Self>) {
-        if self.is_selecting {
-            self.select_to(self.index_for_mouse_position(event.position), cx);
+        if !self.is_selecting {
+            return;
         }
+        let offset = self.index_for_mouse_position(event.position);
+        if self.select_granularity == SelectGranularity::Character {
+            self.select_to(offset, cx);
+            return;
+        }
+        let (range, reversed) = extend_range_for_granularity(
+            &self.content,
+            &self.select_anchor,
+            offset,
+            self.select_granularity,
+            !self.single_line,
+        );
+        if range == self.selected_range && reversed == self.selection_reversed {
+            return;
+        }
+        self.selected_range = range;
+        self.selection_reversed = reversed;
+        self.last_edit_kind = None;
+        self.pending_caret_reveal = true;
+        self.caret_blink.pause_blinking(cx);
+        cx.notify();
     }
 
     fn offset_from_utf16(&self, offset: usize) -> usize {
@@ -1037,14 +989,17 @@ impl Render for TextArea {
         let min_height = self.min_height;
 
         div()
-            .key_context(KEY_CONTEXT)
+            .key_context(TEXT_INPUT_CONTEXT)
             .track_focus(&self.focus_handle)
             .cursor(CursorStyle::IBeam)
             .on_action(cx.listener(Self::backspace))
             .on_action(cx.listener(Self::delete))
             .on_action(cx.listener(Self::enter))
+            .on_action(cx.listener(Self::newline))
             .on_action(cx.listener(Self::up))
             .on_action(cx.listener(Self::down))
+            .on_action(cx.listener(Self::select_up))
+            .on_action(cx.listener(Self::select_down))
             .on_action(cx.listener(Self::left))
             .on_action(cx.listener(Self::right))
             .on_action(cx.listener(Self::select_left))

--- a/crates/mezon-ui/src/components/primitives/textarea.rs
+++ b/crates/mezon-ui/src/components/primitives/textarea.rs
@@ -410,18 +410,34 @@ impl TextArea {
     }
 
     fn up(&mut self, _: &Up, _: &mut Window, cx: &mut Context<Self>) {
+        if self.single_line {
+            cx.propagate();
+            return;
+        }
         self.move_caret_line(-1, cx);
     }
 
     fn down(&mut self, _: &Down, _: &mut Window, cx: &mut Context<Self>) {
+        if self.single_line {
+            cx.propagate();
+            return;
+        }
         self.move_caret_line(1, cx);
     }
 
     fn select_up(&mut self, _: &SelectUp, _: &mut Window, cx: &mut Context<Self>) {
+        if self.single_line {
+            cx.propagate();
+            return;
+        }
         self.select_to(self.caret_line_target(-1), cx);
     }
 
     fn select_down(&mut self, _: &SelectDown, _: &mut Window, cx: &mut Context<Self>) {
+        if self.single_line {
+            cx.propagate();
+            return;
+        }
         self.select_to(self.caret_line_target(1), cx);
     }
 

--- a/crates/mezon-ui/src/lib.rs
+++ b/crates/mezon-ui/src/lib.rs
@@ -96,8 +96,7 @@ pub fn init(cx: &mut gpui::App) {
     cx.on_action(|_: &OpenCommandPalette, cx: &mut gpui::App| {
         command_palette::CommandPaletteModal::try_toggle_authenticated(cx);
     });
-    components::primitives::init_input(cx);
-    components::primitives::init_textarea(cx);
+    components::primitives::init_text_input(cx);
     chat::mention_input::init(cx);
     mezon_canvas::init(cx);
     canvas_navigation::init(cx);
@@ -109,7 +108,7 @@ pub fn init(cx: &mut gpui::App) {
 
 /// macOS menu bar and standard shortcuts. Edit items reuse the input component's clipboard actions.
 fn init_menus(cx: &mut gpui::App) {
-    use crate::components::primitives::input::{Copy, Cut, Paste, SelectAll};
+    use crate::components::primitives::text_actions::{Copy, Cut, Paste, SelectAll};
 
     #[cfg(target_os = "macos")]
     init_macos_menu_actions(cx);
@@ -149,10 +148,10 @@ fn init_macos_menu_actions(cx: &mut gpui::App) {
 }
 
 fn app_menus(
-    cut: crate::components::primitives::input::Cut,
-    copy: crate::components::primitives::input::Copy,
-    paste: crate::components::primitives::input::Paste,
-    select_all: crate::components::primitives::input::SelectAll,
+    cut: crate::components::primitives::text_actions::Cut,
+    copy: crate::components::primitives::text_actions::Copy,
+    paste: crate::components::primitives::text_actions::Paste,
+    select_all: crate::components::primitives::text_actions::SelectAll,
 ) -> Vec<gpui::Menu> {
     use gpui::{Menu, MenuItem};
 
@@ -184,10 +183,10 @@ fn app_menus(
 }
 
 fn edit_menu_items(
-    cut: crate::components::primitives::input::Cut,
-    copy: crate::components::primitives::input::Copy,
-    paste: crate::components::primitives::input::Paste,
-    select_all: crate::components::primitives::input::SelectAll,
+    cut: crate::components::primitives::text_actions::Cut,
+    copy: crate::components::primitives::text_actions::Copy,
+    paste: crate::components::primitives::text_actions::Paste,
+    select_all: crate::components::primitives::text_actions::SelectAll,
 ) -> [gpui::MenuItem; 5] {
     use gpui::{MenuItem, OsAction};
 

--- a/crates/mezon-ui/src/util/text_edit.rs
+++ b/crates/mezon-ui/src/util/text_edit.rs
@@ -1,4 +1,5 @@
 pub(crate) use mezon_widgets::text_edit::{
-    EditKind, HistoryEntry, MAX_UNDO_HISTORY, home_target, line_end, line_start,
-    next_word_boundary, previous_word_boundary, should_coalesce,
+    EditKind, HistoryEntry, MAX_UNDO_HISTORY, SelectGranularity, extend_range_for_granularity,
+    granularity_for_click, home_target, line_end, line_start, next_word_boundary,
+    previous_word_boundary, range_for_granularity, should_coalesce,
 };

--- a/crates/mezon-widgets/src/input.rs
+++ b/crates/mezon-widgets/src/input.rs
@@ -369,10 +369,18 @@ impl InputState {
     }
 
     fn select_up(&mut self, _: &SelectUp, _: &mut Window, cx: &mut Context<Self>) {
+        if !self.multi_line {
+            cx.propagate();
+            return;
+        }
         self.select_to(self.caret_line_target(-1), cx);
     }
 
     fn select_down(&mut self, _: &SelectDown, _: &mut Window, cx: &mut Context<Self>) {
+        if !self.multi_line {
+            cx.propagate();
+            return;
+        }
         self.select_to(self.caret_line_target(1), cx);
     }
 

--- a/crates/mezon-widgets/src/input.rs
+++ b/crates/mezon-widgets/src/input.rs
@@ -5,135 +5,30 @@ use super::blink_manager::{CaretBlink, HasCaretBlink};
 use gpui::{
     App, Bounds, ClipboardItem, Context, Corners, CursorStyle, Div, Element, ElementId,
     ElementInputHandler, Entity, EntityInputHandler, EventEmitter, FocusHandle, Focusable,
-    FontWeight, GlobalElementId, Hsla, InspectorElementId, IntoElement, KeyBinding, LayoutId,
-    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point, Render,
-    RenderOnce, ShapedLine, SharedString, Style, StyleRefinement, Styled, TextAlign, TextRun,
-    UTF16Selection, UnderlineStyle, Window, WrappedLine, actions, div, fill, point, prelude::*, px,
-    size, svg,
+    FontWeight, GlobalElementId, Hsla, InspectorElementId, IntoElement, LayoutId, MouseButton,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point, Render, RenderOnce,
+    ShapedLine, SharedString, Style, StyleRefinement, Styled, TextAlign, TextRun, UTF16Selection,
+    UnderlineStyle, Window, WrappedLine, div, fill, point, prelude::*, px, size, svg,
 };
 use unicode_segmentation::UnicodeSegmentation;
 
 use mezon_theme::ActiveTheme;
 
+use crate::text_actions::{
+    Backspace, Copy, Cut, Delete, DeleteToLineEnd, DeleteToLineStart, DeleteToNextWordEnd,
+    DeleteToPreviousWordStart, Down, End, Enter, Home, Left, MoveToDocEnd, MoveToDocStart,
+    MoveToNextWordEnd, MoveToPreviousWordStart, Newline, Paste, Redo, Right, SelectAll, SelectDown,
+    SelectLeft, SelectRight, SelectToDocEnd, SelectToDocStart, SelectToLineEnd, SelectToLineStart,
+    SelectToNextWordEnd, SelectToPreviousWordStart, SelectUp, ShowCharacterPalette,
+    TEXT_INPUT_CONTEXT, Undo, Up,
+};
 use crate::text_edit::{
-    EditKind, HistoryEntry, MAX_UNDO_HISTORY, home_target, line_end, line_start,
-    next_word_boundary, previous_word_boundary, should_coalesce,
+    EditKind, HistoryEntry, MAX_UNDO_HISTORY, SelectGranularity, extend_range_for_granularity,
+    granularity_for_click, home_target, line_end, line_start, next_word_boundary,
+    previous_word_boundary, range_for_granularity, should_coalesce,
 };
 
 const MASK: char = '\u{2022}';
-const KEY_CONTEXT: &str = "MezonInput";
-
-actions!(
-    mezon_input,
-    [
-        Backspace,
-        Delete,
-        Enter,
-        Left,
-        Right,
-        SelectLeft,
-        SelectRight,
-        SelectAll,
-        Home,
-        End,
-        MoveToPreviousWordStart,
-        MoveToNextWordEnd,
-        SelectToPreviousWordStart,
-        SelectToNextWordEnd,
-        DeleteToPreviousWordStart,
-        DeleteToNextWordEnd,
-        SelectToLineStart,
-        SelectToLineEnd,
-        MoveToDocStart,
-        MoveToDocEnd,
-        SelectToDocStart,
-        SelectToDocEnd,
-        DeleteToLineStart,
-        DeleteToLineEnd,
-        Undo,
-        Redo,
-        ShowCharacterPalette,
-        Paste,
-        Cut,
-        Copy,
-    ]
-);
-
-pub fn init(cx: &mut App) {
-    let mut bindings = vec![
-        KeyBinding::new("backspace", Backspace, Some(KEY_CONTEXT)),
-        KeyBinding::new("delete", Delete, Some(KEY_CONTEXT)),
-        KeyBinding::new("enter", Enter, Some(KEY_CONTEXT)),
-        KeyBinding::new("left", Left, Some(KEY_CONTEXT)),
-        KeyBinding::new("right", Right, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-left", SelectLeft, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-right", SelectRight, Some(KEY_CONTEXT)),
-        KeyBinding::new("home", Home, Some(KEY_CONTEXT)),
-        KeyBinding::new("end", End, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-home", SelectToLineStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("shift-end", SelectToLineEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-a", SelectAll, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-v", Paste, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-c", Copy, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-x", Cut, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-z", Undo, Some(KEY_CONTEXT)),
-        KeyBinding::new("secondary-shift-z", Redo, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-cmd-space", ShowCharacterPalette, Some(KEY_CONTEXT)),
-    ];
-
-    #[cfg(target_os = "macos")]
-    bindings.extend([
-        KeyBinding::new("alt-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("alt-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new(
-            "alt-shift-left",
-            SelectToPreviousWordStart,
-            Some(KEY_CONTEXT),
-        ),
-        KeyBinding::new("alt-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new(
-            "alt-backspace",
-            DeleteToPreviousWordStart,
-            Some(KEY_CONTEXT),
-        ),
-        KeyBinding::new("alt-delete", DeleteToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-left", Home, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-right", End, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-shift-left", SelectToLineStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-shift-right", SelectToLineEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-up", MoveToDocStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-down", MoveToDocEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-shift-up", SelectToDocStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-shift-down", SelectToDocEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-backspace", DeleteToLineStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("cmd-delete", DeleteToLineEnd, Some(KEY_CONTEXT)),
-    ]);
-
-    #[cfg(not(target_os = "macos"))]
-    bindings.extend([
-        KeyBinding::new("ctrl-left", MoveToPreviousWordStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-right", MoveToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new(
-            "ctrl-shift-left",
-            SelectToPreviousWordStart,
-            Some(KEY_CONTEXT),
-        ),
-        KeyBinding::new("ctrl-shift-right", SelectToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new(
-            "ctrl-backspace",
-            DeleteToPreviousWordStart,
-            Some(KEY_CONTEXT),
-        ),
-        KeyBinding::new("ctrl-delete", DeleteToNextWordEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-home", MoveToDocStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-end", MoveToDocEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-shift-home", SelectToDocStart, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-shift-end", SelectToDocEnd, Some(KEY_CONTEXT)),
-        KeyBinding::new("ctrl-y", Redo, Some(KEY_CONTEXT)),
-    ]);
-
-    cx.bind_keys(bindings);
-}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum InputEvent {
@@ -156,6 +51,8 @@ pub struct InputState {
     line_height: Pixels,
     page_scroll_offset: Point<Pixels>,
     is_selecting: bool,
+    select_granularity: SelectGranularity,
+    select_anchor: Range<usize>,
     masked: bool,
     multi_line: bool,
     embedded: bool,
@@ -205,6 +102,8 @@ impl InputState {
             line_height: Pixels::ZERO,
             page_scroll_offset: Point::default(),
             is_selecting: false,
+            select_granularity: SelectGranularity::Character,
+            select_anchor: 0..0,
             masked: false,
             multi_line: false,
             embedded: false,
@@ -418,6 +317,71 @@ impl InputState {
         } else {
             self.move_to(self.selected_range.end, cx)
         }
+    }
+
+    fn caret_line_target(&self, delta: isize) -> usize {
+        if !self.multi_line || self.last_lines.len() <= 1 || self.line_height <= Pixels::ZERO {
+            return if delta < 0 { 0 } else { self.content.len() };
+        }
+        let line_height = self.line_height;
+        let display_offset = self.to_display_offset(self.cursor_offset());
+        let (line_ix, local) = self
+            .last_lines
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, line)| line.start <= display_offset)
+            .map(|(ix, line)| (ix, display_offset - line.start))
+            .unwrap_or((0, 0));
+        let caret_x = self.last_lines[line_ix]
+            .line
+            .position_for_index(local, line_height)
+            .map(|position| position.x)
+            .unwrap_or(Pixels::ZERO);
+        let target_ix = line_ix as isize + delta;
+        if target_ix < 0 {
+            return 0;
+        }
+        let Some(target) = self.last_lines.get(target_ix as usize) else {
+            return self.content.len();
+        };
+        let local_target = target
+            .line
+            .closest_index_for_position(point(caret_x, px(0.)), line_height)
+            .unwrap_or_else(|ix| ix);
+        self.display_to_content_offset(target.start + local_target)
+    }
+
+    fn up(&mut self, _: &Up, _: &mut Window, cx: &mut Context<Self>) {
+        if !self.multi_line {
+            cx.propagate();
+            return;
+        }
+        self.move_to(self.caret_line_target(-1), cx);
+    }
+
+    fn down(&mut self, _: &Down, _: &mut Window, cx: &mut Context<Self>) {
+        if !self.multi_line {
+            cx.propagate();
+            return;
+        }
+        self.move_to(self.caret_line_target(1), cx);
+    }
+
+    fn select_up(&mut self, _: &SelectUp, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(self.caret_line_target(-1), cx);
+    }
+
+    fn select_down(&mut self, _: &SelectDown, _: &mut Window, cx: &mut Context<Self>) {
+        self.select_to(self.caret_line_target(1), cx);
+    }
+
+    fn newline(&mut self, _: &Newline, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.multi_line {
+            cx.propagate();
+            return;
+        }
+        self.replace_text_in_range(None, "\n", window, cx);
     }
 
     fn select_left(&mut self, _: &SelectLeft, _: &mut Window, cx: &mut Context<Self>) {
@@ -680,11 +644,35 @@ impl InputState {
         window.focus(&self.focus_handle, cx);
         self.caret_blink.sync_focused(cx);
         self.is_selecting = true;
+        let offset = self.index_for_mouse_position(event.position);
+
         if event.modifiers.shift {
-            self.select_to(self.index_for_mouse_position(event.position), cx);
-        } else {
-            self.move_to(self.index_for_mouse_position(event.position), cx)
+            self.select_granularity = SelectGranularity::Character;
+            self.select_to(offset, cx);
+            return;
         }
+
+        self.select_granularity = granularity_for_click(event.click_count);
+        if self.select_granularity == SelectGranularity::Character {
+            self.select_anchor = offset..offset;
+            self.move_to(offset, cx);
+            return;
+        }
+
+        let range = self.granularity_range(offset, self.select_granularity);
+        self.select_anchor = range.clone();
+        self.selection_reversed = false;
+        self.selected_range = range;
+        self.last_edit_kind = None;
+        self.pause_caret_blink(cx);
+        cx.notify();
+    }
+
+    fn granularity_range(&self, offset: usize, granularity: SelectGranularity) -> Range<usize> {
+        if self.is_masked() {
+            return 0..self.content.len();
+        }
+        range_for_granularity(&self.content, offset, granularity, self.multi_line)
     }
 
     fn on_mouse_up(&mut self, _: &MouseUpEvent, _: &mut Window, _: &mut Context<Self>) {
@@ -692,9 +680,32 @@ impl InputState {
     }
 
     fn on_mouse_move(&mut self, event: &MouseMoveEvent, _: &mut Window, cx: &mut Context<Self>) {
-        if self.is_selecting {
-            self.select_to(self.index_for_mouse_position(event.position), cx);
+        if !self.is_selecting {
+            return;
         }
+        let offset = self.index_for_mouse_position(event.position);
+        if self.select_granularity == SelectGranularity::Character {
+            self.select_to(offset, cx);
+            return;
+        }
+        if self.is_masked() {
+            return;
+        }
+        let (range, reversed) = extend_range_for_granularity(
+            &self.content,
+            &self.select_anchor,
+            offset,
+            self.select_granularity,
+            self.multi_line,
+        );
+        if range == self.selected_range && reversed == self.selection_reversed {
+            return;
+        }
+        self.selected_range = range;
+        self.selection_reversed = reversed;
+        self.last_edit_kind = None;
+        self.pause_caret_blink(cx);
+        cx.notify();
     }
 
     fn show_character_palette(
@@ -1136,16 +1147,21 @@ impl Render for InputState {
         let show_border = self.show_border;
 
         div()
-            .key_context(KEY_CONTEXT)
+            .key_context(TEXT_INPUT_CONTEXT)
             .track_focus(&self.focus_handle)
             .cursor(CursorStyle::IBeam)
             .on_action(cx.listener(Self::backspace))
             .on_action(cx.listener(Self::delete))
             .on_action(cx.listener(Self::enter))
+            .on_action(cx.listener(Self::newline))
             .on_action(cx.listener(Self::left))
             .on_action(cx.listener(Self::right))
+            .on_action(cx.listener(Self::up))
+            .on_action(cx.listener(Self::down))
             .on_action(cx.listener(Self::select_left))
             .on_action(cx.listener(Self::select_right))
+            .on_action(cx.listener(Self::select_up))
+            .on_action(cx.listener(Self::select_down))
             .on_action(cx.listener(Self::select_all))
             .on_action(cx.listener(Self::home))
             .on_action(cx.listener(Self::end))

--- a/crates/mezon-widgets/src/lib.rs
+++ b/crates/mezon-widgets/src/lib.rs
@@ -5,12 +5,13 @@ pub mod input;
 mod sizing;
 mod spinner;
 mod stack;
+pub mod text_actions;
 pub mod text_edit;
 
 pub use button::{Button, ButtonVariant, ButtonVariants};
 pub use icon::{Icon, IconName};
-pub use input::init as init_input;
 pub use input::{Input, InputEvent, InputState};
 pub use sizing::{Sizable, Size};
 pub use spinner::Spinner;
 pub use stack::{h_flex, v_flex};
+pub use text_actions::init as init_text_input;

--- a/crates/mezon-widgets/src/text_actions.rs
+++ b/crates/mezon-widgets/src/text_actions.rs
@@ -1,0 +1,200 @@
+use gpui::{App, KeyBinding, actions};
+
+pub const TEXT_INPUT_CONTEXT: &str = "MezonTextInput";
+
+actions!(
+    mezon_text_input,
+    [
+        Backspace,
+        Delete,
+        Enter,
+        Newline,
+        Left,
+        Right,
+        Up,
+        Down,
+        SelectLeft,
+        SelectRight,
+        SelectUp,
+        SelectDown,
+        SelectAll,
+        Home,
+        End,
+        MoveToPreviousWordStart,
+        MoveToNextWordEnd,
+        SelectToPreviousWordStart,
+        SelectToNextWordEnd,
+        DeleteToPreviousWordStart,
+        DeleteToNextWordEnd,
+        SelectToLineStart,
+        SelectToLineEnd,
+        MoveToDocStart,
+        MoveToDocEnd,
+        SelectToDocStart,
+        SelectToDocEnd,
+        DeleteToLineStart,
+        DeleteToLineEnd,
+        Undo,
+        Redo,
+        ShowCharacterPalette,
+        Paste,
+        Cut,
+        Copy,
+    ]
+);
+
+fn text_input_bindings() -> Vec<KeyBinding> {
+    let mut bindings = vec![
+        KeyBinding::new("backspace", Backspace, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("delete", Delete, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("enter", Enter, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("shift-enter", Newline, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("left", Left, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("right", Right, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("up", Up, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("down", Down, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("shift-left", SelectLeft, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("shift-right", SelectRight, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("shift-up", SelectUp, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("shift-down", SelectDown, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("home", Home, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("end", End, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("shift-home", SelectToLineStart, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("shift-end", SelectToLineEnd, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("secondary-a", SelectAll, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("secondary-v", Paste, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("secondary-c", Copy, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("secondary-x", Cut, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("secondary-z", Undo, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("secondary-shift-z", Redo, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new(
+            "ctrl-cmd-space",
+            ShowCharacterPalette,
+            Some(TEXT_INPUT_CONTEXT),
+        ),
+    ];
+
+    #[cfg(target_os = "macos")]
+    bindings.extend([
+        KeyBinding::new(
+            "alt-left",
+            MoveToPreviousWordStart,
+            Some(TEXT_INPUT_CONTEXT),
+        ),
+        KeyBinding::new("alt-right", MoveToNextWordEnd, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new(
+            "alt-shift-left",
+            SelectToPreviousWordStart,
+            Some(TEXT_INPUT_CONTEXT),
+        ),
+        KeyBinding::new(
+            "alt-shift-right",
+            SelectToNextWordEnd,
+            Some(TEXT_INPUT_CONTEXT),
+        ),
+        KeyBinding::new(
+            "alt-backspace",
+            DeleteToPreviousWordStart,
+            Some(TEXT_INPUT_CONTEXT),
+        ),
+        KeyBinding::new("alt-delete", DeleteToNextWordEnd, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("cmd-left", Home, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("cmd-right", End, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new(
+            "cmd-shift-left",
+            SelectToLineStart,
+            Some(TEXT_INPUT_CONTEXT),
+        ),
+        KeyBinding::new("cmd-shift-right", SelectToLineEnd, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("cmd-up", MoveToDocStart, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("cmd-down", MoveToDocEnd, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("cmd-shift-up", SelectToDocStart, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("cmd-shift-down", SelectToDocEnd, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("cmd-backspace", DeleteToLineStart, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("cmd-delete", DeleteToLineEnd, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-a", Home, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-e", End, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-p", Up, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-n", Down, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-d", Delete, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-h", Backspace, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-k", DeleteToLineEnd, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-shift-a", SelectToLineStart, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-shift-e", SelectToLineEnd, Some(TEXT_INPUT_CONTEXT)),
+    ]);
+
+    #[cfg(not(target_os = "macos"))]
+    bindings.extend([
+        KeyBinding::new(
+            "ctrl-left",
+            MoveToPreviousWordStart,
+            Some(TEXT_INPUT_CONTEXT),
+        ),
+        KeyBinding::new("ctrl-right", MoveToNextWordEnd, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new(
+            "ctrl-shift-left",
+            SelectToPreviousWordStart,
+            Some(TEXT_INPUT_CONTEXT),
+        ),
+        KeyBinding::new(
+            "ctrl-shift-right",
+            SelectToNextWordEnd,
+            Some(TEXT_INPUT_CONTEXT),
+        ),
+        KeyBinding::new(
+            "ctrl-backspace",
+            DeleteToPreviousWordStart,
+            Some(TEXT_INPUT_CONTEXT),
+        ),
+        KeyBinding::new("ctrl-delete", DeleteToNextWordEnd, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-home", MoveToDocStart, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-end", MoveToDocEnd, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new(
+            "ctrl-shift-home",
+            SelectToDocStart,
+            Some(TEXT_INPUT_CONTEXT),
+        ),
+        KeyBinding::new("ctrl-shift-end", SelectToDocEnd, Some(TEXT_INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-y", Redo, Some(TEXT_INPUT_CONTEXT)),
+    ]);
+
+    bindings
+}
+
+pub fn init(cx: &mut App) {
+    cx.bind_keys(text_input_bindings());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn no_keystroke_is_bound_twice() {
+        let mut seen: HashMap<String, String> = HashMap::new();
+        for binding in text_input_bindings() {
+            let keystroke = binding
+                .keystrokes()
+                .iter()
+                .map(|key| format!("{key:?}"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            let action = binding.action().name().to_string();
+            if let Some(previous) = seen.insert(keystroke.clone(), action.clone()) {
+                panic!("{keystroke} bound to both {previous} and {action}");
+            }
+        }
+    }
+
+    #[test]
+    fn every_bound_action_is_reachable_from_one_context() {
+        for binding in text_input_bindings() {
+            assert!(
+                binding.predicate().is_some(),
+                "{} must be scoped to the text input context",
+                binding.action().name()
+            );
+        }
+    }
+}

--- a/crates/mezon-widgets/src/text_actions.rs
+++ b/crates/mezon-widgets/src/text_actions.rs
@@ -168,6 +168,7 @@ pub fn init(cx: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui::KeyContext;
     use std::collections::HashMap;
 
     #[test]
@@ -188,12 +189,23 @@ mod tests {
     }
 
     #[test]
-    fn every_bound_action_is_reachable_from_one_context() {
+    fn every_binding_fires_only_inside_the_text_input_context() {
+        let mut inside = KeyContext::default();
+        inside.add(TEXT_INPUT_CONTEXT);
+        let outside = KeyContext::default();
+
         for binding in text_input_bindings() {
+            let name = binding.action().name().to_string();
+            let predicate = binding
+                .predicate()
+                .unwrap_or_else(|| panic!("{name} must be scoped to a context"));
             assert!(
-                binding.predicate().is_some(),
-                "{} must be scoped to the text input context",
-                binding.action().name()
+                predicate.eval(std::slice::from_ref(&inside)),
+                "{name} must fire inside {TEXT_INPUT_CONTEXT}"
+            );
+            assert!(
+                !predicate.eval(std::slice::from_ref(&outside)),
+                "{name} must not fire outside {TEXT_INPUT_CONTEXT}"
             );
         }
     }

--- a/crates/mezon-widgets/src/text_edit.rs
+++ b/crates/mezon-widgets/src/text_edit.rs
@@ -91,6 +91,82 @@ pub fn home_target(text: &str, offset: usize) -> usize {
     }
 }
 
+pub fn word_range_at(text: &str, offset: usize) -> Range<usize> {
+    let offset = offset.min(text.len());
+    let before = text[..offset].chars().next_back().map(char_kind);
+    let after = text[offset..].chars().next().map(char_kind);
+    let kind = match (before, after) {
+        (_, Some(a)) if a != CharKind::Whitespace => a,
+        (Some(b), _) if b != CharKind::Whitespace => b,
+        (_, Some(a)) => a,
+        (Some(b), None) => b,
+        (None, None) => return 0..0,
+    };
+    let start = text[..offset]
+        .char_indices()
+        .rev()
+        .take_while(|(_, c)| char_kind(*c) == kind)
+        .map(|(idx, _)| idx)
+        .last()
+        .unwrap_or(offset);
+    let end = text[offset..]
+        .char_indices()
+        .take_while(|(_, c)| char_kind(*c) == kind)
+        .map(|(idx, c)| offset + idx + c.len_utf8())
+        .last()
+        .unwrap_or(offset);
+    start..end
+}
+
+pub fn line_range_at(text: &str, offset: usize) -> Range<usize> {
+    line_start(text, offset)..line_end(text, offset)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum SelectGranularity {
+    #[default]
+    Character,
+    Word,
+    Line,
+}
+
+pub fn granularity_for_click(click_count: usize) -> SelectGranularity {
+    match click_count {
+        0 | 1 => SelectGranularity::Character,
+        2 => SelectGranularity::Word,
+        _ => SelectGranularity::Line,
+    }
+}
+
+pub fn range_for_granularity(
+    text: &str,
+    offset: usize,
+    granularity: SelectGranularity,
+    multi_line: bool,
+) -> Range<usize> {
+    match granularity {
+        SelectGranularity::Character => offset..offset,
+        SelectGranularity::Word => word_range_at(text, offset),
+        SelectGranularity::Line if multi_line => line_range_at(text, offset),
+        SelectGranularity::Line => 0..text.len(),
+    }
+}
+
+pub fn extend_range_for_granularity(
+    text: &str,
+    anchor: &Range<usize>,
+    offset: usize,
+    granularity: SelectGranularity,
+    multi_line: bool,
+) -> (Range<usize>, bool) {
+    let unit = range_for_granularity(text, offset, granularity, multi_line);
+    if unit.start < anchor.start {
+        (unit.start..anchor.end, true)
+    } else {
+        (anchor.start..unit.end.max(anchor.end), false)
+    }
+}
+
 #[derive(Clone)]
 pub struct HistoryEntry {
     pub content: SharedString,
@@ -173,5 +249,81 @@ mod tests {
         let text = "one\ntwo";
         assert_eq!(home_target(text, 6), 4);
         assert_eq!(home_target(text, 4), 4);
+    }
+
+    #[test]
+    fn word_range_covers_the_word_under_the_caret() {
+        let text = "foo bar baz";
+        assert_eq!(word_range_at(text, 5), 4..7);
+        assert_eq!(word_range_at(text, 4), 4..7);
+        assert_eq!(word_range_at(text, 7), 4..7);
+    }
+
+    #[test]
+    fn word_range_prefers_the_word_before_a_trailing_space() {
+        let text = "foo bar";
+        assert_eq!(word_range_at(text, 3), 0..3);
+        assert_eq!(word_range_at(text, 7), 4..7);
+    }
+
+    #[test]
+    fn word_range_treats_punctuation_as_its_own_run() {
+        let text = "foo.bar";
+        assert_eq!(word_range_at(text, 0), 0..3);
+        assert_eq!(word_range_at(text, 4), 4..7);
+    }
+
+    #[test]
+    fn word_range_respects_utf8_boundaries() {
+        let text = "chào bạn";
+        assert_eq!(word_range_at(text, 2), 0..5);
+        assert_eq!(word_range_at(text, 7), 6..text.len());
+    }
+
+    #[test]
+    fn word_range_on_empty_text_is_empty() {
+        assert_eq!(word_range_at("", 0), 0..0);
+        assert_eq!(word_range_at("   ", 1), 0..3);
+    }
+
+    #[test]
+    fn triple_click_selects_the_line_only_when_multi_line() {
+        let text = "one\ntwo";
+        let line = SelectGranularity::Line;
+        assert_eq!(range_for_granularity(text, 5, line, true), 4..7);
+        assert_eq!(range_for_granularity(text, 5, line, false), 0..7);
+    }
+
+    #[test]
+    fn granularity_maps_click_count_to_word_then_line() {
+        assert_eq!(granularity_for_click(1), SelectGranularity::Character);
+        assert_eq!(granularity_for_click(2), SelectGranularity::Word);
+        assert_eq!(granularity_for_click(3), SelectGranularity::Line);
+        assert_eq!(granularity_for_click(4), SelectGranularity::Line);
+    }
+
+    #[test]
+    fn dragging_by_word_keeps_the_anchor_word_whole() {
+        let text = "foo bar baz";
+        let anchor = 4..7;
+        let word = SelectGranularity::Word;
+
+        let (forward, reversed) = extend_range_for_granularity(text, &anchor, 9, word, false);
+        assert_eq!(forward, 4..11);
+        assert!(!reversed);
+
+        let (backward, reversed) = extend_range_for_granularity(text, &anchor, 1, word, false);
+        assert_eq!(backward, 0..7);
+        assert!(reversed);
+    }
+
+    #[test]
+    fn dragging_back_inside_the_anchor_word_does_not_shrink_it() {
+        let text = "foo bar baz";
+        let anchor = 4..7;
+        let (range, reversed) =
+            extend_range_for_granularity(text, &anchor, 5, SelectGranularity::Word, false);
+        assert_eq!(range, 4..7);
+        assert!(!reversed);
     }
 }

--- a/crates/mezon-widgets/src/text_edit.rs
+++ b/crates/mezon-widgets/src/text_edit.rs
@@ -96,6 +96,9 @@ pub fn word_range_at(text: &str, offset: usize) -> Range<usize> {
     let before = text[..offset].chars().next_back().map(char_kind);
     let after = text[offset..].chars().next().map(char_kind);
     let kind = match (before, after) {
+        (Some(b), Some(a)) if b != CharKind::Whitespace && a != CharKind::Whitespace => {
+            if b == CharKind::Word { b } else { a }
+        }
         (_, Some(a)) if a != CharKind::Whitespace => a,
         (Some(b), _) if b != CharKind::Whitespace => b,
         (_, Some(a)) => a,
@@ -270,6 +273,13 @@ mod tests {
     fn word_range_treats_punctuation_as_its_own_run() {
         let text = "foo.bar";
         assert_eq!(word_range_at(text, 0), 0..3);
+        assert_eq!(word_range_at(text, 4), 4..7);
+    }
+
+    #[test]
+    fn word_range_at_a_run_boundary_prefers_the_word_over_the_punctuation() {
+        let text = "foo.bar";
+        assert_eq!(word_range_at(text, 3), 0..3);
         assert_eq!(word_range_at(text, 4), 4..7);
     }
 


### PR DESCRIPTION
All four text inputs (mezon-widgets input, mezon-ui textarea, the chat mention composer and the canvas editor) each declared their own action set and their own ~35-entry keybinding table. They had drifted: only the composer supported shift-enter, only the canvas editor supported shift-up/shift-down, none of them read MouseDownEvent::click_count, and the macOS Edit menu dispatched actions that only the widgets input handled, so menu Cut/Copy/Paste/Select All did nothing in the composer.

Introduce a single shared action set + key context in mezon-widgets/src/text_actions.rs, registered once, and move the four inputs onto it. The canvas editor stacks its formatting context on top via KeyContext::add so cmd-b/i/k stay scoped to it.

Adds, across every input:
- double-click selects the word, triple-click selects the line (whole value in a single-line input); dragging after either keeps extending by that unit
- shift-enter inserts a newline
- shift-up / shift-down extend the selection by line
- macOS emacs bindings: ctrl-a/e/p/n/d/h/k and ctrl-shift-a/e
- arrow up/down move the caret between lines in multi-line inputs
- word-wise and document-wise navigation in the canvas editor

ctrl-f and ctrl-b are deliberately left unbound: ctrl-f is already the global OpenMessageSearch shortcut, and cmd-f remains the macOS-native way to open search.

A binding in the shared context resolves before an ancestor's, so single-line inputs call cx.propagate() for up/down/shift-enter instead of swallowing them -- otherwise the command palette and message search dropdown, which embed a single-line input and bind up/down for list navigation, would stop responding.

The selection maths lives in text_edit.rs behind pure functions with unit tests, and text_actions.rs asserts no keystroke is bound twice. Registering one table instead of four cuts the text-input bindings scanned on every keystroke from ~132 to ~53.