### PR TITLE
fix(messages): open a message link on the first click

### DIFF
--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -324,6 +324,12 @@ fn message_offset_at(
 }
 
 const EXPANDED_SELECTION_DRAG_THRESHOLD_PX: f32 = 2.;
+const SELECTION_DRAG_THRESHOLD_PX: f32 = 3.;
+
+fn pointer_left_press_origin(origin: Point<Pixels>, position: Point<Pixels>) -> bool {
+    (position.x - origin.x).as_f32().abs() > SELECTION_DRAG_THRESHOLD_PX
+        || (position.y - origin.y).as_f32().abs() > SELECTION_DRAG_THRESHOLD_PX
+}
 
 #[derive(Clone, Copy)]
 struct ExpandedSelection {
@@ -968,6 +974,19 @@ mod selection_hit_tests {
         assert!(!expanded.drag_started(point(px(12.), px(8.))));
         assert!(expanded.drag_started(point(px(12.1), px(10.))));
     }
+
+    #[test]
+    fn press_jitter_below_the_threshold_stays_a_click() {
+        let origin = point(px(100.), px(200.));
+
+        assert!(!pointer_left_press_origin(origin, origin));
+        assert!(!pointer_left_press_origin(
+            origin,
+            point(px(103.), px(197.))
+        ));
+        assert!(pointer_left_press_origin(origin, point(px(104.), px(200.))));
+        assert!(pointer_left_press_origin(origin, point(px(100.), px(206.))));
+    }
 }
 
 #[cfg(test)]
