### PR TITLE
fix(audio): report unavailable audio output instead of opening a browser

### DIFF
--- a/crates/mezon-ui/src/chat/files_popover.rs
+++ b/crates/mezon-ui/src/chat/files_popover.rs
@@ -262,10 +262,8 @@ impl FilesPopoverPanel {
             .inspect_err(|err| tracing::warn!("audio output unavailable: {err}"))
             .ok();
         if self.audio_player.is_none() {
-            if let Some(store) = mezon_store::PlatformStore::try_global(cx) {
-                let _ = store.read(cx).open_url_external(url.as_ref());
-            }
             self.audio_url = None;
+            cx.defer(crate::chat::message::report_audio_output_unavailable);
             cx.notify();
             return;
         }

--- a/crates/mezon-ui/src/chat/message/audio_player.rs
+++ b/crates/mezon-ui/src/chat/message/audio_player.rs
@@ -7,10 +7,11 @@ use gpui::{
     http_client::HttpClient, prelude::*, px,
 };
 use mezon_audio::{AudioPlayer, DecodedPcm, PcmStream};
-use mezon_store::PlatformStore;
 
+use crate::app::shell::Shell;
 use crate::components::primitives::{Icon, IconName, Sizable, Size, Spinner};
 
+const AUDIO_OUTPUT_TOAST_KEY: &str = "audio-output-unavailable";
 const AUDIO_FETCH_MAX_BYTES: usize = 64 * 1024 * 1024;
 const AUDIO_TICK_INTERVAL: Duration = Duration::from_millis(250);
 const AUDIO_FETCH_CHUNK: usize = 64 * 1024;
@@ -65,14 +66,11 @@ impl AudioPlayerView {
             download_url,
             download_name,
         } = activation;
-        let player = AudioPlayer::new()
-            .inspect_err(|err| tracing::warn!("audio output unavailable: {err}"))
-            .ok();
         let mut view = Self {
             url: url.clone(),
             download_url,
             download_name,
-            player,
+            player: None,
             state: LoadState::Loading,
             want_play: true,
             server_duration: duration,
@@ -81,8 +79,28 @@ impl AudioPlayerView {
             _load_task: None,
             tick_task: None,
         };
-        view.start_loading(url, cx);
+        if view.ensure_player(cx) {
+            view.start_loading(url, cx);
+        }
         view
+    }
+
+    fn ensure_player(&mut self, cx: &mut Context<Self>) -> bool {
+        if self.player.is_some() {
+            return true;
+        }
+        match AudioPlayer::new() {
+            Ok(player) => {
+                self.player = Some(player);
+                true
+            }
+            Err(err) => {
+                tracing::warn!("audio output unavailable: {err}");
+                self.state = LoadState::Failed;
+                cx.defer(report_audio_output_unavailable);
+                false
+            }
+        }
     }
 
     fn start_loading(&mut self, url: SharedString, cx: &mut Context<Self>) {
@@ -207,6 +225,19 @@ impl AudioPlayerView {
     }
 
     fn toggle_play(&mut self, cx: &mut Context<Self>) {
+        if !self.ensure_player(cx) {
+            cx.notify();
+            return;
+        }
+        if matches!(self.state, LoadState::Failed) {
+            self.state = LoadState::Loading;
+            self.want_play = true;
+            self.time_label = SharedString::from(time_label(0.0, self.server_duration));
+            self.last_label_seconds = (0, whole_seconds(self.server_duration));
+            self.start_loading(self.url.clone(), cx);
+            cx.notify();
+            return;
+        }
         match &self.player {
             Some(player) if self.is_ready() => {
                 if player.is_playing() {
@@ -217,12 +248,8 @@ impl AudioPlayerView {
                     self.restart_tick(cx);
                 }
             }
-            Some(_) => {
+            _ => {
                 self.want_play = !self.want_play;
-            }
-            None => {
-                open_audio_external(&self.url, cx);
-                return;
             }
         }
         cx.notify();
@@ -236,12 +263,17 @@ impl Render for AudioPlayerView {
             .as_ref()
             .map(|player| player.is_playing())
             .unwrap_or(false);
+        let play_icon = match self.state {
+            LoadState::Failed => IconName::TriangleAlert,
+            _ if playing => IconName::AudioPause,
+            _ => IconName::AudioPlay,
+        };
         let download_url = self.download_url.clone();
         let download_name = self.download_name.clone();
         audio_pill(
             "audio-play",
             "audio-download",
-            playing,
+            play_icon,
             self.time_label.clone(),
             cx.listener(|view, _, _window, cx| view.toggle_play(cx)),
             move |_, _, cx| {
@@ -258,16 +290,11 @@ impl Render for AudioPlayerView {
 pub(crate) fn audio_pill(
     play_id: impl Into<ElementId>,
     download_id: impl Into<ElementId>,
-    playing: bool,
+    play_icon: IconName,
     time_label: SharedString,
     on_toggle: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
     on_download: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
 ) -> gpui::AnyElement {
-    let play_icon = if playing {
-        IconName::AudioPause
-    } else {
-        IconName::AudioPlay
-    };
     div()
         .flex()
         .w_full()
@@ -441,10 +468,10 @@ async fn fetch_audio(
     Ok(body)
 }
 
-fn open_audio_external(url: &str, cx: &mut App) {
-    if let Some(store) = PlatformStore::try_global(cx) {
-        let _ = store.read(cx).open_url_external(url);
-    }
+pub(crate) fn report_audio_output_unavailable(cx: &mut App) {
+    Shell::global(cx).update(cx, |shell, cx| {
+        shell.error_once(AUDIO_OUTPUT_TOAST_KEY, "Audio output unavailable", cx)
+    });
 }
 
 fn whole_seconds(total: f64) -> u64 {

--- a/crates/mezon-ui/src/chat/message/mod.rs
+++ b/crates/mezon-ui/src/chat/message/mod.rs
@@ -1,4 +1,5 @@
 mod audio_player;
+pub(crate) use audio_player::report_audio_output_unavailable;
 mod call_log_card;
 mod channel_messages;
 mod content;

--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -836,7 +836,7 @@ fn render_audio(
     audio_pill(
         ("audio-play", index),
         ("audio-dl", index),
-        false,
+        IconName::AudioPlay,
         audio_time_label(0.0, duration),
         move |_, _, cx| {
             if activate_selection.borrow().has_selection() {


### PR DESCRIPTION
When AudioPlayer::new() failed to open an output device the view kept player as None for its whole lifetime, and toggle_play handed the CDN url to the system browser. render() never read LoadState, so the pill still looked idle: clicking a voice message simply opened it in the browser with no explanation.

Retry the device on every play instead of only at construction, so a transient failure no longer wedges the pill, and restart the load when a previous attempt failed. On a persistent failure surface an error toast and an alert icon on the pill rather than leaving the channel. The files popover took the same browser fallback and now reports it the same way.