### PR TITLE
fix(video): size the theater box to the video instead of the viewport

### DIFF
--- a/crates/mezon-ui/src/chat/message/video_player.rs
+++ b/crates/mezon-ui/src/chat/message/video_player.rs
@@ -163,6 +163,8 @@ impl VideoPlayerView {
         player: Rc<VideoPlayer>,
         shared: Shared,
         poster: SharedString,
+        width: f32,
+        height: f32,
         window: &mut Window,
         cx: &mut App,
     ) {
@@ -174,8 +176,8 @@ impl VideoPlayerView {
             url: SharedString::default(),
             filename: SharedString::default(),
             poster,
-            width: 0.0,
-            height: 0.0,
+            width,
+            height,
             player: Some(player),
             shared,
             track_bounds: Bounds::default(),
@@ -383,6 +385,8 @@ impl VideoPlayerView {
                         player,
                         self.shared.clone(),
                         self.poster.clone(),
+                        self.width,
+                        self.height,
                         window,
                         cx,
                     );
@@ -745,8 +749,13 @@ impl Render for VideoPlayerView {
             root.w_full().h_full()
         } else if self.theater {
             let viewport = window.viewport_size();
-            root.w(viewport.width * THEATER_FILL)
-                .h(viewport.height * THEATER_FILL)
+            let (w, h) = theater_box(
+                viewport.width * THEATER_FILL,
+                viewport.height * THEATER_FILL,
+                self.width,
+                self.height,
+            );
+            root.w(w).h(h)
         } else {
             root.w(px(self.width))
                 .h(px(self.height))
@@ -788,6 +797,19 @@ impl Render for VideoPlayerView {
             .child(self.download_button(cx))
             .into_any_element()
     }
+}
+
+fn theater_box(
+    max_width: Pixels,
+    max_height: Pixels,
+    media_width: f32,
+    media_height: f32,
+) -> (Pixels, Pixels) {
+    if media_width <= 0.0 || media_height <= 0.0 {
+        return (max_width, max_height);
+    }
+    let scale = (f32::from(max_width) / media_width).min(f32::from(max_height) / media_height);
+    (px(media_width * scale), px(media_height * scale))
 }
 
 fn control_button(
@@ -865,4 +887,48 @@ fn whole_seconds(total: f64) -> u64 {
 fn format_seconds(total: f64) -> String {
     let seconds = whole_seconds(total);
     format!("{:02}:{:02}", seconds / 60, seconds % 60)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{THEATER_FILL, theater_box};
+    use gpui::px;
+
+    #[test]
+    fn a_portrait_video_gets_a_portrait_theater_box() {
+        let (w, h) = theater_box(
+            px(1920. * THEATER_FILL),
+            px(1080. * THEATER_FILL),
+            576.,
+            1024.,
+        );
+        assert_eq!(h, px(1080. * THEATER_FILL));
+        assert!(w < px(700.));
+    }
+
+    #[test]
+    fn a_landscape_video_fills_the_available_width() {
+        let (w, h) = theater_box(
+            px(1920. * THEATER_FILL),
+            px(1080. * THEATER_FILL),
+            1920.,
+            1080.,
+        );
+        assert_eq!(w, px(1920. * THEATER_FILL));
+        assert_eq!(h, px(1080. * THEATER_FILL));
+    }
+
+    #[test]
+    fn a_small_video_is_scaled_up_but_keeps_its_ratio() {
+        let (w, h) = theater_box(px(1000.), px(1000.), 100., 200.);
+        assert_eq!(w, px(500.));
+        assert_eq!(h, px(1000.));
+    }
+
+    #[test]
+    fn unknown_dimensions_fall_back_to_the_whole_box() {
+        let (w, h) = theater_box(px(800.), px(600.), 0., 0.);
+        assert_eq!(w, px(800.));
+        assert_eq!(h, px(600.));
+    }
 }


### PR DESCRIPTION
Opening a message video fullscreen goes through `open_theater`, which builds a separate modal view and dropped the source dimensions on the way -- it passed `width: 0.0, height: 0.0`. With nothing left to go on, the theater branch sized the box to `0.92 * viewport` on each axis independently, so a portrait video landed in a landscape box: on a maximised 1920x1080 screen, 1766x994 for a 576x1024 clip.

That mismatch is what made the bug visible, and why only 9:16 clips showed it. Every other video container already scales both axes by one factor -- inline attachments through `fit_within_box`, the viewer through VIEWER_VIDEO_MAX_W/H -- so the box always matched the media and the fit mode never mattered. The theater was the one place it did: macOS letterboxed correctly but drew a wide slab of background over the conversation, and Windows filled the box and cropped the clip to its middle third.

Thread the dimensions through to the theater view and fit the box to them. Sizing the box to the media's own ratio also makes the two fit modes coincide -- there is no letterbox area to leave and no overflow to crop -- so both platforms now show the whole frame undistorted. Falls back to the full box when the dimensions are unknown.

This does not explain why the Windows frame behaves as Cover where macOS behaves as Contain; it removes the only container where the two differ.