### PR TITLE
fix(nav): keep the back/forward arrows on a real history trail

### DIFF
--- a/crates/mezon-ui/src/chat/layout.rs
+++ b/crates/mezon-ui/src/chat/layout.rs
@@ -1171,10 +1171,8 @@ impl ChatLayout {
     }
 
     fn ensure_active_channel_for_clan(&mut self, cx: &mut Context<Self>) {
-        if !matches!(
-            Router::global(cx).read(cx).route(),
-            Route::Chat | Route::Channel { .. }
-        ) {
+        let route = Router::global(cx).read(cx).route();
+        if !matches!(route, Route::Chat | Route::Channel { .. }) {
             return;
         }
         let Some(clan_id) = self.clan_list.read(cx).active_clan_id else {
@@ -1184,7 +1182,7 @@ impl ChatLayout {
         if let Route::Channel {
             clan_id: route_clan,
             channel_id,
-        } = Router::global(cx).read(cx).route()
+        } = route
             && route_clan == clan_id
         {
             if self
@@ -1215,13 +1213,23 @@ impl ChatLayout {
             return;
         };
 
-        crate::router::navigate(
-            cx,
+        let resolved = Route::Channel {
+            clan_id,
+            channel_id,
+        };
+        let is_redirect = match route {
+            Route::Chat => true,
             Route::Channel {
-                clan_id,
-                channel_id,
-            },
-        );
+                clan_id: route_clan,
+                ..
+            } => route_clan == clan_id,
+            _ => false,
+        };
+        if is_redirect {
+            crate::router::replace(cx, resolved);
+        } else {
+            crate::router::navigate(cx, resolved);
+        }
     }
 
     fn maybe_prefetch_voice_token(&mut self, cx: &mut Context<Self>) {

--- a/crates/mezon-ui/src/router.rs
+++ b/crates/mezon-ui/src/router.rs
@@ -686,6 +686,23 @@ mod tests {
     }
 
     #[test]
+    fn replacing_transitional_chat_route_keeps_previous_entry_reachable() {
+        let mut router = Router::new();
+        let dm = Route::DirectMessage {
+            direct_id: ChannelId(5),
+            message_type: "3".into(),
+        };
+        router.navigate(dm.clone());
+        router.navigate(Route::Chat);
+        router.replace(Route::Channel {
+            clan_id: ClanId(1),
+            channel_id: ChannelId(2),
+        });
+        router.go_back();
+        assert_eq!(router.route(), dm);
+    }
+
+    #[test]
     fn normalize_path_removes_trailing_slash() {
         assert_eq!(Route::from_path("/chat/direct/"), Route::Direct);
     }

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/mod.rs
@@ -456,6 +456,7 @@ fn nav_arrow(id: &'static str, enabled: bool, is_back: bool, theme: &Theme) -> A
 
     let mut button = div()
         .id(id)
+        .occlude()
         .flex()
         .items_center()
         .justify_center()


### PR DESCRIPTION
Two independent defects in the back/forward arrows next to the DM logo.

Route::Chat is a transitional route: the clan rail navigates there first and ensure_active_channel_for_clan resolves the clan's real channel. That resolution used router::navigate, so /chat was pushed onto the back stack and the arrow landed the user on the blank limbo screen; the router observe then re-fired the redirect, and navigate clears the forward stack, so back bounced straight forward again and forward died. Leaving the limbo route (or a routed channel that no longer exists in the active clan) is a redirect and now uses router::replace; only a channel of a *different* clan - the rail click that switches clan - stays a real navigation. The route is also read once per call instead of twice, since this runs from the ChannelList observe on every incoming message.

The arrows sit at y 33..61 while the invisible macOS window-drag strip covers the top 50px, and a plain div does not block mouse events behind it, so a mouse-down on the upper part of an arrow also reached the strip: clicking back twice quickly counted as a titlebar double-click and zoomed the window. Marking the arrow .occlude() blocks the strip's hitbox.

Verified on the running app over the MCP control socket: an eight-route walk (DM, friends, same-clan switch, cross-clan, clan members, settings, thread, limbo) now retraces exactly backwards and forwards, with /chat never trapped in the history.