### PR TITLE
fix(attachments): upload with the type the backend filters on

### DIFF
--- a/crates/mezon-client/src/app_api.rs
+++ b/crates/mezon-client/src/app_api.rs
@@ -28,6 +28,19 @@ pub fn sanitize_upload_filename(name: &str) -> String {
         .collect()
 }
 
+pub fn upload_attachment_type(filetype: &str) -> &'static str {
+    let lower = filetype.to_ascii_lowercase();
+    if lower.contains("image") {
+        "image"
+    } else if lower.contains("video") {
+        "video"
+    } else if lower.contains("audio") {
+        "audio"
+    } else {
+        "doc"
+    }
+}
+
 fn clamp_i32(value: usize) -> i32 {
     i32::try_from(value).unwrap_or(i32::MAX)
 }
@@ -1709,6 +1722,7 @@ impl AppApi {
             thumbnail,
         } = file;
         let upload_name = sanitize_upload_filename(&filename);
+        let upload_type = upload_attachment_type(&filetype);
         let raw_size = crate::transport_runtime::file_len(path.clone()).await?;
         let size = i32::try_from(raw_size)
             .map_err(|_| anyhow::anyhow!("attachment too large to upload: {raw_size} bytes"))?;
@@ -1722,7 +1736,7 @@ impl AppApi {
                 .transport
                 .multipart_upload_attachment_file_start(mezon_proto::api::UploadAttachmentRequest {
                     filename: upload_name.clone(),
-                    filetype: filetype.clone(),
+                    filetype: upload_type.to_string(),
                     size,
                     width,
                     height,
@@ -1744,14 +1758,14 @@ impl AppApi {
                     part_urls: started.urls,
                     ranges,
                     path,
-                    content_type: filetype.clone(),
+                    content_type: filetype,
                     filename: started.filename,
                 },
             )
         } else {
             let upload = self
                 .transport
-                .upload_attachment_file(&upload_name, &filetype, size, width, height)
+                .upload_attachment_file(&upload_name, upload_type, size, width, height)
                 .await?;
             let url = attachment_cdn_url(&self.base_img_url, &upload.filename)?;
             (
@@ -1767,7 +1781,7 @@ impl AppApi {
                 filename,
                 size,
                 url,
-                filetype,
+                filetype: upload_type.to_string(),
                 width,
                 height,
                 thumbnail: thumbnail_url,
@@ -2222,15 +2236,16 @@ impl AppApi {
             (0, 0)
         };
 
+        let upload_type = upload_attachment_type(&filetype);
         let url = self
-            .upload_bytes(&upload_name, &filetype, size, width, height, data)
+            .upload_bytes(&upload_name, upload_type, size, width, height, data)
             .await?;
 
         Ok(mezon_proto::api::MessageAttachment {
             filename,
             size,
             url,
-            filetype,
+            filetype: upload_type.to_string(),
             width,
             height,
             thumbnail: String::new(),
@@ -2760,7 +2775,24 @@ impl AppApi {
 mod tests {
     use super::{
         MULTIPART_PART_SIZE, attachment_cdn_url, multipart_part_ranges, sanitize_upload_filename,
+        upload_attachment_type,
     };
+
+    #[test]
+    fn everything_that_is_not_media_uploads_as_a_doc() {
+        assert_eq!(upload_attachment_type("image/png"), "image");
+        assert_eq!(upload_attachment_type("video/mp4"), "video");
+        assert_eq!(upload_attachment_type("audio/webm"), "audio");
+        assert_eq!(upload_attachment_type("application/pdf"), "doc");
+        assert_eq!(upload_attachment_type("text/csv"), "doc");
+        assert_eq!(upload_attachment_type(""), "doc");
+        assert_eq!(
+            upload_attachment_type(
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            ),
+            "doc"
+        );
+    }
 
     #[test]
     fn upload_filename_folds_every_non_ascii_char() {

--- a/crates/mezon-store/src/channel_media.rs
+++ b/crates/mezon-store/src/channel_media.rs
@@ -911,7 +911,7 @@ async fn upload_timeline_file(
         id: 0,
         file_name: att.filename,
         file_url: att.url,
-        file_type: att.filetype,
+        file_type: filetype,
         file_size: i64::from(att.size),
         thumbnail: att.thumbnail,
         width: att.width,

--- a/crates/mezon-store/src/gallery.rs
+++ b/crates/mezon-store/src/gallery.rs
@@ -421,10 +421,10 @@ where
 }
 
 fn is_video_type(filetype: &str, url: &str) -> bool {
-    if filetype.starts_with("video/") {
+    let lower = filetype.to_ascii_lowercase();
+    if lower.starts_with("video/") || lower == "video" {
         return true;
     }
-    let lower = filetype.to_ascii_lowercase();
     if lower.contains("mp4") || lower.contains("mov") || lower.contains("webm") {
         return true;
     }
@@ -904,6 +904,38 @@ mod tests {
             uploader_avatar: SharedString::default(),
             uploader_avatar_raw: SharedString::default(),
         }
+    }
+
+    #[test]
+    fn bare_upload_category_is_recognised_as_media() {
+        use mezon_client::transport::ApiChannelAttachment;
+
+        let cfg = AppConfig::dev_defaults();
+        let video = ChannelAttachment::from_api(
+            ApiChannelAttachment {
+                url: "https://cdn.example/2016174228608389120/2072236531032002560.m4v".into(),
+                filetype: "video".into(),
+                ..ApiChannelAttachment::default()
+            },
+            ChannelId(1),
+            ClanId(1),
+            &cfg,
+        );
+        assert!(video.is_video);
+        assert!(!video.is_image);
+
+        let image = ChannelAttachment::from_api(
+            ApiChannelAttachment {
+                url: format!("{}/2072236531032002561.png", cfg.base_img_url),
+                filetype: "image".into(),
+                ..ApiChannelAttachment::default()
+            },
+            ChannelId(1),
+            ClanId(1),
+            &cfg,
+        );
+        assert!(image.is_image);
+        assert!(!image.is_video);
     }
 
     #[test]

--- a/crates/mezon-store/src/message.rs
+++ b/crates/mezon-store/src/message.rs
@@ -49,11 +49,14 @@ pub fn url_extension(url: &str) -> Option<String> {
 }
 
 pub fn is_image_type(filetype: &str, url: &str) -> bool {
-    let mime_image =
-        (filetype.starts_with("image") || filetype == STICKER_FILETYPE) && !is_svg_type(filetype);
+    let ext = url_extension(url);
+    if is_svg_type(filetype) || ext.as_deref() == Some("svg") {
+        return false;
+    }
+    let mime_image = filetype.starts_with("image") || filetype == STICKER_FILETYPE;
     mime_image
         || matches!(
-            url_extension(url).as_deref(),
+            ext.as_deref(),
             Some("png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "avif")
         )
 }
@@ -92,7 +95,7 @@ impl MessageAttachment {
     }
 
     pub fn is_unsupported_media(&self) -> bool {
-        matches!(
+        if matches!(
             self.filetype.as_str(),
             "video/x-ms-wmv"
                 | "video/wmv"
@@ -106,6 +109,25 @@ impl MessageAttachment {
                 | "image/tiff"
                 | "image/bmp"
                 | "image/psd"
+        ) {
+            return true;
+        }
+        let ext = url_extension(&self.filename).or_else(|| url_extension(&self.url));
+        matches!(
+            ext.as_deref(),
+            Some(
+                "wmv"
+                    | "avi"
+                    | "flv"
+                    | "mkv"
+                    | "rmvb"
+                    | "wma"
+                    | "ra"
+                    | "tiff"
+                    | "tif"
+                    | "bmp"
+                    | "psd"
+            )
         )
     }
 }
@@ -2405,6 +2427,7 @@ mod tests {
     fn svg_is_a_file_row_not_an_image() {
         assert!(!attachment("image/svg+xml", "https://cdn.example/logo.svg").is_image());
         assert!(!attachment("", "https://cdn.example/logo.svg").is_image());
+        assert!(!attachment("image", "https://cdn.example/logo.svg").is_image());
     }
 
     #[test]
@@ -2588,6 +2611,12 @@ mod tests {
         let bmp = attachment("image/bmp", "https://cdn.example/x.bmp");
         assert!(bmp.is_unsupported_media());
         assert!(bmp.is_image());
+
+        let uploaded_bmp = attachment("image", "https://cdn.example/1234.bmp");
+        assert!(uploaded_bmp.is_unsupported_media());
+
+        let uploaded_wmv = attachment("video", "https://cdn.example/1234.wmv");
+        assert!(uploaded_wmv.is_unsupported_media());
     }
 
     #[test]


### PR DESCRIPTION
ListChannelAttachment matches filetype exactly against the value the message payload stored, and mezon-api no longer falls back to the FILE + application/pdf pair, so attachments sent as their raw MIME type stop coming back in the Files tab. Send the same doc/image/video/audio category the web client sends.

Keep every reader of a server-provided filetype working with a bare category: media-channel uploads keep their local MIME because that surface still uploads through the MIME path, the gallery recognises "video", SVGs stay file rows, and unsupported media falls back to the file extension.