### PR TITLE
fix(stream): keep the stream session when viewing another stream room

### DIFF
--- a/crates/mezon-store/src/stream.rs
+++ b/crates/mezon-store/src/stream.rs
@@ -183,11 +183,10 @@ impl StreamStore {
         if !self.show_chat {
             return;
         }
-        let viewing_session = matches!(
-            active,
-            Some((ChannelType::Stream, channel_id)) if self.is_session_channel(channel_id)
-        );
-        if viewing_session && (self.is_joined() || self.is_joining()) {
+        let Some((ChannelType::Stream, channel_id)) = active else {
+            return;
+        };
+        if self.is_session_channel(channel_id) && (self.is_joined() || self.is_joining()) {
             return;
         }
         self.show_chat = false;

--- a/crates/mezon-store/src/stream.rs
+++ b/crates/mezon-store/src/stream.rs
@@ -171,20 +171,27 @@ impl StreamStore {
         }
     }
 
-    pub fn should_leave_for_active_channel(
-        &self,
+    pub fn is_session_channel(&self, channel_id: ChannelId) -> bool {
+        self.session_channel_id() == Some(channel_id)
+    }
+
+    pub fn sync_chat_for_active_channel(
+        &mut self,
         active: Option<(ChannelType, ChannelId)>,
-    ) -> bool {
-        if !self.is_joined() && !self.is_joining() {
-            return false;
+        cx: &mut Context<Self>,
+    ) {
+        if !self.show_chat {
+            return;
         }
-        let Some(session_channel) = self.session_channel_id() else {
-            return false;
-        };
-        match active {
-            Some((ChannelType::Stream, channel_id)) => session_channel != channel_id,
-            _ => false,
+        let viewing_session = matches!(
+            active,
+            Some((ChannelType::Stream, channel_id)) if self.is_session_channel(channel_id)
+        );
+        if viewing_session && (self.is_joined() || self.is_joining()) {
+            return;
         }
+        self.show_chat = false;
+        cx.notify();
     }
 
     pub fn show_chat(&self) -> bool {
@@ -758,6 +765,63 @@ mod tests {
             channel_id,
             display_name: name.into(),
         }
+    }
+
+    fn init_store(cx: &mut gpui::TestAppContext) -> Entity<StreamStore> {
+        cx.update(|cx| {
+            let api = Arc::new(mezon_client::AppApi::new(
+                Arc::new(mezon_client::TransportClient::new(String::new())),
+                String::new(),
+            ));
+            RealtimeDispatch::init(api.clone(), cx);
+            cx.new(|cx| StreamStore::new(api, cx))
+        })
+    }
+
+    #[gpui::test]
+    fn viewing_another_stream_channel_keeps_the_session(cx: &mut gpui::TestAppContext) {
+        let joined = ChannelId(1);
+        let other = ChannelId(2);
+        let store = init_store(cx);
+        cx.update(|cx| {
+            store.update(cx, |store, cx| {
+                store.phase = StreamPhase::Joined {
+                    channel_id: joined,
+                    clan_id: ClanId(9),
+                    is_live: true,
+                };
+                store.show_chat = true;
+                store.sync_chat_for_active_channel(Some((ChannelType::Stream, other)), cx);
+            });
+        });
+
+        cx.update(|cx| {
+            let store = store.read(cx);
+            assert!(store.is_joined());
+            assert_eq!(store.session_channel_id(), Some(joined));
+            assert!(store.is_session_channel(joined));
+            assert!(!store.is_session_channel(other));
+            assert!(!store.show_chat());
+        });
+    }
+
+    #[gpui::test]
+    fn viewing_the_session_channel_keeps_chat_open(cx: &mut gpui::TestAppContext) {
+        let joined = ChannelId(1);
+        let store = init_store(cx);
+        cx.update(|cx| {
+            store.update(cx, |store, cx| {
+                store.phase = StreamPhase::Joined {
+                    channel_id: joined,
+                    clan_id: ClanId(9),
+                    is_live: true,
+                };
+                store.show_chat = true;
+                store.sync_chat_for_active_channel(Some((ChannelType::Stream, joined)), cx);
+            });
+        });
+
+        assert!(cx.update(|cx| store.read(cx).show_chat()));
     }
 
     #[test]

--- a/crates/mezon-ui/src/chat/layout.rs
+++ b/crates/mezon-ui/src/chat/layout.rs
@@ -1488,9 +1488,7 @@ impl ChatLayout {
             .active_channel()
             .map(|ch| (ch.channel_type, ch.id));
         self.stream_store.update(cx, |store, cx| {
-            if store.should_leave_for_active_channel(active) {
-                store.leave_stream(cx);
-            }
+            store.sync_chat_for_active_channel(active, cx);
             store.clear_error_on_active_channel_change(active, cx);
         });
     }
@@ -1502,7 +1500,9 @@ impl ChatLayout {
             .channel_list
             .read(cx)
             .active_channel()
-            .is_some_and(|ch| ch.channel_type == ChannelType::Stream);
+            .is_some_and(|ch| {
+                ch.channel_type == ChannelType::Stream && stream.is_session_channel(ch.id)
+            });
         let want_pump =
             stream.is_joined() && stream.remote_video() && (on_stream || stream.fullscreen());
         if !want_pump {

--- a/crates/mezon-ui/src/chat/stream.rs
+++ b/crates/mezon-ui/src/chat/stream.rs
@@ -49,7 +49,8 @@ pub fn render_stream_channel(
     let clan_name = channel.clan_name.clone();
     let error_message = store.error_message().map(str::to_owned);
     let output_device = output_device_id.clone();
-    let joined = store.is_joined() || store.is_joining();
+    let session_here = store.is_session_channel(channel_id);
+    let joined = session_here && (store.is_joined() || store.is_joining());
     let shell_bg = stream_channel_bg(theme, joined);
 
     let body = if let Some(message) = error_message {
@@ -69,7 +70,7 @@ pub fn render_stream_channel(
             output_device,
             cx,
         )
-    } else if store.is_joined() || store.is_joining() {
+    } else if joined {
         render_joined(
             window,
             theme,
@@ -89,7 +90,7 @@ pub fn render_stream_channel(
             &channel_label,
             &members,
             window_width,
-            store.is_joining(),
+            session_here && store.is_joining(),
             stream_entity,
             auth_entity,
             clan_id,
@@ -114,8 +115,8 @@ pub fn render_stream_channel(
             locale,
             &channel.name,
             show_chat,
+            joined,
             stream.clone(),
-            cx,
         ))
         .child(body)
         .into_any_element()
@@ -353,16 +354,15 @@ fn stream_header(
     locale: &str,
     name: &str,
     show_chat: bool,
+    streaming: bool,
     stream: Entity<StreamStore>,
-    cx: &App,
 ) -> AnyElement {
     let chat_label = if show_chat {
         mezon_i18n::t(locale, "channelTopbar.tooltips.hideChat")
     } else {
         mezon_i18n::t(locale, "channelTopbar.tooltips.showChat")
     };
-    let stream_toggle = stream.clone();
-    let streaming = stream.read(cx).is_joined() || stream.read(cx).is_joining();
+    let stream_toggle = stream;
     let stream_icon_color = if streaming {
         theme.text_primary
     } else {


### PR DESCRIPTION
Clicking a different stream room tore down the active session before the user pressed Join Stream. sync_stream_session called leave_stream whenever the active channel was a stream channel other than the session one.

Drop that auto-leave and gate the stream view on the rendered channel being the session channel, so a non-session stream room shows the Join Stream screen while the current session keeps running - matching ChannelStream.tsx. join_stream already disconnects the previous session, so switching rooms via Join Stream is unaffected.