### PR TITLE
fix: fix layout expand for long custom status

### DIFF
--- a/crates/mezon-ui/src/chat/user_profile_modal.rs
+++ b/crates/mezon-ui/src/chat/user_profile_modal.rs
@@ -355,8 +355,12 @@ impl Render for UserProfileModal {
                             .bg(theme.tokens.bg_primary)
                             .child(
                                 div()
+                                    .w(px(96.))
+                                    .min_w_0()
                                     .child(
                                         div()
+                                            .w_full()
+                                            .truncate()
                                             .text_size(px(24.))
                                             .font_weight(FontWeight::SEMIBOLD)
                                             .text_color(theme.text_secondary)
@@ -364,6 +368,8 @@ impl Render for UserProfileModal {
                                     )
                                     .child(
                                         div()
+                                            .w_full()
+                                            .truncate()
                                             .text_sm()
                                             .text_color(theme.text_secondary)
                                             .child(username),

--- a/crates/mezon-ui/src/chat/user_profile_modal.rs
+++ b/crates/mezon-ui/src/chat/user_profile_modal.rs
@@ -30,6 +30,7 @@ pub struct UserProfileModal {
     edit_options_open: bool,
     live_status: String,
     live_custom_status: String,
+    custom_status_expanded: bool,
     _banner_task: Option<Task<()>>,
     _members_sub: Subscription,
     _presence_sub: Subscription,
@@ -104,6 +105,7 @@ impl UserProfileModal {
             edit_options_open: false,
             live_status,
             live_custom_status,
+            custom_status_expanded: false,
             _banner_task: None,
             _members_sub: members_sub,
             _presence_sub: presence_sub,
@@ -445,15 +447,23 @@ impl Render for UserProfileModal {
                     .when(!custom_status.is_empty(), |card| {
                         card.child(deferred(
                             div()
+                                .id("full-profile-custom-status")
                                 .absolute()
                                 .left(px(134.))
                                 .top(px(194.))
+                                .w(px(250.))
                                 .max_w(px(250.))
-                                .max_h(px(64.))
+                                .max_h(px(144.))
+                                .on_hover(cx.listener(|this, hovered: &bool, _window, cx| {
+                                    if this.custom_status_expanded != *hovered {
+                                        this.custom_status_expanded = *hovered;
+                                        cx.notify();
+                                    }
+                                }))
                                 .child(
                                     div()
-                                        .max_w(px(250.))
-                                        .max_h(px(64.))
+                                        .w_full()
+                                        .max_h(px(144.))
                                         .px_4()
                                         .py_3()
                                         .rounded_xl()
@@ -464,6 +474,12 @@ impl Render for UserProfileModal {
                                         .text_sm()
                                         .text_color(theme.text_secondary)
                                         .overflow_hidden()
+                                        .when(!self.custom_status_expanded, |status| {
+                                            status.truncate()
+                                        })
+                                        .when(self.custom_status_expanded, |status| {
+                                            status.whitespace_normal()
+                                        })
                                         .child(custom_status),
                                 ),
                         ))

--- a/crates/mezon-ui/src/chat/user_profile_modal.rs
+++ b/crates/mezon-ui/src/chat/user_profile_modal.rs
@@ -3,6 +3,7 @@ use crate::chat::message::{SendTokenModal, ShareContactModal, share_contact_subj
 use crate::chat::user_profile_popover::{
     banner_icon_button, banner_icon_shell, format_member_since, share_contact_icon,
 };
+use crate::components::compositions::CustomStatusBubble;
 use crate::components::primitives::{Avatar, Icon, IconName};
 use crate::image_cache::LruImageCache;
 use crate::router::{Route, navigate};
@@ -30,7 +31,7 @@ pub struct UserProfileModal {
     edit_options_open: bool,
     live_status: String,
     live_custom_status: String,
-    custom_status_expanded: bool,
+    custom_status_bubble: Entity<CustomStatusBubble>,
     _banner_task: Option<Task<()>>,
     _members_sub: Subscription,
     _presence_sub: Subscription,
@@ -105,7 +106,7 @@ impl UserProfileModal {
             edit_options_open: false,
             live_status,
             live_custom_status,
-            custom_status_expanded: false,
+            custom_status_bubble: cx.new(|_| CustomStatusBubble::new()),
             _banner_task: None,
             _members_sub: members_sub,
             _presence_sub: presence_sub,
@@ -240,7 +241,7 @@ impl Focusable for UserProfileModal {
 
 impl Render for UserProfileModal {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let theme = cx.theme();
+        let theme = cx.theme().clone();
         let locale = self.settings.read(cx).language.clone();
         let member = ClanMembersStore::global(cx)
             .read(cx)
@@ -261,7 +262,18 @@ impl Render for UserProfileModal {
         let avatar = crate::util::imgproxy::avatar_url(cx, &raw_avatar);
         let is_self = self.is_self;
         let custom_status = self.live_custom_status.clone();
-        let (status_icon, status_color) = profile_status(&self.live_status, theme);
+        let custom_status_bubble = self.custom_status_bubble.clone();
+        custom_status_bubble.update(cx, |bubble, cx| {
+            bubble.set_content(
+                custom_status.clone().into(),
+                px(250.),
+                theme.tokens.bg_secondary,
+                theme.border,
+                theme.text_secondary,
+                cx,
+            );
+        });
+        let (status_icon, status_color) = profile_status(&self.live_status, &theme);
         let friend_state = FriendStore::global(cx)
             .read(cx)
             .friend(self.user_id)
@@ -448,40 +460,20 @@ impl Render for UserProfileModal {
                         card.child(deferred(
                             div()
                                 .id("full-profile-custom-status")
+                                .group("full-profile-custom-status")
                                 .absolute()
                                 .left(px(134.))
                                 .top(px(194.))
-                                .w(px(250.))
                                 .max_w(px(250.))
-                                .max_h(px(144.))
-                                .on_hover(cx.listener(|this, hovered: &bool, _window, cx| {
-                                    if this.custom_status_expanded != *hovered {
-                                        this.custom_status_expanded = *hovered;
-                                        cx.notify();
+                                .on_hover({
+                                    let custom_status_bubble = custom_status_bubble.clone();
+                                    move |hovered: &bool, _window, cx| {
+                                        custom_status_bubble.update(cx, |bubble, cx| {
+                                            bubble.set_expanded(*hovered, cx);
+                                        });
                                     }
-                                }))
-                                .child(
-                                    div()
-                                        .w_full()
-                                        .max_h(px(144.))
-                                        .px_4()
-                                        .py_3()
-                                        .rounded_xl()
-                                        .bg(theme.tokens.bg_secondary)
-                                        .border_1()
-                                        .border_color(theme.border)
-                                        .shadow_md()
-                                        .text_sm()
-                                        .text_color(theme.text_secondary)
-                                        .overflow_hidden()
-                                        .when(!self.custom_status_expanded, |status| {
-                                            status.truncate()
-                                        })
-                                        .when(self.custom_status_expanded, |status| {
-                                            status.whitespace_normal()
-                                        })
-                                        .child(custom_status),
-                                ),
+                                })
+                                .child(custom_status_bubble),
                         ))
                     })
                     .when(is_self, |card| {

--- a/crates/mezon-ui/src/components/compositions/custom_status_bubble.rs
+++ b/crates/mezon-ui/src/components/compositions/custom_status_bubble.rs
@@ -7,6 +7,7 @@ pub struct CustomStatusBubble {
     background: Rgba,
     border: Rgba,
     text_color: Rgba,
+    expandable: bool,
     expanded: bool,
 }
 
@@ -18,6 +19,7 @@ impl CustomStatusBubble {
             background: gpui::rgba(0x00000000),
             border: gpui::rgba(0x00000000),
             text_color: gpui::rgba(0x00000000),
+            expandable: false,
             expanded: false,
         }
     }
@@ -44,11 +46,13 @@ impl CustomStatusBubble {
         self.background = background;
         self.border = border;
         self.text_color = text_color;
+        self.expandable = false;
         self.expanded = false;
         cx.notify();
     }
 
     pub fn set_expanded(&mut self, expanded: bool, cx: &mut Context<Self>) {
+        let expanded = expanded && self.expandable;
         if self.expanded != expanded {
             self.expanded = expanded;
             cx.notify();
@@ -76,7 +80,19 @@ impl CustomStatusBubble {
             .overflow_hidden()
             .whitespace_normal()
             .when(!expanded, |surface| surface.h(px(64.)))
-            .child(div().w_full().min_w_0().whitespace_normal().child(text))
+            .child(
+                div()
+                    .id(if expanded {
+                        "custom-status-expanded-text"
+                    } else {
+                        "custom-status-collapsed-text"
+                    })
+                    .w_full()
+                    .min_w_0()
+                    .whitespace_normal()
+                    .when(!expanded, |text| text.line_clamp(2).text_ellipsis())
+                    .child(text),
+            )
     }
 }
 
@@ -88,7 +104,8 @@ impl Render for CustomStatusBubble {
             .shape_line(self.text.clone(), px(14.), &[run], None)
             .width();
         let width = (text_width + px(40.)).min(self.max_width);
-        let show_full = self.expanded || text_width + px(40.) <= self.max_width;
+        self.expandable = text_width + px(40.) > self.max_width;
+        let show_full = self.expanded || !self.expandable;
         let text = break_long_words(self.text.as_ref());
 
         div()

--- a/crates/mezon-ui/src/components/compositions/custom_status_bubble.rs
+++ b/crates/mezon-ui/src/components/compositions/custom_status_bubble.rs
@@ -11,6 +11,12 @@ pub struct CustomStatusBubble {
     expanded: bool,
 }
 
+impl Default for CustomStatusBubble {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CustomStatusBubble {
     pub fn new() -> Self {
         Self {

--- a/crates/mezon-ui/src/components/compositions/custom_status_bubble.rs
+++ b/crates/mezon-ui/src/components/compositions/custom_status_bubble.rs
@@ -1,0 +1,136 @@
+use gpui::{Context, Pixels, Render, Rgba, SharedString, Window, div, prelude::*, px};
+use unicode_segmentation::UnicodeSegmentation;
+
+pub struct CustomStatusBubble {
+    text: SharedString,
+    max_width: Pixels,
+    background: Rgba,
+    border: Rgba,
+    text_color: Rgba,
+    expanded: bool,
+}
+
+impl CustomStatusBubble {
+    pub fn new() -> Self {
+        Self {
+            text: SharedString::default(),
+            max_width: px(0.),
+            background: gpui::rgba(0x00000000),
+            border: gpui::rgba(0x00000000),
+            text_color: gpui::rgba(0x00000000),
+            expanded: false,
+        }
+    }
+
+    pub fn set_content(
+        &mut self,
+        text: SharedString,
+        max_width: Pixels,
+        background: Rgba,
+        border: Rgba,
+        text_color: Rgba,
+        cx: &mut Context<Self>,
+    ) {
+        if self.text == text
+            && self.max_width == max_width
+            && self.background == background
+            && self.border == border
+            && self.text_color == text_color
+        {
+            return;
+        }
+        self.text = text;
+        self.max_width = max_width;
+        self.background = background;
+        self.border = border;
+        self.text_color = text_color;
+        self.expanded = false;
+        cx.notify();
+    }
+
+    pub fn set_expanded(&mut self, expanded: bool, cx: &mut Context<Self>) {
+        if self.expanded != expanded {
+            self.expanded = expanded;
+            cx.notify();
+        }
+    }
+
+    fn surface(&self, text: SharedString, expanded: bool) -> impl IntoElement {
+        div()
+            .id(if expanded {
+                "custom-status-expanded"
+            } else {
+                "custom-status-collapsed"
+            })
+            .w_full()
+            .min_w_0()
+            .px_4()
+            .py_3()
+            .rounded_xl()
+            .bg(self.background)
+            .border_1()
+            .border_color(self.border)
+            .shadow_md()
+            .text_sm()
+            .text_color(self.text_color)
+            .overflow_hidden()
+            .whitespace_normal()
+            .when(!expanded, |surface| surface.h(px(64.)))
+            .child(div().w_full().min_w_0().whitespace_normal().child(text))
+    }
+}
+
+impl Render for CustomStatusBubble {
+    fn render(&mut self, window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let run = window.text_style().to_run(self.text.len());
+        let text_width = window
+            .text_system()
+            .shape_line(self.text.clone(), px(14.), &[run], None)
+            .width();
+        let width = (text_width + px(40.)).min(self.max_width);
+        let show_full = self.expanded || text_width + px(40.) <= self.max_width;
+        let text = break_long_words(self.text.as_ref());
+
+        div()
+            .id("custom-status-bubble")
+            .relative()
+            .w(width)
+            .child(self.surface(text, show_full))
+    }
+}
+
+fn break_long_words(text: &str) -> SharedString {
+    text.split_inclusive(char::is_whitespace)
+        .map(|segment| {
+            let word = segment.trim_end_matches(char::is_whitespace);
+            let whitespace = &segment[word.len()..];
+            if UnicodeSegmentation::graphemes(word, true).count() <= 24 {
+                segment.to_owned()
+            } else {
+                let mut breakable = UnicodeSegmentation::graphemes(word, true)
+                    .collect::<Vec<_>>()
+                    .join("\u{200b}");
+                breakable.push_str(whitespace);
+                breakable
+            }
+        })
+        .collect::<String>()
+        .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::break_long_words;
+
+    #[test]
+    fn keeps_short_status_text_unchanged() {
+        assert_eq!(break_long_words("oh hi").as_ref(), "oh hi");
+    }
+
+    #[test]
+    fn adds_break_points_only_to_long_tokens() {
+        let url = "oremIpsumissimplydummytextoftheprintingandtypesettingindustry";
+        assert!(break_long_words(url).contains('\u{200b}'));
+        assert!(!break_long_words("Lorem Ipsum is simply dummy text").contains('\u{200b}'));
+    }
+}

--- a/crates/mezon-ui/src/components/compositions/footer_profile_popup.rs
+++ b/crates/mezon-ui/src/components/compositions/footer_profile_popup.rs
@@ -1,12 +1,13 @@
 use std::time::Duration;
 
 use gpui::{
-    App, ClickEvent, ClipboardItem, Context, DismissEvent, EventEmitter, FocusHandle, Focusable,
-    FontWeight, Rgba, SharedString, Task, Window, deferred, div, prelude::*, px,
+    App, ClickEvent, ClipboardItem, Context, DismissEvent, Entity, EventEmitter, FocusHandle,
+    Focusable, FontWeight, Rgba, SharedString, Task, Window, deferred, div, prelude::*, px,
 };
 use mezon_store::{AccountStore, BadgeService, Settings, WalletStore};
 
 use crate::chat::message::{CustomStatusModal, SendTokenModal, TransactionHistoryModal};
+use crate::components::compositions::CustomStatusBubble;
 use crate::components::primitives::{Avatar, Icon, IconName};
 use crate::theme::ActiveTheme;
 
@@ -76,7 +77,7 @@ pub struct FooterProfilePopup {
     user_status: String,
     status_menu_open: bool,
     status_duration_for: Option<&'static str>,
-    custom_status_expanded: bool,
+    custom_status_bubble: Entity<CustomStatusBubble>,
     user_id_copied: bool,
     _copy_user_id_reset: Option<Task<()>>,
 }
@@ -148,7 +149,7 @@ impl FooterProfilePopup {
             user_status,
             status_menu_open: false,
             status_duration_for: None,
-            custom_status_expanded: false,
+            custom_status_bubble: cx.new(|_| CustomStatusBubble::new()),
             user_id_copied: false,
             _copy_user_id_reset: None,
         }
@@ -257,177 +258,130 @@ impl Render for FooterProfilePopup {
 
         let custom_status = self.user_status.clone();
         let has_custom = !custom_status.is_empty();
-        let custom_status_expandable = custom_status.chars().count() > 24;
-        let avatar_row = div()
-            .relative()
+        let custom_status_bubble = self.custom_status_bubble.clone();
+        custom_status_bubble.update(cx, |bubble, cx| {
+            bubble.set_content(
+                custom_status.clone().into(),
+                px(212.),
+                bubble_bg,
+                border,
+                text_primary,
+                cx,
+            );
+        });
+        let avatar_row = div().relative().flex().flex_row().mt(px(-50.)).child(
+            div()
+                .relative()
+                .ml(px(16.))
+                .p(px(6.))
+                .w(px(90.))
+                .h(px(90.))
+                .rounded_full()
+                .bg(bg_card)
+                .child(
+                    Avatar::new()
+                        .name(self.display_name.clone())
+                        .src(self.avatar.clone())
+                        .size_px(px(78.)),
+                )
+                .child(
+                    div()
+                        .absolute()
+                        .bottom(px(4.))
+                        .right(px(6.))
+                        .size(px(18.))
+                        .rounded_full()
+                        .border_2()
+                        .border_color(bg_card)
+                        .bg(current_status_color),
+                ),
+        );
+
+        let custom_status_overlay = div()
+            .id("footer-custom-status-wrap")
+            .group("footer-custom-status")
+            .absolute()
+            .left(px(112.))
+            .top(px(85.))
             .flex()
-            .flex_row()
-            .mt(px(-50.))
+            .flex_col()
+            .gap(px(12.))
+            .on_hover({
+                let custom_status_bubble = custom_status_bubble.clone();
+                move |hovered: &bool, _window, cx| {
+                    custom_status_bubble.update(cx, |bubble, cx| {
+                        bubble.set_expanded(*hovered, cx);
+                    });
+                }
+            })
+            .child(div().size(px(12.)).rounded_full().bg(bubble_bg).shadow_md())
             .child(
                 div()
                     .relative()
-                    .ml(px(16.))
-                    .p(px(6.))
-                    .w(px(90.))
-                    .h(px(90.))
-                    .rounded_full()
-                    .bg(bg_card)
-                    .child(
-                        Avatar::new()
-                            .name(self.display_name.clone())
-                            .src(self.avatar.clone())
-                            .size_px(px(78.)),
-                    )
+                    .max_w(px(212.))
+                    .child(custom_status_bubble)
                     .child(
                         div()
                             .absolute()
-                            .bottom(px(4.))
-                            .right(px(6.))
-                            .size(px(18.))
-                            .rounded_full()
-                            .border_2()
-                            .border_color(bg_card)
-                            .bg(current_status_color),
-                    ),
-            )
-            .when(has_custom, |row| {
-                row.child(
-                    deferred(
-                        div()
-                            .id("footer-custom-status-wrap")
-                            .group("footer-custom-status")
-                            .absolute()
-                            .left(px(112.))
-                            .top(px(30.))
+                            .top(px(-16.))
+                            .right(px(4.))
                             .flex()
-                            .flex_col()
-                            .gap(px(12.))
-                            .on_hover(cx.listener(move |this, hovered: &bool, _window, cx| {
-                                let expanded = *hovered && custom_status_expandable;
-                                if this.custom_status_expanded != expanded {
-                                    this.custom_status_expanded = expanded;
-                                    cx.notify();
-                                }
-                            }))
-                            .child(div().size(px(12.)).rounded_full().bg(bubble_bg).shadow_md())
+                            .flex_row()
+                            .items_center()
+                            .rounded_full()
+                            .bg(bubble_bg)
+                            .border_1()
+                            .border_color(border)
+                            .p(px(2.))
+                            .shadow_md()
+                            .opacity(0.)
+                            .group_hover("footer-custom-status", |s| s.opacity(1.))
                             .child(
                                 div()
-                                    .id("footer-custom-status-bubble")
-                                    .relative()
+                                    .id("footer-custom-status-edit")
                                     .flex()
                                     .items_center()
-                                    .when(custom_status_expandable, |bubble| bubble.w(px(212.)))
-                                    .when(!custom_status_expandable, |bubble| {
-                                        bubble.max_w(px(212.))
-                                    })
-                                    .max_h(px(144.))
-                                    .bg(bubble_bg)
-                                    .px(px(16.))
-                                    .py(px(12.))
-                                    .rounded(px(12.))
-                                    .shadow_lg()
+                                    .justify_center()
+                                    .px_1()
+                                    .cursor_pointer()
+                                    .hover(move |s| s.bg(hover_bg))
+                                    .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
+                                        let locale = this.locale.clone();
+                                        cx.emit(DismissEvent);
+                                        CustomStatusModal::open(locale, window, cx);
+                                    }))
                                     .child(
-                                        div()
-                                            .w_full()
-                                            .min_w_0()
-                                            .max_h(px(120.))
-                                            .overflow_hidden()
-                                            .when(
-                                                custom_status_expandable
-                                                    && !self.custom_status_expanded,
-                                                |d| d.truncate(),
-                                            )
-                                            .when(!custom_status_expandable, |d| {
-                                                d.whitespace_nowrap()
-                                            })
-                                            .when(self.custom_status_expanded, |d| {
-                                                d.whitespace_normal()
-                                            })
-                                            .text_size(px(14.))
-                                            .text_color(text_primary)
-                                            .child(custom_status.clone()),
-                                    )
+                                        Icon::new(IconName::PenEdit)
+                                            .size(px(14.))
+                                            .text_color(text_secondary),
+                                    ),
+                            )
+                            .child(
+                                div()
+                                    .id("footer-custom-status-clear")
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .px_1()
+                                    .cursor_pointer()
+                                    .hover(move |s| s.bg(hover_bg))
+                                    .on_click(cx.listener(|this, _: &ClickEvent, _window, cx| {
+                                        this.user_status = String::new();
+                                        if let Some(store) = AccountStore::try_global(cx) {
+                                            store.update(cx, |store, cx| {
+                                                store.set_custom_status(String::new(), 0, true, cx)
+                                            });
+                                        }
+                                        cx.notify();
+                                    }))
                                     .child(
-                                        div()
-                                            .absolute()
-                                            .top(px(-16.))
-                                            .right(px(4.))
-                                            .flex()
-                                            .flex_row()
-                                            .items_center()
-                                            .rounded_full()
-                                            .bg(bubble_bg)
-                                            .border_1()
-                                            .border_color(border)
-                                            .p(px(2.))
-                                            .shadow_md()
-                                            .opacity(0.)
-                                            .group_hover("footer-custom-status", |s| s.opacity(1.))
-                                            .child(
-                                                div()
-                                                    .id("footer-custom-status-edit")
-                                                    .flex()
-                                                    .items_center()
-                                                    .justify_center()
-                                                    .px_1()
-                                                    .cursor_pointer()
-                                                    .hover(move |s| s.bg(hover_bg))
-                                                    .on_click(cx.listener(
-                                                        |this, _: &ClickEvent, window, cx| {
-                                                            let locale = this.locale.clone();
-                                                            cx.emit(DismissEvent);
-                                                            CustomStatusModal::open(
-                                                                locale, window, cx,
-                                                            );
-                                                        },
-                                                    ))
-                                                    .child(
-                                                        Icon::new(IconName::PenEdit)
-                                                            .size(px(14.))
-                                                            .text_color(text_secondary),
-                                                    ),
-                                            )
-                                            .child(
-                                                div()
-                                                    .id("footer-custom-status-clear")
-                                                    .flex()
-                                                    .items_center()
-                                                    .justify_center()
-                                                    .px_1()
-                                                    .cursor_pointer()
-                                                    .hover(move |s| s.bg(hover_bg))
-                                                    .on_click(cx.listener(
-                                                        |this, _: &ClickEvent, _window, cx| {
-                                                            this.user_status = String::new();
-                                                            if let Some(store) =
-                                                                AccountStore::try_global(cx)
-                                                            {
-                                                                store.update(cx, |store, cx| {
-                                                                    store.set_custom_status(
-                                                                        String::new(),
-                                                                        0,
-                                                                        true,
-                                                                        cx,
-                                                                    )
-                                                                });
-                                                            }
-                                                            cx.notify();
-                                                        },
-                                                    ))
-                                                    .child(
-                                                        Icon::new(
-                                                            IconName::DeleteMessageRightClick,
-                                                        )
-                                                        .size(px(14.))
-                                                        .text_color(gpui::rgb(0xdc2626)),
-                                                    ),
-                                            ),
+                                        Icon::new(IconName::DeleteMessageRightClick)
+                                            .size(px(14.))
+                                            .text_color(gpui::rgb(0xdc2626)),
                                     ),
                             ),
-                    )
-                    .with_priority(2),
-                )
-            });
+                    ),
+            );
 
         let identity = div()
             .flex()
@@ -687,6 +641,7 @@ impl Render for FooterProfilePopup {
 
         div()
             .track_focus(&self.focus_handle)
+            .relative()
             .key_context("menu")
             .on_action(cx.listener(|this, _: &::menu::Cancel, _window, cx| {
                 if this.status_duration_for.is_some() {
@@ -713,21 +668,25 @@ impl Render for FooterProfilePopup {
             .child(banner)
             .child(avatar_row)
             .child(
-                div().px(px(16.)).child(
-                    div()
-                        .w_full()
-                        .my(px(16.))
-                        .p_2()
-                        .rounded(px(10.))
-                        .border_1()
-                        .border_color(border)
-                        .bg(bg_box)
-                        .flex()
-                        .flex_col()
-                        .child(identity)
-                        .child(actions),
-                ),
+                div()
+                    .px(px(16.))
+                    .when(has_custom, |container| container.mt(px(24.)))
+                    .child(
+                        div()
+                            .w_full()
+                            .my(px(16.))
+                            .p_2()
+                            .rounded(px(10.))
+                            .border_1()
+                            .border_color(border)
+                            .bg(bg_box)
+                            .flex()
+                            .flex_col()
+                            .child(identity)
+                            .child(actions),
+                    ),
             )
+            .when(has_custom, |popup| popup.child(custom_status_overlay))
     }
 }
 

--- a/crates/mezon-ui/src/components/compositions/footer_profile_popup.rs
+++ b/crates/mezon-ui/src/components/compositions/footer_profile_popup.rs
@@ -257,6 +257,7 @@ impl Render for FooterProfilePopup {
 
         let custom_status = self.user_status.clone();
         let has_custom = !custom_status.is_empty();
+        let custom_status_expandable = custom_status.chars().count() > 24;
         let avatar_row = div()
             .relative()
             .flex()
@@ -291,114 +292,140 @@ impl Render for FooterProfilePopup {
             )
             .when(has_custom, |row| {
                 row.child(
-                    div()
-                        .id("footer-custom-status-wrap")
-                        .group("footer-custom-status")
-                        .absolute()
-                        .left(px(112.))
-                        .top(px(30.))
-                        .flex()
-                        .flex_col()
-                        .gap(px(12.))
-                        .on_hover(cx.listener(|this, hovered: &bool, _window, cx| {
-                            if this.custom_status_expanded != *hovered {
-                                this.custom_status_expanded = *hovered;
-                                cx.notify();
-                            }
-                        }))
-                        .child(div().size(px(12.)).rounded_full().bg(bubble_bg).shadow_md())
-                        .child(
-                            div()
-                                .id("footer-custom-status-bubble")
-                                .relative()
-                                .flex()
-                                .items_center()
-                                .bg(bubble_bg)
-                                .px(px(16.))
-                                .py(px(12.))
-                                .rounded(px(12.))
-                                .shadow_lg()
-                                .child(
-                                    div()
-                                        .max_w(px(180.))
-                                        .when(!self.custom_status_expanded, |d| d.truncate())
-                                        .text_size(px(14.))
-                                        .text_color(text_primary)
-                                        .child(custom_status.clone()),
-                                )
-                                .child(
-                                    div()
-                                        .absolute()
-                                        .top(px(-16.))
-                                        .right(px(4.))
-                                        .flex()
-                                        .flex_row()
-                                        .items_center()
-                                        .rounded_full()
-                                        .bg(bubble_bg)
-                                        .border_1()
-                                        .border_color(border)
-                                        .p(px(2.))
-                                        .shadow_md()
-                                        .opacity(0.)
-                                        .group_hover("footer-custom-status", |s| s.opacity(1.))
-                                        .child(
-                                            div()
-                                                .id("footer-custom-status-edit")
-                                                .flex()
-                                                .items_center()
-                                                .justify_center()
-                                                .px_1()
-                                                .cursor_pointer()
-                                                .hover(move |s| s.bg(hover_bg))
-                                                .on_click(cx.listener(
-                                                    |this, _: &ClickEvent, window, cx| {
-                                                        let locale = this.locale.clone();
-                                                        cx.emit(DismissEvent);
-                                                        CustomStatusModal::open(locale, window, cx);
-                                                    },
-                                                ))
-                                                .child(
-                                                    Icon::new(IconName::PenEdit)
-                                                        .size(px(14.))
-                                                        .text_color(text_secondary),
-                                                ),
-                                        )
-                                        .child(
-                                            div()
-                                                .id("footer-custom-status-clear")
-                                                .flex()
-                                                .items_center()
-                                                .justify_center()
-                                                .px_1()
-                                                .cursor_pointer()
-                                                .hover(move |s| s.bg(hover_bg))
-                                                .on_click(cx.listener(
-                                                    |this, _: &ClickEvent, _window, cx| {
-                                                        this.user_status = String::new();
-                                                        if let Some(store) =
-                                                            AccountStore::try_global(cx)
-                                                        {
-                                                            store.update(cx, |store, cx| {
-                                                                store.set_custom_status(
-                                                                    String::new(),
-                                                                    0,
-                                                                    true,
-                                                                    cx,
-                                                                )
-                                                            });
-                                                        }
-                                                        cx.notify();
-                                                    },
-                                                ))
-                                                .child(
-                                                    Icon::new(IconName::DeleteMessageRightClick)
+                    deferred(
+                        div()
+                            .id("footer-custom-status-wrap")
+                            .group("footer-custom-status")
+                            .absolute()
+                            .left(px(112.))
+                            .top(px(30.))
+                            .flex()
+                            .flex_col()
+                            .gap(px(12.))
+                            .on_hover(cx.listener(move |this, hovered: &bool, _window, cx| {
+                                let expanded = *hovered && custom_status_expandable;
+                                if this.custom_status_expanded != expanded {
+                                    this.custom_status_expanded = expanded;
+                                    cx.notify();
+                                }
+                            }))
+                            .child(div().size(px(12.)).rounded_full().bg(bubble_bg).shadow_md())
+                            .child(
+                                div()
+                                    .id("footer-custom-status-bubble")
+                                    .relative()
+                                    .flex()
+                                    .items_center()
+                                    .when(custom_status_expandable, |bubble| bubble.w(px(212.)))
+                                    .when(!custom_status_expandable, |bubble| {
+                                        bubble.max_w(px(212.))
+                                    })
+                                    .max_h(px(144.))
+                                    .bg(bubble_bg)
+                                    .px(px(16.))
+                                    .py(px(12.))
+                                    .rounded(px(12.))
+                                    .shadow_lg()
+                                    .child(
+                                        div()
+                                            .w_full()
+                                            .min_w_0()
+                                            .max_h(px(120.))
+                                            .overflow_hidden()
+                                            .when(
+                                                custom_status_expandable
+                                                    && !self.custom_status_expanded,
+                                                |d| d.truncate(),
+                                            )
+                                            .when(!custom_status_expandable, |d| {
+                                                d.whitespace_nowrap()
+                                            })
+                                            .when(self.custom_status_expanded, |d| {
+                                                d.whitespace_normal()
+                                            })
+                                            .text_size(px(14.))
+                                            .text_color(text_primary)
+                                            .child(custom_status.clone()),
+                                    )
+                                    .child(
+                                        div()
+                                            .absolute()
+                                            .top(px(-16.))
+                                            .right(px(4.))
+                                            .flex()
+                                            .flex_row()
+                                            .items_center()
+                                            .rounded_full()
+                                            .bg(bubble_bg)
+                                            .border_1()
+                                            .border_color(border)
+                                            .p(px(2.))
+                                            .shadow_md()
+                                            .opacity(0.)
+                                            .group_hover("footer-custom-status", |s| s.opacity(1.))
+                                            .child(
+                                                div()
+                                                    .id("footer-custom-status-edit")
+                                                    .flex()
+                                                    .items_center()
+                                                    .justify_center()
+                                                    .px_1()
+                                                    .cursor_pointer()
+                                                    .hover(move |s| s.bg(hover_bg))
+                                                    .on_click(cx.listener(
+                                                        |this, _: &ClickEvent, window, cx| {
+                                                            let locale = this.locale.clone();
+                                                            cx.emit(DismissEvent);
+                                                            CustomStatusModal::open(
+                                                                locale, window, cx,
+                                                            );
+                                                        },
+                                                    ))
+                                                    .child(
+                                                        Icon::new(IconName::PenEdit)
+                                                            .size(px(14.))
+                                                            .text_color(text_secondary),
+                                                    ),
+                                            )
+                                            .child(
+                                                div()
+                                                    .id("footer-custom-status-clear")
+                                                    .flex()
+                                                    .items_center()
+                                                    .justify_center()
+                                                    .px_1()
+                                                    .cursor_pointer()
+                                                    .hover(move |s| s.bg(hover_bg))
+                                                    .on_click(cx.listener(
+                                                        |this, _: &ClickEvent, _window, cx| {
+                                                            this.user_status = String::new();
+                                                            if let Some(store) =
+                                                                AccountStore::try_global(cx)
+                                                            {
+                                                                store.update(cx, |store, cx| {
+                                                                    store.set_custom_status(
+                                                                        String::new(),
+                                                                        0,
+                                                                        true,
+                                                                        cx,
+                                                                    )
+                                                                });
+                                                            }
+                                                            cx.notify();
+                                                        },
+                                                    ))
+                                                    .child(
+                                                        Icon::new(
+                                                            IconName::DeleteMessageRightClick,
+                                                        )
                                                         .size(px(14.))
                                                         .text_color(gpui::rgb(0xdc2626)),
-                                                ),
-                                        ),
-                                ),
-                        ),
+                                                    ),
+                                            ),
+                                    ),
+                            ),
+                    )
+                    .with_priority(2),
                 )
             });
 

--- a/crates/mezon-ui/src/components/compositions/mod.rs
+++ b/crates/mezon-ui/src/components/compositions/mod.rs
@@ -1,11 +1,13 @@
 pub mod channel_row;
 pub mod channel_row_element;
+pub mod custom_status_bubble;
 pub mod dm_row;
 pub mod footer_profile_popup;
 pub mod form_field;
 pub mod otp_input;
 pub mod user_info_bar;
 
+pub use custom_status_bubble::CustomStatusBubble;
 pub use dm_row::{DM_ROW_HEIGHT, DmRow};
 pub use form_field::FormField;
 pub use otp_input::OtpInput;

--- a/crates/mezon-ui/src/settings/clan_profile_section.rs
+++ b/crates/mezon-ui/src/settings/clan_profile_section.rs
@@ -1,12 +1,13 @@
 use std::time::Duration;
 
+use crate::components::compositions::CustomStatusBubble;
 use crate::components::primitives::{
     Avatar, Button as GpuiButton, ButtonVariants, Dropdown, DropdownTriggerStyle, Icon, Input,
     InputEvent, InputState, Label, h_flex, v_flex,
 };
 use gpui::{
-    App, Context, Entity, FontWeight, PathPromptOptions, Rgba, SharedString, Subscription, Task,
-    Window, div, prelude::*, px,
+    Context, Entity, FontWeight, PathPromptOptions, Rgba, SharedString, Subscription, Task, Window,
+    div, prelude::*, px,
 };
 use mezon_store::{AccountEvent, AccountStore, ClanList, Settings};
 
@@ -46,7 +47,7 @@ pub struct ClanProfileSection {
     banner_color: Option<Rgba>,
     banner_source: String,
     banner_task: Option<Task<()>>,
-    custom_status_expanded: bool,
+    custom_status_bubble: Entity<CustomStatusBubble>,
 }
 
 impl ClanProfileSection {
@@ -177,7 +178,7 @@ impl ClanProfileSection {
             banner_color: None,
             banner_source: String::new(),
             banner_task: None,
-            custom_status_expanded: false,
+            custom_status_bubble: cx.new(|_| CustomStatusBubble::new()),
         };
         this.refresh_banner_color(cx);
         this
@@ -400,14 +401,18 @@ impl Render for ClanProfileSection {
             .map(|url| SharedString::from(crate::util::imgproxy::profile_url(cx, url.as_ref())));
 
         let duplicate_error = self.profile.as_ref().is_some_and(|s| s.duplicate_error);
-
-        let on_custom_status_hover = cx.listener(|this, hovered: &bool, _window, cx| {
-            let expanded = *hovered && this.custom_status.chars().count() > 24;
-            if this.custom_status_expanded != expanded {
-                this.custom_status_expanded = expanded;
-                cx.notify();
-            }
+        let custom_status_bubble = self.custom_status_bubble.clone();
+        custom_status_bubble.update(cx, |bubble, cx| {
+            bubble.set_content(
+                self.custom_status.clone(),
+                px(214.),
+                theme.tokens.bg_secondary,
+                theme.border,
+                theme.text_secondary,
+                cx,
+            );
         });
+
         let form = self.render_clan_form(
             &theme,
             &clan_options,
@@ -429,7 +434,6 @@ impl Render for ClanProfileSection {
             &self.custom_status,
             self.banner_color,
             self.avatar_image_cache.clone(),
-            on_custom_status_hover,
         );
 
         v_flex()
@@ -690,7 +694,6 @@ impl ClanProfileSection {
         custom_status: &SharedString,
         banner_color: Option<Rgba>,
         avatar_image_cache: Entity<LruImageCache>,
-        on_custom_status_hover: impl Fn(&bool, &mut Window, &mut App) + 'static,
     ) -> impl IntoElement {
         let display_label = if nick_name.is_empty() {
             display_name.clone()
@@ -698,7 +701,6 @@ impl ClanProfileSection {
             nick_name.clone()
         };
         let (status_icon, status_color) = profile_status(status, theme);
-        let custom_status_expandable = custom_status.chars().count() > 24;
         let banner_color = banner_color
             .map(gpui::Hsla::from)
             .unwrap_or(theme.tokens.bg_secondary.into());
@@ -802,34 +804,20 @@ impl ClanProfileSection {
                 preview.child(
                     div()
                         .id("clan-profile-preview-custom-status")
+                        .group("clan-profile-preview-custom-status")
                         .absolute()
                         .left(px(120.))
-                        .when(custom_status_expandable, |status| status.right(px(20.)))
-                        .when(!custom_status_expandable, |status| status.max_w(px(214.)))
                         .top(px(168.))
-                        .max_h(px(144.))
-                        .px_4()
-                        .py_3()
-                        .rounded_xl()
-                        .bg(theme.tokens.bg_secondary)
-                        .border_1()
-                        .border_color(theme.border)
-                        .shadow_md()
-                        .text_sm()
-                        .text_color(theme.text_secondary)
-                        .overflow_hidden()
-                        .when(
-                            custom_status_expandable && !self.custom_status_expanded,
-                            |status| status.truncate(),
-                        )
-                        .when(!custom_status_expandable, |status| {
-                            status.whitespace_nowrap()
+                        .max_w(px(214.))
+                        .on_hover({
+                            let custom_status_bubble = self.custom_status_bubble.clone();
+                            move |hovered: &bool, _window, cx| {
+                                custom_status_bubble.update(cx, |bubble, cx| {
+                                    bubble.set_expanded(*hovered, cx);
+                                });
+                            }
                         })
-                        .when(self.custom_status_expanded, |status| {
-                            status.whitespace_normal()
-                        })
-                        .on_hover(on_custom_status_hover)
-                        .child(custom_status.clone()),
+                        .child(self.custom_status_bubble.clone()),
                 )
             })
     }

--- a/crates/mezon-ui/src/settings/clan_profile_section.rs
+++ b/crates/mezon-ui/src/settings/clan_profile_section.rs
@@ -5,8 +5,8 @@ use crate::components::primitives::{
     InputEvent, InputState, Label, h_flex, v_flex,
 };
 use gpui::{
-    Context, Entity, FontWeight, PathPromptOptions, Rgba, SharedString, Subscription, Task, Window,
-    div, prelude::*, px,
+    App, Context, Entity, FontWeight, PathPromptOptions, Rgba, SharedString, Subscription, Task,
+    Window, div, prelude::*, px,
 };
 use mezon_store::{AccountEvent, AccountStore, ClanList, Settings};
 
@@ -46,6 +46,7 @@ pub struct ClanProfileSection {
     banner_color: Option<Rgba>,
     banner_source: String,
     banner_task: Option<Task<()>>,
+    custom_status_expanded: bool,
 }
 
 impl ClanProfileSection {
@@ -176,6 +177,7 @@ impl ClanProfileSection {
             banner_color: None,
             banner_source: String::new(),
             banner_task: None,
+            custom_status_expanded: false,
         };
         this.refresh_banner_color(cx);
         this
@@ -399,6 +401,13 @@ impl Render for ClanProfileSection {
 
         let duplicate_error = self.profile.as_ref().is_some_and(|s| s.duplicate_error);
 
+        let on_custom_status_hover = cx.listener(|this, hovered: &bool, _window, cx| {
+            let expanded = *hovered && this.custom_status.chars().count() > 24;
+            if this.custom_status_expanded != expanded {
+                this.custom_status_expanded = expanded;
+                cx.notify();
+            }
+        });
         let form = self.render_clan_form(
             &theme,
             &clan_options,
@@ -409,7 +418,7 @@ impl Render for ClanProfileSection {
             duplicate_error,
             cx,
         );
-        let preview = Self::render_clan_preview(
+        let preview = self.render_clan_preview(
             &theme,
             &locale,
             &nick_name,
@@ -420,6 +429,7 @@ impl Render for ClanProfileSection {
             &self.custom_status,
             self.banner_color,
             self.avatar_image_cache.clone(),
+            on_custom_status_hover,
         );
 
         v_flex()
@@ -669,6 +679,7 @@ impl ClanProfileSection {
     }
 
     fn render_clan_preview(
+        &self,
         theme: &Theme,
         locale: &str,
         nick_name: &SharedString,
@@ -679,6 +690,7 @@ impl ClanProfileSection {
         custom_status: &SharedString,
         banner_color: Option<Rgba>,
         avatar_image_cache: Entity<LruImageCache>,
+        on_custom_status_hover: impl Fn(&bool, &mut Window, &mut App) + 'static,
     ) -> impl IntoElement {
         let display_label = if nick_name.is_empty() {
             display_name.clone()
@@ -686,6 +698,7 @@ impl ClanProfileSection {
             nick_name.clone()
         };
         let (status_icon, status_color) = profile_status(status, theme);
+        let custom_status_expandable = custom_status.chars().count() > 24;
         let banner_color = banner_color
             .map(gpui::Hsla::from)
             .unwrap_or(theme.tokens.bg_secondary.into());
@@ -702,7 +715,7 @@ impl ClanProfileSection {
             .child(
                 div()
                     .relative()
-                    .h(px(330.))
+                    .h(px(320.))
                     .w_full()
                     .rounded_lg()
                     .overflow_hidden()
@@ -722,7 +735,7 @@ impl ClanProfileSection {
                             .absolute()
                             .left(px(20.))
                             .right(px(20.))
-                            .bottom(px(48.))
+                            .bottom(px(20.))
                             .p_4()
                             .rounded_lg()
                             .border_1()
@@ -788,11 +801,13 @@ impl ClanProfileSection {
             .when(!custom_status.is_empty(), |preview| {
                 preview.child(
                     div()
+                        .id("clan-profile-preview-custom-status")
                         .absolute()
                         .left(px(120.))
+                        .when(custom_status_expandable, |status| status.right(px(20.)))
+                        .when(!custom_status_expandable, |status| status.max_w(px(214.)))
                         .top(px(168.))
-                        .max_w(px(250.))
-                        .max_h(px(64.))
+                        .max_h(px(144.))
                         .px_4()
                         .py_3()
                         .rounded_xl()
@@ -803,6 +818,17 @@ impl ClanProfileSection {
                         .text_sm()
                         .text_color(theme.text_secondary)
                         .overflow_hidden()
+                        .when(
+                            custom_status_expandable && !self.custom_status_expanded,
+                            |status| status.truncate(),
+                        )
+                        .when(!custom_status_expandable, |status| {
+                            status.whitespace_nowrap()
+                        })
+                        .when(self.custom_status_expanded, |status| {
+                            status.whitespace_normal()
+                        })
+                        .on_hover(on_custom_status_hover)
                         .child(custom_status.clone()),
                 )
             })

--- a/crates/mezon-ui/src/settings/clan_profile_section.rs
+++ b/crates/mezon-ui/src/settings/clan_profile_section.rs
@@ -744,15 +744,25 @@ impl ClanProfileSection {
                             .border_color(theme.border)
                             .bg(theme.bg_primary)
                             .child(
-                                Label::new(display_label.clone())
-                                    .text_xl()
-                                    .font_weight(FontWeight::BOLD)
-                                    .text_color(theme.text_secondary),
-                            )
-                            .child(
-                                Label::new(username.clone())
-                                    .text_sm()
-                                    .text_color(theme.text_muted),
+                                v_flex()
+                                    .w(px(300.))
+                                    .max_w_full()
+                                    .min_w_0()
+                                    .child(
+                                        Label::new(display_label.clone())
+                                            .w_full()
+                                            .truncate()
+                                            .text_xl()
+                                            .font_weight(FontWeight::BOLD)
+                                            .text_color(theme.text_secondary),
+                                    )
+                                    .child(
+                                        Label::new(username.clone())
+                                            .w_full()
+                                            .truncate()
+                                            .text_sm()
+                                            .text_color(theme.text_muted),
+                                    ),
                             ),
                     )
                     .child(

--- a/crates/mezon-ui/src/settings/profile_page.rs
+++ b/crates/mezon-ui/src/settings/profile_page.rs
@@ -1,11 +1,11 @@
+use crate::components::compositions::CustomStatusBubble;
 use crate::components::primitives::{
     Avatar, Button as GpuiButton, ButtonVariants, Icon, IconName, Input, InputEvent, InputState,
     Label, TextArea, TextAreaEvent, TextAreaField, h_flex, v_flex,
 };
 use gpui::{
-    App, Context, Entity, FontWeight, MouseButton, MouseDownEvent, PathPromptOptions, Pixels,
-    Point, Rgba, SharedString, Subscription, Task, Window, anchored, deferred, div, img,
-    prelude::*, px,
+    Context, Entity, FontWeight, MouseButton, MouseDownEvent, PathPromptOptions, Pixels, Point,
+    Rgba, SharedString, Subscription, Task, Window, anchored, deferred, div, img, prelude::*, px,
 };
 use mezon_store::{AccountEvent, AccountStore, AppConfig, ClanList, Settings, UserAccount};
 
@@ -81,7 +81,7 @@ pub struct ProfilePage {
     banner_source: String,
     banner_task: Option<Task<()>>,
     discard_on_next_render: bool,
-    custom_status_expanded: bool,
+    custom_status_bubble: Entity<CustomStatusBubble>,
     #[allow(dead_code)]
     show_delete_confirm: bool,
 }
@@ -217,7 +217,7 @@ impl ProfilePage {
             banner_source: String::new(),
             banner_task: None,
             discard_on_next_render: false,
-            custom_status_expanded: false,
+            custom_status_bubble: cx.new(|_| CustomStatusBubble::new()),
             show_delete_confirm: false,
         };
         this.refresh_banner_color(cx);
@@ -444,16 +444,22 @@ impl ProfilePage {
             .as_ref()
             .and_then(|p| p.avatar_url.as_ref())
             .map(|url| SharedString::from(crate::util::imgproxy::profile_url(cx, url.as_ref())));
-        let on_custom_status_hover = cx.listener(|this, hovered: &bool, _window, cx| {
-            let expandable = this
-                .profile
-                .as_ref()
-                .is_some_and(|profile| profile.custom_status.chars().count() > 24);
-            let expanded = *hovered && expandable;
-            if this.custom_status_expanded != expanded {
-                this.custom_status_expanded = expanded;
-                cx.notify();
-            }
+        let custom_status = self
+            .profile
+            .as_ref()
+            .map_or_else(SharedString::default, |profile| {
+                profile.custom_status.clone()
+            });
+        let custom_status_bubble = self.custom_status_bubble.clone();
+        custom_status_bubble.update(cx, |bubble, cx| {
+            bubble.set_content(
+                custom_status,
+                px(214.),
+                theme.tokens.bg_secondary,
+                theme.border,
+                theme.text_secondary,
+                cx,
+            );
         });
         let form = self.render_form(theme, cx, avatar_display.clone());
         let preview = self.render_preview(
@@ -461,7 +467,6 @@ impl ProfilePage {
             &locale,
             avatar_display,
             self.avatar_local_preview.clone(),
-            on_custom_status_hover,
         );
         v_flex().gap_6().child(
             h_flex()
@@ -1139,7 +1144,6 @@ impl ProfilePage {
                     )
                     .when_some(dm_icon_menu, |element, menu| element.child(menu)),
             )
-            .into_any_element()
     }
 
     fn render_preview(
@@ -1148,7 +1152,6 @@ impl ProfilePage {
         locale: &str,
         avatar_display: Option<SharedString>,
         avatar_local_preview: Option<std::path::PathBuf>,
-        on_custom_status_hover: impl Fn(&bool, &mut Window, &mut App) + 'static,
     ) -> impl IntoElement {
         let display_name: SharedString = self
             .profile
@@ -1166,7 +1169,6 @@ impl ProfilePage {
             .profile
             .as_ref()
             .map_or_else(SharedString::default, |p| p.custom_status.clone());
-        let custom_status_expandable = custom_status.chars().count() > 24;
         let (status_icon, status_color) = profile_status(status, theme);
         let banner_color = self
             .banner_color
@@ -1282,34 +1284,20 @@ impl ProfilePage {
                 preview.child(
                     div()
                         .id("user-profile-preview-custom-status")
+                        .group("user-profile-preview-custom-status")
                         .absolute()
                         .left(px(120.))
-                        .when(custom_status_expandable, |status| status.right(px(20.)))
-                        .when(!custom_status_expandable, |status| status.max_w(px(214.)))
                         .top(px(168.))
-                        .max_h(px(144.))
-                        .px_4()
-                        .py_3()
-                        .rounded_xl()
-                        .bg(theme.tokens.bg_secondary)
-                        .border_1()
-                        .border_color(theme.border)
-                        .shadow_md()
-                        .text_sm()
-                        .text_color(theme.text_secondary)
-                        .overflow_hidden()
-                        .when(
-                            custom_status_expandable && !self.custom_status_expanded,
-                            |status| status.truncate(),
-                        )
-                        .when(!custom_status_expandable, |status| {
-                            status.whitespace_nowrap()
+                        .max_w(px(214.))
+                        .on_hover({
+                            let custom_status_bubble = self.custom_status_bubble.clone();
+                            move |hovered: &bool, _window, cx| {
+                                custom_status_bubble.update(cx, |bubble, cx| {
+                                    bubble.set_expanded(*hovered, cx);
+                                });
+                            }
                         })
-                        .when(self.custom_status_expanded, |status| {
-                            status.whitespace_normal()
-                        })
-                        .on_hover(on_custom_status_hover)
-                        .child(custom_status),
+                        .child(self.custom_status_bubble.clone()),
                 )
             })
     }

--- a/crates/mezon-ui/src/settings/profile_page.rs
+++ b/crates/mezon-ui/src/settings/profile_page.rs
@@ -3,8 +3,9 @@ use crate::components::primitives::{
     Label, TextArea, TextAreaEvent, TextAreaField, h_flex, v_flex,
 };
 use gpui::{
-    Context, Entity, FontWeight, MouseButton, MouseDownEvent, PathPromptOptions, Pixels, Point,
-    Rgba, SharedString, Subscription, Task, Window, anchored, deferred, div, img, prelude::*, px,
+    App, Context, Entity, FontWeight, MouseButton, MouseDownEvent, PathPromptOptions, Pixels,
+    Point, Rgba, SharedString, Subscription, Task, Window, anchored, deferred, div, img,
+    prelude::*, px,
 };
 use mezon_store::{AccountEvent, AccountStore, AppConfig, ClanList, Settings, UserAccount};
 
@@ -80,6 +81,7 @@ pub struct ProfilePage {
     banner_source: String,
     banner_task: Option<Task<()>>,
     discard_on_next_render: bool,
+    custom_status_expanded: bool,
     #[allow(dead_code)]
     show_delete_confirm: bool,
 }
@@ -215,6 +217,7 @@ impl ProfilePage {
             banner_source: String::new(),
             banner_task: None,
             discard_on_next_render: false,
+            custom_status_expanded: false,
             show_delete_confirm: false,
         };
         this.refresh_banner_color(cx);
@@ -441,12 +444,24 @@ impl ProfilePage {
             .as_ref()
             .and_then(|p| p.avatar_url.as_ref())
             .map(|url| SharedString::from(crate::util::imgproxy::profile_url(cx, url.as_ref())));
+        let on_custom_status_hover = cx.listener(|this, hovered: &bool, _window, cx| {
+            let expandable = this
+                .profile
+                .as_ref()
+                .is_some_and(|profile| profile.custom_status.chars().count() > 24);
+            let expanded = *hovered && expandable;
+            if this.custom_status_expanded != expanded {
+                this.custom_status_expanded = expanded;
+                cx.notify();
+            }
+        });
         let form = self.render_form(theme, cx, avatar_display.clone());
         let preview = self.render_preview(
             theme,
             &locale,
             avatar_display,
             self.avatar_local_preview.clone(),
+            on_custom_status_hover,
         );
         v_flex().gap_6().child(
             h_flex()
@@ -1124,6 +1139,7 @@ impl ProfilePage {
                     )
                     .when_some(dm_icon_menu, |element, menu| element.child(menu)),
             )
+            .into_any_element()
     }
 
     fn render_preview(
@@ -1132,6 +1148,7 @@ impl ProfilePage {
         locale: &str,
         avatar_display: Option<SharedString>,
         avatar_local_preview: Option<std::path::PathBuf>,
+        on_custom_status_hover: impl Fn(&bool, &mut Window, &mut App) + 'static,
     ) -> impl IntoElement {
         let display_name: SharedString = self
             .profile
@@ -1149,6 +1166,7 @@ impl ProfilePage {
             .profile
             .as_ref()
             .map_or_else(SharedString::default, |p| p.custom_status.clone());
+        let custom_status_expandable = custom_status.chars().count() > 24;
         let (status_icon, status_color) = profile_status(status, theme);
         let banner_color = self
             .banner_color
@@ -1167,7 +1185,7 @@ impl ProfilePage {
             .child(
                 div()
                     .relative()
-                    .h(px(330.))
+                    .h(px(320.))
                     .w_full()
                     .rounded_lg()
                     .overflow_hidden()
@@ -1188,7 +1206,7 @@ impl ProfilePage {
                             .absolute()
                             .left(px(20.))
                             .right(px(20.))
-                            .bottom(px(48.))
+                            .bottom(px(20.))
                             .p_4()
                             .rounded_lg()
                             .border_1()
@@ -1263,11 +1281,13 @@ impl ProfilePage {
             .when(!custom_status.is_empty(), |preview| {
                 preview.child(
                     div()
+                        .id("user-profile-preview-custom-status")
                         .absolute()
                         .left(px(120.))
+                        .when(custom_status_expandable, |status| status.right(px(20.)))
+                        .when(!custom_status_expandable, |status| status.max_w(px(214.)))
                         .top(px(168.))
-                        .max_w(px(250.))
-                        .max_h(px(64.))
+                        .max_h(px(144.))
                         .px_4()
                         .py_3()
                         .rounded_xl()
@@ -1278,6 +1298,17 @@ impl ProfilePage {
                         .text_sm()
                         .text_color(theme.text_secondary)
                         .overflow_hidden()
+                        .when(
+                            custom_status_expandable && !self.custom_status_expanded,
+                            |status| status.truncate(),
+                        )
+                        .when(!custom_status_expandable, |status| {
+                            status.whitespace_nowrap()
+                        })
+                        .when(self.custom_status_expanded, |status| {
+                            status.whitespace_normal()
+                        })
+                        .on_hover(on_custom_status_hover)
                         .child(custom_status),
                 )
             })

--- a/crates/mezon-ui/src/settings/profile_page.rs
+++ b/crates/mezon-ui/src/settings/profile_page.rs
@@ -1215,12 +1215,26 @@ impl ProfilePage {
                             .border_color(theme.border)
                             .bg(theme.bg_primary)
                             .child(
-                                Label::new(display_name.clone())
-                                    .text_xl()
-                                    .font_weight(FontWeight::BOLD)
-                                    .text_color(theme.text_secondary),
-                            )
-                            .child(Label::new(username).text_sm().text_color(theme.text_muted)),
+                                v_flex()
+                                    .w(px(300.))
+                                    .max_w_full()
+                                    .min_w_0()
+                                    .child(
+                                        Label::new(display_name.clone())
+                                            .w_full()
+                                            .truncate()
+                                            .text_xl()
+                                            .font_weight(FontWeight::BOLD)
+                                            .text_color(theme.text_secondary),
+                                    )
+                                    .child(
+                                        Label::new(username)
+                                            .w_full()
+                                            .truncate()
+                                            .text_sm()
+                                            .text_color(theme.text_muted),
+                                    ),
+                            ),
                     )
                     .child(
                         div()


### PR DESCRIPTION
> `Description:`

**env development:** window
- fix ui of profile expand custom status layout with long custom status.
<img width="615" height="522" alt="image" src="https://github.com/user-attachments/assets/98216ce0-1581-480f-9161-39ef87be351f" />

<img width="420" height="317" alt="image" src="https://github.com/user-attachments/assets/910dfa6c-4566-4b7a-87b1-0918ba74eda0" />











