### PR TITLE
feat(emoji): give emoji, stickers and reactions their own bounded caches

### DIFF
--- a/crates/mezon-store/src/message.rs
+++ b/crates/mezon-store/src/message.rs
@@ -8,6 +8,7 @@ use mezon_client::transport::{
 };
 
 use crate::album_layout::AlbumLayout;
+use crate::config::AppConfig;
 use crate::ids::{ChannelId, MessageId, UserId};
 use crate::message_time::{format_local_time_hhmm, local_datetime, local_day_key};
 
@@ -1444,6 +1445,31 @@ pub fn message_sort_key(m: &Message) -> (u8, i64) {
 
 pub fn sort_messages(messages: &mut [Message]) {
     messages.sort_by_key(message_sort_key);
+}
+
+/// The 2x source size an emoji span is painted at: a message of only emoji
+/// renders them jumbo, everything else inline. Resolved once here, when the
+/// message is built, because the render path would otherwise rebuild the same
+/// imgproxy URL for every emoji of every visible message on every frame.
+const INLINE_EMOJI_SOURCE_PX: u32 = 48;
+const JUMBO_EMOJI_SOURCE_PX: u32 = 96;
+
+pub fn fill_emoji_sources(spans: &mut [MessageSpan], cfg: Option<&AppConfig>) {
+    let Some(cfg) = cfg else {
+        return;
+    };
+    let source_px = if spans_only_emoji(spans) {
+        JUMBO_EMOJI_SOURCE_PX
+    } else {
+        INLINE_EMOJI_SOURCE_PX
+    };
+    for span in spans.iter_mut() {
+        if let MessageSpan::Emoji { emoji_id, src, .. } = span
+            && !emoji_id.is_empty()
+        {
+            *src = cfg.emoji_src_sized(emoji_id, source_px).into();
+        }
+    }
 }
 
 impl Message {

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -3909,7 +3909,9 @@ impl MessagesStore {
                 mk,
                 ..Default::default()
             };
-            optimistic = optimistic.with_spans(parse_spans(&tokens));
+            let mut optimistic_spans = parse_spans(&tokens);
+            crate::message::fill_emoji_sources(&mut optimistic_spans, AppConfig::try_global(cx));
+            optimistic = optimistic.with_spans(optimistic_spans);
             if ogp.is_some() {
                 optimistic =
                     optimistic.with_ogp(build_ogp_preview(&tokens, AppConfig::try_global(cx)));
@@ -6745,15 +6747,7 @@ fn message_from_api(m: ApiMessage, cfg: Option<&AppConfig>, viewer_id: Option<Us
         .map(|c| c.avatar_proxy(&m.avatar))
         .unwrap_or_else(|| m.avatar.clone());
     let mut spans = parse_spans(&m.content_tokens);
-    if let Some(cfg) = cfg {
-        for span in &mut spans {
-            if let MessageSpan::Emoji { emoji_id, src, .. } = span
-                && !emoji_id.is_empty()
-            {
-                *src = cfg.emoji_src(emoji_id).into();
-            }
-        }
-    }
+    crate::message::fill_emoji_sources(&mut spans, cfg);
     let mention_targets: Vec<MentionTarget> = m
         .entity_mentions
         .iter()

--- a/crates/mezon-ui/src/chat/gif_sticker_emoji/sticker_panel.rs
+++ b/crates/mezon-ui/src/chat/gif_sticker_emoji/sticker_panel.rs
@@ -18,9 +18,7 @@ const STICKER_CELL_PX: f32 = 92.;
 const STICKER_IMG_PX: f32 = 80.;
 const STICKER_ROW_PX: f32 = 104.;
 const HEADER_PX: f32 = 40.;
-const STICKER_CACHE_CAPACITY: usize = 96;
-const STICKER_CACHE_BYTES: u64 = 12 * 1024 * 1024;
-const STICKER_ENTRY_MAX_BYTES: u64 = 4 * 1024 * 1024;
+const PREFETCH_ROWS: usize = 4;
 
 #[derive(Clone)]
 struct StickerCell {
@@ -59,6 +57,8 @@ pub struct StickerPanel {
     selected: Option<String>,
     empty_label: SharedString,
     list_state: ListState,
+    /// Last row the warm-ahead reached; the list closure runs per row per frame.
+    warmed_through: std::cell::Cell<usize>,
     list_dirty: bool,
     image_cache: Entity<LruImageCache>,
     _sub: Option<Subscription>,
@@ -78,9 +78,9 @@ impl StickerPanel {
         let image_cache = cx.new(|cx| {
             LruImageCache::sticker_thumbnail(
                 "gse-sticker-panel",
-                STICKER_CACHE_CAPACITY,
-                STICKER_CACHE_BYTES,
-                STICKER_ENTRY_MAX_BYTES,
+                crate::image_cache::STICKER_CACHE_CAPACITY,
+                crate::image_cache::STICKER_CACHE_BYTES,
+                crate::image_cache::STICKER_ENTRY_MAX_BYTES,
                 cx,
             )
         });
@@ -96,6 +96,7 @@ impl StickerPanel {
                 "chat.stickerPicker.noStickers",
             )),
             list_state: ListState::new(0, ListAlignment::Top, px(200.)),
+            warmed_through: std::cell::Cell::new(0),
             list_dirty: true,
             image_cache,
             _sub: sub,
@@ -168,6 +169,7 @@ impl StickerPanel {
     }
 
     fn rebuild(&mut self) {
+        self.warmed_through.set(0);
         let needle = self.query.trim().to_lowercase();
         let mut rows = Vec::new();
         let mut header_row = Vec::new();
@@ -198,6 +200,26 @@ impl StickerPanel {
         self.rows = rows;
         self.header_row = header_row;
         self.list_dirty = true;
+    }
+
+    /// Stickers a few rows below the one being painted. A cell only starts
+    /// fetching once it is on screen, so scrolling into fresh rows shows empty
+    /// squares for as long as the request takes; a sticker is a ~2 MB decode
+    /// when animated, so that wait is longer here than in the emoji grid.
+    fn sources_ahead(&self, row: usize) -> Vec<SharedString> {
+        let target = row + PREFETCH_ROWS;
+        if self.warmed_through.get() >= target {
+            return Vec::new();
+        }
+        self.warmed_through.set(target);
+        match self.rows.get(target) {
+            Some(PickerRow::Stickers(cells)) => cells
+                .iter()
+                .filter(|cell| !cell.src.is_empty())
+                .map(|cell| cell.src.clone())
+                .collect(),
+            _ => Vec::new(),
+        }
     }
 
     fn sync_list(&mut self) {
@@ -284,19 +306,26 @@ impl Render for StickerPanel {
 
         self.sync_list();
         let list_entity = entity.clone();
-        let list = list(self.list_state.clone(), move |ix, _window, cx| {
+        let list = list(self.list_state.clone(), move |ix, window, cx| {
             let theme = cx.theme().clone();
-            let this = list_entity.read(cx);
-            match this.rows.get(ix) {
-                Some(PickerRow::Header { cat_ix, collapsed }) => {
-                    match this.categories.get(*cat_ix) {
-                        Some(cat) => render_header(&theme, cat, *collapsed, &list_entity),
-                        None => div().h(px(HEADER_PX)).into_any_element(),
+            let (row, ahead, cache) = {
+                let this = list_entity.read(cx);
+                let row = match this.rows.get(ix) {
+                    Some(PickerRow::Header { cat_ix, collapsed }) => {
+                        match this.categories.get(*cat_ix) {
+                            Some(cat) => render_header(&theme, cat, *collapsed, &list_entity),
+                            None => div().h(px(HEADER_PX)).into_any_element(),
+                        }
                     }
-                }
-                Some(PickerRow::Stickers(cells)) => render_sticker_row(&theme, cells, &list_entity),
-                None => div().h(px(STICKER_ROW_PX)).into_any_element(),
-            }
+                    Some(PickerRow::Stickers(cells)) => {
+                        render_sticker_row(&theme, cells, &list_entity)
+                    }
+                    None => div().h(px(STICKER_ROW_PX)).into_any_element(),
+                };
+                (row, this.sources_ahead(ix), this.image_cache.clone())
+            };
+            warm_sticker_sources(&cache, ahead, window, cx);
+            row
         })
         .size_full();
 
@@ -460,4 +489,22 @@ fn initial_letter(name: &str) -> String {
         .next()
         .map(|c| c.to_uppercase().to_string())
         .unwrap_or_default()
+}
+
+/// Decode sticker rows that have not scrolled into view yet. The row being
+/// painted is built first, so it takes the pipeline's permits ahead of these.
+fn warm_sticker_sources(
+    cache: &Entity<LruImageCache>,
+    sources: Vec<SharedString>,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    if sources.is_empty() {
+        return;
+    }
+    cache.update(cx, |cache, cx| {
+        for src in sources {
+            cache.prefetch(&gpui::Resource::Uri(src.to_string().into()), window, cx);
+        }
+    });
 }

--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -460,6 +460,7 @@ pub struct MentionInput {
     toggle_bounds: Rc<Cell<Bounds<Pixels>>>,
     _popup_subs: Vec<Subscription>,
     avatar_cache: Entity<LruImageCache>,
+    emoji_cache: Entity<LruImageCache>,
     preview_cache: Entity<LruImageCache>,
     settings: Entity<Settings>,
     pending_attachments: Vec<PendingAttachment>,
@@ -561,6 +562,8 @@ fn write_clipboard_image(image: &Image, base: i64, index: usize) -> Option<PathB
     Some(path)
 }
 
+const SUGGESTION_EMOJI_SOURCE_PX: u32 = 48;
+
 impl MentionInput {
     pub fn new(
         placeholder: impl Into<SharedString>,
@@ -619,6 +622,7 @@ impl MentionInput {
         );
         let store_subs = Self::subscribe_pool_sources(cx);
         let avatar_cache = crate::image_cache::shared_avatar_cache(cx);
+        let emoji_cache = crate::image_cache::shared_emoji_cache(cx);
         let preview_cache = cx.new(|cx| {
             LruImageCache::avatar_thumbnail(
                 "composer-attachment-preview",
@@ -651,6 +655,7 @@ impl MentionInput {
             toggle_bounds: Rc::new(Cell::new(Bounds::default())),
             _popup_subs: Vec::new(),
             avatar_cache,
+            emoji_cache,
             preview_cache,
             settings,
             pending_attachments: Vec::new(),
@@ -1906,7 +1911,11 @@ impl MentionInput {
                 break;
             }
             if emoji.shortname.contains(&needle) {
-                let src = crate::util::imgproxy::emoji_url(cx, &emoji.emoji_id);
+                let src = crate::util::imgproxy::emoji_url_sized(
+                    cx,
+                    &emoji.emoji_id,
+                    SUGGESTION_EMOJI_SOURCE_PX,
+                );
                 out.push(Suggestion::Emoji(emoji.clone(), src.into()));
             }
         }
@@ -2297,7 +2306,13 @@ impl MentionInput {
                     let leading = if src.is_empty() {
                         None
                     } else {
-                        Some(img(src.clone()).size(px(22.)).into_any_element())
+                        Some(
+                            img(src.clone())
+                                .image_cache(&self.emoji_cache)
+                                .id("suggestion-emoji-frames")
+                                .size(px(22.))
+                                .into_any_element(),
+                        )
                     };
                     (
                         leading,

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -1801,11 +1801,11 @@ impl ChannelMessages {
         });
         let avatar_image_cache = crate::image_cache::shared_avatar_cache(cx);
         let icon_image_cache = cx.new(|cx| {
-            crate::image_cache::LruImageCache::icon_thumbnail(
+            crate::image_cache::LruImageCache::emoji_thumbnail(
                 "message-icons",
-                1024,
-                8 * 1024 * 1024,
-                256 * 1024,
+                crate::image_cache::MESSAGE_ICON_CACHE_CAPACITY,
+                crate::image_cache::MESSAGE_ICON_CACHE_BYTES,
+                crate::image_cache::EMOJI_ENTRY_MAX_BYTES,
                 cx,
             )
         });

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -38,6 +38,14 @@ const FACEBOOK_ACCENT: u32 = 0x18_77_f2;
 const SOCIAL_CARD_BG: u32 = 0x2b_2d_31;
 const EMOJI_SIZE: f32 = 24.;
 const EMOJI_JUMBO_SIZE: f32 = 48.;
+
+/// The image proxy is asked for the emoji at the size it will actually be
+/// painted on a 2x display. An atlas tile smaller than its box is magnified
+/// with a linear filter across a gutterless atlas, which samples the
+/// neighbouring tile -- the next animation frame -- into the emoji's edges.
+fn emoji_source_px(size: Pixels) -> u32 {
+    (f32::from(size) * 2.0).round().max(1.0) as u32
+}
 pub(crate) const INLINE_ICON_PLACEHOLDER: char = '\u{2800}';
 pub(crate) const ATTACHMENT_PLACEHOLDER: char = '\u{fffc}';
 const RICH_TEXT_PLAN_LIMIT: usize = 512;
@@ -177,7 +185,7 @@ fn render_message_content_with_options(
         );
     }
     let mut row = rich_content_row(body_color, options.inline);
-    let mut link_key = 0usize;
+    let mut span_key = 0usize;
     match msg
         .rich_layout
         .as_deref()
@@ -194,14 +202,14 @@ fn render_message_content_with_options(
                         ctx,
                         body_color,
                         emoji_size,
-                        &mut link_key,
+                        &mut span_key,
                     ),
                 };
             }
         }
         None => {
             for span in &msg.spans {
-                row = append_span(row, span, ctx, body_color, emoji_size, &mut link_key);
+                row = append_span(row, span, ctx, body_color, emoji_size, &mut span_key);
             }
         }
     }
@@ -565,13 +573,13 @@ fn render_mention_only_content(
         return div().into_any_element();
     }
     let mut row = rich_content_row(body_color, inline);
-    let mut link_key = 0usize;
+    let mut span_key = 0usize;
     for span in msg
         .spans
         .iter()
         .filter(|s| matches!(s, MessageSpan::Mention { .. }))
     {
-        row = append_span(row, span, ctx, body_color, px(EMOJI_SIZE), &mut link_key);
+        row = append_span(row, span, ctx, body_color, px(EMOJI_SIZE), &mut span_key);
     }
     if msg.is_edited {
         row = row.child(edited_marker(ctx.theme, ctx.locale));
@@ -697,7 +705,7 @@ fn render_selectable_segmented_spans(
                 let bounds = Rc::new(Cell::new(None));
                 segments.push(TextSegment::bounded(base..end, bounds.clone()));
                 row = row.child(SelectableRegion::new(
-                    render_emoji_span(name, emoji_id, src, body_color, ctx, emoji_size),
+                    render_emoji_span(name, emoji_id, src, body_color, ctx, emoji_size, base),
                     bounds,
                     is_selected.then(|| rgba(SELECTION_BG)),
                 ));
@@ -1624,7 +1632,7 @@ fn append_span(
     ctx: &RowCtx,
     body_color: gpui::Rgba,
     emoji_size: Pixels,
-    link_key: &mut usize,
+    span_key: &mut usize,
 ) -> gpui::Div {
     let theme = ctx.theme;
     match span {
@@ -1677,8 +1685,8 @@ fn append_span(
             ))
         }
         MessageSpan::Link { text, url, .. } => {
-            let key = *link_key;
-            *link_key += 1;
+            let key = *span_key;
+            *span_key += 1;
             row.child(message_link_element(
                 text,
                 &resolve_link_url(url, text),
@@ -1708,9 +1716,13 @@ fn append_span(
             name,
             emoji_id,
             src,
-        } => row.child(render_emoji_span(
-            name, emoji_id, src, body_color, ctx, emoji_size,
-        )),
+        } => {
+            let key = *span_key;
+            *span_key += 1;
+            row.child(render_emoji_span(
+                name, emoji_id, src, body_color, ctx, emoji_size, key,
+            ))
+        }
         MessageSpan::Canvas { title, .. } => row.child(render_canvas_chip(title.clone())),
         MessageSpan::Heading { level, text } => row.child(render_heading(*level, text.clone())),
     }
@@ -1863,9 +1875,10 @@ fn render_emoji_span(
     body_color: gpui::Rgba,
     ctx: &RowCtx,
     size: Pixels,
+    key: usize,
 ) -> AnyElement {
     let src: SharedString = if precomputed_src.is_empty() {
-        crate::util::imgproxy::emoji_url(ctx.app, emoji_id).into()
+        crate::util::imgproxy::emoji_url_sized(ctx.app, emoji_id, emoji_source_px(size)).into()
     } else {
         precomputed_src.clone()
     };
@@ -1881,6 +1894,7 @@ fn render_emoji_span(
         .image_cache(ctx.icon_cache.clone())
         .child(
             img(src)
+                .id(("msg-emoji-frames", key))
                 .size(size)
                 .object_fit(ObjectFit::Contain)
                 .with_fallback(super::reaction_detail::emoji_error_fallback(

--- a/crates/mezon-ui/src/chat/message/context.rs
+++ b/crates/mezon-ui/src/chat/message/context.rs
@@ -128,6 +128,10 @@ pub struct RowMemo {
     pub role_styles: HashMap<(Option<ClanId>, UserId), (Hsla, Option<SharedString>)>,
     /// message -> formatted head time label ("14:03" / "Yesterday at 14:03").
     pub time_labels: HashMap<MessageId, SharedString>,
+    /// emoji id -> reaction pill image url. Reactions are not precomputed by the
+    /// store the way message spans are, so without this the imgproxy url for
+    /// every pill of every visible message is rebuilt on every frame.
+    pub reaction_srcs: HashMap<SharedString, SharedString>,
     pub rich_text: HashMap<MessageId, RichTextRenderPlan>,
     pub selection_layouts: HashMap<MessageId, super::content::SelectableMessageLayoutCacheEntry>,
     pub selection_text_pieces:

--- a/crates/mezon-ui/src/chat/message/create_poll_modal.rs
+++ b/crates/mezon-ui/src/chat/message/create_poll_modal.rs
@@ -11,6 +11,8 @@ use crate::components::primitives::{
 };
 use crate::theme::ActiveTheme;
 
+const ANSWER_EMOJI_SOURCE_PX: u32 = 40;
+
 const MIN_ANSWERS: usize = 2;
 const MAX_ANSWERS: usize = 20;
 const MAX_QUESTION_LEN: usize = 300;
@@ -242,6 +244,7 @@ impl CreatePollModal {
 
 impl Render for CreatePollModal {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let emoji_cache = crate::image_cache::shared_emoji_cache(cx);
         let theme = cx.theme();
         let locale = self.locale.clone();
         let t = |key: &'static str| mezon_i18n::t(&locale, key).to_string();
@@ -323,10 +326,16 @@ impl Render for CreatePollModal {
                 .and_then(Option::as_ref)
                 .cloned();
             let emoji_glyph = match &emoji_id {
-                Some(id) => img(crate::util::imgproxy::emoji_url(cx, id))
-                    .size(px(20.))
-                    .flex_none()
-                    .into_any_element(),
+                Some(id) => img(crate::util::imgproxy::emoji_url_sized(
+                    cx,
+                    id,
+                    ANSWER_EMOJI_SOURCE_PX,
+                ))
+                .image_cache(&emoji_cache)
+                .id(("poll-answer-emoji-frames", index))
+                .size(px(20.))
+                .flex_none()
+                .into_any_element(),
                 None => Icon::new(IconName::Smile)
                     .size(px(20.))
                     .flex_none()

--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -1074,8 +1074,7 @@ fn render_photo(
             .w(px(att.display_width))
             .h(px(att.display_height))
             .rounded_md()
-            .overflow_hidden()
-            .bg(theme.bg_tertiary);
+            .overflow_hidden();
         el = el.when(
             !sending && !att.upload_failed && !att.presign_pending && !viewer_att.url.is_empty(),
             |d| {
@@ -1099,6 +1098,7 @@ fn render_photo(
                 .id(("msg-img-frames", msg.id.0 as usize))
                 .size_full()
                 .object_fit(ObjectFit::Cover)
+                .with_loading(move || div().size_full().bg(fallback_bg).into_any_element())
                 .with_fallback(move || {
                     div()
                         .size_full()
@@ -1165,8 +1165,7 @@ fn render_photo(
         .w(px(att.display_width))
         .h(px(att.display_height))
         .rounded_md()
-        .overflow_hidden()
-        .bg(theme.bg_tertiary);
+        .overflow_hidden();
     el = el.when(!is_sticker && !att.upload_failed, |d| {
         d.cursor_pointer().on_click(move |_, window, cx| {
             if !selection.borrow().has_selection() {
@@ -1187,6 +1186,7 @@ fn render_photo(
             .id(("msg-img-frames", msg.id.0 as usize))
             .size_full()
             .object_fit(object_fit)
+            .with_loading(move || div().size_full().bg(fallback_bg).into_any_element())
             .with_fallback(move || {
                 div()
                     .size_full()
@@ -1640,18 +1640,35 @@ pub fn recent_emoji_cells(emojis: &[Emoji], cx: &App) -> Vec<RecentEmojiCell> {
         .collect()
 }
 
-fn reaction_emoji_src(reaction: &Reaction, app: &gpui::App) -> SharedString {
+const REACTION_SRC_MEMO_LIMIT: usize = 512;
+
+fn reaction_emoji_src(reaction: &Reaction, ctx: &RowCtx) -> SharedString {
     if reaction.emoji_id.is_empty() || reaction.emoji_id.as_ref() == "0" {
         return SharedString::default();
     }
-    crate::util::imgproxy::emoji_url_sized(app, &reaction.emoji_id, REACTION_EMOJI_SOURCE_PX).into()
+    let mut memo = ctx.row_memo.borrow_mut();
+    if let Some(src) = memo.reaction_srcs.get(&reaction.emoji_id) {
+        return src.clone();
+    }
+    if memo.reaction_srcs.len() >= REACTION_SRC_MEMO_LIMIT {
+        memo.reaction_srcs.clear();
+    }
+    let src: SharedString = crate::util::imgproxy::emoji_url_sized(
+        ctx.app,
+        &reaction.emoji_id,
+        REACTION_EMOJI_SOURCE_PX,
+    )
+    .into();
+    memo.reaction_srcs
+        .insert(reaction.emoji_id.clone(), src.clone());
+    src
 }
 
 fn reaction_pill(reaction: &Reaction, message_id: MessageId, ctx: &RowCtx) -> AnyElement {
     let theme = ctx.theme;
     let reacted = !ctx.current_user_id.is_empty() && reaction.has_sender(ctx.current_user_id);
     let count_label = reaction.count_label.clone();
-    let src = reaction_emoji_src(reaction, ctx.app);
+    let src = reaction_emoji_src(reaction, ctx);
 
     let mut pill = div()
         .id(super::content::hashed_element_id(
@@ -1730,6 +1747,7 @@ fn reaction_pill(reaction: &Reaction, message_id: MessageId, ctx: &RowCtx) -> An
             .image_cache(ctx.icon_cache.clone())
             .child(
                 img(src)
+                    .id("reaction-emoji-frames")
                     .size(px(REACTION_EMOJI_PX))
                     .object_fit(ObjectFit::ScaleDown)
                     .with_fallback(emoji_error_fallback(
@@ -1835,6 +1853,7 @@ pub fn render_hover_actions(msg: &Message, is_different_day: bool, ctx: &RowCtx)
                         .size(px(RECENT_EMOJI_PX))
                         .object_fit(ObjectFit::ScaleDown)
                         .image_cache(&ctx.icon_cache)
+                        .id("recent-emoji-frames")
                         .with_fallback(emoji_error_fallback(
                             px(RECENT_EMOJI_PX),
                             theme.text_secondary,

--- a/crates/mezon-ui/src/chat/message/poll_card.rs
+++ b/crates/mezon-ui/src/chat/message/poll_card.rs
@@ -390,7 +390,7 @@ fn render_poll_label(
 ) -> AnyElement {
     let mut row = div().flex().flex_row().items_center().overflow_hidden();
     let mut cursor = base.map(SelectableSectionCursor::new);
-    for segment in &answer.segments {
+    for (segment_index, segment) in answer.segments.iter().enumerate() {
         match segment {
             PollLabelSegment::Text(text) => {
                 let range = cursor.as_mut().and_then(|cursor| cursor.inline(text));
@@ -415,7 +415,8 @@ fn render_poll_label(
                     .w(px(20.))
                     .h(px(20.))
                     .object_fit(ObjectFit::Contain)
-                    .image_cache(&ctx.avatar_cache)
+                    .image_cache(&ctx.icon_cache)
+                    .id(("poll-label-emoji-frames", segment_index))
                     .into_any_element();
                 if let Some(range) = range {
                     let bounds = Rc::new(Cell::new(None));

--- a/crates/mezon-ui/src/chat/message/reaction_detail.rs
+++ b/crates/mezon-ui/src/chat/message/reaction_detail.rs
@@ -11,6 +11,8 @@ use crate::components::primitives::{Avatar, Icon, IconName};
 use crate::image_cache::LruImageCache;
 use crate::theme::ActiveTheme;
 
+const HEADER_EMOJI_SOURCE_PX: u32 = 40;
+
 pub struct UserReactionPanel {
     message_id: MessageId,
     emoji_id: SharedString,
@@ -47,12 +49,14 @@ impl UserReactionPanel {
 
 impl Render for UserReactionPanel {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let emoji_cache = crate::image_cache::shared_emoji_cache(cx);
         let theme = cx.theme();
         let (count, senders) = MessagesStore::global(cx)
             .read(cx)
             .reaction_view(self.message_id, &self.emoji_id, &self.emoji)
             .unwrap_or((0, Vec::new()));
-        let emoji_src = crate::util::imgproxy::emoji_url(cx, &self.emoji_id);
+        let emoji_src =
+            crate::util::imgproxy::emoji_url_sized(cx, &self.emoji_id, HEADER_EMOJI_SOURCE_PX);
         let current_uid = BadgeService::global(cx).read(cx).current_user_id(cx);
         let is_dm = MessagesStore::global(cx).read(cx).is_dm();
         let clan_id = (!is_dm)
@@ -100,6 +104,8 @@ impl Render for UserReactionPanel {
                 .into_any_element()
         } else {
             img(SharedString::from(emoji_src))
+                .image_cache(&emoji_cache)
+                .id("reaction-panel-emoji-frames")
                 .size(px(20.))
                 .object_fit(ObjectFit::ScaleDown)
                 .with_fallback(emoji_error_fallback(px(20.), theme.text_muted))

--- a/crates/mezon-ui/src/chat/message/reaction_picker.rs
+++ b/crates/mezon-ui/src/chat/message/reaction_picker.rs
@@ -19,6 +19,7 @@ const ACCENT_BLUE: u32 = 0x5865f2;
 const CELL_PX: f32 = 36.;
 const EMOJI_PX: f32 = 32.;
 const ROW_PX: f32 = 48.;
+const PREFETCH_ROWS: usize = 8;
 const EMOJI_ROW_GAP: f32 = 12.;
 const PANEL_W: f32 = 500.;
 const PANEL_MAX_H: f32 = 512.;
@@ -85,10 +86,20 @@ pub struct ReactionPicker {
     collapsed: HashSet<String>,
     selected: Option<String>,
     hover_emoji: Option<(SharedString, SharedString)>,
+    /// The cell the pointer is over. Only that one animates: a grid is scanned
+    /// rather than watched, and animating every visible cell uploads all 24
+    /// frames of each to the sprite atlas and redraws the window at the rate of
+    /// whichever emoji is fastest. Animating what the pointer is on keeps the
+    /// motion where the eye is for a fraction of the cost.
+    hovered_cell: Option<SharedString>,
     embedded_search: bool,
     fill_container: bool,
     scroll: UniformListScrollHandle,
     image_cache: Entity<LruImageCache>,
+    /// Last row the warm-ahead reached. The list closure runs every frame while
+    /// scrolling, and re-walking the same rows to re-request images already in
+    /// flight is pure per-frame cost.
+    warmed_through: std::cell::Cell<usize>,
     _emoji_sub: Option<Subscription>,
     _search_sub: Subscription,
 }
@@ -149,11 +160,11 @@ impl ReactionPicker {
             })
         });
         let image_cache = cx.new(|cx| {
-            LruImageCache::avatar_thumbnail_small(
+            LruImageCache::icon_thumbnail(
                 "reaction-picker",
-                256,
-                12 * 1024 * 1024,
-                4 * 1024 * 1024,
+                crate::image_cache::EMOJI_PICKER_CACHE_CAPACITY,
+                crate::image_cache::EMOJI_PICKER_CACHE_BYTES,
+                crate::image_cache::ICON_ENTRY_MAX_BYTES,
                 cx,
             )
         });
@@ -168,15 +179,47 @@ impl ReactionPicker {
             collapsed: HashSet::new(),
             selected: None,
             hover_emoji: None,
+            hovered_cell: None,
             embedded_search,
             fill_container,
             scroll: UniformListScrollHandle::new(),
             image_cache,
+            warmed_through: std::cell::Cell::new(0),
             _emoji_sub: emoji_sub,
             _search_sub: search_sub,
         };
         picker.rebuild_snapshot(cx);
         picker
+    }
+
+    /// Emoji just past the bottom of the viewport. A cell only starts fetching
+    /// once it is painted, so scrolling into fresh rows shows empty squares for
+    /// as long as the request takes; warming the next rows means the images are
+    /// already decoded by the time they scroll in.
+    fn set_hovered_cell(&mut self, emoji_id: Option<SharedString>, cx: &mut Context<Self>) {
+        if self.hovered_cell != emoji_id {
+            self.hovered_cell = emoji_id;
+            cx.notify();
+        }
+    }
+
+    fn sources_below(&self, first_unseen_row: usize) -> Vec<SharedString> {
+        if self.warmed_through.get() == first_unseen_row {
+            return Vec::new();
+        }
+        self.warmed_through.set(first_unseen_row);
+        self.rows
+            .iter()
+            .skip(first_unseen_row)
+            .take(PREFETCH_ROWS)
+            .filter_map(|row| match row {
+                PickerRow::Emojis(emojis) => Some(emojis),
+                PickerRow::Header { .. } => None,
+            })
+            .flatten()
+            .filter(|emoji| !emoji.src.is_empty())
+            .map(|emoji| emoji.src.clone())
+            .collect()
     }
 
     fn rebuild_snapshot(&mut self, cx: &mut Context<Self>) {
@@ -239,6 +282,7 @@ impl ReactionPicker {
     }
 
     fn rebuild(&mut self) {
+        self.warmed_through.set(0);
         let query = self.query.trim().to_lowercase();
         let mut rows = Vec::new();
         let mut nav = Vec::new();
@@ -411,23 +455,34 @@ impl Render for ReactionPicker {
         let count = self.rows.len();
         let list_entity = entity.clone();
         let track_hover = self.embedded_search;
-        let list = uniform_list("reaction-picker-list", count, move |range, _window, cx| {
+        let list = uniform_list("reaction-picker-list", count, move |range, window, cx| {
             let theme = cx.theme().clone();
-            let this = list_entity.read(cx);
-            range
-                .map(|ix| match this.rows.get(ix) {
-                    Some(PickerRow::Header {
-                        name,
-                        icon,
-                        initial,
-                        collapsed,
-                    }) => render_header(&theme, name, icon, initial, *collapsed, &list_entity),
-                    Some(PickerRow::Emojis(emojis)) => {
-                        render_emoji_row(&theme, emojis, &list_entity, track_hover)
-                    }
-                    None => div().h(px(ROW_PX)).into_any_element(),
-                })
-                .collect::<Vec<_>>()
+            let (rows, ahead, cache) = {
+                let this = list_entity.read(cx);
+                let rows = range
+                    .clone()
+                    .map(|ix| match this.rows.get(ix) {
+                        Some(PickerRow::Header {
+                            name,
+                            icon,
+                            initial,
+                            collapsed,
+                        }) => render_header(&theme, name, icon, initial, *collapsed, &list_entity),
+                        Some(PickerRow::Emojis(emojis)) => render_emoji_row(
+                            &theme,
+                            emojis,
+                            &list_entity,
+                            track_hover,
+                            this.hovered_cell.as_ref(),
+                        ),
+                        None => div().h(px(ROW_PX)).into_any_element(),
+                    })
+                    .collect::<Vec<_>>();
+                let ahead = this.sources_below(range.end);
+                (rows, ahead, this.image_cache.clone())
+            };
+            warm_emoji_sources(&cache, ahead, window, cx);
+            rows
         })
         .track_scroll(&self.scroll)
         .flex_1();
@@ -481,6 +536,7 @@ impl Render for ReactionPicker {
                 el.when(!src.is_empty(), |el| {
                     el.child(
                         img(src)
+                            .id("picker-hover-emoji-frames")
                             .max_w(px(28.))
                             .max_h(px(28.))
                             .with_fallback(emoji_error_fallback(px(28.), text_muted)),
@@ -622,6 +678,7 @@ fn render_emoji_row(
     emojis: &[PickerEmoji],
     entity: &Entity<ReactionPicker>,
     track_hover: bool,
+    hovered_cell: Option<&SharedString>,
 ) -> AnyElement {
     let hover_bg = theme.bg_hover;
     let text_muted = theme.text_muted;
@@ -645,25 +702,32 @@ fn render_emoji_row(
             .cursor_pointer()
             .hover(|s| s.bg(hover_bg));
         if !emoji.src.is_empty() {
-            cell = cell.child(
-                img(emoji.src.clone())
-                    .size(px(EMOJI_PX))
-                    .object_fit(gpui::ObjectFit::Contain)
-                    .with_fallback(emoji_error_fallback(px(EMOJI_PX), text_muted)),
-            );
-        }
-        if track_hover {
-            let hover_ent = entity.clone();
-            let hover_name = emoji.emoji.clone();
-            let hover_src = emoji.src.clone();
-            cell = cell.on_hover(move |hovered, _window, cx| {
-                if *hovered {
-                    let name = hover_name.clone();
-                    let src = hover_src.clone();
-                    hover_ent.update(cx, |this, cx| this.set_hover_emoji(src, name, cx));
-                }
+            let image = img(emoji.src.clone())
+                .size(px(EMOJI_PX))
+                .object_fit(gpui::ObjectFit::Contain)
+                .with_fallback(emoji_error_fallback(px(EMOJI_PX), text_muted));
+            cell = cell.child(if hovered_cell == Some(&emoji.emoji_id) {
+                image.id("picker-emoji-frames").into_any_element()
+            } else {
+                image.into_any_element()
             });
         }
+        let hover_ent = entity.clone();
+        let hover_name = emoji.emoji.clone();
+        let hover_src = emoji.src.clone();
+        let hover_id = emoji.emoji_id.clone();
+        cell = cell.on_hover(move |hovered, _window, cx| {
+            let entered = *hovered;
+            let id = entered.then(|| hover_id.clone());
+            let name = hover_name.clone();
+            let src = hover_src.clone();
+            hover_ent.update(cx, |this, cx| {
+                this.set_hovered_cell(id, cx);
+                if entered && track_hover {
+                    this.set_hover_emoji(src, name, cx);
+                }
+            });
+        });
         let cell = cell.on_click(move |_event, _window, cx| {
             let emoji_id = emoji_id.to_string();
             let emoji = shortname.to_string();
@@ -674,4 +738,22 @@ fn render_emoji_row(
         row = row.child(cell);
     }
     row.into_any_element()
+}
+
+/// Ask the picker's cache to decode sources that are not on screen yet. Visible
+/// rows are built before this runs, so they take the pipeline's permits first.
+fn warm_emoji_sources(
+    cache: &Entity<LruImageCache>,
+    sources: Vec<SharedString>,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    if sources.is_empty() {
+        return;
+    }
+    cache.update(cx, |cache, cx| {
+        for src in sources {
+            cache.prefetch(&gpui::Resource::Uri(src.to_string().into()), window, cx);
+        }
+    });
 }

--- a/crates/mezon-ui/src/chat/voice.rs
+++ b/crates/mezon-ui/src/chat/voice.rs
@@ -1175,6 +1175,7 @@ fn reaction_float(r: &DisplayedReaction) -> AnyElement {
                 .justify_center()
                 .child(
                     img(r.emoji_src.clone())
+                        .id(("voice-reaction-frames", seq))
                         .size(px(40.))
                         .object_fit(ObjectFit::Contain)
                         .with_animation(
@@ -1208,7 +1209,10 @@ fn reaction_float(r: &DisplayedReaction) -> AnyElement {
         .into_any_element()
 }
 
-fn reactions_overlay(store: &VoiceStore) -> Option<AnyElement> {
+fn reactions_overlay(
+    store: &VoiceStore,
+    emoji_cache: Entity<crate::image_cache::LruImageCache>,
+) -> Option<AnyElement> {
     let reactions = store.displayed_reactions();
     if reactions.is_empty() {
         return None;
@@ -1218,6 +1222,7 @@ fn reactions_overlay(store: &VoiceStore) -> Option<AnyElement> {
             .absolute()
             .inset_0()
             .overflow_hidden()
+            .image_cache(emoji_cache)
             .children(reactions.iter().map(reaction_float))
             .into_any_element(),
     )
@@ -1357,6 +1362,9 @@ fn render_in_call(
         ),
     });
 
+    let emoji_cache = crate::image_cache::shared_emoji_cache(cx);
+    let reactions = reactions_overlay(voice.read(cx), emoji_cache);
+
     let theme = cx.theme();
     let connection_status: Option<(SharedString, Hsla, bool)> = if connecting {
         Some((
@@ -1484,7 +1492,7 @@ fn render_in_call(
             ))
         })
         .children(connection_toast)
-        .children(reactions_overlay(voice.read(cx)))
+        .children(reactions)
         .children(raised_hands_overlay(cx, channel.clan_id, voice.read(cx)))
         .children(mic_modal)
         .children(participant_menu)

--- a/crates/mezon-ui/src/components/primitives/context_menu.rs
+++ b/crates/mezon-ui/src/components/primitives/context_menu.rs
@@ -378,6 +378,7 @@ impl RenderOnce for ContextMenu {
                     let fallback_color = muted;
                     cell = cell.child(
                         img(SharedString::from(src))
+                            .id("quick-reaction-emoji-frames")
                             .size(px(QUICK_REACTION_EMOJI_PX))
                             .with_fallback(move || {
                                 div()
@@ -668,6 +669,7 @@ impl RenderOnce for ContextMenu {
                             if !src.is_empty() {
                                 row = row.child(
                                     img(SharedString::from(src))
+                                        .id("reaction-sub-emoji-frames")
                                         .size(px(QUICK_REACTION_EMOJI_PX))
                                         .flex_none()
                                         .with_fallback(move || {

--- a/crates/mezon-ui/src/image_cache.rs
+++ b/crates/mezon-ui/src/image_cache.rs
@@ -130,9 +130,35 @@ const SHARED_AVATAR_CACHE_BYTES: u64 = 24 * 1024 * 1024;
 const SHARED_SMALL_AVATAR_CACHE_BYTES: u64 = 12 * 1024 * 1024;
 const SHARED_ROLE_ICON_CACHE_CAPACITY: usize = 512;
 const SHARED_ROLE_ICON_CACHE_BYTES: u64 = 4 * 1024 * 1024;
-const ROLE_ICON_ENTRY_MAX_BYTES: u64 = 256 * 1024;
 const SHARED_EMOJI_CACHE_CAPACITY: usize = 256;
 const SHARED_EMOJI_CACHE_BYTES: u64 = 12 * 1024 * 1024;
+
+/// The emoji picker grid holds far more cells on screen at once than any other
+/// emoji surface, and every one of them may be animated. Its budget is sized so
+/// that a fully animated screenful still fits — an entry evicted while it is
+/// visible reloads immediately and blinks.
+/// Sized to hold a whole clan's emoji corpus rather than a screenful. The grid
+/// is scrolled back and forth, and an entry evicted between two passes costs a
+/// fresh fetch + decode, which shows as a cell that stays blank for seconds. A
+/// clan with ~700 emoji fits here when they are still images (16 KB each) and
+/// still keeps a few hundred animated ones (128 KB each) resident.
+pub const EMOJI_PICKER_CACHE_CAPACITY: usize = 1024;
+pub const EMOJI_PICKER_CACHE_BYTES: u64 = 48 * 1024 * 1024;
+
+/// The sticker panel, sized on the same reasoning as the emoji picker: a cell
+/// evicted between two passes of the same scroll costs a fetch and a decode
+/// before it paints again. Sticker cells are 92px, so an entry is far larger
+/// than an emoji's -- a still is ~100 KB and an animated one ~2 MB -- which is
+/// why this budget buys fewer of them.
+pub const STICKER_CACHE_CAPACITY: usize = 256;
+pub const STICKER_CACHE_BYTES: u64 = 32 * 1024 * 1024;
+pub const STICKER_ENTRY_MAX_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Emoji and role icons painted inside one channel's message list: reaction
+/// pills, inline `:emoji:` spans and role chips, all of which animate when the
+/// source does.
+pub const MESSAGE_ICON_CACHE_CAPACITY: usize = 1024;
+pub const MESSAGE_ICON_CACHE_BYTES: u64 = 16 * 1024 * 1024;
 
 struct SharedAvatarCache(Entity<LruImageCache>);
 impl Global for SharedAvatarCache {}
@@ -204,7 +230,7 @@ pub fn shared_role_icon_cache(cx: &mut App) -> Entity<LruImageCache> {
             "role-icons-shared",
             SHARED_ROLE_ICON_CACHE_CAPACITY,
             SHARED_ROLE_ICON_CACHE_BYTES,
-            ROLE_ICON_ENTRY_MAX_BYTES,
+            ICON_ENTRY_MAX_BYTES,
             cx,
         )
     });
@@ -249,11 +275,11 @@ pub fn shared_emoji_cache(cx: &mut App) -> Entity<LruImageCache> {
         return existing.0.clone();
     }
     let cache = cx.new(|cx| {
-        LruImageCache::avatar_thumbnail(
+        LruImageCache::emoji_thumbnail(
             "emoji-shared",
             SHARED_EMOJI_CACHE_CAPACITY,
             SHARED_EMOJI_CACHE_BYTES,
-            AVATAR_ENTRY_MAX_BYTES,
+            EMOJI_ENTRY_MAX_BYTES,
             cx,
         )
     });
@@ -378,6 +404,16 @@ const IMAGE_PIPELINE_CONCURRENCY: usize = 3;
 static IMAGE_PIPELINE_PERMITS: LazyLock<Arc<tokio::sync::Semaphore>> =
     LazyLock::new(|| Arc::new(tokio::sync::Semaphore::new(IMAGE_PIPELINE_CONCURRENCY)));
 
+/// Avatars, icons and emoji get their own, wider lane. [`IMAGE_PIPELINE_PERMITS`]
+/// is narrow because one message attachment can hold [`MESSAGE_ENTRY_MAX_BYTES`]
+/// while it decodes, so a handful in flight is already a lot of memory. These
+/// decode to at most [`AVATAR_ENTRY_MAX_BYTES`], and an emoji grid asks for a
+/// screenful at once: sharing the narrow lane makes the picker fill a few cells
+/// at a time, which reads as a panel that stays blank for seconds.
+const ICON_PIPELINE_CONCURRENCY: usize = 8;
+static ICON_PIPELINE_PERMITS: LazyLock<Arc<tokio::sync::Semaphore>> =
+    LazyLock::new(|| Arc::new(tokio::sync::Semaphore::new(ICON_PIPELINE_CONCURRENCY)));
+
 async fn acquire_image_pipeline_permit()
 -> Result<tokio::sync::OwnedSemaphorePermit, ImageCacheError> {
     IMAGE_PIPELINE_PERMITS
@@ -386,6 +422,17 @@ async fn acquire_image_pipeline_permit()
         .await
         .map_err(|_| {
             ImageCacheError::Other(Arc::new(anyhow::anyhow!("image pipeline semaphore closed")))
+        })
+}
+
+async fn acquire_icon_pipeline_permit() -> Result<tokio::sync::OwnedSemaphorePermit, ImageCacheError>
+{
+    ICON_PIPELINE_PERMITS
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|_| {
+            ImageCacheError::Other(Arc::new(anyhow::anyhow!("icon pipeline semaphore closed")))
         })
 }
 
@@ -448,11 +495,18 @@ pub const PREVIEW_ENTRY_MAX_BYTES: u64 = 4 * 1024 * 1024;
 /// blowing up RAM by refusing to retain anything decoded larger than this and
 /// negatively caching it (shown as the initials fallback instead).
 pub const AVATAR_ANIMATION_MAX_BYTES: u64 = 4 * 1024 * 1024;
-/// Every cache fed by the icon loader keeps a 256 KB per-entry cap, so an
-/// animated emoji or role icon has to be decimated to fit inside it. Decoding
-/// against the larger avatar budget instead produced entries the cache then
-/// threw away, leaving the error placeholder in place of the emoji.
-pub const ICON_ANIMATION_MAX_BYTES: u64 = 256 * 1024;
+/// Backstop for the emoji loaders. [`AnimationCaps::max_frames`] is what
+/// normally bounds an animation; this only binds when a source arrives larger
+/// than the surface that requested it, and it is sized to hold
+/// [`MESSAGE_EMOJI_MAX_FRAMES`] frames at [`MESSAGE_EMOJI_DECODE_MAX_PX`].
+pub const EMOJI_ANIMATION_MAX_BYTES: u64 = 896 * 1024;
+/// Per-entry cap for the caches the message/menu emoji loader feeds. A jumbo
+/// animated emoji is the largest legitimate entry, so the cap sits just above
+/// [`EMOJI_ANIMATION_MAX_BYTES`]; anything above that is a source we should not
+/// be keeping.
+pub const EMOJI_ENTRY_MAX_BYTES: u64 = 1024 * 1024;
+/// Per-entry cap for the picker's cache, which trades frames for cells.
+pub const ICON_ENTRY_MAX_BYTES: u64 = 512 * 1024;
 pub const AVATAR_ENTRY_MAX_BYTES: u64 = 2 * 1024 * 1024;
 pub const MESSAGE_ENTRY_MAX_BYTES: u64 = 32 * 1024 * 1024;
 pub const MESSAGE_ANIMATION_MAX_BYTES: u64 = MESSAGE_IMAGE_CACHE_BYTES / 4;
@@ -572,6 +626,9 @@ enum LoaderKind {
     AvatarThumbnail,
     AvatarThumbnailSmall,
     IconThumbnail,
+    /// Emoji painted next to text (messages, reaction pills, menus): decodes at
+    /// the surface's own 2x source size and keeps a watchable frame count.
+    EmojiThumbnail,
     GalleryThumbnail,
     /// Aspect-preserving, animation-preserving thumbnail for the sticker picker,
     /// capped at [`STICKER_DECODE_MAX_PX`].
@@ -688,6 +745,26 @@ impl LruImageCache {
         Self::with_loader(
             label,
             LoaderKind::IconThumbnail,
+            max_items,
+            max_bytes,
+            max_entry_bytes,
+            cx,
+        )
+    }
+
+    /// A cache for emoji painted next to text. Unlike [`Self::icon_thumbnail`]
+    /// it decodes up to a jumbo emoji's 2x size and keeps enough frames for the
+    /// animation to read as motion rather than as a slideshow.
+    pub fn emoji_thumbnail(
+        label: &'static str,
+        max_items: usize,
+        max_bytes: u64,
+        max_entry_bytes: u64,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self::with_loader(
+            label,
+            LoaderKind::EmojiThumbnail,
             max_items,
             max_bytes,
             max_entry_bytes,
@@ -1145,6 +1222,9 @@ impl LruImageCache {
             LoaderKind::IconThumbnail => {
                 AssetLogger::<IconImageLoader>::load(resource.clone(), cx).boxed()
             }
+            LoaderKind::EmojiThumbnail => {
+                AssetLogger::<EmojiImageLoader>::load(resource.clone(), cx).boxed()
+            }
             LoaderKind::GalleryThumbnail => {
                 AssetLogger::<GalleryImageLoader>::load(resource.clone(), cx).boxed()
             }
@@ -1202,6 +1282,15 @@ impl LruImageCache {
     }
 }
 
+impl LruImageCache {
+    /// Decode a resource that is not on screen yet so it is ready by the time it
+    /// scrolls into view. Takes the same path a painted `img()` takes, so it
+    /// fills the entry that element will look up rather than a parallel one.
+    pub fn prefetch(&mut self, resource: &Resource, window: &mut Window, cx: &mut App) {
+        let _ = self.load(resource, window, cx);
+    }
+}
+
 impl ImageCache for LruImageCache {
     fn load(
         &mut self,
@@ -1219,6 +1308,36 @@ impl ImageCache for LruImageCache {
 const AVATAR_DECODE_MAX_PX: u32 = 160;
 const AVATAR_SMALL_DECODE_MAX_PX: u32 = 80;
 const ICON_DECODE_MAX_PX: u32 = 64;
+/// How an animated GIF/WebP is bounded while decoding.
+///
+/// Frames are what an animation costs: every one is resident in RAM and, once
+/// painted, holds a sprite-atlas tile. `max_frames` bounds that count directly
+/// so the *size* of a frame stays free to match the surface, and `max_bytes` is
+/// the backstop for a source larger than the surface expects.
+///
+/// `max_px` must be at least the size the surface paints at on a 2x display.
+/// Atlas tiles are packed with no gutter and the shaders magnify with a linear
+/// filter, so an undersized tile does not merely look soft: sampling past its
+/// edge picks up the neighbouring tile, which for an animation is the adjacent
+/// frame, and the emoji drags a ghost of itself behind every movement.
+#[derive(Clone, Copy)]
+struct AnimationCaps {
+    max_px: u32,
+    max_frames: usize,
+    max_bytes: u64,
+}
+
+/// Emoji painted in the message list: a 24px inline `:emoji:` span, a 48px
+/// jumbo emoji in an emoji-only message, and the reaction pills between them.
+/// 96px covers the largest of those on a 2x display; each surface requests its
+/// own source size, so a small one decodes small and only jumbo pays for 96px.
+const MESSAGE_EMOJI_DECODE_MAX_PX: u32 = 96;
+/// How many frames an animated emoji keeps, on every surface. The picker used to
+/// keep fewer to fit a hundred cells in its budget, but the same emoji then
+/// played visibly choppier there than in a message, which reads as a bug rather
+/// than as a budget. Its cache is sized for this instead.
+const MESSAGE_EMOJI_MAX_FRAMES: usize = 24;
+
 const GALLERY_THUMB_DECODE_MAX_PX: u32 = 320;
 /// OGP link-preview thumbnails render at ≤200px tall; decode to 512px longest
 /// side (aspect-preserving, ~2x for retina) so a large external OG image
@@ -1250,13 +1369,14 @@ const STICKER_ANIMATION_MAX_BYTES: u64 = 2 * 1024 * 1024;
 fn load_avatar_scaled(
     source: Resource,
     max_px: u32,
+    animation: AnimationCaps,
     cx: &mut App,
 ) -> impl Future<Output = Result<Arc<RenderImage>, ImageCacheError>> + Send + 'static {
     let client = cx.http_client();
     let svg_renderer = cx.svg_renderer();
     let asset_source = cx.asset_source().clone();
     async move {
-        let _permit = acquire_image_pipeline_permit().await?;
+        let _permit = acquire_icon_pipeline_permit().await?;
         let bytes = match source.clone() {
             Resource::Path(uri) => {
                 if let Some(decoded) = decode_scaled_dynamic_path(uri.as_ref(), max_px) {
@@ -1295,14 +1415,7 @@ fn load_avatar_scaled(
         };
 
         if image::guess_format(&bytes).is_ok() {
-            let animation_budget = if max_px <= ICON_DECODE_MAX_PX {
-                ICON_ANIMATION_MAX_BYTES
-            } else if max_px <= AVATAR_SMALL_DECODE_MAX_PX {
-                AVATAR_ANIMATION_MAX_BYTES
-            } else {
-                AVATAR_ENTRY_MAX_BYTES
-            };
-            decode_avatar_image(&bytes, max_px, animation_budget)
+            decode_avatar_image(&bytes, max_px, animation)
         } else {
             svg_renderer
                 .render_single_frame(&bytes, 1.0)
@@ -1321,7 +1434,16 @@ impl Asset for AvatarImageLoader {
         source: Self::Source,
         cx: &mut App,
     ) -> impl Future<Output = Self::Output> + Send + 'static {
-        load_avatar_scaled(source, AVATAR_DECODE_MAX_PX, cx)
+        load_avatar_scaled(
+            source,
+            AVATAR_DECODE_MAX_PX,
+            AnimationCaps {
+                max_px: AVATAR_DECODE_MAX_PX,
+                max_frames: usize::MAX,
+                max_bytes: AVATAR_ENTRY_MAX_BYTES,
+            },
+            cx,
+        )
     }
 }
 
@@ -1335,7 +1457,16 @@ impl Asset for AvatarImageLoaderSmall {
         source: Self::Source,
         cx: &mut App,
     ) -> impl Future<Output = Self::Output> + Send + 'static {
-        load_avatar_scaled(source, AVATAR_SMALL_DECODE_MAX_PX, cx)
+        load_avatar_scaled(
+            source,
+            AVATAR_SMALL_DECODE_MAX_PX,
+            AnimationCaps {
+                max_px: AVATAR_SMALL_DECODE_MAX_PX,
+                max_frames: usize::MAX,
+                max_bytes: AVATAR_ANIMATION_MAX_BYTES,
+            },
+            cx,
+        )
     }
 }
 
@@ -1349,7 +1480,43 @@ impl Asset for IconImageLoader {
         source: Self::Source,
         cx: &mut App,
     ) -> impl Future<Output = Self::Output> + Send + 'static {
-        load_avatar_scaled(source, ICON_DECODE_MAX_PX, cx)
+        load_avatar_scaled(
+            source,
+            ICON_DECODE_MAX_PX,
+            AnimationCaps {
+                max_px: ICON_DECODE_MAX_PX,
+                max_frames: MESSAGE_EMOJI_MAX_FRAMES,
+                max_bytes: ICON_ENTRY_MAX_BYTES,
+            },
+            cx,
+        )
+    }
+}
+
+/// Emoji painted next to text: message spans, reaction pills, hover panels and
+/// menus. Each surface asks the image proxy for its own 2x source size, so this
+/// cap only binds for the largest of them (a jumbo emoji), and the frame count
+/// is what bounds the rest.
+pub enum EmojiImageLoader {}
+
+impl Asset for EmojiImageLoader {
+    type Source = Resource;
+    type Output = Result<Arc<RenderImage>, ImageCacheError>;
+
+    fn load(
+        source: Self::Source,
+        cx: &mut App,
+    ) -> impl Future<Output = Self::Output> + Send + 'static {
+        load_avatar_scaled(
+            source,
+            MESSAGE_EMOJI_DECODE_MAX_PX,
+            AnimationCaps {
+                max_px: MESSAGE_EMOJI_DECODE_MAX_PX,
+                max_frames: MESSAGE_EMOJI_MAX_FRAMES,
+                max_bytes: EMOJI_ANIMATION_MAX_BYTES,
+            },
+            cx,
+        )
     }
 }
 
@@ -1520,6 +1687,7 @@ where
 fn downscaled_avatar_animation_frames<I>(
     frames: I,
     max_px: u32,
+    frame_cap: usize,
     byte_budget: u64,
 ) -> Result<Vec<image::Frame>, AnimationDecodeError>
 where
@@ -1535,7 +1703,7 @@ where
         let side = buffer.width().min(buffer.height()).clamp(1, max_px);
         if max_frames == usize::MAX {
             let frame_bytes = u64::from(side) * u64::from(side) * 4;
-            max_frames = (byte_budget / frame_bytes).max(2) as usize;
+            max_frames = ((byte_budget / frame_bytes) as usize).clamp(2, frame_cap);
         }
 
         if source_index.is_multiple_of(stride) && out.len() >= max_frames {
@@ -1649,10 +1817,25 @@ fn reject_oversized_canvas(
     Ok(())
 }
 
+/// An animated WebP whose frames declare `DISPOSE_BACKGROUND` only disposes if
+/// the decoder has been given a background colour: `image-webp` reads the
+/// container's colour into a *hint* and leaves the field it actually composites
+/// with as `None`, so every frame alpha-blends onto the one before it and a
+/// moving sprite drags a trail of its own previous positions. Browsers clear to
+/// transparent black, which is what the GIF path does too -- ask for the same.
+fn animated_webp_decoder(
+    bytes: &[u8],
+) -> Result<image::codecs::webp::WebPDecoder<std::io::Cursor<&[u8]>>, ImageCacheError> {
+    let mut decoder = image::codecs::webp::WebPDecoder::new(std::io::Cursor::new(bytes))?;
+    image::ImageDecoder::set_limits(&mut decoder, decoder_limits())?;
+    decoder.set_background_color(image::Rgba([0, 0, 0, 0]))?;
+    Ok(decoder)
+}
+
 fn decode_avatar_image(
     bytes: &[u8],
     max_px: u32,
-    animation_byte_budget: u64,
+    animation: AnimationCaps,
 ) -> Result<Arc<RenderImage>, ImageCacheError> {
     use image::AnimationDecoder as _;
     let format = image::guess_format(bytes)?;
@@ -1663,8 +1846,9 @@ fn decode_avatar_image(
             image::ImageDecoder::set_limits(&mut decoder, decoder_limits())?;
             match downscaled_avatar_animation_frames(
                 decoder.into_frames(),
-                max_px,
-                animation_byte_budget,
+                animation.max_px,
+                animation.max_frames,
+                animation.max_bytes,
             ) {
                 Ok(frames) => frames,
                 Err(AnimationDecodeError::BudgetExceeded) => vec![avatar_frame(
@@ -1675,13 +1859,13 @@ fn decode_avatar_image(
             }
         }
         image::ImageFormat::WebP => {
-            let mut decoder = image::codecs::webp::WebPDecoder::new(std::io::Cursor::new(bytes))?;
-            image::ImageDecoder::set_limits(&mut decoder, decoder_limits())?;
+            let decoder = animated_webp_decoder(bytes)?;
             if decoder.has_animation() {
                 match downscaled_avatar_animation_frames(
                     decoder.into_frames(),
-                    max_px,
-                    animation_byte_budget,
+                    animation.max_px,
+                    animation.max_frames,
+                    animation.max_bytes,
                 ) {
                     Ok(frames) => frames,
                     Err(AnimationDecodeError::BudgetExceeded) => vec![avatar_frame(
@@ -1734,8 +1918,7 @@ fn decode_message_image(
             }
         }
         image::ImageFormat::WebP => {
-            let mut decoder = image::codecs::webp::WebPDecoder::new(std::io::Cursor::new(bytes))?;
-            image::ImageDecoder::set_limits(&mut decoder, decoder_limits())?;
+            let decoder = animated_webp_decoder(bytes)?;
             if decoder.has_animation() {
                 match downscaled_animation_frames(
                     decoder.into_frames(),
@@ -1744,9 +1927,7 @@ fn decode_message_image(
                 ) {
                     Ok(frames) => frames,
                     Err(AnimationDecodeError::BudgetExceeded) => {
-                        let mut decoder =
-                            image::codecs::webp::WebPDecoder::new(std::io::Cursor::new(bytes))?;
-                        image::ImageDecoder::set_limits(&mut decoder, decoder_limits())?;
+                        let decoder = animated_webp_decoder(bytes)?;
                         first_frame_fallback(decoder, static_max_px)?
                     }
                     Err(AnimationDecodeError::Image(err)) => return Err(err),
@@ -1967,13 +2148,18 @@ fn load_bounded(
     animation_max_px: u32,
     static_max_px: u32,
     animation_byte_budget: u64,
+    wide_lane: bool,
     cx: &mut App,
 ) -> impl Future<Output = Result<Arc<RenderImage>, ImageCacheError>> + Send + 'static {
     let client = cx.http_client();
     let svg_renderer = cx.svg_renderer();
     let asset_source = cx.asset_source().clone();
     async move {
-        let _permit = acquire_image_pipeline_permit().await?;
+        let _permit = if wide_lane {
+            acquire_icon_pipeline_permit().await?
+        } else {
+            acquire_image_pipeline_permit().await?
+        };
         let bytes = match source.clone() {
             Resource::Path(uri) => std::fs::read(uri.as_ref())?,
             Resource::Uri(uri) => {
@@ -2041,6 +2227,7 @@ impl Asset for SharedImageLoader {
             SHARED_ANIMATION_MAX_PX,
             SHARED_STATIC_MAX_PX,
             SHARED_ENTRY_MAX_BYTES,
+            false,
             cx,
         )
     }
@@ -2066,6 +2253,7 @@ impl Asset for StickerImageLoader {
             STICKER_DECODE_MAX_PX,
             STICKER_DECODE_MAX_PX,
             STICKER_ANIMATION_MAX_BYTES,
+            true,
             cx,
         )
     }
@@ -2350,31 +2538,104 @@ mod tests {
 
     #[test]
     fn picker_decode_caps_cover_two_x_their_largest_cell() {
-        const EMOJI_PICKER_LARGEST_LOGICAL_PX: u32 = 28;
+        const EMOJI_PICKER_LARGEST_LOGICAL_PX: u32 = 32;
         const STICKER_PANEL_CELL_LOGICAL_PX: u32 = 80;
-        const _: () = assert!(AVATAR_SMALL_DECODE_MAX_PX >= EMOJI_PICKER_LARGEST_LOGICAL_PX * 2);
+        const _: () = assert!(ICON_DECODE_MAX_PX >= EMOJI_PICKER_LARGEST_LOGICAL_PX * 2);
         const _: () = assert!(STICKER_DECODE_MAX_PX >= STICKER_PANEL_CELL_LOGICAL_PX * 2);
     }
 
     #[test]
+    fn every_emoji_surface_decodes_at_least_its_two_x_paint_size() {
+        const JUMBO_EMOJI_LOGICAL_PX: u32 = 48;
+        const PICKER_CELL_LOGICAL_PX: u32 = 32;
+
+        const _: () = assert!(
+            MESSAGE_EMOJI_DECODE_MAX_PX >= JUMBO_EMOJI_LOGICAL_PX * 2,
+            "atlas tiles carry no gutter and the shaders magnify with a linear filter, so a tile \
+             smaller than the box it is painted into samples past its own edge into the \
+             neighbouring tile -- for an animation that is the adjacent frame, and the emoji \
+             drags a ghost of itself behind every movement"
+        );
+        const _: () = assert!(
+            ICON_DECODE_MAX_PX >= PICKER_CELL_LOGICAL_PX * 2,
+            "the picker trades frame rate for cell count, never resolution, for the same reason"
+        );
+    }
+
+    const EMOJI_PICKER_VISIBLE_CELLS: u64 = 9 * 12;
+
+    #[test]
     fn a_screenful_of_picker_cells_fits_inside_its_cache_budget() {
-        const EMOJI_PICKER_VISIBLE_CELLS: u64 = 9 * 12;
-        const EMOJI_PICKER_CACHE_BYTES: u64 = 12 * 1024 * 1024;
         const STICKER_PANEL_VISIBLE_CELLS: u64 = 3 * 8;
-        const STICKER_PANEL_CACHE_BYTES: u64 = 12 * 1024 * 1024;
 
         let bytes_at_cap = |max_px: u32| u64::from(max_px) * u64::from(max_px) * 4;
 
         assert!(
-            bytes_at_cap(AVATAR_SMALL_DECODE_MAX_PX) * EMOJI_PICKER_VISIBLE_CELLS
+            bytes_at_cap(ICON_DECODE_MAX_PX) * EMOJI_PICKER_VISIBLE_CELLS
                 <= EMOJI_PICKER_CACHE_BYTES,
             "a screenful of emoji must fit the picker's budget: once the visible cells alone \
              exceed it, every frame evicts one of them and blinks a different cell"
         );
         assert!(
             bytes_at_cap(STICKER_DECODE_MAX_PX) * STICKER_PANEL_VISIBLE_CELLS
-                <= STICKER_PANEL_CACHE_BYTES,
+                <= STICKER_CACHE_BYTES,
             "a screenful of stickers must fit the sticker panel's budget for the same reason"
+        );
+    }
+
+    #[test]
+    fn a_screenful_of_animated_emoji_fits_inside_its_cache_budget() {
+        const MESSAGE_ANIMATED_EMOJI_WORKING_SET: u64 = 16;
+        const fn animated_entry_bytes(max_px: u32, max_frames: usize) -> u64 {
+            (max_px as u64) * (max_px as u64) * 4 * (max_frames as u64)
+        }
+        const PICKER_ENTRY: u64 =
+            animated_entry_bytes(ICON_DECODE_MAX_PX, MESSAGE_EMOJI_MAX_FRAMES);
+        const MESSAGE_ENTRY: u64 =
+            animated_entry_bytes(MESSAGE_EMOJI_DECODE_MAX_PX, MESSAGE_EMOJI_MAX_FRAMES);
+
+        const CLAN_EMOJI_CORPUS: u64 = 700;
+        const STILL_ENTRY: u64 = (ICON_DECODE_MAX_PX as u64) * (ICON_DECODE_MAX_PX as u64) * 4;
+
+        const _: () = assert!(
+            STILL_ENTRY * CLAN_EMOJI_CORPUS <= EMOJI_PICKER_CACHE_BYTES,
+            "the picker is scrolled back and forth, and an entry evicted between two passes costs \
+             a fetch and a decode before the cell paints again -- seconds of blank. Its budget \
+             holds a whole clan's emoji, not merely the screenful that is visible at once"
+        );
+        const _: () = assert!(
+            CLAN_EMOJI_CORPUS <= EMOJI_PICKER_CACHE_CAPACITY as u64,
+            "the item cap must not evict what the byte budget can still afford to keep"
+        );
+        const _: () = assert!(
+            PICKER_ENTRY * EMOJI_PICKER_VISIBLE_CELLS <= EMOJI_PICKER_CACHE_BYTES,
+            "an animated emoji holds every frame it decoded, so a grid where all of them animate \
+             costs a full animation budget per cell; once that exceeds the picker's byte budget \
+             the visible cells evict each other and the grid blinks"
+        );
+        const _: () = assert!(
+            MESSAGE_ENTRY * MESSAGE_ANIMATED_EMOJI_WORKING_SET <= MESSAGE_ICON_CACHE_BYTES,
+            "reaction pills, inline spans and jumbo emoji share one cache per channel view, and a \
+             screenful of distinct animated ones must fit it for the same reason"
+        );
+        const _: () = assert!(
+            MESSAGE_ENTRY <= EMOJI_ANIMATION_MAX_BYTES && MESSAGE_ENTRY <= EMOJI_ENTRY_MAX_BYTES,
+            "an entry decoded above the per-entry cap is thrown away and negatively cached, which \
+             shows the error placeholder instead of the emoji"
+        );
+        const _: () = assert!(PICKER_ENTRY <= ICON_ENTRY_MAX_BYTES);
+
+        const STICKER_PANEL_VISIBLE_CELLS: u64 = 3 * 8;
+        const STICKER_ANIMATED_ENTRY: u64 = STICKER_ANIMATION_MAX_BYTES;
+        const _: () = assert!(
+            STICKER_ANIMATED_ENTRY <= STICKER_ENTRY_MAX_BYTES,
+            "an animated sticker decoded above the per-entry cap is thrown away and negatively \
+             cached, which leaves the cell blank for the rest of the session"
+        );
+        const _: () = assert!(
+            STICKER_ANIMATED_ENTRY * (STICKER_PANEL_VISIBLE_CELLS / 2) <= STICKER_CACHE_BYTES,
+            "half a screenful of animated stickers must fit, or scrolling the panel evicts cells \
+             that are still on screen and they reload from the network on the way back"
         );
     }
 
@@ -2396,12 +2657,128 @@ mod tests {
                 encoder.encode_frame(frame).expect("GIF frame");
             }
         }
-        let image = decode_avatar_image(&bytes, AVATAR_SMALL_DECODE_MAX_PX, AVATAR_ENTRY_MAX_BYTES)
-            .expect("animated avatar");
+        let image = decode_avatar_image(
+            &bytes,
+            AVATAR_SMALL_DECODE_MAX_PX,
+            AnimationCaps {
+                max_px: AVATAR_SMALL_DECODE_MAX_PX,
+                max_frames: usize::MAX,
+                max_bytes: AVATAR_ENTRY_MAX_BYTES,
+            },
+        )
+        .expect("animated avatar");
         assert_eq!(image.frame_count(), 2);
         let size = image.size(0);
         assert_eq!(size.width, size.height);
         assert_eq!(image.delay(0), image::Delay::from_numer_denom_ms(50, 1));
+    }
+
+    /// A 64x64 animated WebP of a 16x16 sprite (opaque core, transparent margin,
+    /// so the file carries alpha like a real sticker) that jumps from y=0 to y=40.
+    /// Both frames are sub-rectangles flagged `DISPOSE_BACKGROUND`, which is how
+    /// the image proxy re-encodes an animated sticker. Built with:
+    ///   cwebp -lossless -exact sprite.png -o sprite.webp
+    ///   webpmux -frame sprite.webp +100+0+0+1+b -frame sprite.webp +100+0+40+1+b \
+    ///           -bgcolor 0,0,0,0 -loop 0 -o fixture.webp
+    const DISPOSE_BACKGROUND_WEBP: &[u8] = &[
+        0x52, 0x49, 0x46, 0x46, 0xa0, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
+        0x58, 0x0a, 0x00, 0x00, 0x00, 0x12, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x37, 0x00, 0x00,
+        0x41, 0x4e, 0x49, 0x4d, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x41,
+        0x4e, 0x4d, 0x46, 0x36, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f, 0x00,
+        0x00, 0x0f, 0x00, 0x00, 0x64, 0x00, 0x00, 0x01, 0x56, 0x50, 0x38, 0x4c, 0x1d, 0x00, 0x00,
+        0x00, 0x2f, 0x0f, 0xc0, 0x03, 0x10, 0x0f, 0x10, 0xf3, 0x1f, 0xf3, 0x1f, 0x0c, 0x82, 0x6c,
+        0x9b, 0x19, 0xcc, 0xdf, 0xf2, 0x12, 0xcb, 0x15, 0x22, 0xfa, 0x3f, 0x01, 0xe4, 0x7c, 0x48,
+        0x00, 0x41, 0x4e, 0x4d, 0x46, 0x36, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14, 0x00, 0x00,
+        0x0f, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x64, 0x00, 0x00, 0x01, 0x56, 0x50, 0x38, 0x4c, 0x1d,
+        0x00, 0x00, 0x00, 0x2f, 0x0f, 0xc0, 0x03, 0x10, 0x0f, 0x10, 0xf3, 0x1f, 0xf3, 0x1f, 0x0c,
+        0x82, 0x6c, 0x9b, 0x19, 0xcc, 0xdf, 0xf2, 0x12, 0xcb, 0x15, 0x22, 0xfa, 0x3f, 0x01, 0xe4,
+        0x7c, 0x48, 0x00,
+    ];
+
+    #[test]
+    fn an_animated_webp_disposes_the_frame_it_moved_away_from() {
+        let image = decode_message_image(
+            DISPOSE_BACKGROUND_WEBP,
+            MESSAGE_ANIMATION_MAX_PX,
+            MESSAGE_STATIC_MAX_PX,
+            MESSAGE_ANIMATION_MAX_BYTES,
+        )
+        .expect("animated webp");
+        assert_eq!(image.frame_count(), 2);
+
+        let size = image.size(1);
+        let width = size.width.0 as usize;
+        let bytes = image.as_bytes(1).expect("second frame");
+        let opaque_at = |y: usize| (0..width).any(|x| bytes[(y * width + x) * 4 + 3] > 8);
+
+        const FIRST_POSITION_ROW: usize = 8;
+        const SECOND_POSITION_ROW: usize = 48;
+
+        assert!(
+            opaque_at(SECOND_POSITION_ROW),
+            "the sprite must be drawn where the second frame places it"
+        );
+        assert!(
+            !opaque_at(FIRST_POSITION_ROW),
+            "the second frame declares DISPOSE_BACKGROUND on the rectangle the first one \
+             occupied, so the sprite's old position must be cleared; leaving it behind is what \
+             makes an animated sticker drag a trail of its own previous frames"
+        );
+    }
+
+    #[test]
+    fn the_picker_animates_an_emoji_as_smoothly_as_a_message_does() {
+        use image::codecs::gif::{GifEncoder, Repeat};
+        const SOURCE_FRAMES: u32 = 48;
+
+        let mut bytes = Vec::new();
+        {
+            let mut encoder = GifEncoder::new(&mut bytes);
+            encoder.set_repeat(Repeat::Infinite).expect("GIF repeat");
+            for index in 0..SOURCE_FRAMES {
+                let buffer = image::RgbaImage::from_pixel(
+                    100,
+                    100,
+                    image::Rgba([(index * 5) as u8, 0, 0, 255]),
+                );
+                let frame = image::Frame::from_parts(
+                    buffer,
+                    0,
+                    0,
+                    image::Delay::from_numer_denom_ms(30, 1),
+                );
+                encoder.encode_frame(frame).expect("GIF frame");
+            }
+        }
+
+        let decode = |max_px: u32, caps: AnimationCaps| {
+            decode_avatar_image(&bytes, max_px, caps)
+                .expect("animated emoji")
+                .frame_count()
+        };
+        let in_message = decode(
+            MESSAGE_EMOJI_DECODE_MAX_PX,
+            AnimationCaps {
+                max_px: MESSAGE_EMOJI_DECODE_MAX_PX,
+                max_frames: MESSAGE_EMOJI_MAX_FRAMES,
+                max_bytes: EMOJI_ANIMATION_MAX_BYTES,
+            },
+        );
+        let in_picker = decode(
+            ICON_DECODE_MAX_PX,
+            AnimationCaps {
+                max_px: ICON_DECODE_MAX_PX,
+                max_frames: MESSAGE_EMOJI_MAX_FRAMES,
+                max_bytes: ICON_ENTRY_MAX_BYTES,
+            },
+        );
+
+        assert_eq!(
+            in_picker, in_message,
+            "the same emoji played choppier in the picker than in a message, which reads as a \
+             bug rather than as a memory budget; the picker's cache is sized to afford the same \
+             frame count"
+        );
     }
 
     #[test]
@@ -2443,7 +2820,7 @@ mod tests {
     fn an_animated_icon_decodes_within_the_icon_cache_entry_cap() {
         use image::codecs::gif::{GifEncoder, Repeat};
         const _: () = assert!(
-            ICON_ANIMATION_MAX_BYTES <= ROLE_ICON_ENTRY_MAX_BYTES,
+            EMOJI_ANIMATION_MAX_BYTES <= EMOJI_ENTRY_MAX_BYTES,
             "every cache fed by the icon loader rejects entries above its per-entry cap, so a \
              decode budget above that cap produces animated emoji and role icons that are \
              decoded and then thrown away, leaving the error placeholder on screen"
@@ -2469,16 +2846,86 @@ mod tests {
             }
         }
 
-        let image = decode_avatar_image(&bytes, ICON_DECODE_MAX_PX, ICON_ANIMATION_MAX_BYTES)
-            .expect("animated icon");
+        let image = decode_avatar_image(
+            &bytes,
+            MESSAGE_EMOJI_DECODE_MAX_PX,
+            AnimationCaps {
+                max_px: MESSAGE_EMOJI_DECODE_MAX_PX,
+                max_frames: MESSAGE_EMOJI_MAX_FRAMES,
+                max_bytes: EMOJI_ANIMATION_MAX_BYTES,
+            },
+        )
+        .expect("animated icon");
         assert!(
             image.frame_count() > 1,
             "the animation must be decimated, not flattened"
         );
         assert!(
-            image_bytes(&image) <= ROLE_ICON_ENTRY_MAX_BYTES,
-            "a 40-frame icon decoded to {} bytes, above the {ROLE_ICON_ENTRY_MAX_BYTES}-byte cap",
+            image.size(0).width.0 as u32 <= MESSAGE_EMOJI_DECODE_MAX_PX,
+            "an animated icon keeps every frame resident, so it decodes against the smaller \
+             animated cap rather than the still-image one"
+        );
+        assert!(
+            image_bytes(&image) <= EMOJI_ANIMATION_MAX_BYTES,
+            "a 40-frame icon decoded to {} bytes, above the {EMOJI_ANIMATION_MAX_BYTES}-byte budget",
             image_bytes(&image)
+        );
+    }
+
+    #[test]
+    fn a_high_frame_rate_emoji_keeps_a_watchable_frame_rate() {
+        use image::codecs::gif::{GifEncoder, Repeat};
+        const SOURCE_FRAMES: u32 = 48;
+        const SOURCE_DELAY_MS: u32 = 30;
+        const MIN_RETAINED_FPS: u32 = 15;
+
+        let mut bytes = Vec::new();
+        {
+            let mut encoder = GifEncoder::new(&mut bytes);
+            encoder.set_repeat(Repeat::Infinite).expect("GIF repeat");
+            for index in 0..SOURCE_FRAMES {
+                let buffer = image::RgbaImage::from_pixel(
+                    100,
+                    100,
+                    image::Rgba([(index * 5) as u8, 0, 0, 255]),
+                );
+                let frame = image::Frame::from_parts(
+                    buffer,
+                    0,
+                    0,
+                    image::Delay::from_numer_denom_ms(SOURCE_DELAY_MS, 1),
+                );
+                encoder.encode_frame(frame).expect("GIF frame");
+            }
+        }
+
+        let image = decode_avatar_image(
+            &bytes,
+            MESSAGE_EMOJI_DECODE_MAX_PX,
+            AnimationCaps {
+                max_px: MESSAGE_EMOJI_DECODE_MAX_PX,
+                max_frames: MESSAGE_EMOJI_MAX_FRAMES,
+                max_bytes: EMOJI_ANIMATION_MAX_BYTES,
+            },
+        )
+        .expect("animated emoji");
+
+        let loop_ms: u128 = (0..image.frame_count())
+            .map(|index| Duration::from(image.delay(index)).as_millis())
+            .sum();
+        assert_eq!(
+            loop_ms,
+            u128::from(SOURCE_FRAMES * SOURCE_DELAY_MS),
+            "decimation scales the delay of every frame it keeps, so the animation must still \
+             take exactly as long to loop as the source did"
+        );
+        assert!(
+            image.frame_count() as u32 * 1000 / (SOURCE_FRAMES * SOURCE_DELAY_MS)
+                >= MIN_RETAINED_FPS,
+            "a 33fps emoji decimated to {} frames plays back at under {MIN_RETAINED_FPS}fps, which \
+             reads as stutter rather than animation; the animation budget buys frames, so spend it \
+             on frames rather than on pixels the emoji is never painted at",
+            image.frame_count()
         );
     }
 


### PR DESCRIPTION
Emoji, stickers and message icons shared the general image path, so their budgets, decode sizes and animation costs were whatever that path happened to do. Each surface now owns its cache with an explicit ceiling — 1024 entries / 48 MB for the picker, 256 / 32 MB for stickers, 1024 / 16 MB for message icons — plus per-entry caps (1 MB emoji, 4 MB sticker, 512 KB icon) and a separate animation byte cap, so one oversized asset cannot evict a screenful of small ones.

Sources are requested per surface at twice their paint size (`emoji_source_px`), so a 24px inline `:emoji:` decodes small and only the 48px jumbo pays for 96px; `MESSAGE_EMOJI_DECODE_MAX_PX` bounds the largest of them. `EmojiImageLoader` and an animated-WebP decoder carry the animation with frame disposal, and `AnimationCaps` bounds pixels, frame count and bytes together. Upcoming rows are warmed ahead of the viewport (`sources_ahead`, `sources_below`, `warm_emoji_sources`, `warm_sticker_sources`) so scrolling into a run of emoji does not decode on the frame that needs them, and reaction pills resolve their source once through a `reaction_srcs` memo on `RowMemo` instead of per render.

Tests cover the invariants rather than the plumbing: every surface decodes at least its 2x paint size, a screenful of animated emoji stays inside the cache budget, an animated WebP disposes the frame it moved away from, the picker animates as smoothly as a message does, and a high-frame-rate emoji keeps a watchable rate.