### PR TITLE
fix(messages): give the social link card its own line and tag link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5872,6 +5872,7 @@ dependencies = [
  "proptest",
  "prost 0.13.5",
  "rand 0.9.4",
+ "regex",
  "reqwest_client",
  "serde",
  "serde_json",

--- a/crates/mezon-client/Cargo.toml
+++ b/crates/mezon-client/Cargo.toml
@@ -31,6 +31,7 @@ flate2 = "1"
 bytes.workspace = true
 foyer.workspace = true
 parking_lot.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/mezon-client/src/lib.rs
+++ b/crates/mezon-client/src/lib.rs
@@ -72,8 +72,8 @@ pub use transport::{
     ApiCanvas, ApiCanvasDetail, ApiCategoryDesc, ApiChannelApp, ApiChannelAttachment,
     ApiChannelDesc, ApiFriend, ApiPinMessage, ApiStatusError, ApiThreadDesc, ApiVoiceChannelUser,
     CANVAS_LIST_LIMIT, CANVAS_STATUS_CREATED, CANVAS_STATUS_UPDATE, HttpFallbackSession,
-    api_status_from_error, is_channel_limit_api_error, parse_search_attachment_field,
-    parse_search_mentions_field,
+    api_status_from_error, is_channel_limit_api_error, link_markdown_kind,
+    parse_search_attachment_field, parse_search_mentions_field,
 };
 pub use transport_adapter::TransportAdapter;
 pub use transport_runtime::TransportClient;

--- a/crates/mezon-client/src/lib.rs
+++ b/crates/mezon-client/src/lib.rs
@@ -71,8 +71,9 @@ pub use transport::RealtimeEvent;
 pub use transport::{
     ApiCanvas, ApiCanvasDetail, ApiCategoryDesc, ApiChannelApp, ApiChannelAttachment,
     ApiChannelDesc, ApiFriend, ApiPinMessage, ApiStatusError, ApiThreadDesc, ApiVoiceChannelUser,
-    CANVAS_LIST_LIMIT, CANVAS_STATUS_CREATED, CANVAS_STATUS_UPDATE, HttpFallbackSession,
-    api_status_from_error, is_channel_limit_api_error, link_markdown_kind,
+    CANVAS_LIST_LIMIT, CANVAS_STATUS_CREATED, CANVAS_STATUS_UPDATE, FACEBOOK_LINK_MARKDOWN_KIND,
+    HttpFallbackSession, LINK_MARKDOWN_KIND, TIKTOK_LINK_MARKDOWN_KIND, YOUTUBE_LINK_MARKDOWN_KIND,
+    api_status_from_error, is_channel_limit_api_error, is_link_markdown_kind, link_markdown_kind,
     parse_search_attachment_field, parse_search_mentions_field,
 };
 pub use transport_adapter::TransportAdapter;

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -2544,6 +2544,38 @@ struct MarkdownMatch {
     marker: usize,
 }
 
+pub const LINK_MARKDOWN_KIND: &str = "lk";
+pub const YOUTUBE_LINK_MARKDOWN_KIND: &str = "lk_yt";
+pub const FACEBOOK_LINK_MARKDOWN_KIND: &str = "lk_fb";
+pub const TIKTOK_LINK_MARKDOWN_KIND: &str = "lk_tt";
+
+static YOUTUBE_LINK: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(r"(?:youtube\.com/(?:watch\?v=|embed/|v/|e/|shorts/)|youtu\.be/)")
+        .expect("static youtube link pattern")
+});
+static FACEBOOK_LINK: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(r"(?:facebook\.com/(?:reel/|watch\?v=|[\w.]+/videos/(?:[\w.]+/)?))[\w-]+")
+        .expect("static facebook link pattern")
+});
+static TIKTOK_LINK: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(
+        r"(?:tiktok\.com/@[^/]+/video/\d+|vm\.tiktok\.com/[a-zA-Z0-9]+|tiktok\.com/t/[a-zA-Z0-9]+)",
+    )
+    .expect("static tiktok link pattern")
+});
+
+pub fn link_markdown_kind(url: &str) -> &'static str {
+    if YOUTUBE_LINK.is_match(url) {
+        YOUTUBE_LINK_MARKDOWN_KIND
+    } else if FACEBOOK_LINK.is_match(url) {
+        FACEBOOK_LINK_MARKDOWN_KIND
+    } else if TIKTOK_LINK.is_match(url) {
+        TIKTOK_LINK_MARKDOWN_KIND
+    } else {
+        LINK_MARKDOWN_KIND
+    }
+}
+
 fn scan_markdown(chars: &[char]) -> Vec<MarkdownMatch> {
     let n = chars.len();
     let is_triple =
@@ -2585,8 +2617,9 @@ fn scan_markdown(chars: &[char]) -> Vec<MarkdownMatch> {
                 j += 1;
             }
             if j > i + scheme {
+                let url: String = chars[i..j].iter().collect();
                 out.push(MarkdownMatch {
-                    kind: "lk",
+                    kind: link_markdown_kind(&url),
                     start: i,
                     end: j,
                     marker: 0,
@@ -9916,6 +9949,27 @@ mod tests {
     #[test]
     fn detect_markdown_link_has_no_trailing_punctuation_trim() {
         assert_eq!(detect_markdown("see https://a.com."), vec![md("lk", 4, 18)]);
+    }
+
+    #[test]
+    fn detect_markdown_tags_social_links_by_platform() {
+        assert_eq!(
+            detect_markdown("https://www.youtube.com/watch?v=lHW3fsJQ1sg"),
+            vec![md("lk_yt", 0, 43)]
+        );
+        assert_eq!(
+            detect_markdown("https://youtu.be/abc"),
+            vec![md("lk_yt", 0, 20)]
+        );
+        assert_eq!(
+            detect_markdown("https://www.tiktok.com/@user/video/123"),
+            vec![md("lk_tt", 0, 38)]
+        );
+        assert_eq!(
+            detect_markdown("https://www.facebook.com/reel/456"),
+            vec![md("lk_fb", 0, 33)]
+        );
+        assert_eq!(detect_markdown("https://a.com"), vec![md("lk", 0, 13)]);
     }
 
     #[test]

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -2553,13 +2553,18 @@ static YOUTUBE_LINK: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::ne
     regex::Regex::new(r"(?:youtube\.com/(?:watch\?v=|embed/|v/|e/|shorts/)|youtu\.be/)")
         .expect("static youtube link pattern")
 });
+// `\w`/`\d` are Unicode classes here but ASCII-only in JS, so the classes are spelled out to keep
+// this in step with mezon-react's getLinkType — a link this crate tags but the web client's own
+// regex rejects renders as a broken embed there.
 static FACEBOOK_LINK: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
-    regex::Regex::new(r"(?:facebook\.com/(?:reel/|watch\?v=|[\w.]+/videos/(?:[\w.]+/)?))[\w-]+")
-        .expect("static facebook link pattern")
+    regex::Regex::new(
+        r"(?:facebook\.com/(?:reel/|watch\?v=|[0-9A-Za-z_.]+/videos/(?:[0-9A-Za-z_.]+/)?))[0-9A-Za-z_-]+",
+    )
+    .expect("static facebook link pattern")
 });
 static TIKTOK_LINK: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
     regex::Regex::new(
-        r"(?:tiktok\.com/@[^/]+/video/\d+|vm\.tiktok\.com/[a-zA-Z0-9]+|tiktok\.com/t/[a-zA-Z0-9]+)",
+        r"(?:tiktok\.com/@[^/]+/video/[0-9]+|vm\.tiktok\.com/[a-zA-Z0-9]+|tiktok\.com/t/[a-zA-Z0-9]+)",
     )
     .expect("static tiktok link pattern")
 });
