### PR TITLE
feat(dm): show the peer's status in the DM topbar

### DIFF
--- a/crates/mezon-ui/src/chat/channel_header.rs
+++ b/crates/mezon-ui/src/chat/channel_header.rs
@@ -6,8 +6,8 @@ use gpui::{
     Window, div, point, prelude::*, px,
 };
 use mezon_store::{
-    ChannelId, DirectKind, DirectMessageStore, InVoiceInfo, PinnedMessagesStore, Settings,
-    StreamStore, ThreadsStore,
+    ChannelId, DirectKind, DirectMessageStore, DmAvatarPresence, InVoiceInfo, PinnedMessagesStore,
+    Settings, StreamStore, ThreadsStore,
 };
 use ui::{Clickable, PopoverMenu, PopoverMenuHandle, Toggleable, Tooltip};
 
@@ -40,6 +40,8 @@ fn canvas_popover_y_offset() -> Pixels {
 pub struct DmHeaderInfo {
     pub channel_id: ChannelId,
     pub is_group: bool,
+    /// Peer presence for a 1:1 DM; always `None` for a group.
+    pub presence: DmAvatarPresence,
     pub label: SharedString,
     pub avatar_src: SharedString,
     pub avatar_raw: SharedString,
@@ -376,7 +378,16 @@ impl ChannelHeader {
                         } else if !info.avatar_raw.is_empty() {
                             avatar = avatar.src(info.avatar_raw.clone());
                         }
-                        avatar
+                        div()
+                            .relative()
+                            .flex_shrink_0()
+                            .size(px(32.))
+                            .child(avatar)
+                            .children(crate::util::user_status::presence_badge_element(
+                                info.presence,
+                                theme.bg_primary,
+                                theme,
+                            ))
                     }))
                     .child({
                         let name_el = div()
@@ -870,6 +881,17 @@ impl ChannelHeader {
     }
 }
 
+/// The DM peer's badge, matching the sidebar row: the live presence, with the
+/// DM list's `online` flag only bootstrapping it until presence is known.
+/// Groups never carry one.
+fn dm_peer_presence(dm: &mezon_store::DirectChannel, cx: &App) -> DmAvatarPresence {
+    dm.peer_user_id
+        .filter(|_| dm.kind != DirectKind::Group)
+        .zip(mezon_store::PresenceStore::try_global(cx))
+        .map(|(user_id, presence)| presence.read(cx).dm_avatar_presence(user_id, dm.online))
+        .unwrap_or(DmAvatarPresence::None)
+}
+
 pub struct ChatHeader {
     name: SharedString,
     icon: Option<ChannelIcon>,
@@ -901,6 +923,7 @@ pub struct ChatHeader {
     _pinned_observe: Subscription,
     _direct_observe: Subscription,
     _group_members_observe: Subscription,
+    _presence_subscribe: Subscription,
 }
 
 impl ChatHeader {
@@ -924,6 +947,15 @@ impl ChatHeader {
         let _group_members_observe = cx.observe(
             &mezon_store::GroupMembersStore::global(cx),
             |this, _, cx| this.refresh_dm_header(cx),
+        );
+        // Only the status event: presence also notifies on every typing tick.
+        let _presence_subscribe = cx.subscribe(
+            &mezon_store::PresenceStore::global(cx),
+            |this, _, event, cx| {
+                if matches!(event, mezon_store::PresenceEvent::StatusChanged) {
+                    this.refresh_dm_presence(cx);
+                }
+            },
         );
         Self {
             name: SharedString::default(),
@@ -954,6 +986,7 @@ impl ChatHeader {
             _pinned_observe,
             _direct_observe,
             _group_members_observe,
+            _presence_subscribe,
         }
     }
 
@@ -971,6 +1004,7 @@ impl ChatHeader {
         let store = DirectMessageStore::try_global(cx)?;
         let dm = store.read(cx).find(direct_id)?;
         let is_group = dm.kind == DirectKind::Group;
+        let presence = dm_peer_presence(dm, cx);
         let avatar_src = if dm.avatar.is_empty() {
             String::new()
         } else {
@@ -994,6 +1028,7 @@ impl ChatHeader {
         Some(DmHeaderInfo {
             channel_id: dm.id,
             is_group,
+            presence,
             label: SharedString::from(dm.label.clone()),
             avatar_src: SharedString::from(avatar_src),
             avatar_raw: SharedString::from(dm.avatar.clone()),
@@ -1014,6 +1049,33 @@ impl ChatHeader {
         };
         self.dm_header.as_ref().map(|info| info.channel_id) == route_id
             && self.locale.as_deref() == locale
+    }
+
+    /// Presence-only refresh. The status tick fires for every peer the app
+    /// tracks, so it patches the cached block's badge in place instead of
+    /// rebuilding it -- a hash lookup rather than a fresh set of strings.
+    fn refresh_dm_presence(&mut self, cx: &mut Context<Self>) {
+        let Some(channel_id) = self
+            .dm_header
+            .as_ref()
+            .filter(|info| !info.is_group)
+            .map(|info| info.channel_id)
+        else {
+            return;
+        };
+        let next = DirectMessageStore::try_global(cx)
+            .and_then(|store| {
+                let store = store.read(cx);
+                let dm = store.find(channel_id)?;
+                Some(dm_peer_presence(dm, cx))
+            })
+            .unwrap_or(DmAvatarPresence::None);
+        if let Some(info) = self.dm_header.as_mut()
+            && info.presence != next
+        {
+            info.presence = next;
+            cx.notify();
+        }
     }
 
     fn refresh_dm_header(&mut self, cx: &mut Context<Self>) {

--- a/crates/mezon-ui/src/components/compositions/dm_row.rs
+++ b/crates/mezon-ui/src/components/compositions/dm_row.rs
@@ -8,8 +8,6 @@ use crate::theme::Theme;
 pub const DM_ROW_HEIGHT: f32 = 42.;
 
 const DM_AVATAR_SIZE: Pixels = px(32.);
-const PRESENCE_DOT_SIZE: Pixels = px(12.);
-const PRESENCE_IDLE_ICON_SIZE: Pixels = px(10.);
 
 pub struct DmRow {
     id: SharedString,
@@ -256,50 +254,10 @@ impl DmRow {
     }
 
     fn render_presence_badge(&self, theme: &Theme) -> Option<AnyElement> {
-        let badge_size = PRESENCE_DOT_SIZE;
-        let border = theme.bg_secondary;
-        match self.presence_badge {
-            DmAvatarPresence::None => None,
-            DmAvatarPresence::Online | DmAvatarPresence::Dnd => {
-                let fill = crate::util::user_status::presence_badge_color(self.presence_badge)
-                    .unwrap_or(theme.status_online);
-                Some(
-                    div()
-                        .absolute()
-                        .bottom(px(-1.))
-                        .right(px(-1.))
-                        .size(badge_size)
-                        .rounded_full()
-                        .border_2()
-                        .border_color(border)
-                        .bg(fill)
-                        .into_any_element(),
-                )
-            }
-            DmAvatarPresence::Idle => Some(
-                div()
-                    .absolute()
-                    .bottom(px(-1.))
-                    .right(px(-1.))
-                    .size(badge_size)
-                    .flex()
-                    .items_end()
-                    .justify_end()
-                    .child(
-                        Icon::new(IconName::DarkModeIcon)
-                            .size(PRESENCE_IDLE_ICON_SIZE)
-                            .with_transformation(gpui::Transformation::rotate(gpui::radians(
-                                -std::f32::consts::FRAC_PI_2,
-                            )))
-                            .text_color(
-                                crate::util::user_status::presence_badge_color(
-                                    DmAvatarPresence::Idle,
-                                )
-                                .unwrap_or(theme.status_idle),
-                            ),
-                    )
-                    .into_any_element(),
-            ),
-        }
+        crate::util::user_status::presence_badge_element(
+            self.presence_badge,
+            theme.bg_secondary,
+            theme,
+        )
     }
 }

--- a/crates/mezon-ui/src/util/user_status.rs
+++ b/crates/mezon-ui/src/util/user_status.rs
@@ -1,8 +1,11 @@
-use gpui::{Rgba, rgba};
+use gpui::{AnyElement, Pixels, Rgba, div, prelude::*, px, rgba};
 use mezon_store::{DmAvatarPresence, UserPresence};
 
-use crate::components::primitives::IconName;
+use crate::components::primitives::{Icon, IconName};
 use crate::theme::Theme;
+
+pub const PRESENCE_DOT_SIZE: Pixels = px(12.);
+const PRESENCE_IDLE_ICON_SIZE: Pixels = px(10.);
 
 pub fn presence_badge_color(presence: DmAvatarPresence) -> Option<Rgba> {
     match presence {
@@ -10,6 +13,57 @@ pub fn presence_badge_color(presence: DmAvatarPresence) -> Option<Rgba> {
         DmAvatarPresence::Online => Some(rgba(0x22c55eff)),
         DmAvatarPresence::Dnd => Some(rgba(0xef4444ff)),
         DmAvatarPresence::Idle => Some(rgba(0xf0b232ff)),
+    }
+}
+
+/// The presence dot drawn over a DM avatar: a filled circle for online/dnd and
+/// the crescent glyph for idle, nothing when the peer reads as offline. Expects
+/// a `relative()` parent sized to the avatar; `surface` is the background the
+/// avatar sits on, so the dot cuts a ring out of it.
+pub fn presence_badge_element(
+    presence: DmAvatarPresence,
+    surface: Rgba,
+    theme: &Theme,
+) -> Option<AnyElement> {
+    match presence {
+        DmAvatarPresence::None => None,
+        DmAvatarPresence::Online | DmAvatarPresence::Dnd => {
+            let fill = presence_badge_color(presence).unwrap_or(theme.status_online);
+            Some(
+                div()
+                    .absolute()
+                    .bottom(px(-1.))
+                    .right(px(-1.))
+                    .size(PRESENCE_DOT_SIZE)
+                    .rounded_full()
+                    .border_2()
+                    .border_color(surface)
+                    .bg(fill)
+                    .into_any_element(),
+            )
+        }
+        DmAvatarPresence::Idle => Some(
+            div()
+                .absolute()
+                .bottom(px(-1.))
+                .right(px(-1.))
+                .size(PRESENCE_DOT_SIZE)
+                .flex()
+                .items_end()
+                .justify_end()
+                .child(
+                    Icon::new(IconName::DarkModeIcon)
+                        .size(PRESENCE_IDLE_ICON_SIZE)
+                        .with_transformation(gpui::Transformation::rotate(gpui::radians(
+                            -std::f32::consts::FRAC_PI_2,
+                        )))
+                        .text_color(
+                            presence_badge_color(DmAvatarPresence::Idle)
+                                .unwrap_or(theme.status_idle),
+                        ),
+                )
+                .into_any_element(),
+        ),
     }
 }
 


### PR DESCRIPTION
The DM topbar drew a bare avatar, so a 1:1 conversation gave no sign of whether the other side was around -- the React app draws the peer's presence over that avatar (ChannelTopbar's UserStatusIconDM).

Lift the DM sidebar row's badge into util::user_status and reuse it in the header, fed by PresenceStore::dm_avatar_presence -- the same source the sidebar dots read, bootstrap flag included, so the two never disagree. Groups carry no badge, matching the web app.

The status tick is debounced store-side and fires for every peer the app tracks, so the header patches the cached block's badge in place instead of rebuilding it: a hash lookup rather than a fresh set of strings, and a repaint only when the badge actually moved.