### PR TITLE
fix(command-palette): color unread rows and section headers like the …

### DIFF
--- a/crates/mezon-ui/src/command_palette/groups.rs
+++ b/crates/mezon-ui/src/command_palette/groups.rs
@@ -182,7 +182,7 @@ pub fn render_section_header(theme: &Theme, label: &SharedString) -> AnyElement 
         .px(px(10.))
         .text_size(px(12.))
         .font_weight(FontWeight::SEMIBOLD)
-        .text_color(theme.tokens.text_theme_primary_hover)
+        .text_color(theme.tokens.text_secondary)
         .child(label.to_string().to_uppercase())
         .into_any_element()
 }

--- a/crates/mezon-ui/src/command_palette/items.rs
+++ b/crates/mezon-ui/src/command_palette/items.rs
@@ -382,9 +382,14 @@ pub fn render_palette_row(
         FontWeight::MEDIUM
     };
     let label_color = if emphasized {
-        theme.tokens.text_theme_primary_hover
+        theme.tokens.text_secondary
     } else {
         theme.tokens.text_theme_primary
+    };
+    let icon_color = if emphasized || selected {
+        theme.tokens.bg_icon_theme_active
+    } else {
+        theme.tokens.bg_icon_theme
     };
     let (subtext_size, subtext_uppercase) = match item.kind {
         PaletteItemKind::Channel => (px(10.), true),
@@ -406,11 +411,7 @@ pub fn render_palette_row(
                     item.private,
                 ))
                 .size(px(14.))
-                .text_color(if emphasized {
-                    theme.tokens.text_theme_primary_hover
-                } else {
-                    theme.tokens.text_theme_primary
-                }),
+                .text_color(icon_color),
             )
             .into_any_element(),
         PaletteItemKind::Direct | PaletteItemKind::Member => render_palette_avatar(item),


### PR DESCRIPTION
…channel list

React resolves both .text-theme-primary-active and .text-theme-primary-hover:hover to --text-secondary, but the port read tokens.text_theme_primary_hover, a token that carries a different value per theme: #97979F at 12% alpha on sunrise and cisher (invisible on their near-white modal), pure red on purple_haze, blue on light. Unread rows, their icons and the PREVIOUS/UNREAD section headers all used it.

Use the same tokens the sidebar channel row does: text_secondary for the emphasized label and the headers, bg_icon_theme_active/bg_icon_theme for the channel glyph, which also picks up React's isRowFocused icon emphasis.