@@ -2574,6 +2579,18 @@ pub fn link_markdown_kind(url: &str) -> &'static str {
     } else {
         LINK_MARKDOWN_KIND
     }
+}
+
+/// Every kind [`link_markdown_kind`] can return. Consumers that filter detected markdown down to
+/// links must use this instead of comparing against `"lk"`, or they silently drop social links.
+pub fn is_link_markdown_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        LINK_MARKDOWN_KIND
+            | YOUTUBE_LINK_MARKDOWN_KIND
+            | FACEBOOK_LINK_MARKDOWN_KIND
+            | TIKTOK_LINK_MARKDOWN_KIND
+    )
 }
 
 fn scan_markdown(chars: &[char]) -> Vec<MarkdownMatch> {
@@ -9970,6 +9987,28 @@ mod tests {
             vec![md("lk_fb", 0, 33)]
         );
         assert_eq!(detect_markdown("https://a.com"), vec![md("lk", 0, 13)]);
+    }
+
+    #[test]
+    fn link_markdown_kind_matches_js_ascii_classes() {
+        // mezon-react's getLinkType uses JS `\w`/`\d`, which are ASCII-only. Tagging a link the
+        // web client's own regex then fails to expand leaves it with a broken embed there.
+        assert_eq!(
+            link_markdown_kind("https://www.facebook.com/José/videos/abc"),
+            "lk"
+        );
+        assert_eq!(
+            link_markdown_kind("https://www.facebook.com/jose/videos/abc"),
+            "lk_fb"
+        );
+        assert_eq!(
+            link_markdown_kind("https://www.tiktok.com/@user/video/١٢٣"),
+            "lk"
+        );
+        assert_eq!(
+            link_markdown_kind("https://www.tiktok.com/@user/video/123"),
+            "lk_tt"
+        );
     }
 
     #[test]