@@ -1244,6 +1263,7 @@ pub struct ChannelMessages {
     focus_handle: FocusHandle,
     selection: SharedSelection,
     selection_pointer: Option<Point<Pixels>>,
+    selection_press_origin: Option<Point<Pixels>>,
     expanded_selection: Option<ExpandedSelection>,
     selection_autoscroll_scheduled: bool,
     keyboard_scroll: Option<KeyboardScrollAnimation>,
@@ -1883,6 +1903,7 @@ impl ChannelMessages {
             focus_handle: cx.focus_handle(),
             selection: MessageSelectionState::new_shared(),
             selection_pointer: None,
+            selection_press_origin: None,
             expanded_selection: None,
             selection_autoscroll_scheduled: false,
             keyboard_scroll: None,
@@ -2315,6 +2336,7 @@ impl ChannelMessages {
     ) {
         self.selection.borrow_mut().clear();
         self.selection_pointer = None;
+        self.selection_press_origin = None;
         self.expanded_selection = None;
         self.selection_autoscroll_scheduled = false;
         let (initial_content, initial_spans) = MessagesStore::global(cx)
@@ -3182,6 +3204,7 @@ impl ChannelMessages {
         self.cached_for_channel = channel_id;
         self.selection.borrow_mut().clear();
         self.selection_pointer = None;
+        self.selection_press_origin = None;
         self.expanded_selection = None;
         self.selection_autoscroll_scheduled = false;
         self.last_seen_at_bottom = None;
@@ -3837,6 +3860,7 @@ impl ChannelMessages {
                 // unset here prevents a click near a viewport edge from moving
                 // the message list while the button is merely held down.
                 self.selection_pointer = None;
+                self.selection_press_origin = Some(event.position);
                 self.expanded_selection = expanded_selection;
                 if !self.focus_handle.is_focused(window) {
                     window.focus(&self.focus_handle, cx);
@@ -3856,6 +3880,7 @@ impl ChannelMessages {
                 selection.clear();
                 drop(selection);
                 self.selection_pointer = None;
+                self.selection_press_origin = None;
                 self.expanded_selection = None;
                 if had {
                     cx.notify();
@@ -3939,6 +3964,7 @@ impl ChannelMessages {
                 selection.selecting = false;
             }
             self.selection_pointer = None;
+            self.selection_press_origin = None;
             self.expanded_selection = None;
             return;
         }
@@ -3947,6 +3973,12 @@ impl ChannelMessages {
             .is_some_and(|expanded| !expanded.drag_started(event.position))
         {
             return;
+        }
+        if let Some(origin) = self.selection_press_origin {
+            if !pointer_left_press_origin(origin, event.position) {
+                return;
+            }
+            self.selection_press_origin = None;
         }
         self.selection_pointer = Some(event.position);
         let point = {
@@ -4007,6 +4039,9 @@ impl ChannelMessages {
         let preserve_expanded = self
             .expanded_selection
             .is_some_and(|expanded| !expanded.drag_started(event.position));
+        let stayed_a_click = self
+            .selection_press_origin
+            .is_some_and(|origin| !pointer_left_press_origin(origin, event.position));
         let (empty, head_changed) = {
             let Ok(mut state) = self.selection.try_borrow_mut() else {
                 return;
@@ -4015,6 +4050,7 @@ impl ChannelMessages {
                 return;
             }
             let head_changed = !preserve_expanded
+                && !stayed_a_click
                 && point.is_some_and(|point| {
                     update_selection_head(&mut state, point, self.expanded_selection)
                 });
@@ -4022,6 +4058,7 @@ impl ChannelMessages {
             (!state.has_selection(), head_changed)
         };
         self.selection_pointer = None;
+        self.selection_press_origin = None;
         self.expanded_selection = None;
         if empty && let Ok(mut selection) = self.selection.try_borrow_mut() {
             selection.clear();

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -323,10 +323,9 @@ fn message_offset_at(
         })
 }
 
-const EXPANDED_SELECTION_DRAG_THRESHOLD_PX: f32 = 2.;
-const SELECTION_DRAG_THRESHOLD_PX: f32 = 3.;
+const SELECTION_DRAG_THRESHOLD_PX: f32 = 2.;
 
-fn pointer_left_press_origin(origin: Point<Pixels>, position: Point<Pixels>) -> bool {
+fn press_drag_started(origin: Point<Pixels>, position: Point<Pixels>) -> bool {
     (position.x - origin.x).as_f32().abs() > SELECTION_DRAG_THRESHOLD_PX
         || (position.y - origin.y).as_f32().abs() > SELECTION_DRAG_THRESHOLD_PX
 }
@@ -341,8 +340,7 @@ struct ExpandedSelection {
 
 impl ExpandedSelection {
     fn drag_started(self, position: Point<Pixels>) -> bool {
-        (position.x - self.origin.x).as_f32().abs() > EXPANDED_SELECTION_DRAG_THRESHOLD_PX
-            || (position.y - self.origin.y).as_f32().abs() > EXPANDED_SELECTION_DRAG_THRESHOLD_PX
+        press_drag_started(self.origin, position)
     }
 }
 
@@ -979,13 +977,10 @@ mod selection_hit_tests {
     fn press_jitter_below_the_threshold_stays_a_click() {
         let origin = point(px(100.), px(200.));
 
-        assert!(!pointer_left_press_origin(origin, origin));
-        assert!(!pointer_left_press_origin(
-            origin,
-            point(px(103.), px(197.))
-        ));
-        assert!(pointer_left_press_origin(origin, point(px(104.), px(200.))));
-        assert!(pointer_left_press_origin(origin, point(px(100.), px(206.))));
+        assert!(!press_drag_started(origin, origin));
+        assert!(!press_drag_started(origin, point(px(102.), px(198.))));
+        assert!(press_drag_started(origin, point(px(102.1), px(200.))));
+        assert!(press_drag_started(origin, point(px(100.), px(202.1))));
     }
 }
 
@@ -3975,7 +3970,7 @@ impl ChannelMessages {
             return;
         }
         if let Some(origin) = self.selection_press_origin {
-            if !pointer_left_press_origin(origin, event.position) {
+            if !press_drag_started(origin, event.position) {
                 return;
             }
             self.selection_press_origin = None;
@@ -4041,7 +4036,7 @@ impl ChannelMessages {
             .is_some_and(|expanded| !expanded.drag_started(event.position));
         let stayed_a_click = self
             .selection_press_origin
-            .is_some_and(|origin| !pointer_left_press_origin(origin, event.position));
+            .is_some_and(|origin| !press_drag_started(origin, event.position));
         let (empty, head_changed) = {
             let Ok(mut state) = self.selection.try_borrow_mut() else {
                 return;

--- a/crates/vendor/gpui/src/elements/text.rs
+++ b/crates/vendor/gpui/src/elements/text.rs
@@ -1229,6 +1229,11 @@ impl Element for InteractiveText {
                         window.set_cursor_style(crate::CursorStyle::PointingHand, hitbox)
                     }
 
+                    // mezon vendor edit: register both listeners on every paint
+                    // behind one shared cell so a press resolves inside a single
+                    // frame. Upstream registers one per paint and refreshes in
+                    // between, which drops the click when no repaint lands or the
+                    // element id changed; re-apply on snapshot bump.
                     let mouse_down = interactive_state.mouse_down_index.clone();
                     window.on_mouse_event({
                         let hitbox = hitbox.clone();

--- a/crates/vendor/gpui/src/elements/text.rs
+++ b/crates/vendor/gpui/src/elements/text.rs
@@ -1,8 +1,8 @@
 use crate::{
     ActiveTooltip, AnyView, App, Bounds, DispatchPhase, Element, ElementId, GlobalElementId,
     HighlightStyle, Hitbox, HitboxBehavior, InspectorElementId, IntoElement, LayoutId,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, SharedString, Size, TextOverflow,
-    TextRun, TextStyle, TooltipId, TruncateFrom, WhiteSpace, Window, WrappedLine,
+    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, SharedString, Size,
+    TextOverflow, TextRun, TextStyle, TooltipId, TruncateFrom, WhiteSpace, Window, WrappedLine,
     WrappedLineLayout, register_tooltip_mouse_handlers, set_tooltip_on_window,
 };
 use anyhow::Context as _;
@@ -1229,46 +1229,53 @@ impl Element for InteractiveText {
                         window.set_cursor_style(crate::CursorStyle::PointingHand, hitbox)
                     }
 
-                    let text_layout = text_layout.clone();
                     let mouse_down = interactive_state.mouse_down_index.clone();
-                    if let Some(mouse_down_index) = mouse_down.get() {
+                    window.on_mouse_event({
                         let hitbox = hitbox.clone();
-                        let clickable_ranges = self.clickable_ranges.clone();
-                        window.on_mouse_event(
-                            move |event: &MouseUpEvent, phase, window: &mut Window, cx| {
-                                if phase == DispatchPhase::Bubble && hitbox.is_hovered(window) {
-                                    if let Some(Ok(mouse_up_index)) =
-                                        text_layout.try_index_for_position(event.position)
-                                    {
-                                        click_listener(
-                                            &clickable_ranges,
-                                            InteractiveTextClickEvent {
-                                                mouse_down_index,
-                                                mouse_up_index,
-                                            },
-                                            window,
-                                            cx,
-                                        )
-                                    }
-
-                                    mouse_down.take();
-                                    window.refresh();
-                                }
-                            },
-                        );
-                    } else {
-                        let hitbox = hitbox.clone();
-                        window.on_mouse_event(move |event: &MouseDownEvent, phase, window, _| {
+                        let text_layout = text_layout.clone();
+                        let mouse_down = mouse_down.clone();
+                        move |event: &MouseDownEvent, phase, window, _| {
                             if phase == DispatchPhase::Bubble
+                                && event.button == MouseButton::Left
                                 && hitbox.is_hovered(window)
                                 && let Some(Ok(mouse_down_index)) =
                                     text_layout.try_index_for_position(event.position)
                             {
                                 mouse_down.set(Some(mouse_down_index));
-                                window.refresh();
                             }
-                        });
-                    }
+                        }
+                    });
+                    window.on_mouse_event({
+                        let hitbox = hitbox.clone();
+                        let text_layout = text_layout.clone();
+                        let clickable_ranges = self.clickable_ranges.clone();
+                        move |event: &MouseUpEvent, phase, window: &mut Window, cx| {
+                            if phase != DispatchPhase::Bubble
+                                || event.button != MouseButton::Left
+                            {
+                                return;
+                            }
+                            let Some(mouse_down_index) = mouse_down.take() else {
+                                return;
+                            };
+                            if !hitbox.is_hovered(window) {
+                                return;
+                            }
+                            if let Some(Ok(mouse_up_index)) =
+                                text_layout.try_index_for_position(event.position)
+                            {
+                                click_listener(
+                                    &clickable_ranges,
+                                    InteractiveTextClickEvent {
+                                        mouse_down_index,
+                                        mouse_up_index,
+                                    },
+                                    window,
+                                    cx,
+                                )
+                            }
+                        }
+                    });
                 }
 
                 window.on_mouse_event({


### PR DESCRIPTION
InteractiveText registered either its mouse-down or its mouse-up listener depending on the pending index, so a press only completed as a click when a repaint landed in between under an unchanged element id. Message text churns that id on every hover-out to reset the link underline, and the timeline sits inside a cached view, so the first press was routinely dropped and only the second one opened the link. Register both listeners on every paint behind the shared pending cell, guard them on the left button so a right-click no longer arms a click, and drop the two window refreshes the old handshake needed.

Selection had no drag threshold either: a few pixels of pointer jitter while the button was held moved the head onto the neighbouring character, and the resulting one-character selection makes every has_selection() gated handler in the message item - links, cards, image and download buttons - do nothing. Keep a press that stays within 3px of its origin a click.