### PR TITLE
fix(messages): keep the timeline in sync when a fetch lands out of turn

### DIFF
--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -109,6 +109,9 @@ pub enum MessagesEvent {
     Reset {
         count: usize,
     },
+    Resized {
+        count: usize,
+    },
     /// The viewport window slid: rows were added/removed at either edge. The UI
     /// applies the matching splices so the visible scroll position is preserved.
     Shifted {
@@ -547,6 +550,7 @@ pub struct MessagesStore {
     last_load_more: Option<Instant>,
     consecutive_loads: u32,
     fetch_generation: u64,
+    latest_fetch: HashMap<ChannelId, u64>,
     reset_generation: u64,
     /// Active reply target for the composer, if any.
     reply_target: Option<ReplyDraft>,
@@ -917,6 +921,7 @@ impl MessagesStore {
         self.last_load_more = None;
         self.consecutive_loads = 0;
         self.fetch_generation = self.fetch_generation.wrapping_add(1);
+        self.latest_fetch.clear();
         self.reset_generation = self.reset_generation.wrapping_add(1);
         self.reply_target = None;
         self.editing = None;
@@ -969,6 +974,7 @@ impl MessagesStore {
             last_load_more: None,
             consecutive_loads: 0,
             fetch_generation: 0,
+            latest_fetch: HashMap::new(),
             reset_generation: 0,
             reply_target: None,
             editing: None,
@@ -4177,6 +4183,16 @@ impl MessagesStore {
         self.open_channel(channel_id, cx);
     }
 
+    fn fetch_in_flight(&self, channel_id: ChannelId) -> bool {
+        self.latest_fetch.contains_key(&channel_id)
+    }
+
+    pub fn resync_viewport(&mut self, cx: &mut Context<Self>) {
+        let count = self.messages().len();
+        cx.emit(MessagesEvent::Resized { count });
+        cx.notify();
+    }
+
     pub fn close(&mut self, cx: &mut Context<Self>) {
         self.pending_jump = None;
         if self.active_channel_id.is_none() && !self.is_dm {
@@ -4204,7 +4220,7 @@ impl MessagesStore {
         cx: &mut Context<Self>,
     ) {
         if self.active_channel_id == Some(channel_id) && !self.is_dm {
-            if self.loading {
+            if self.fetch_in_flight(channel_id) {
                 return;
             }
             let empty = self
@@ -4255,7 +4271,7 @@ impl MessagesStore {
         cx: &mut Context<Self>,
     ) {
         if self.active_channel_id == Some(channel_id) && self.is_dm {
-            if self.loading {
+            if self.fetch_in_flight(channel_id) {
                 return;
             }
             let empty = self
@@ -4329,6 +4345,7 @@ impl MessagesStore {
             cx.emit(MessagesEvent::Reset { count: 0 });
         }
         cx.notify();
+        self.latest_fetch.insert(channel_id, generation);
         self.spawn_initial_fetch(clan_id, channel_id, generation, cx);
     }
 
@@ -4378,8 +4395,19 @@ impl MessagesStore {
         result: Result<mezon_client::transport::ListChannelMessagesResult, anyhow::Error>,
         cx: &mut Context<Self>,
     ) {
+        if self
+            .latest_fetch
+            .get(&channel_id)
+            .is_some_and(|latest| *latest != generation)
+        {
+            return;
+        }
+        self.latest_fetch.remove(&channel_id);
         let is_active = self.active_channel_id == Some(channel_id);
         let is_current = is_active && self.fetch_generation == generation;
+        if is_active {
+            self.loading = false;
+        }
 
         match result {
             Ok(page) => {
@@ -4393,20 +4421,24 @@ impl MessagesStore {
                 self.set_channel(channel_id, messages);
                 self.schedule_presign_expiry(cx);
                 if is_current {
-                    self.loading = false;
                     let count = self.messages().len();
                     cx.emit(MessagesEvent::Reset { count });
                     cx.notify();
                     self.try_consume_pending_jump(cx);
+                } else if is_active {
+                    let count = self.messages().len();
+                    cx.emit(MessagesEvent::Resized { count });
+                    cx.notify();
                 }
             }
             Err(e) => {
                 tracing::error!("Failed to fetch messages for {channel_id}: {e}");
                 if is_current {
-                    self.loading = false;
                     let count = self.messages().len();
                     cx.emit(MessagesEvent::Reset { count });
                     self.try_consume_pending_jump(cx);
+                    cx.notify();
+                } else if is_active {
                     cx.notify();
                 }
             }
@@ -5679,6 +5711,7 @@ impl MessagesStore {
         self.loading_more = false;
         self.fetch_generation = self.fetch_generation.wrapping_add(1);
         let generation = self.fetch_generation;
+        self.latest_fetch.insert(channel_id, generation);
         cx.notify();
 
         let api = self.api.clone();
@@ -7503,6 +7536,56 @@ mod tests {
         assert_eq!(first_non_empty("live", "baked"), "live");
         assert_eq!(first_non_empty("", "baked"), "baked");
         assert_eq!(first_non_empty("", ""), "");
+    }
+
+    #[gpui::test]
+    fn a_superseded_fetch_result_is_dropped(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let api = Arc::new(mezon_client::AppApi::new(
+                Arc::new(mezon_client::TransportClient::new(String::new())),
+                String::new(),
+            ));
+            crate::realtime::RealtimeDispatch::init(api.clone(), cx);
+            crate::clan::ClanList::init(api.clone(), cx);
+            ChannelList::init(api.clone(), cx);
+            let store = MessagesStore::init(api, cx);
+            let channel = ChannelId(9);
+
+            store.update(cx, |store, cx| {
+                store.active_channel_id = Some(channel);
+                store.active_clan_id = Some(ClanId(1));
+                store.loading = true;
+                store.fetch_generation = 7;
+                store.latest_fetch.insert(channel, 7);
+
+                store.apply_initial_fetch_result(
+                    channel,
+                    5,
+                    Err(anyhow::anyhow!("superseded")),
+                    cx,
+                );
+                assert!(
+                    store.loading,
+                    "a superseded result must not settle the newer fetch"
+                );
+                assert_eq!(
+                    store.latest_fetch.get(&channel),
+                    Some(&7),
+                    "the newer fetch keeps its slot"
+                );
+                assert!(
+                    store.fetch_in_flight(channel),
+                    "the channel is still fetching"
+                );
+
+                store.apply_initial_fetch_result(channel, 7, Err(anyhow::anyhow!("failed")), cx);
+                assert!(!store.loading, "the awaited result settles the flag");
+                assert!(
+                    !store.fetch_in_flight(channel),
+                    "a settled fetch releases its slot"
+                );
+            });
+        });
     }
 
     #[gpui::test]

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -1298,7 +1298,6 @@ pub struct ChannelMessages {
     scroll_anchors: HashMap<ChannelId, SavedScrollAnchor>,
     last_scroll_sync: Option<(ChannelId, usize, u32, usize, u32, u32, bool)>,
     current_channel: Option<ChannelId>,
-    restore_pending: Option<ChannelId>,
     welcome: Option<WelcomeContext>,
     onboarding: Option<OnboardingContext>,
     cached_unread_boundary: Option<MessageId>,
@@ -1514,6 +1513,7 @@ impl ChannelMessages {
             let structural = matches!(
                 event,
                 MessagesEvent::Reset { .. }
+                    | MessagesEvent::Resized { .. }
                     | MessagesEvent::Shifted { .. }
                     | MessagesEvent::RemovedAt { .. }
             );
@@ -1522,90 +1522,15 @@ impl ChannelMessages {
             }
             match event {
                 MessagesEvent::Reset { count } => {
-                    this.reaction_picker = None;
-                    this._reaction_picker_sub = None;
-                    this._reaction_picker_dismiss_sub = None;
-                    this.mention_popover = None;
-                    this._mention_popover_sub = None;
-                    this.context_menu_target = None;
-                    this.hovered_row = None;
-                    this.raw_hover = None;
-                    this.overlay_hover = None;
-                    this.clear_hover_tasks();
-                    this.edit_input = None;
-                    this._edit_input_sub = None;
-                    Rc::make_mut(&mut this.active_videos).clear();
-                    Rc::make_mut(&mut this.active_audios).clear();
-                    Rc::make_mut(&mut this.gif_videos).clear();
-                    Rc::make_mut(&mut this.embed_inputs).clear();
-                    this.embed_input_subs.clear();
-                    this.embed_input_fingerprint = None;
-                    this.embed_select_seeded.clear();
-                    this.list_state.reset(*count);
-                    this.last_visible_start = 0;
-                    this.last_visible_end = 0;
-                    this.paginate_retry_pending = false;
-                    this.header_shown = false;
-
-                    let new_channel = _store.read(cx).active_channel_id();
-                    if new_channel != this.current_channel {
-                        this.last_seen_at_bottom = None;
-                    }
-                    let is_loading = _store.read(cx).is_loading();
-                    let transition = reset_transition(
-                        this.current_channel,
-                        new_channel,
-                        this.restore_pending,
-                        this.fab_scroll_pending,
-                        is_loading,
-                    );
-                    this.current_channel = transition.current_channel;
-                    this.restore_pending = transition.restore_pending;
-                    this.fab_scroll_pending = false;
-
-                    let anchor = new_channel
-                        .and_then(|channel_id| this.scroll_anchors.get(&channel_id).copied());
-                    let decision = decide_reset_scroll(
-                        transition.want_restore,
-                        is_loading,
-                        anchor,
-                        _store.read(cx).viewport_messages(),
-                        _store.read(cx).has_more_bottom(),
-                    );
-                    let at_bottom = match decision {
-                        ResetScroll::Restore {
-                            item_ix,
-                            offset_in_item,
-                        } => {
-                            this.list_state.scroll_to(gpui::ListOffset {
-                                item_ix,
-                                offset_in_item,
-                            });
-                            false
-                        }
-                        ResetScroll::ToBottom => {
-                            this.list_state.scroll_to_end();
-                            true
-                        }
-                        ResetScroll::Defer => true,
-                    };
-                    this.at_bottom = at_bottom;
-
-                    if let Some(channel_id) = new_channel {
-                        _store.update(cx, |store, _cx| {
-                            store.set_viewing_older(channel_id, !at_bottom);
-                        });
-                    }
-                    if matches!(decision, ResetScroll::ToBottom) {
-                        if let Some(last) = _store
-                            .read(cx)
-                            .viewport_messages()
-                            .last()
-                            .filter(|m| !m.id.is_optimistic())
-                        {
-                            this.last_seen_at_bottom = Some(last.id);
-                        }
-                        this.sync_channel_seen(cx);
+                    this.clear_row_ui_state();
+                    this.rebuild_list(&_store, *count, cx);
+                }
+                MessagesEvent::Resized { count } => {
+                    let rows = this.list_state.item_count();
+                    if rows == *count + usize::from(this.header_shown) {
+                        this.list_state.remeasure_items(0..rows);
+                    } else {
+                        this.rebuild_list(&_store, *count, cx);
                     }
                 }
                 MessagesEvent::Shifted {
@@ -1785,6 +1710,9 @@ impl ChannelMessages {
             };
             let finished = this.pagination_fetch_active && !fetching;
             this.pagination_fetch_active = fetching;
+            if this.list_state.item_count() == 0 && !store.read(cx).viewport_messages().is_empty() {
+                store.update(cx, |store, cx| store.resync_viewport(cx));
+            }
             if !finished {
                 return;
             }
@@ -2013,7 +1941,6 @@ impl ChannelMessages {
             scroll_anchors: HashMap::new(),
             last_scroll_sync: None,
             current_channel: None,
-            restore_pending: None,
             welcome,
             onboarding,
             cached_unread_boundary,
@@ -3142,6 +3069,95 @@ impl ChannelMessages {
         self.cached_unread_boundary = unread;
         self.cached_fab_unread_count = fab_unread_count;
         true
+    }
+
+    fn clear_row_ui_state(&mut self) {
+        self.reaction_picker = None;
+        self._reaction_picker_sub = None;
+        self._reaction_picker_dismiss_sub = None;
+        self.mention_popover = None;
+        self._mention_popover_sub = None;
+        self.context_menu_target = None;
+        self.hovered_row = None;
+        self.raw_hover = None;
+        self.overlay_hover = None;
+        self.clear_hover_tasks();
+        self.edit_input = None;
+        self._edit_input_sub = None;
+        Rc::make_mut(&mut self.active_videos).clear();
+        Rc::make_mut(&mut self.active_audios).clear();
+        Rc::make_mut(&mut self.gif_videos).clear();
+        Rc::make_mut(&mut self.embed_inputs).clear();
+        self.embed_input_subs.clear();
+        self.embed_input_fingerprint = None;
+        self.embed_select_seeded.clear();
+    }
+
+    fn rebuild_list(
+        &mut self,
+        store: &Entity<MessagesStore>,
+        count: usize,
+        cx: &mut Context<Self>,
+    ) {
+        self.list_state.reset(count);
+        self.last_visible_start = 0;
+        self.last_visible_end = 0;
+        self.paginate_retry_pending = false;
+        self.header_shown = false;
+
+        let new_channel = store.read(cx).active_channel_id();
+        if new_channel != self.current_channel {
+            self.last_seen_at_bottom = None;
+        }
+        let is_loading = store.read(cx).is_loading();
+        let transition = reset_transition(new_channel, self.fab_scroll_pending);
+        self.current_channel = transition.current_channel;
+        self.fab_scroll_pending = false;
+
+        let anchor =
+            new_channel.and_then(|channel_id| self.scroll_anchors.get(&channel_id).copied());
+        let decision = decide_reset_scroll(
+            transition.want_restore,
+            is_loading,
+            anchor,
+            store.read(cx).viewport_messages(),
+            store.read(cx).has_more_bottom(),
+        );
+        let at_bottom = match decision {
+            ResetScroll::Restore {
+                item_ix,
+                offset_in_item,
+            } => {
+                self.list_state.scroll_to(gpui::ListOffset {
+                    item_ix,
+                    offset_in_item,
+                });
+                false
+            }
+            ResetScroll::ToBottom => {
+                self.list_state.scroll_to_end();
+                true
+            }
+            ResetScroll::Defer => true,
+        };
+        self.at_bottom = at_bottom;
+
+        if let Some(channel_id) = new_channel {
+            store.update(cx, |store, _cx| {
+                store.set_viewing_older(channel_id, !at_bottom);
+            });
+        }
+        if matches!(decision, ResetScroll::ToBottom) {
+            if let Some(last) = store
+                .read(cx)
+                .viewport_messages()
+                .last()
+                .filter(|m| !m.id.is_optimistic())
+            {
+                self.last_seen_at_bottom = Some(last.id);
+            }
+            self.sync_channel_seen(cx);
+        }
     }
 
     fn sync_header(&mut self, is_empty: bool, has_more_top: bool) {
@@ -4759,27 +4775,13 @@ const RESET_NEAR_BOTTOM_ROWS: usize = 10;
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 struct ResetTransition {
     current_channel: Option<ChannelId>,
-    restore_pending: Option<ChannelId>,
     want_restore: bool,
 }
 
-fn reset_transition(
-    _prev_channel: Option<ChannelId>,
-    new_channel: Option<ChannelId>,
-    _prev_restore_pending: Option<ChannelId>,
-    fab_scroll_pending: bool,
-    is_loading: bool,
-) -> ResetTransition {
-    let want_restore = !fab_scroll_pending && new_channel.is_some();
-    let restore_pending = if is_loading && want_restore {
-        new_channel
-    } else {
-        None
-    };
+fn reset_transition(new_channel: Option<ChannelId>, fab_scroll_pending: bool) -> ResetTransition {
     ResetTransition {
         current_channel: new_channel,
-        restore_pending,
-        want_restore,
+        want_restore: !fab_scroll_pending && new_channel.is_some(),
     }
 }
 
@@ -5381,65 +5383,30 @@ mod scroll_restore_tests {
         );
     }
 
-    const X: Option<ChannelId> = Some(ChannelId(1));
     const Y: Option<ChannelId> = Some(ChannelId(2));
     const Z: Option<ChannelId> = Some(ChannelId(3));
 
     #[test]
-    fn cold_miss_double_reset_arms_then_finalizes() {
-        let intermediate = reset_transition(X, Y, None, false, true);
-        assert_eq!(
-            intermediate,
-            ResetTransition {
-                current_channel: Y,
-                restore_pending: Y,
-                want_restore: true,
-            }
-        );
-        let settled = reset_transition(Y, Y, Y, false, false);
-        assert_eq!(
-            settled,
-            ResetTransition {
-                current_channel: Y,
-                restore_pending: None,
-                want_restore: true,
-            }
-        );
-    }
-
-    #[test]
-    fn warm_stale_double_reset_keeps_restore_armed_until_settled() {
-        let intermediate = reset_transition(X, Y, None, false, true);
-        assert!(intermediate.want_restore && intermediate.restore_pending == Y);
-        let settled = reset_transition(Y, Y, Y, false, false);
-        assert!(settled.want_restore && settled.restore_pending.is_none());
-    }
-
-    #[test]
     fn fab_scroll_pending_forces_bottom() {
-        let transition = reset_transition(Y, Y, Y, true, false);
+        let transition = reset_transition(Y, true);
         assert!(!transition.want_restore);
-        assert_eq!(transition.restore_pending, None);
+        assert_eq!(transition.current_channel, Y);
     }
 
     #[test]
-    fn same_channel_resync_preserves_anchor() {
-        let loading = reset_transition(Y, Y, None, false, true);
-        assert!(loading.want_restore);
-        assert_eq!(loading.restore_pending, Y);
-        let settled = reset_transition(Y, Y, None, false, false);
-        assert!(settled.want_restore);
-        assert_eq!(settled.restore_pending, None);
+    fn closed_conversation_does_not_restore() {
+        let transition = reset_transition(None, false);
+        assert!(!transition.want_restore);
+        assert_eq!(transition.current_channel, None);
     }
 
     #[test]
-    fn switching_again_rearms_to_new_channel() {
-        let transition = reset_transition(Y, Z, Y, false, true);
+    fn switching_adopts_new_channel_and_restores() {
+        let transition = reset_transition(Z, false);
         assert_eq!(
             transition,
             ResetTransition {
                 current_channel: Z,
-                restore_pending: Z,
                 want_restore: true,
             }
         );


### PR DESCRIPTION
A list_channel_messages response always rewrote the channel buffer but only emitted Reset while its generation was still current, so the gpui list kept the previous row count against a buffer it no longer described. Re-entering a DM after visiting a clan channel could therefore render an empty timeline for good: the store held the messages, ListState held zero rows, and nothing ever re-synced them.

Track the newest in-flight fetch per channel and drop a response a newer one has superseded, so an older page can no longer overwrite newer data or pin it fresh for the cache TTL. fetch_generation alone could not tell "superseded" apart from "the generation moved because another channel was opened". A response that is not superseded but no longer current now emits Resized, which resizes and re-anchors the list without clearing per-row UI state, and the timeline re-syncs itself if it is ever left holding zero rows against a non-empty buffer.

Gate re-opening a conversation on that per-channel in-flight state rather than the global loading flag, and settle loading for every result that belongs to the open conversation so pagination cannot stay blocked by a flag that describes a different channel.

Drop restore_pending, which was written on every reset and never read; reset_transition keeps only the inputs that still decide the outcome.