--- a/crates/mezon-store/src/message.rs
+++ b/crates/mezon-store/src/message.rs
@@ -1042,6 +1042,16 @@ fn link_kind_from_marker(marker: &str) -> LinkKind {
     }
 }
 
+/// Inverse of [`link_kind_from_marker`] — `None` for a plain link, which carries no marker.
+pub(crate) fn link_marker_from_kind(kind: LinkKind) -> Option<&'static str> {
+    match kind {
+        LinkKind::YouTube => Some(mezon_client::YOUTUBE_LINK_MARKDOWN_KIND),
+        LinkKind::Facebook => Some(mezon_client::FACEBOOK_LINK_MARKDOWN_KIND),
+        LinkKind::TikTok => Some(mezon_client::TIKTOK_LINK_MARKDOWN_KIND),
+        LinkKind::Plain => None,
+    }
+}
+
 struct ChannelUrlIds {
     clan_id: String,
     channel_id: String,

--- a/crates/mezon-store/src/message.rs
+++ b/crates/mezon-store/src/message.rs
@@ -910,7 +910,18 @@ pub fn parse_spans(content: &ApiMessageContent) -> Vec<MessageSpan> {
     collect(&content.hg, Kind::Hashtag, &mut toks);
     collect(&content.ej, Kind::Emoji, &mut toks);
     collect(&content.mk, Kind::Markdown, &mut toks);
-    collect(&content.lk, Kind::Link(LinkKind::Plain), &mut toks);
+    if content.mk.is_empty() {
+        for t in &content.lk {
+            let s = t.s.unwrap_or(0);
+            let e = t.e.unwrap_or(0);
+            if e > s {
+                let kind = link_kind_from_marker(mezon_client::link_markdown_kind(&slice(s, e)));
+                toks.push((s, e, Kind::Link(kind), t.clone()));
+            }
+        }
+    } else {
+        collect(&content.lk, Kind::Link(LinkKind::Plain), &mut toks);
+    }
     collect(&content.vk, Kind::Link(LinkKind::Plain), &mut toks);
     collect(&content.lky, Kind::Link(LinkKind::YouTube), &mut toks);
     toks.sort_by_key(|t| t.0);
@@ -1806,6 +1817,46 @@ mod tests {
         assert_eq!(
             parse_spans(&content),
             vec![MessageSpan::Text("hello world".into())]
+        );
+    }
+
+    #[test]
+    fn parse_spans_classifies_a_bare_link_token_by_platform() {
+        let url = "https://www.youtube.com/watch?v=lHW3fsJQ1sg";
+        let content = ApiMessageContent {
+            t: url.into(),
+            lk: vec![token(0, url.len() as i64)],
+            ..Default::default()
+        };
+        assert_eq!(
+            parse_spans(&content),
+            vec![MessageSpan::Link {
+                text: url.into(),
+                url: url.into(),
+                kind: LinkKind::YouTube,
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_spans_keeps_a_link_token_plain_when_markdown_tokens_decide_the_kind() {
+        let url = "https://www.youtube.com/watch?v=lHW3fsJQ1sg";
+        let content = ApiMessageContent {
+            t: url.into(),
+            mk: vec![ContentToken {
+                kind: Some("lk".into()),
+                ..token(0, url.len() as i64)
+            }],
+            lk: vec![token(0, url.len() as i64)],
+            ..Default::default()
+        };
+        assert_eq!(
+            parse_spans(&content),
+            vec![MessageSpan::Link {
+                text: url.into(),
+                url: url.into(),
+                kind: LinkKind::Plain,
+            }]
         );
     }
 

--- a/crates/mezon-store/src/message_search.rs
+++ b/crates/mezon-store/src/message_search.rs
@@ -684,7 +684,11 @@ fn merge_detected_markdown_links(tokens: &mut ApiMessageContent) {
         if existing.contains(&(s, e)) {
             continue;
         }
-        if tok.kind.as_deref() == Some("lk") {
+        if tok
+            .kind
+            .as_deref()
+            .is_some_and(mezon_client::is_link_markdown_kind)
+        {
             tokens.mk.push(tok);
         }
     }
@@ -861,6 +865,17 @@ mod tests {
     #[test]
     fn content_preview_hides_unparseable_json_without_text() {
         assert_eq!(content_preview_from_raw(r#"{"broken":true"#), "");
+    }
+
+    #[test]
+    fn merge_detected_markdown_links_keeps_social_link_kinds() {
+        let mut tokens = ApiMessageContent {
+            t: "https://youtu.be/abc".into(),
+            ..Default::default()
+        };
+        merge_detected_markdown_links(&mut tokens);
+        assert_eq!(tokens.mk.len(), 1);
+        assert_eq!(tokens.mk[0].kind.as_deref(), Some("lk_yt"));
     }
 
     #[test]

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -7031,7 +7031,7 @@ fn first_content_link_url(content: &ApiMessageContent) -> Option<String> {
     }
     detect_markdown(&content.t)
         .into_iter()
-        .find(|tok| tok.kind == "lk")
+        .find(|tok| mezon_client::is_link_markdown_kind(&tok.kind))
         .map(|tok| utf16_slice(&content.t, i64::from(tok.s), i64::from(tok.e)))
         .filter(|url| !url.is_empty())
 }
@@ -7051,9 +7051,25 @@ fn text_to_spans(text: &str) -> Vec<MessageSpan> {
         return Vec::new();
     }
     let markdowns = detect_markdown(text);
+    // Embed bodies stay inline. React only runs its social-link classifier over message content,
+    // so a YouTube URL in a description is a link there, not the block-level card the classified
+    // kinds would render inside the embed's column.
+    let mk = markdown_content_tokens(&markdowns)
+        .into_iter()
+        .map(|mut tok| {
+            if tok
+                .kind
+                .as_deref()
+                .is_some_and(mezon_client::is_link_markdown_kind)
+            {
+                tok.kind = Some(mezon_client::LINK_MARKDOWN_KIND.to_string());
+            }
+            tok
+        })
+        .collect();
     parse_spans(&ApiMessageContent {
         t: text.to_string(),
-        mk: markdown_content_tokens(&markdowns),
+        mk,
         ..Default::default()
     })
 }
@@ -8555,6 +8571,33 @@ mod tests {
                 .iter()
                 .any(|s| matches!(s, MessageSpan::CodeBlock { .. })),
             "embed description should parse a ``` fence into a CodeBlock span"
+        );
+    }
+
+    #[test]
+    fn text_to_spans_keeps_social_links_inline() {
+        let spans = text_to_spans("watch https://youtu.be/abc");
+        assert!(
+            spans.iter().any(|s| matches!(
+                s,
+                MessageSpan::Link {
+                    kind: crate::message::LinkKind::Plain,
+                    ..
+                }
+            )),
+            "an embed description renders inline, so it must not classify a social card"
+        );
+    }
+
+    #[test]
+    fn first_content_link_url_falls_back_to_a_detected_social_link() {
+        let content = ApiMessageContent {
+            t: "https://www.tiktok.com/@user/video/123".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            first_content_link_url(&content).as_deref(),
+            Some("https://www.tiktok.com/@user/video/123")
         );
     }
 

--- a/crates/mezon-store/src/pinned.rs
+++ b/crates/mezon-store/src/pinned.rs
@@ -14,7 +14,7 @@ use crate::AppConfig;
 use crate::ids::{ChannelId, ClanId, MessageId, UserId};
 use crate::message::{
     Embed, Message, MessageAttachment, MessageSpan, OgpPreview, RichLayout, build_rich_layout,
-    parse_spans,
+    link_marker_from_kind, parse_spans,
 };
 use crate::messages::{MessagesEvent, MessagesStore, build_embeds, build_ogp_preview};
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
@@ -592,7 +592,7 @@ fn rebuild_pin_content_json(msg: &Message) -> String {
                 }
                 ej.push(serde_json::Value::Object(item));
             }
-            MessageSpan::Link { text, url, .. } => {
+            MessageSpan::Link { text, url, kind } => {
                 let start = pin_utf16_len(&t);
                 t.push_str(text);
                 let mut item = serde_json::Map::new();
@@ -601,7 +601,17 @@ fn rebuild_pin_content_json(msg: &Message) -> String {
                 if !url.is_empty() {
                     item.insert("url".into(), url.clone().into());
                 }
-                lk.push(serde_json::Value::Object(item));
+                // `parse_spans` only classifies a bare `lk` token when `mk` is empty (mirroring
+                // React's `patchLinkTokens`), so the kind rides in `mk` instead. Dropping it into
+                // `lk` would downgrade the card to a plain link whenever the pinned message also
+                // carries bold or code.
+                match link_marker_from_kind(*kind) {
+                    Some(marker) => {
+                        item.insert("type".into(), marker.into());
+                        mk.push(serde_json::Value::Object(item));
+                    }
+                    None => lk.push(serde_json::Value::Object(item)),
+                }
             }
             MessageSpan::Canvas { title, .. } => t.push_str(title),
         }
@@ -808,5 +818,32 @@ mod tests {
     #[test]
     fn context_from_active_cleared() {
         assert_eq!(context_from_active(None, None), (None, None));
+    }
+
+    #[test]
+    fn rebuild_pin_content_json_round_trips_a_social_link_beside_markdown() {
+        let mut msg = Message::new(MessageId(1), "", "1", "user", 0);
+        msg.spans = vec![
+            crate::message::MessageSpan::Bold("hi".into()),
+            crate::message::MessageSpan::Text(" ".into()),
+            crate::message::MessageSpan::Link {
+                text: "https://youtu.be/abc".into(),
+                url: "https://youtu.be/abc".into(),
+                kind: crate::message::LinkKind::YouTube,
+            },
+        ];
+        let json = rebuild_pin_content_json(&msg);
+        let content: mezon_client::transport::ApiMessageContent =
+            serde_json::from_str(&json).expect("valid content json");
+        assert!(
+            parse_spans(&content).iter().any(|span| matches!(
+                span,
+                crate::message::MessageSpan::Link {
+                    kind: crate::message::LinkKind::YouTube,
+                    ..
+                }
+            )),
+            "a pinned social link must stay classified when the message also carries markdown"
+        );
     }
 }

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -851,17 +851,16 @@ fn render_selectable_segmented_spans(
                         url_row = url_row.child(styled);
                         part_base += part.len();
                     }
-                    url_col = url_col.child(if line.trim().is_empty() {
-                        empty_text_line()
-                    } else {
-                        url_row
-                    });
+                    url_col = url_col.child(url_row);
                     line_base += line.len() + 1;
                 }
+                let card_key = link_part_index;
+                link_part_index += 1;
                 row = row.child(render_social_link_card(
                     *kind,
                     &ctx.selection,
                     resolved,
+                    card_key,
                     url_col,
                 ));
                 base += text.len();
@@ -1409,10 +1408,6 @@ pub(crate) enum CachedSelectableTextPiece {
     LineBreak,
 }
 
-fn empty_text_line() -> gpui::Div {
-    div().w_full().h(rems(1.375))
-}
-
 fn memoized_selectable_text_pieces(
     text: &SharedString,
     ctx: &RowCtx,
@@ -1677,10 +1672,13 @@ fn append_span(
                 .child(text.clone()),
         ),
         MessageSpan::Link { text, url, kind } if *kind != LinkKind::Plain => {
+            let key = *span_key;
+            *span_key += 1;
             row.child(render_social_link_card(
                 *kind,
                 &ctx.selection,
                 SharedString::from(resolve_link_url(url, text)),
+                key,
                 render_social_link_url_row(text, theme),
             ))
         }
@@ -1823,6 +1821,9 @@ fn render_social_link_card(
     kind: LinkKind,
     selection: &SharedSelection,
     resolved: SharedString,
+    // Keyed by position, not by url: the same social link twice in one message would otherwise
+    // hash to one id and the two cards would share their interactive state.
+    key: usize,
     url_row: impl IntoElement,
 ) -> AnyElement {
     let (accent, label) = match kind {
@@ -1831,7 +1832,7 @@ fn render_social_link_card(
         LinkKind::TikTok => (TIKTOK_ACCENT, "TikTok"),
         LinkKind::Plain => (SOCIAL_CARD_BG, ""),
     };
-    let id = hashed_element_id("msg-social", &resolved);
+    let id = ("msg-social", key);
     let selection = selection.clone();
     div()
         .flex()

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -1834,37 +1834,42 @@ fn render_social_link_card(
     let id = hashed_element_id("msg-social", &resolved);
     let selection = selection.clone();
     div()
-        .id(id)
         .flex()
-        .flex_col()
-        .gap_1()
-        .when(kind != LinkKind::Plain, |card| {
-            card.flex_basis(relative(1.))
-        })
+        .flex_row()
+        .flex_basis(relative(1.))
         .w_full()
         .min_w_0()
-        .max_w(px(400.))
-        .my_1()
-        .p(px(16.))
-        .rounded(px(4.))
-        .border_l_4()
-        .border_color(rgb(accent))
-        .bg(rgb(SOCIAL_CARD_BG))
-        .overflow_hidden()
-        .cursor_pointer()
-        .on_click(move |_, _, cx| {
-            if !selection.borrow().has_selection() {
-                open_message_link(resolved.to_string(), cx);
-            }
-        })
         .child(
             div()
-                .text_size(px(12.))
-                .font_weight(FontWeight::SEMIBOLD)
-                .text_color(rgb(accent))
-                .child(label),
+                .id(id)
+                .flex()
+                .flex_col()
+                .gap_1()
+                .w_full()
+                .min_w_0()
+                .max_w(px(400.))
+                .my_1()
+                .p(px(16.))
+                .rounded(px(4.))
+                .border_l_4()
+                .border_color(rgb(accent))
+                .bg(rgb(SOCIAL_CARD_BG))
+                .overflow_hidden()
+                .cursor_pointer()
+                .on_click(move |_, _, cx| {
+                    if !selection.borrow().has_selection() {
+                        open_message_link(resolved.to_string(), cx);
+                    }
+                })
+                .child(
+                    div()
+                        .text_size(px(12.))
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(rgb(accent))
+                        .child(label),
+                )
+                .child(url_row),
         )
-        .child(url_row)
         .into_any_element()
 }
 


### PR DESCRIPTION

The YouTube/TikTok/Facebook card is a child of the message's wrapping flex row. It asked for a full line with flex_basis(100%) + w_full, but its own max_w(400) clamped the size taffy uses to break flex lines (flex_basis.maybe_clamp(min, max_size.main)), so the card packed onto the same line as the text around it: "text [card] text" on one row instead of three blocks. Wrap it in an unclamped full-width line and keep the 400px cap on the card itself, matching React's block-level SocialEmbed. CodeBlock already got this right because it sets w_full with no max_w.

The card was unreachable from this client anyway: scan_markdown tagged every URL "lk", so LinkKind stayed Plain and only messages composed in mezon-react ever rendered one. Port React's getLinkType (embed-social.ts) — the send path now emits lk_yt/lk_fb/lk_tt like processEntitiesDirectly, and parse_spans mirrors patchLinkTokens by classifying a bare lk token when mk is empty, which is the only case React runs that check. parse_spans runs at DTO to domain mapping, so the fallback costs one match per message on ingest, not per frame.