### PR TITLE
fix(channels): fetch favorites with the clan structure, not after it

### DIFF
--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -265,13 +265,12 @@ struct TopicParentBadge {
 
 struct ClanExtras {
     voice_map: Option<HashMap<ChannelId, Vec<UserId>>>,
-    favorite_ids: Option<HashSet<ChannelId>>,
     app_channels: Option<Vec<AppChannel>>,
 }
 
 impl ClanExtras {
     fn is_complete(&self) -> bool {
-        self.voice_map.is_some() && self.favorite_ids.is_some() && self.app_channels.is_some()
+        self.voice_map.is_some() && self.app_channels.is_some()
     }
 }
 
@@ -693,6 +692,7 @@ impl ChannelList {
                     );
                 }
                 this.pending_badge_seed.insert(clan_id, seed);
+                this.sync_clan_after_read(clan_id, 0, cx);
                 if applied {
                     this.notify_channel_list(clan_id, cx);
                 }
@@ -754,6 +754,7 @@ impl ChannelList {
     pub fn load_for_clan(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
         self.want_extras.insert(clan_id);
         if self.cache.is_fresh(&clan_id, crate::CACHE_TTL) {
+            self.sync_clan_after_read(clan_id, 0, cx);
             self.ensure_extras(clan_id, cx);
             return;
         }
@@ -857,8 +858,12 @@ impl ChannelList {
         &mut self,
         clan_id: ClanId,
         mut categories: Vec<Category>,
+        favorite_ids: Option<HashSet<ChannelId>>,
         cx: &mut Context<Self>,
     ) {
+        if let Some(favorite_ids) = favorite_ids {
+            self.favorites.insert(clan_id, favorite_ids);
+        }
         self.consume_badge_seed(clan_id, &mut categories);
         self.merge_pending_badges(&mut categories);
         let previous_badges = collect_channel_badges(&self.cache, clan_id);
@@ -898,12 +903,12 @@ impl ChannelList {
             .spawn(async move |this, cx| {
                 let result = Self::fetch_clan_structure(&api, clan_id).await;
                 match result {
-                    Ok(categories) => {
+                    Ok((categories, favorite_ids)) => {
                         let _ = this.update(cx, |this, cx| {
                             if this.reset_generation != generation {
                                 return;
                             }
-                            this.apply_clan_structure(clan_id, categories, cx);
+                            this.apply_clan_structure(clan_id, categories, favorite_ids, cx);
                             this.loading.remove(&clan_id);
                         });
                     }
@@ -1061,14 +1066,19 @@ impl ChannelList {
         }
     }
 
-    async fn fetch_clan_structure(api: &AppApi, clan_id: ClanId) -> anyhow::Result<Vec<Category>> {
-        let (channels_res, categories_res) = tokio::join!(
+    async fn fetch_clan_structure(
+        api: &AppApi,
+        clan_id: ClanId,
+    ) -> anyhow::Result<(Vec<Category>, Option<HashSet<ChannelId>>)> {
+        let (channels_res, categories_res, favorites_res) = tokio::join!(
             api.list_channel_descs(clan_id.get(), 1),
             api.list_categories_typed(clan_id.get()),
+            api.list_favorite_channels(clan_id.get()),
         );
 
         let api_channels = channels_res?;
         let api_categories = categories_res?;
+        let favorite_ids = parse_favorite_ids(favorites_res);
 
         let mut channels: Vec<Channel> = api_channels
             .into_iter()
@@ -1091,27 +1101,21 @@ impl ChannelList {
             );
         }
 
-        Ok(build_categories(api_categories, &mut channels))
+        Ok((
+            build_categories(api_categories, &mut channels),
+            favorite_ids,
+        ))
     }
 
     async fn fetch_clan_extras(api: &AppApi, clan_id: ClanId) -> ClanExtras {
-        let (voice_res, favorites_res, apps_res) = tokio::join!(
+        let (voice_res, apps_res) = tokio::join!(
             api.list_voice_channel_users(clan_id.get()),
-            api.list_favorite_channels(clan_id.get()),
             api.list_channel_apps(clan_id.get()),
         );
 
         let voice_users = voice_res
             .inspect_err(|e| tracing::warn!("list_voice_channel_users failed: {e}"))
             .ok();
-        let favorite_ids: Option<HashSet<ChannelId>> = favorites_res
-            .inspect_err(|e| tracing::warn!("list_favorite_channels failed: {e}"))
-            .ok()
-            .map(|ids| {
-                ids.into_iter()
-                    .filter_map(|s| s.parse::<ChannelId>().ok())
-                    .collect()
-            });
         let app_channels: Option<Vec<AppChannel>> = apps_res
             .inspect_err(|e| tracing::warn!("list_channel_apps failed: {e}"))
             .ok()
@@ -1131,7 +1135,6 @@ impl ChannelList {
 
         ClanExtras {
             voice_map,
-            favorite_ids,
             app_channels,
         }
     }
@@ -1148,13 +1151,6 @@ impl ChannelList {
             self.app_channels_cache.insert(clan_id, app_channels);
         }
 
-        let mut favorites_changed = false;
-        let favorites_len = extras.favorite_ids.as_ref().map(HashSet::len);
-        if let Some(favorite_ids) = extras.favorite_ids {
-            favorites_changed = self.favorites.get(&clan_id) != Some(&favorite_ids);
-            self.favorites.insert(clan_id, favorite_ids);
-        }
-
         let Some(slot) = self.cache.get_mut(&clan_id) else {
             cx.notify();
             return false;
@@ -1163,7 +1159,7 @@ impl ChannelList {
         let mut owned = std::mem::take(slot);
         owned.retain(|category| category.id != FAVOR_CATE_ID);
 
-        let mut changed = app_channels_changed || favorites_changed;
+        let mut changed = app_channels_changed;
         if let Some(voice_map) = extras.voice_map.as_ref() {
             for ch in owned
                 .iter_mut()
@@ -1201,7 +1197,6 @@ impl ChannelList {
         tracing::debug!(
             target: "clan_load",
             clan_id = clan_id.get(),
-            favorites = favorites_len,
             voice_channels = extras.voice_map.as_ref().map(HashMap::len),
             changed,
             "extras patched into cached clan structure"
@@ -3699,6 +3694,17 @@ fn carry_live_channel_badges(
     }
 }
 
+fn parse_favorite_ids(result: anyhow::Result<Vec<String>>) -> Option<HashSet<ChannelId>> {
+    result
+        .inspect_err(|e| tracing::warn!("list_favorite_channels failed: {e}"))
+        .ok()
+        .map(|ids| {
+            ids.into_iter()
+                .filter_map(|s| s.parse::<ChannelId>().ok())
+                .collect()
+        })
+}
+
 fn rebuild_favorites(
     mut categories: Vec<Category>,
     clan_id: ClanId,
@@ -5001,10 +5007,13 @@ mod tests {
         build_categories(api_cats, &mut channels)
     }
 
-    fn favorite_extras(ids: &[ChannelId]) -> ClanExtras {
+    fn favor_ids(ids: &[ChannelId]) -> Option<HashSet<ChannelId>> {
+        Some(ids.iter().copied().collect())
+    }
+
+    fn complete_extras() -> ClanExtras {
         ClanExtras {
             voice_map: Some(HashMap::new()),
-            favorite_ids: Some(ids.iter().copied().collect()),
             app_channels: Some(Vec::new()),
         }
     }
@@ -5015,7 +5024,6 @@ mod tests {
     fn voice_extras(voice_map: HashMap<ChannelId, Vec<UserId>>) -> ClanExtras {
         ClanExtras {
             voice_map: Some(voice_map),
-            favorite_ids: Some([VOICE_CHANNEL].into_iter().collect()),
             app_channels: Some(Vec::new()),
         }
     }
@@ -5056,7 +5064,12 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[VOICE_CHANNEL]),
+                    cx,
+                );
                 channels.apply_clan_extras(ClanId(1), voice_extras(one_user_in_voice()), cx);
 
                 assert_voice_member_on_both_copies(channels, "extras apply");
@@ -5069,14 +5082,18 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[VOICE_CHANNEL]),
+                    cx,
+                );
                 channels.apply_clan_extras(ClanId(1), voice_extras(one_user_in_voice()), cx);
 
                 channels.apply_clan_extras(
                     ClanId(1),
                     ClanExtras {
                         voice_map: None,
-                        favorite_ids: None,
                         app_channels: None,
                     },
                     cx,
@@ -5092,7 +5109,12 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[VOICE_CHANNEL]),
+                    cx,
+                );
                 channels.apply_clan_extras(ClanId(1), voice_extras(one_user_in_voice()), cx);
 
                 channels.apply_clan_extras(ClanId(1), voice_extras(HashMap::new()), cx);
@@ -5109,7 +5131,12 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[VOICE_CHANNEL]),
+                    cx,
+                );
                 channels.apply_clan_extras(ClanId(1), voice_extras(HashMap::new()), cx);
 
                 channels.handle_event(
@@ -5124,7 +5151,7 @@ mod tests {
                 );
                 assert_voice_member_on_both_copies(channels, "realtime join");
 
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 assert_voice_member_on_both_copies(channels, "structure refetch");
             });
         });
@@ -5303,7 +5330,7 @@ mod tests {
                     thread.name = "Tes Private thread".into();
                     thread.private = true;
                 }
-                channels.apply_clan_structure(ClanId(1), structure, cx);
+                channels.apply_clan_structure(ClanId(1), structure, None, cx);
                 channels.merge_user_channels_from_api_descs(vec![], cx);
 
                 let thread = channels.user_channel(ChannelId(9)).expect("private thread");
@@ -5328,7 +5355,7 @@ mod tests {
                     thread.private = true;
                     thread.active = CHANNEL_ACTIVE_ARCHIVED;
                 }
-                channels.apply_clan_structure(ClanId(1), structure, cx);
+                channels.apply_clan_structure(ClanId(1), structure, None, cx);
 
                 let archived = channels
                     .user_channel(ChannelId(9))
@@ -5354,7 +5381,7 @@ mod tests {
         cx.update(|cx| {
             let channels = init_authenticated_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), None, cx);
                 assert!(channels.user_channel(ChannelId(42)).is_none());
 
                 channels.handle_event(&added_to_channel(42, 1, &[REMOVED_SELF]), cx);
@@ -5374,7 +5401,7 @@ mod tests {
         cx.update(|cx| {
             let channels = init_authenticated_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 assert!(channels.user_channel(ChannelId(9)).is_none());
 
                 channels.handle_event(&added_to_channel(9, 1, &[REMOVED_SELF]), cx);
@@ -5392,7 +5419,7 @@ mod tests {
         cx.update(|cx| {
             let channels = init_authenticated_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), None, cx);
 
                 channels.handle_event(&added_to_channel(42, 1, &[REMOVED_SELF]), cx);
 
@@ -5410,7 +5437,7 @@ mod tests {
         cx.update(|cx| {
             let channels = init_authenticated_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), None, cx);
 
                 let mut event = added_to_channel(42, 1, &[REMOVED_SELF]);
                 if let RealtimeEvent::UserChannelAdded(ref mut e) = event
@@ -5463,7 +5490,7 @@ mod tests {
                 clans.update_clans(vec![make_clan(1)], cx);
             });
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), None, cx);
                 set_channel_badge(channels, ClanId(1), ChannelId(9), 3);
                 channels.sync_clan_after_read(ClanId(1), 0, cx);
                 assert_eq!(
@@ -5487,7 +5514,7 @@ mod tests {
         cx.update(|cx| {
             let channels = init_authenticated_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), None, cx);
 
                 channels.handle_event(&added_to_channel(42, 1, &[REMOVED_SELF]), cx);
                 channels.handle_event(&removed_from_channel(42, &[REMOVED_SELF]), cx);
@@ -5503,7 +5530,7 @@ mod tests {
         cx.update(|cx| {
             let channels = init_authenticated_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), None, cx);
                 channels.select_channel(ChannelId(9), cx);
 
                 channels.handle_event(&removed_from_channel(9, &[REMOVED_SELF]), cx);
@@ -5526,7 +5553,7 @@ mod tests {
         cx.update(|cx| {
             let channels = init_authenticated_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), None, cx);
                 channels.select_channel(ChannelId(1), cx);
 
                 channels.handle_event(&removed_from_channel(9, &[REMOVED_SELF]), cx);
@@ -5541,7 +5568,7 @@ mod tests {
         cx.update(|cx| {
             let channels = init_authenticated_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_a_thread(), None, cx);
                 channels.select_channel(ChannelId(9), cx);
 
                 channels.handle_event(&removed_from_channel(9, &[REMOVED_SELF + 1]), cx);
@@ -5559,12 +5586,17 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
-                channels.apply_clan_extras(ClanId(1), favorite_extras(&[ChannelId(2)]), cx);
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[ChannelId(2)]),
+                    cx,
+                );
+                channels.apply_clan_extras(ClanId(1), complete_extras(), cx);
                 channels.extras_loaded.insert(ClanId(1));
                 assert_eq!(channels.categories_for_clan(ClanId(1))[0].channels.len(), 1);
 
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
 
                 let favor = &channels.categories_for_clan(ClanId(1))[0];
                 assert_eq!(favor.id, FAVOR_CATE_ID);
@@ -5586,11 +5618,15 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
-                channels.apply_clan_extras(ClanId(1), favorite_extras(&[]), cx);
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[]),
+                    cx,
+                );
 
                 channels.add_channel_favorite(ChannelId(1), ClanId(1), cx);
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 assert_eq!(
                     channels.categories_for_clan(ClanId(1))[0].channels.len(),
                     1,
@@ -5598,7 +5634,7 @@ mod tests {
                 );
 
                 channels.remove_channel_favorite(ChannelId(1), ClanId(1), cx);
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 assert!(
                     channels.categories_for_clan(ClanId(1))[0]
                         .channels
@@ -5614,15 +5650,19 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
-                channels.apply_clan_extras(ClanId(1), favorite_extras(&[]), cx);
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[]),
+                    cx,
+                );
                 channels.extras_loaded.insert(ClanId(1));
 
                 channels.apply_favorite_locally(ChannelId(1), ClanId(1), true, cx);
                 assert_eq!(channels.categories_for_clan(ClanId(1))[0].channels.len(), 1);
 
                 channels.apply_favorite_locally(ChannelId(1), ClanId(1), false, cx);
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
 
                 assert!(
                     channels.categories_for_clan(ClanId(1))[0]
@@ -5639,8 +5679,12 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
-                channels.apply_clan_extras(ClanId(1), favorite_extras(&[ChannelId(2)]), cx);
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[ChannelId(2)]),
+                    cx,
+                );
                 channels.extras_loaded.insert(ClanId(1));
 
                 channels.apply_favorite_locally(ChannelId(2), ClanId(1), false, cx);
@@ -5651,7 +5695,7 @@ mod tests {
                 );
 
                 channels.apply_favorite_locally(ChannelId(2), ClanId(1), true, cx);
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
 
                 assert_eq!(
                     channels.categories_for_clan(ClanId(1))[0].channels.len(),
@@ -5663,34 +5707,47 @@ mod tests {
     }
 
     #[gpui::test]
-    fn failed_favorites_fetch_keeps_favorites_and_stays_unloaded(cx: &mut gpui::TestAppContext) {
+    fn the_first_structure_apply_already_carries_favorites(cx: &mut gpui::TestAppContext) {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
-                channels.finish_extras(ClanId(1), favorite_extras(&[ChannelId(2)]), cx);
-                assert!(channels.extras_loaded.contains(&ClanId(1)));
-
-                channels.extras_loaded.remove(&ClanId(1));
-                channels.finish_extras(
+                channels.apply_clan_structure(
                     ClanId(1),
-                    ClanExtras {
-                        voice_map: Some(HashMap::new()),
-                        favorite_ids: None,
-                        app_channels: None,
-                    },
+                    structure_with_two_channels(),
+                    favor_ids(&[ChannelId(2)]),
                     cx,
                 );
+
+                let favor = &channels.categories_for_clan(ClanId(1))[0];
+                assert_eq!(favor.id, FAVOR_CATE_ID);
+                assert_eq!(
+                    favor.channels.len(),
+                    1,
+                    "favorites ride along with the structure, so the first paint is already correct"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn failed_favorites_fetch_keeps_favorites(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[ChannelId(2)]),
+                    cx,
+                );
+
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
 
                 let favor = &channels.categories_for_clan(ClanId(1))[0];
                 assert_eq!(
                     favor.channels.len(),
                     1,
                     "a failed list_favorite_channels must not wipe known favorites"
-                );
-                assert!(
-                    !channels.extras_loaded.contains(&ClanId(1)),
-                    "a failed fetch must leave the gate open so the next clan entry retries"
                 );
             });
         });
@@ -5704,12 +5761,11 @@ mod tests {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
                 channels.load_for_clan(ClanId(1), cx);
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 channels.finish_extras(
                     ClanId(1),
                     ClanExtras {
                         voice_map: None,
-                        favorite_ids: None,
                         app_channels: None,
                     },
                     cx,
@@ -5724,7 +5780,7 @@ mod tests {
                 );
 
                 channels.extras_loading.clear();
-                channels.finish_extras(ClanId(1), favorite_extras(&[ChannelId(2)]), cx);
+                channels.finish_extras(ClanId(1), complete_extras(), cx);
                 channels.load_for_clan(ClanId(1), cx);
                 assert!(
                     channels.extras_loading.is_empty(),
@@ -5784,7 +5840,7 @@ mod tests {
                     )]),
                 );
 
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 assert_eq!(
                     channels.channel(ClanId(1), ChannelId(1)).unwrap().badge_count,
                     4,
@@ -5807,7 +5863,7 @@ mod tests {
                 {
                     ch.badge_count = 0;
                 }
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 assert_eq!(
                     channels.channel(ClanId(1), ChannelId(1)).unwrap().badge_count,
                     4,
@@ -5825,7 +5881,7 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 channels.note_channel_message(ClanId(1), ChannelId(1), true, false, 100, MessageId(9), cx);
                 assert_eq!(
                     channels.channel(ClanId(1), ChannelId(1)).unwrap().badge_count,
@@ -5833,7 +5889,7 @@ mod tests {
                     "a realtime mention must bump the live badge"
                 );
 
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 assert_eq!(
                     channels.channel(ClanId(1), ChannelId(1)).unwrap().badge_count,
                     1,
@@ -5852,7 +5908,7 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 {
                     let cats = channels.cache.get_mut(&ClanId(1)).unwrap();
                     for ch in cats.iter_mut().flat_map(|c| c.channels.iter_mut()) {
@@ -5865,7 +5921,7 @@ mod tests {
                     }
                 }
 
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 let ch = channels.channel(ClanId(1), ChannelId(1)).unwrap();
                 assert_eq!(
                     (ch.last_sent_timestamp, ch.last_seen_timestamp),
@@ -5881,7 +5937,7 @@ mod tests {
                         ch.last_seen_message_id = MessageId(70);
                     }
                 }
-                channels.apply_clan_structure(ClanId(1), fresher, cx);
+                channels.apply_clan_structure(ClanId(1), fresher, None, cx);
                 let ch = channels.channel(ClanId(1), ChannelId(1)).unwrap();
                 assert_eq!(
                     ch.last_seen_timestamp, 700,
@@ -5909,7 +5965,7 @@ mod tests {
                     cx,
                 );
 
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 let ch = channels.channel(ClanId(1), ChannelId(1)).unwrap();
                 assert_eq!(
                     ch.badge_count, 1,
@@ -5948,7 +6004,7 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 channels.note_channel_message(
                     ClanId(1),
                     ChannelId(1),
@@ -5979,7 +6035,7 @@ mod tests {
                         },
                     )]),
                 );
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 let ch = channels.channel(ClanId(1), ChannelId(1)).unwrap();
                 assert_eq!(
                     ch.badge_count, 1,
@@ -6071,7 +6127,7 @@ mod tests {
                         },
                     )]),
                 );
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 assert_eq!(
                     channels
                         .channel(ClanId(1), ChannelId(1))
@@ -6097,7 +6153,7 @@ mod tests {
                     "marking the category read must evict the channel from the parked seed"
                 );
 
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 assert_eq!(
                     channels
                         .channel(ClanId(1), ChannelId(1))
@@ -6116,7 +6172,7 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
                 channels.load_for_clan(ClanId(1), cx);
 
                 assert!(
@@ -6139,8 +6195,8 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
-                channels.finish_extras(ClanId(1), favorite_extras(&[ChannelId(2)]), cx);
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
+                channels.finish_extras(ClanId(1), complete_extras(), cx);
 
                 assert!(
                     channels.extras_loaded.contains(&ClanId(1)),
@@ -6155,17 +6211,17 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.finish_extras(ClanId(1), favorite_extras(&[ChannelId(2)]), cx);
+                channels.finish_extras(ClanId(1), complete_extras(), cx);
                 assert!(
                     !channels.extras_loaded.contains(&ClanId(1)),
                     "extras that could not be applied must be re-requested"
                 );
 
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), cx);
-                assert_eq!(
-                    channels.categories_for_clan(ClanId(1))[0].channels.len(),
-                    1,
-                    "the favorite ids are kept even when the structure arrives later"
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
+                channels.finish_extras(ClanId(1), complete_extras(), cx);
+                assert!(
+                    channels.extras_loaded.contains(&ClanId(1)),
+                    "the retry lands once the structure is there to patch"
                 );
             });
         });

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -2029,7 +2029,7 @@ impl ChannelList {
         &mut self,
         clan_id: ClanId,
         channel_id: ChannelId,
-        new_badge: u32,
+        cleared_badge: u32,
         seen_ts: i64,
         seen_message_id: MessageId,
         cx: &mut Context<Self>,
@@ -2038,7 +2038,7 @@ impl ChannelList {
             target: "badge_flow",
             clan = clan_id.get(),
             channel = channel_id.get(),
-            new_badge,
+            cleared_badge,
             seen_ts,
             "apply_last_seen (realtime LastSeenUpdated)"
         );
@@ -2055,7 +2055,7 @@ impl ChannelList {
             {
                 let was_unread = ch.is_unread();
                 let was_badge = ch.badge_count;
-                ch.badge_count = new_badge;
+                ch.badge_count = 0;
                 if seen_ts > ch.last_seen_timestamp {
                     ch.last_seen_timestamp = seen_ts;
                 }
@@ -2065,9 +2065,7 @@ impl ChannelList {
                 if !computed {
                     computed = true;
                     visible_changed = was_unread != ch.is_unread() || was_badge != ch.badge_count;
-                    if was_badge > new_badge {
-                        badge_delta = was_badge - new_badge;
-                    }
+                    badge_delta = was_badge;
                 }
             }
         }
@@ -5869,6 +5867,52 @@ mod tests {
                     4,
                     "a later refetch (e.g. after the clan's CACHE_TTL expires) must reapply the \
                      seed itself — the zeroed live rows prove the carry cannot mask this"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn last_seen_echo_never_repaints_the_badge_it_just_cleared(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
+                channels.note_channel_message(
+                    ClanId(1),
+                    ChannelId(1),
+                    true,
+                    false,
+                    100,
+                    MessageId(9),
+                    cx,
+                );
+                channels.apply_read(ClanId(1), ChannelId(1), cx);
+                assert_eq!(
+                    channels
+                        .channel(ClanId(1), ChannelId(1))
+                        .unwrap()
+                        .badge_count,
+                    0
+                );
+
+                channels.apply_last_seen(ClanId(1), ChannelId(1), 1, 100, MessageId(9), cx);
+                assert_eq!(
+                    channels
+                        .channel(ClanId(1), ChannelId(1))
+                        .unwrap()
+                        .badge_count,
+                    0,
+                    "LastSeenUpdated carries the badge count the writer CLEARED (React overrides \
+                     lastSeenMess.badge_count with the local count for exactly this reason), so \
+                     echoing our own read back must never repaint the row"
+                );
+                assert!(
+                    !channels
+                        .channel(ClanId(1), ChannelId(1))
+                        .unwrap()
+                        .is_unread(),
+                    "the row must stay read after its own echo"
                 );
             });
         });

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -7,7 +7,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use futures::FutureExt as _;
 use futures::future::Shared;
-use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Subscription, Task};
+use gpui::{
+    App, AppContext, BackgroundExecutor, Context, Entity, EventEmitter, Global, Subscription, Task,
+};
 use mezon_client::transport::{ApiCategoryDesc, ApiChannelDesc, is_channel_limit_api_error};
 use mezon_client::{
     ApiChannelApp, AppApi, ChannelAppLaunchParams, ConnectionStatus, RealtimeEvent,
@@ -30,6 +32,7 @@ const CATEGORY_EVENT_UPDATED: i32 = 2;
 const PREVIOUS_CHANNELS_PERSIST_DEBOUNCE: Duration = Duration::from_millis(500);
 const BADGE_SEED_MAX_ATTEMPTS: u32 = 3;
 const BADGE_SEED_RETRY_BACKOFF: Duration = Duration::from_millis(400);
+const FAVORITES_PAINT_BUDGET: Duration = Duration::from_millis(1500);
 const CHANNEL_DETAIL_MAX_ATTEMPTS: u32 = 3;
 const CHANNEL_DETAIL_RETRY_BACKOFF: Duration = Duration::from_secs(1);
 const THREAD_ARCHIVE_DURATION_SECONDS: i64 = 7 * 24 * 60 * 60;
@@ -692,7 +695,6 @@ impl ChannelList {
                     );
                 }
                 this.pending_badge_seed.insert(clan_id, seed);
-                this.sync_clan_after_read(clan_id, 0, cx);
                 if applied {
                     this.notify_channel_list(clan_id, cx);
                 }
@@ -754,7 +756,6 @@ impl ChannelList {
     pub fn load_for_clan(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
         self.want_extras.insert(clan_id);
         if self.cache.is_fresh(&clan_id, crate::CACHE_TTL) {
-            self.sync_clan_after_read(clan_id, 0, cx);
             self.ensure_extras(clan_id, cx);
             return;
         }
@@ -861,6 +862,8 @@ impl ChannelList {
         favorite_ids: Option<HashSet<ChannelId>>,
         cx: &mut Context<Self>,
     ) {
+        let favorites_missing = favorite_ids.is_none();
+        let favorites_len = favorite_ids.as_ref().map(HashSet::len);
         if let Some(favorite_ids) = favorite_ids {
             self.favorites.insert(clan_id, favorite_ids);
         }
@@ -883,6 +886,16 @@ impl ChannelList {
         }
         self.sync_user_channels_from_clan_structure(&categories, cx);
         self.cache.insert(clan_id, categories, None);
+        if favorites_missing {
+            self.cache.mark_stale(&clan_id);
+        }
+        tracing::debug!(
+            target: "clan_load",
+            clan_id = clan_id.get(),
+            favorites = favorites_len,
+            stale = favorites_missing,
+            "clan structure applied"
+        );
         self.invalidate_channel_index(clan_id);
         self.channel_detail_failed.clear();
         self.sync_clan_after_read(clan_id, 0, cx);
@@ -899,9 +912,10 @@ impl ChannelList {
         }
         let api = self.api.clone();
         let generation = self.reset_generation;
+        let executor = cx.background_executor().clone();
         let task = cx
             .spawn(async move |this, cx| {
-                let result = Self::fetch_clan_structure(&api, clan_id).await;
+                let result = Self::fetch_clan_structure(&api, clan_id, executor).await;
                 match result {
                     Ok((categories, favorite_ids)) => {
                         let _ = this.update(cx, |this, cx| {
@@ -1069,16 +1083,16 @@ impl ChannelList {
     async fn fetch_clan_structure(
         api: &AppApi,
         clan_id: ClanId,
+        executor: BackgroundExecutor,
     ) -> anyhow::Result<(Vec<Category>, Option<HashSet<ChannelId>>)> {
-        let (channels_res, categories_res, favorites_res) = tokio::join!(
+        let (channels_res, categories_res, favorite_ids) = tokio::join!(
             api.list_channel_descs(clan_id.get(), 1),
             api.list_categories_typed(clan_id.get()),
-            api.list_favorite_channels(clan_id.get()),
+            fetch_favorites_within_paint_budget(api, clan_id, &executor),
         );
 
         let api_channels = channels_res?;
         let api_categories = categories_res?;
-        let favorite_ids = parse_favorite_ids(favorites_res);
 
         let mut channels: Vec<Channel> = api_channels
             .into_iter()
@@ -3692,13 +3706,45 @@ fn carry_live_channel_badges(
     }
 }
 
-fn parse_favorite_ids(result: anyhow::Result<Vec<String>>) -> Option<HashSet<ChannelId>> {
+async fn fetch_favorites_within_paint_budget(
+    api: &AppApi,
+    clan_id: ClanId,
+    executor: &BackgroundExecutor,
+) -> Option<HashSet<ChannelId>> {
+    let favorites = std::pin::pin!(api.list_favorite_channels(clan_id.get()));
+    let budget = std::pin::pin!(executor.timer(FAVORITES_PAINT_BUDGET));
+    match futures::future::select(favorites, budget).await {
+        futures::future::Either::Left((result, _)) => parse_favorite_ids(result, clan_id),
+        futures::future::Either::Right(_) => {
+            tracing::warn!(
+                target: "clan_load",
+                clan_id = clan_id.get(),
+                budget_ms = FAVORITES_PAINT_BUDGET.as_millis(),
+                "list_favorite_channels outran the paint budget, painting the sidebar without it"
+            );
+            None
+        }
+    }
+}
+
+fn parse_favorite_ids(
+    result: anyhow::Result<Vec<String>>,
+    clan_id: ClanId,
+) -> Option<HashSet<ChannelId>> {
     result
-        .inspect_err(|e| tracing::warn!("list_favorite_channels failed: {e}"))
+        .inspect_err(|e| tracing::warn!("list_favorite_channels failed for clan {clan_id}: {e}"))
         .ok()
         .map(|ids| {
             ids.into_iter()
-                .filter_map(|s| s.parse::<ChannelId>().ok())
+                .filter_map(|s| match s.parse::<ChannelId>() {
+                    Ok(id) => Some(id),
+                    Err(e) => {
+                        tracing::warn!(
+                            "list_favorite_channels returned an unparseable id {s:?} for clan {clan_id}: {e}"
+                        );
+                        None
+                    }
+                })
                 .collect()
         })
 }
@@ -5747,6 +5793,53 @@ mod tests {
                     1,
                     "a failed list_favorite_channels must not wipe known favorites"
                 );
+                assert!(
+                    !channels.cache.is_fresh(&ClanId(1), crate::CACHE_TTL),
+                    "a failed fetch must leave the gate open so the next clan entry retries"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn a_structure_carrying_favorites_is_stamped_fresh(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[ChannelId(2)]),
+                    cx,
+                );
+
+                assert!(
+                    channels.cache.is_fresh(&ClanId(1), crate::CACHE_TTL),
+                    "a complete structure must be pinned for the TTL"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn favorites_carry_a_parsed_id_and_drop_an_unparseable_one(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                let parsed = parse_favorite_ids(
+                    Ok(vec!["2".to_string(), "not-an-id".to_string()]),
+                    ClanId(1),
+                );
+                assert_eq!(parsed, Some([ChannelId(2)].into_iter().collect()));
+
+                assert_eq!(
+                    parse_favorite_ids(Err(anyhow::anyhow!("socket error")), ClanId(1)),
+                    None,
+                    "a favorites error must map to None so the structure still paints"
+                );
+
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), parsed, cx);
+                assert_eq!(channels.categories_for_clan(ClanId(1))[0].channels.len(), 1);
             });
         });
     }
@@ -5759,7 +5852,12 @@ mod tests {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
                 channels.load_for_clan(ClanId(1), cx);
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[]),
+                    cx,
+                );
                 channels.finish_extras(
                     ClanId(1),
                     ClanExtras {
@@ -6216,7 +6314,12 @@ mod tests {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
             channels.update(cx, |channels, cx| {
-                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[]),
+                    cx,
+                );
                 channels.load_for_clan(ClanId(1), cx);
 
                 assert!(


### PR DESCRIPTION
Entering a clan painted the sidebar twice. The structure round-trip (ListChannelDescs + ListCategories) resolved and notified first, and only then did apply_clan_structure kick off the extras round-trip that carried ListFavoriteChannels. On the first visit to a clan there was nothing in self.favorites yet, so the first paint had no favorites category and the second one inserted it, pushing every row below it down — one visible jump per clan, every session.

Move ListFavoriteChannels into the structure join, where it costs nothing: the three requests are concurrent and it returns a list of ids. apply_clan_structure seeds self.favorites before rebuilding, so the first paint is already correct and the extras round-trip is left with voice and apps. Keep the fetch tolerant — a favorites failure yields None and the previously known ids stand, rather than failing the whole structure or emptying the category.