### PR TITLE
fix(messages): give the social link card its own line and tag link 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5872,6 +5872,7 @@ dependencies = [
  "proptest",
  "prost 0.13.5",
  "rand 0.9.4",
+ "regex",
  "reqwest_client",
  "serde",
  "serde_json",

--- a/crates/mezon-client/Cargo.toml
+++ b/crates/mezon-client/Cargo.toml
@@ -31,6 +31,7 @@ flate2 = "1"
 bytes.workspace = true
 foyer.workspace = true
 parking_lot.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/mezon-client/src/lib.rs
+++ b/crates/mezon-client/src/lib.rs
@@ -72,8 +72,8 @@ pub use transport::{
     ApiCanvas, ApiCanvasDetail, ApiCategoryDesc, ApiChannelApp, ApiChannelAttachment,
     ApiChannelDesc, ApiFriend, ApiPinMessage, ApiStatusError, ApiThreadDesc, ApiVoiceChannelUser,
     CANVAS_LIST_LIMIT, CANVAS_STATUS_CREATED, CANVAS_STATUS_UPDATE, HttpFallbackSession,
-    api_status_from_error, is_channel_limit_api_error, parse_search_attachment_field,
-    parse_search_mentions_field,
+    api_status_from_error, is_channel_limit_api_error, link_markdown_kind,
+    parse_search_attachment_field, parse_search_mentions_field,
 };
 pub use transport_adapter::TransportAdapter;
 pub use transport_runtime::TransportClient;

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -2544,6 +2544,38 @@ struct MarkdownMatch {
     marker: usize,
 }
 
+pub const LINK_MARKDOWN_KIND: &str = "lk";
+pub const YOUTUBE_LINK_MARKDOWN_KIND: &str = "lk_yt";
+pub const FACEBOOK_LINK_MARKDOWN_KIND: &str = "lk_fb";
+pub const TIKTOK_LINK_MARKDOWN_KIND: &str = "lk_tt";
+
+static YOUTUBE_LINK: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(r"(?:youtube\.com/(?:watch\?v=|embed/|v/|e/|shorts/)|youtu\.be/)")
+        .expect("static youtube link pattern")
+});
+static FACEBOOK_LINK: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(r"(?:facebook\.com/(?:reel/|watch\?v=|[\w.]+/videos/(?:[\w.]+/)?))[\w-]+")
+        .expect("static facebook link pattern")
+});
+static TIKTOK_LINK: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(
+        r"(?:tiktok\.com/@[^/]+/video/\d+|vm\.tiktok\.com/[a-zA-Z0-9]+|tiktok\.com/t/[a-zA-Z0-9]+)",
+    )
+    .expect("static tiktok link pattern")
+});
+
+pub fn link_markdown_kind(url: &str) -> &'static str {
+    if YOUTUBE_LINK.is_match(url) {
+        YOUTUBE_LINK_MARKDOWN_KIND
+    } else if FACEBOOK_LINK.is_match(url) {
+        FACEBOOK_LINK_MARKDOWN_KIND
+    } else if TIKTOK_LINK.is_match(url) {
+        TIKTOK_LINK_MARKDOWN_KIND
+    } else {
+        LINK_MARKDOWN_KIND
+    }
+}
+
 fn scan_markdown(chars: &[char]) -> Vec<MarkdownMatch> {
     let n = chars.len();
     let is_triple =
@@ -2585,8 +2617,9 @@ fn scan_markdown(chars: &[char]) -> Vec<MarkdownMatch> {
                 j += 1;
             }
             if j > i + scheme {
+                let url: String = chars[i..j].iter().collect();
                 out.push(MarkdownMatch {
-                    kind: "lk",
+                    kind: link_markdown_kind(&url),
                     start: i,
                     end: j,
                     marker: 0,
@@ -9916,6 +9949,27 @@ mod tests {
     #[test]
     fn detect_markdown_link_has_no_trailing_punctuation_trim() {
         assert_eq!(detect_markdown("see https://a.com."), vec![md("lk", 4, 18)]);
+    }
+
+    #[test]
+    fn detect_markdown_tags_social_links_by_platform() {
+        assert_eq!(
+            detect_markdown("https://www.youtube.com/watch?v=lHW3fsJQ1sg"),
+            vec![md("lk_yt", 0, 43)]
+        );
+        assert_eq!(
+            detect_markdown("https://youtu.be/abc"),
+            vec![md("lk_yt", 0, 20)]
+        );
+        assert_eq!(
+            detect_markdown("https://www.tiktok.com/@user/video/123"),
+            vec![md("lk_tt", 0, 38)]
+        );
+        assert_eq!(
+            detect_markdown("https://www.facebook.com/reel/456"),
+            vec![md("lk_fb", 0, 33)]
+        );
+        assert_eq!(detect_markdown("https://a.com"), vec![md("lk", 0, 13)]);
     }
 
     #[test]

--- a/crates/mezon-store/src/message.rs
+++ b/crates/mezon-store/src/message.rs
@@ -910,7 +910,18 @@ pub fn parse_spans(content: &ApiMessageContent) -> Vec<MessageSpan> {
     collect(&content.hg, Kind::Hashtag, &mut toks);
     collect(&content.ej, Kind::Emoji, &mut toks);
     collect(&content.mk, Kind::Markdown, &mut toks);
-    collect(&content.lk, Kind::Link(LinkKind::Plain), &mut toks);
+    if content.mk.is_empty() {
+        for t in &content.lk {
+            let s = t.s.unwrap_or(0);
+            let e = t.e.unwrap_or(0);
+            if e > s {
+                let kind = link_kind_from_marker(mezon_client::link_markdown_kind(&slice(s, e)));
+                toks.push((s, e, Kind::Link(kind), t.clone()));
+            }
+        }
+    } else {
+        collect(&content.lk, Kind::Link(LinkKind::Plain), &mut toks);
+    }
     collect(&content.vk, Kind::Link(LinkKind::Plain), &mut toks);
     collect(&content.lky, Kind::Link(LinkKind::YouTube), &mut toks);
     toks.sort_by_key(|t| t.0);
@@ -1806,6 +1817,46 @@ mod tests {
         assert_eq!(
             parse_spans(&content),
             vec![MessageSpan::Text("hello world".into())]
+        );
+    }
+
+    #[test]
+    fn parse_spans_classifies_a_bare_link_token_by_platform() {
+        let url = "https://www.youtube.com/watch?v=lHW3fsJQ1sg";
+        let content = ApiMessageContent {
+            t: url.into(),
+            lk: vec![token(0, url.len() as i64)],
+            ..Default::default()
+        };
+        assert_eq!(
+            parse_spans(&content),
+            vec![MessageSpan::Link {
+                text: url.into(),
+                url: url.into(),
+                kind: LinkKind::YouTube,
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_spans_keeps_a_link_token_plain_when_markdown_tokens_decide_the_kind() {
+        let url = "https://www.youtube.com/watch?v=lHW3fsJQ1sg";
+        let content = ApiMessageContent {
+            t: url.into(),
+            mk: vec![ContentToken {
+                kind: Some("lk".into()),
+                ..token(0, url.len() as i64)
+            }],
+            lk: vec![token(0, url.len() as i64)],
+            ..Default::default()
+        };
+        assert_eq!(
+            parse_spans(&content),
+            vec![MessageSpan::Link {
+                text: url.into(),
+                url: url.into(),
+                kind: LinkKind::Plain,
+            }]
         );
     }
 

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -1834,37 +1834,42 @@ fn render_social_link_card(
     let id = hashed_element_id("msg-social", &resolved);
     let selection = selection.clone();
     div()
-        .id(id)
         .flex()
-        .flex_col()
-        .gap_1()
-        .when(kind != LinkKind::Plain, |card| {
-            card.flex_basis(relative(1.))
-        })
+        .flex_row()
+        .flex_basis(relative(1.))
         .w_full()
         .min_w_0()
-        .max_w(px(400.))
-        .my_1()
-        .p(px(16.))
-        .rounded(px(4.))
-        .border_l_4()
-        .border_color(rgb(accent))
-        .bg(rgb(SOCIAL_CARD_BG))
-        .overflow_hidden()
-        .cursor_pointer()
-        .on_click(move |_, _, cx| {
-            if !selection.borrow().has_selection() {
-                open_message_link(resolved.to_string(), cx);
-            }
-        })
         .child(
             div()
-                .text_size(px(12.))
-                .font_weight(FontWeight::SEMIBOLD)
-                .text_color(rgb(accent))
-                .child(label),
+                .id(id)
+                .flex()
+                .flex_col()
+                .gap_1()
+                .w_full()
+                .min_w_0()
+                .max_w(px(400.))
+                .my_1()
+                .p(px(16.))
+                .rounded(px(4.))
+                .border_l_4()
+                .border_color(rgb(accent))
+                .bg(rgb(SOCIAL_CARD_BG))
+                .overflow_hidden()
+                .cursor_pointer()
+                .on_click(move |_, _, cx| {
+                    if !selection.borrow().has_selection() {
+                        open_message_link(resolved.to_string(), cx);
+                    }
+                })
+                .child(
+                    div()
+                        .text_size(px(12.))
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(rgb(accent))
+                        .child(label),
+                )
+                .child(url_row),
         )
-        .child(url_row)
         .into_any_element()
 }
 


### PR DESCRIPTION
The YouTube/TikTok/Facebook card is a child of the message's wrapping flex row. It asked for a full line with flex_basis(100%) + w_full, but its own max_w(400) clamped the size taffy uses to break flex lines (flex_basis.maybe_clamp(min, max_size.main)), so the card packed onto the same line as the text around it: "text [card] text" on one row instead of three blocks. Wrap it in an unclamped full-width line and keep the 400px cap on the card itself, matching React's block-level SocialEmbed. CodeBlock already got this right because it sets w_full with no max_w.

The card was unreachable from this client anyway: scan_markdown tagged every URL "lk", so LinkKind stayed Plain and only messages composed in mezon-react ever rendered one. Port React's getLinkType (embed-social.ts) — the send path now emits lk_yt/lk_fb/lk_tt like processEntitiesDirectly, and parse_spans mirrors patchLinkTokens by classifying a bare lk token when mk is empty, which is the only case React runs that check. parse_spans runs at DTO to domain mapping, so the fallback costs one match per message on ingest, not per frame.