### PR TITLE
fix(record): never hand over a call recording with no media in it

### DIFF
--- a/crates/mezon-record/src/container.rs
+++ b/crates/mezon-record/src/container.rs
@@ -1,0 +1,116 @@
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+/// A muxer that dies mid-file still leaves a plausible-looking header behind,
+/// and the Windows sink writer even reports success for one. An MP4 without its
+/// `moov` index plays nowhere, so check the file really carries one before we
+/// hand it to the user as a finished recording.
+pub fn is_playable(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if metadata.len() == 0 {
+        return false;
+    }
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase);
+    match extension.as_deref() {
+        Some("mp4") | Some("mov") | Some("m4a") => has_moov(path).unwrap_or(false),
+        _ => true,
+    }
+}
+
+fn has_moov(path: &Path) -> std::io::Result<bool> {
+    let mut file = File::open(path)?;
+    let end = file.seek(SeekFrom::End(0))?;
+    let mut offset = 0u64;
+
+    while offset + 8 <= end {
+        file.seek(SeekFrom::Start(offset))?;
+        let mut header = [0u8; 8];
+        file.read_exact(&mut header)?;
+        if &header[4..8] == b"moov" {
+            return Ok(true);
+        }
+        let size = u32::from_be_bytes([header[0], header[1], header[2], header[3]]) as u64;
+        let advance = match size {
+            // Zero means "this box runs to the end of the file", so nothing
+            // follows it; one means a 64-bit length comes after the type.
+            0 => return Ok(false),
+            1 => {
+                let mut large = [0u8; 8];
+                file.read_exact(&mut large)?;
+                u64::from_be_bytes(large)
+            }
+            size => size,
+        };
+        if advance < 8 {
+            return Ok(false);
+        }
+        offset += advance;
+    }
+
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(name: &str, bytes: &[u8]) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join(name);
+        std::fs::write(&path, bytes).expect("write");
+        (dir, path)
+    }
+
+    fn box_of(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let mut bytes = ((payload.len() + 8) as u32).to_be_bytes().to_vec();
+        bytes.extend_from_slice(kind);
+        bytes.extend_from_slice(payload);
+        bytes
+    }
+
+    #[test]
+    fn a_header_only_mp4_from_an_abandoned_sink_writer_is_not_playable() {
+        // Byte for byte what Media Foundation left behind on Windows when the
+        // sink writer never encoded a sample: ftyp, its OS-version uuid, and an
+        // mdat that runs to the end of a file with nothing in it.
+        let mut bytes = box_of(b"ftyp", b"mp42\0\0\0\0mp41isom");
+        bytes.extend_from_slice(&box_of(
+            b"uuid",
+            &[
+                0x5c, 0xa7, 0x08, 0xfb, 0x32, 0x8e, 0x42, 0x05, 0xa8, 0x61, 0x65, 0x0e, 0xca, 0x0a,
+                0x95, 0x96, 0x00, 0x00, 0x00, 0x0c, b'1', b'0', b'.', b'0', b'.', b'1', b'9', b'0',
+                b'4', b'5', b'.', b'0',
+            ],
+        ));
+        bytes.extend_from_slice(&[
+            0, 0, 0, 0, b'm', b'd', b'a', b't', 0, 0, 0, 0, 0, 0, 0, 0x10,
+        ]);
+        assert_eq!(bytes.len(), 80);
+
+        let (_dir, path) = write("call.mp4", &bytes);
+        assert!(!is_playable(&path));
+    }
+
+    #[test]
+    fn an_mp4_that_carries_its_index_is_playable() {
+        let mut bytes = box_of(b"ftyp", b"mp42\0\0\0\0mp41isom");
+        bytes.extend_from_slice(&box_of(b"mdat", &[0u8; 32]));
+        bytes.extend_from_slice(&box_of(b"moov", &[0u8; 16]));
+        let (_dir, path) = write("call.mp4", &bytes);
+        assert!(is_playable(&path));
+    }
+
+    #[test]
+    fn a_container_we_cannot_inspect_only_has_to_be_non_empty() {
+        let (_dir, webm) = write("call.webm", &[1, 2, 3, 4]);
+        assert!(is_playable(&webm));
+        let (_dir, empty) = write("empty.webm", &[]);
+        assert!(!is_playable(&empty));
+    }
+}

--- a/crates/mezon-record/src/lib.rs
+++ b/crates/mezon-record/src/lib.rs
@@ -1,3 +1,4 @@
+mod container;
 mod disk;
 mod mixer;
 mod recorder;

--- a/crates/mezon-record/src/mixer.rs
+++ b/crates/mezon-record/src/mixer.rs
@@ -120,13 +120,18 @@ impl Track {
         }
     }
 
-    fn mix_into(&mut self, out: &mut [i16]) {
+    /// Returns how many samples this track actually contributed, so a source
+    /// that never reaches the mix can be told apart from one the mixer dropped.
+    fn mix_into(&mut self, out: &mut [i16]) -> u64 {
+        let mut mixed = 0;
         for slot in out.iter_mut() {
             let Some(sample) = self.buf.pop_front() else {
                 break;
             };
             *slot = (*slot as i32 + sample as i32).clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+            mixed += 1;
         }
+        mixed
     }
 
     fn frames(&self) -> u64 {
@@ -134,10 +139,20 @@ impl Track {
     }
 }
 
+/// Frames each source contributed to the recording, in the order remote, mic,
+/// screen.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Contributions {
+    pub remote: u64,
+    pub mic: u64,
+    pub screen: u64,
+}
+
 pub struct AudioMixer {
     remote: Track,
     mic: Track,
     screen: Track,
+    mixed: Contributions,
 }
 
 impl AudioMixer {
@@ -146,6 +161,7 @@ impl AudioMixer {
             remote: Track::new(),
             mic: Track::new(),
             screen: Track::new(),
+            mixed: Contributions::default(),
         }
     }
 
@@ -165,9 +181,14 @@ impl AudioMixer {
     pub fn drain_block(&mut self, frames: usize, out: &mut Vec<i16>) {
         out.clear();
         out.resize(frames * RECORD_CHANNELS as usize, 0);
-        self.remote.mix_into(out);
-        self.mic.mix_into(out);
-        self.screen.mix_into(out);
+        let channels = RECORD_CHANNELS as u64;
+        self.mixed.remote += self.remote.mix_into(out) / channels;
+        self.mixed.mic += self.mic.mix_into(out) / channels;
+        self.mixed.screen += self.screen.mix_into(out) / channels;
+    }
+
+    pub fn contributions(&self) -> Contributions {
+        self.mixed
     }
 }
 

--- a/crates/mezon-record/src/recorder.rs
+++ b/crates/mezon-record/src/recorder.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
 
+use crate::container;
 use crate::disk;
 use crate::mixer::{AudioMixer, AudioSource};
 use crate::platform;
@@ -203,9 +204,10 @@ impl Recorder {
             dropped_audio_chunks: self.shared.dropped.load(Ordering::Relaxed),
             dropped_video_frames: self.shared.dropped_video.load(Ordering::Relaxed),
             video_frames: frames,
-            video_stalled: self.video.is_some()
-                && frames > 0
-                && pts.saturating_sub(last) > VIDEO_STALL,
+            // `last` sits at zero until the first frame lands, so a video
+            // track that never starts reads as stalled too — which is exactly
+            // what it is.
+            video_stalled: self.video.is_some() && pts.saturating_sub(last) > VIDEO_STALL,
         }
     }
 
@@ -222,8 +224,25 @@ impl Recorder {
         let Some(sink) = sink else {
             return Err(RecordError::Finish);
         };
+        let failed = self.shared.failed.load(Ordering::Relaxed);
         sink.finish()?;
         let part = part_path(&self.path);
+
+        if failed {
+            tracing::warn!("the call recorder gave up mid-call; keeping what it managed to encode");
+        }
+        // A muxer that finalized nothing but a container header still leaves a
+        // file behind, and Media Foundation even reports success for one. Keep
+        // that partial under its own name and report the failure rather than
+        // handing the user an mp4 that opens in no player.
+        if !container::is_playable(&part) {
+            tracing::error!(
+                "the call recording carries no usable media; the partial file stays at {}",
+                part.display()
+            );
+            return Err(RecordError::Incomplete);
+        }
+
         if std::fs::rename(&part, &self.path).is_ok() {
             return Ok(self.path.clone());
         }
@@ -302,6 +321,16 @@ fn audio_worker(shared: Arc<Shared>, rx: flume::Receiver<AudioChunk>) {
         }
 
         if stopping && !received && !wrote {
+            // Whether a source ever reached the mix is the one thing the file
+            // itself cannot tell us — a screen share nobody can hear in the
+            // recording looks identical to one that was never tapped.
+            let mixed = mixer.contributions();
+            tracing::info!(
+                "the call recording mixed {} remote, {} mic and {} screen frames",
+                mixed.remote,
+                mixed.mic,
+                mixed.screen
+            );
             return;
         }
         if !received && !wrote {

--- a/crates/mezon-record/src/sink.rs
+++ b/crates/mezon-record/src/sink.rs
@@ -13,6 +13,8 @@ pub enum RecordError {
     Encode,
     #[error("could not finalize the recording file")]
     Finish,
+    #[error("the recording was cut short and the partial file was kept")]
+    Incomplete,
     #[error("not enough free disk space to record")]
     DiskSpace,
 }

--- a/crates/mezon-record/src/windows.rs
+++ b/crates/mezon-record/src/windows.rs
@@ -3,15 +3,17 @@ use std::sync::Once;
 use std::time::Duration;
 
 use windows::Win32::Media::MediaFoundation::{
-    IMFSinkWriter, MF_MT_AUDIO_AVG_BYTES_PER_SECOND, MF_MT_AUDIO_BITS_PER_SAMPLE,
-    MF_MT_AUDIO_BLOCK_ALIGNMENT, MF_MT_AUDIO_NUM_CHANNELS, MF_MT_AUDIO_SAMPLES_PER_SECOND,
-    MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE, MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE,
-    MF_MT_PIXEL_ASPECT_RATIO, MF_MT_SUBTYPE, MF_TRANSCODE_CONTAINERTYPE, MF_VERSION,
-    MFAudioFormat_AAC, MFAudioFormat_PCM, MFCreateAttributes, MFCreateMediaType,
-    MFCreateMemoryBuffer, MFCreateSample, MFCreateSinkWriterFromURL, MFMediaType_Audio,
-    MFMediaType_Video, MFSTARTUP_FULL, MFStartup, MFTranscodeContainerType_MPEG4,
-    MFVideoFormat_H264, MFVideoFormat_NV12, MFVideoInterlace_Progressive,
+    IMFSinkWriter, MF_MT_ALL_SAMPLES_INDEPENDENT, MF_MT_AUDIO_AVG_BYTES_PER_SECOND,
+    MF_MT_AUDIO_BITS_PER_SAMPLE, MF_MT_AUDIO_BLOCK_ALIGNMENT, MF_MT_AUDIO_NUM_CHANNELS,
+    MF_MT_AUDIO_SAMPLES_PER_SECOND, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE,
+    MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE, MF_MT_MPEG2_PROFILE, MF_MT_PIXEL_ASPECT_RATIO,
+    MF_MT_SUBTYPE, MF_TRANSCODE_CONTAINERTYPE, MF_VERSION, MFAudioFormat_AAC, MFAudioFormat_PCM,
+    MFCreateAttributes, MFCreateMediaType, MFCreateMemoryBuffer, MFCreateSample,
+    MFCreateSinkWriterFromURL, MFMediaType_Audio, MFMediaType_Video, MFSTARTUP_FULL, MFStartup,
+    MFTranscodeContainerType_MPEG4, MFVideoFormat_H264, MFVideoFormat_NV12,
+    MFVideoInterlace_Progressive, eAVEncH264VProfile_Main,
 };
+use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoUninitialize};
 use windows::core::HSTRING;
 use yuv::{YuvBiPlanarImageMut, YuvConversionMode, YuvRange, YuvStandardMatrix, bgra_to_yuv_nv12};
 
@@ -30,6 +32,7 @@ pub fn file_extension() -> &'static str {
 
 const VIDEO_BITRATE: u32 = 2_500_000;
 const AUDIO_BYTES_PER_SECOND: u32 = 16_000;
+const BYTES_PER_AUDIO_FRAME: u32 = 2 * RECORD_CHANNELS;
 
 static MF_INIT: Once = Once::new();
 
@@ -39,6 +42,32 @@ fn ensure_media_foundation() {
             tracing::error!("MFStartup failed for call recording: {error}");
         }
     });
+}
+
+struct Apartment(bool);
+
+impl Drop for Apartment {
+    fn drop(&mut self) {
+        if self.0 {
+            unsafe { CoUninitialize() };
+        }
+    }
+}
+
+thread_local! {
+    static APARTMENT: Apartment = Apartment(unsafe {
+        // RPC_E_CHANGED_MODE means the thread already lives in an apartment we
+        // can call from, so only undo the ones we actually joined.
+        CoInitializeEx(None, COINIT_MULTITHREADED).is_ok()
+    });
+}
+
+/// The sink writer is created on one background thread and then fed from the
+/// audio worker and the compositor, and every one of those calls goes straight
+/// into COM. A thread that never joined an apartment can fail its very first
+/// `WriteSample`, which leaves a header-only MP4 behind, so join before calling.
+fn ensure_thread_apartment() {
+    APARTMENT.with(|_| ());
 }
 
 fn pack_ratio(high: u32, low: u32) -> u64 {
@@ -55,6 +84,9 @@ pub struct WindowsSink {
     audio_stream: u32,
     video: Option<VideoConfig>,
     nv12: Vec<u8>,
+    audio_samples: u64,
+    video_samples: u64,
+    dropped_frames: u64,
     finished: bool,
 }
 
@@ -70,6 +102,7 @@ pub fn create_sink(
 impl WindowsSink {
     fn new(path: &Path, video: Option<VideoConfig>) -> Result<Self, RecordError> {
         ensure_media_foundation();
+        ensure_thread_apartment();
         unsafe {
             let target = HSTRING::from(path.as_os_str());
             let mut attributes = None;
@@ -97,6 +130,9 @@ impl WindowsSink {
                         .SetUINT32(&MF_MT_AVG_BITRATE, VIDEO_BITRATE)
                         .map_err(|_| RecordError::Create)?;
                     out_type
+                        .SetUINT32(&MF_MT_MPEG2_PROFILE, eAVEncH264VProfile_Main.0 as u32)
+                        .map_err(|_| RecordError::Create)?;
+                    out_type
                         .SetUINT32(&MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive.0 as u32)
                         .map_err(|_| RecordError::Create)?;
                     out_type
@@ -108,9 +144,10 @@ impl WindowsSink {
                     out_type
                         .SetUINT64(&MF_MT_PIXEL_ASPECT_RATIO, pack_ratio(1, 1))
                         .map_err(|_| RecordError::Create)?;
-                    let stream = writer
-                        .AddStream(&out_type)
-                        .map_err(|_| RecordError::Create)?;
+                    let stream = writer.AddStream(&out_type).map_err(|error| {
+                        tracing::error!("call recorder could not add the H.264 stream: {error}");
+                        RecordError::Create
+                    })?;
 
                     let in_type = MFCreateMediaType().map_err(|_| RecordError::Create)?;
                     in_type
@@ -161,9 +198,10 @@ impl WindowsSink {
             audio_out
                 .SetUINT32(&MF_MT_AUDIO_AVG_BYTES_PER_SECOND, AUDIO_BYTES_PER_SECOND)
                 .map_err(|_| RecordError::Create)?;
-            let audio_stream = writer
-                .AddStream(&audio_out)
-                .map_err(|_| RecordError::Create)?;
+            let audio_stream = writer.AddStream(&audio_out).map_err(|error| {
+                tracing::error!("call recorder could not add the AAC stream: {error}");
+                RecordError::Create
+            })?;
 
             let audio_in = MFCreateMediaType().map_err(|_| RecordError::Create)?;
             audio_in
@@ -182,7 +220,19 @@ impl WindowsSink {
                 .SetUINT32(&MF_MT_AUDIO_NUM_CHANNELS, RECORD_CHANNELS)
                 .map_err(|_| RecordError::Create)?;
             audio_in
-                .SetUINT32(&MF_MT_AUDIO_BLOCK_ALIGNMENT, 2 * RECORD_CHANNELS)
+                .SetUINT32(&MF_MT_AUDIO_BLOCK_ALIGNMENT, BYTES_PER_AUDIO_FRAME)
+                .map_err(|_| RecordError::Create)?;
+            // An uncompressed audio type is only complete with its byte rate and
+            // its independent-samples flag; without them the AAC encoder is free
+            // to reject every sample we hand it later on.
+            audio_in
+                .SetUINT32(
+                    &MF_MT_AUDIO_AVG_BYTES_PER_SECOND,
+                    RECORD_SAMPLE_RATE * BYTES_PER_AUDIO_FRAME,
+                )
+                .map_err(|_| RecordError::Create)?;
+            audio_in
+                .SetUINT32(&MF_MT_ALL_SAMPLES_INDEPENDENT, 1)
                 .map_err(|_| RecordError::Create)?;
             writer
                 .SetInputMediaType(audio_stream, &audio_in, None)
@@ -202,6 +252,9 @@ impl WindowsSink {
                 audio_stream,
                 video,
                 nv12: Vec::new(),
+                audio_samples: 0,
+                video_samples: 0,
+                dropped_frames: 0,
                 finished: false,
             })
         }
@@ -236,7 +289,9 @@ impl WindowsSink {
                 .SetSampleDuration(hundred_nanos(duration))
                 .map_err(|_| RecordError::Encode)?;
             self.writer.WriteSample(stream, &sample).map_err(|error| {
-                tracing::error!("call recorder could not write a sample: {error}");
+                tracing::error!(
+                    "call recorder could not write a sample to stream {stream}: {error}"
+                );
                 RecordError::Encode
             })
         }
@@ -245,16 +300,32 @@ impl WindowsSink {
 
 impl RecordSink for WindowsSink {
     fn push_audio(&mut self, pcm: &[i16], pts: Duration) -> Result<(), RecordError> {
+        ensure_thread_apartment();
         let mut bytes = Vec::with_capacity(std::mem::size_of_val(pcm));
         for sample in pcm {
             bytes.extend_from_slice(&sample.to_le_bytes());
         }
         let frames = (pcm.len() / RECORD_CHANNELS as usize) as u64;
         let duration = Duration::from_nanos(frames * 1_000_000_000 / RECORD_SAMPLE_RATE as u64);
-        unsafe { self.write(self.audio_stream, &bytes, pts, duration) }
+        unsafe { self.write(self.audio_stream, &bytes, pts, duration) }?;
+        self.audio_samples += 1;
+
+        // The MP4 sink interleaves by timestamp, so it holds every audio sample
+        // in memory until the video stream reaches the same point — and writes
+        // nothing at all to the file while it waits. Tell it the video stream is
+        // simply not there yet so the muxer keeps draining.
+        if let Some(stream) = self.video_stream
+            && self.video_samples == 0
+        {
+            unsafe {
+                let _ = self.writer.SendStreamTick(stream, hundred_nanos(pts));
+            }
+        }
+        Ok(())
     }
 
     fn push_video(&mut self, frame: VideoFrameRef<'_>, pts: Duration) -> Result<(), RecordError> {
+        ensure_thread_apartment();
         let (Some(stream), Some(config)) = (self.video_stream, self.video) else {
             return Ok(());
         };
@@ -277,16 +348,20 @@ impl RecordSink for WindowsSink {
             width,
             height,
         };
-        if bgra_to_yuv_nv12(
+        if let Err(error) = bgra_to_yuv_nv12(
             &mut planar,
             data,
             stride as u32,
             YuvRange::Limited,
             YuvStandardMatrix::Bt709,
             YuvConversionMode::Balanced,
-        )
-        .is_err()
-        {
+        ) {
+            // Dropping every frame silently is how a recording ends up with no
+            // video track at all, so say it once rather than never.
+            if self.dropped_frames == 0 {
+                tracing::error!("call recorder could not convert a frame to NV12: {error}");
+            }
+            self.dropped_frames += 1;
             return Ok(());
         }
 
@@ -294,23 +369,40 @@ impl RecordSink for WindowsSink {
         let bytes = std::mem::take(&mut self.nv12);
         let result = unsafe { self.write(stream, &bytes, pts, duration) };
         self.nv12 = bytes;
-        result
+        result?;
+        self.video_samples += 1;
+        Ok(())
     }
 
     fn finish(mut self: Box<Self>) -> Result<(), RecordError> {
+        ensure_thread_apartment();
         self.finished = true;
         unsafe {
             self.writer.Finalize().map_err(|error| {
                 tracing::error!("could not finalize the call recording: {error}");
                 RecordError::Finish
-            })
+            })?
+        };
+        tracing::info!(
+            "the call recording encoded {} audio and {} video samples ({} frames dropped)",
+            self.audio_samples,
+            self.video_samples,
+            self.dropped_frames
+        );
+        // Media Foundation reports success for a finalize that wrote nothing but
+        // the container header, and that file opens in no player anywhere.
+        if self.audio_samples == 0 && self.video_samples == 0 {
+            tracing::error!("the call recording was finalized without a single encoded sample");
+            return Err(RecordError::Finish);
         }
+        Ok(())
     }
 }
 
 impl Drop for WindowsSink {
     fn drop(&mut self) {
         if !self.finished {
+            ensure_thread_apartment();
             let _ = unsafe { self.writer.Finalize() };
         }
     }

--- a/crates/mezon-record/tests/mixes_every_source.rs
+++ b/crates/mezon-record/tests/mixes_every_source.rs
@@ -1,0 +1,88 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use mezon_record::{AudioSource, RECORD_CHANNELS, RECORD_SAMPLE_RATE, Recorder, RecorderConfig};
+
+const BLOCK_FRAMES: u32 = RECORD_SAMPLE_RATE / 100;
+const SECONDS: u32 = 2;
+
+fn silence() -> Vec<i16> {
+    vec![0i16; (BLOCK_FRAMES * RECORD_CHANNELS) as usize]
+}
+
+fn tone(step: u32) -> Vec<i16> {
+    (0..BLOCK_FRAMES * RECORD_CHANNELS)
+        .map(|index| {
+            let frame = step * BLOCK_FRAMES + index / RECORD_CHANNELS;
+            let t = frame as f32 / RECORD_SAMPLE_RATE as f32;
+            ((t * 440.0 * std::f32::consts::TAU).sin() * 12000.0) as i16
+        })
+        .collect()
+}
+
+fn peak_amplitude(path: &PathBuf) -> Option<i32> {
+    let wav = path.with_extension("probe.wav");
+    let status = std::process::Command::new("afconvert")
+        .args(["-f", "WAVE", "-d", "LEI16"])
+        .arg(path)
+        .arg(&wav)
+        .status()
+        .ok()?;
+    if !status.success() {
+        return None;
+    }
+    let bytes = std::fs::read(&wav).ok()?;
+    let _ = std::fs::remove_file(&wav);
+    let peak = bytes[44..]
+        .chunks_exact(2)
+        .map(|pair| i16::from_le_bytes([pair[0], pair[1]]).unsigned_abs() as i32)
+        .max()?;
+    Some(peak)
+}
+
+/// Sharing a video while nobody in the call is talking is the case that broke:
+/// the only sound in the room comes from a source the recorder does not use to
+/// pace itself, so it must survive on its own.
+#[test]
+fn screen_audio_lands_in_the_recording_when_only_silence_comes_from_the_call() {
+    if !mezon_record::is_supported() {
+        eprintln!("skipping: this platform has no call-recording encoder");
+        return;
+    }
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir
+        .path()
+        .join(format!("call.{}", mezon_record::file_extension()));
+    let recorder = Recorder::start(RecorderConfig {
+        path: path.clone(),
+        video: None,
+    })
+    .expect("the recorder should start");
+
+    let audio = recorder.audio_tap();
+    for step in 0..SECONDS * 100 {
+        audio.push(
+            AudioSource::Remote,
+            &silence(),
+            RECORD_SAMPLE_RATE,
+            RECORD_CHANNELS,
+        );
+        audio.push(
+            AudioSource::Screen,
+            &tone(step),
+            RECORD_SAMPLE_RATE,
+            RECORD_CHANNELS,
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    let written = recorder.finish().expect("the recorder should finalise");
+    let Some(peak) = peak_amplitude(&written) else {
+        eprintln!("skipping the amplitude check: no decoder on this machine");
+        return;
+    };
+    assert!(
+        peak > 2000,
+        "the shared screen's audio never made it into the recording (peak {peak})"
+    );
+}

--- a/crates/mezon-store/src/voice.rs
+++ b/crates/mezon-store/src/voice.rs
@@ -2765,7 +2765,9 @@ impl VoiceStore {
         match self.recording {
             RecordingState::Idle => self.start_recording(window_id, cx),
             RecordingState::Recording => self.stop_recording(cx),
-            RecordingState::Starting | RecordingState::Stopping => {}
+            // Nothing to do, but a button that looks dead is worth a line in the
+            // log — a finalize that never returns lands here every time.
+            state => tracing::warn!("ignoring the record button while the recorder is {state:?}"),
         }
     }
 
@@ -2865,6 +2867,7 @@ impl VoiceStore {
             let path = match receiver.await {
                 Ok(Ok(Some(path))) => path,
                 Ok(Ok(None)) => {
+                    tracing::info!("the recording save dialog was cancelled");
                     let _ = this.update(cx, |this, cx| {
                         this.recording = RecordingState::Idle;
                         cx.notify();

--- a/crates/mezon-voice/src/lib.rs
+++ b/crates/mezon-voice/src/lib.rs
@@ -622,9 +622,19 @@ async fn session_main(
             event = room_events.recv() => {
                 let Some(event) = event else { break };
                 match event {
-                    RoomEvent::TrackSubscribed { track, participant, .. } => {
+                    RoomEvent::TrackSubscribed { track, publication, participant } => {
                         match track {
                             RemoteTrack::Audio(audio_track) => {
+                                // Screen-share audio and a plain microphone are
+                                // the same kind of remote track here, so the
+                                // source is the only way to tell from a log
+                                // whether the shared sound ever reached the mix
+                                // the recorder tees from.
+                                tracing::info!(
+                                    "playing remote {:?} audio from {}",
+                                    publication.source(),
+                                    participant.identity().as_str()
+                                );
                                 if let (Some(mixer), Some(out_fmt)) = (&audio_mixer, out_fmt) {
                                     let key = track_frame_key(participant.identity().as_str(), audio_track.sid().as_str());
                                     if let Some(handle) = audio_tracks.remove(&key) {
@@ -825,9 +835,10 @@ async fn session_main(
                             let tx = screen_tx.clone();
                             let generation = screen_gen;
                             let taps = record_taps.clone();
+                            let events = evt_tx.clone();
                             screen_task = Some(runtime::runtime().spawn(async move {
                                 let result =
-                                    start_screen_track(&room, &identity, store, full_res, pick, share_audio, taps).await;
+                                    start_screen_track(&room, &identity, store, full_res, pick, share_audio, taps, events).await;
                                 let _ = tx.send_async((generation, result)).await;
                             }));
                         }
@@ -1082,7 +1093,11 @@ async fn start_screen_track(
     pick: PickedScreen,
     share_audio: bool,
     record_taps: Option<record::RecordTaps>,
+    evt_tx: flume::Sender<VoiceEvent>,
 ) -> Result<ScreenSession> {
+    // Whether the switch in the picker was on is the first thing to know when a
+    // recording comes out silent, and it left no trace anywhere before.
+    tracing::info!("starting screen share (share system audio: {share_audio})");
     let (stopper, track_rx) =
         screen::start_screen(identity.to_string(), frame_store, full_res, pick);
     let track = track_rx
@@ -1107,9 +1122,16 @@ async fn start_screen_track(
         .await?;
     let audio = if share_audio {
         match start_screen_audio_track(room, record_taps).await {
-            Ok(audio) => Some(audio),
+            Ok(audio) => {
+                tracing::info!("sharing this machine's system audio with the call");
+                Some(audio)
+            }
             Err(e) => {
+                // The screen keeps sharing without it, so a log line was the
+                // only sign — nobody in the call hears the shared sound and the
+                // recording has none either, with nothing to explain why.
                 tracing::warn!("system audio share unavailable: {e:#}");
+                let _ = evt_tx.send(VoiceEvent::Error(format!("screen audio: {e}")));
                 None
             }
         }

--- a/crates/mezon-voice/src/screen_audio.rs
+++ b/crates/mezon-voice/src/screen_audio.rs
@@ -136,3 +136,135 @@ mod macos {
         }
     }
 }
+
+#[cfg(all(test, target_os = "macos"))]
+mod probe {
+    //! Run with `cargo test -p mezon-voice --lib probe -- --ignored --nocapture`
+    //! while something outside Mezon is playing sound.
+    use std::time::{Duration, Instant};
+
+    /// The whole production chain minus LiveKit: the real ScreenCaptureKit
+    /// stream, the same pump loop `start_screen_audio_track` runs, the real
+    /// `RecordTaps` the recorder is wired through, and a real encoded file.
+    #[test]
+    #[ignore]
+    fn shared_system_audio_reaches_the_recorded_file() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let path = std::env::temp_dir().join("mezon-screen-audio-probe.mp4");
+        let _ = std::fs::remove_file(&path);
+        let recorder = mezon_record::Recorder::start(mezon_record::RecorderConfig {
+            path: path.clone(),
+            video: None,
+        })
+        .expect("recorder");
+
+        let taps = crate::record::RecordTaps::default();
+        taps.set(Some(recorder.audio_tap()));
+
+        let capture = super::start_screen_audio().expect("screen audio");
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let pump_taps = taps.clone();
+        let pump_rx = capture.rx.clone();
+        let pump_stop = stop.clone();
+        let pump = std::thread::spawn(move || {
+            while !pump_stop.load(Ordering::Relaxed) {
+                let Ok(samples) = pump_rx.recv_timeout(Duration::from_millis(100)) else {
+                    continue;
+                };
+                if samples.len() as u32 / super::SCREEN_AUDIO_CHANNELS == 0 {
+                    continue;
+                }
+                pump_taps.push(
+                    mezon_record::AudioSource::Screen,
+                    &samples,
+                    super::SCREEN_AUDIO_SAMPLE_RATE,
+                    super::SCREEN_AUDIO_CHANNELS,
+                );
+            }
+        });
+
+        // The playback device tees silence into the recorder the whole call,
+        // and that is what paces the mixer, so a faithful run needs it.
+        let silence = vec![0i16; 480 * 2];
+        let deadline = Instant::now() + Duration::from_secs(4);
+        while Instant::now() < deadline {
+            taps.push(mezon_record::AudioSource::Remote, &silence, 48_000, 2);
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        stop.store(true, Ordering::Relaxed);
+        pump.join().expect("pump");
+        taps.set(None);
+        let written = recorder.finish().expect("finish");
+
+        let wav = written.with_extension("probe.wav");
+        let status = std::process::Command::new("afconvert")
+            .args(["-f", "WAVE", "-d", "LEI16"])
+            .arg(&written)
+            .arg(&wav)
+            .status()
+            .expect("afconvert");
+        assert!(status.success(), "afconvert could not read the recording");
+        let bytes = std::fs::read(&wav).expect("wav");
+        let peak = bytes[44..]
+            .chunks_exact(2)
+            .map(|pair| i16::from_le_bytes([pair[0], pair[1]]).unsigned_abs() as i32)
+            .max()
+            .unwrap_or(0);
+        println!("recorded {} bytes, audio peak={peak}", bytes.len());
+        assert!(peak > 500, "the shared system audio never reached the file");
+    }
+
+    /// The real app already holds an SCStream for the shared video when the
+    /// audio one is opened, so a second stream has to be allowed.
+    #[test]
+    #[ignore]
+    fn a_second_capture_stream_still_delivers() {
+        let first = match super::start_screen_audio() {
+            Ok(capture) => capture,
+            Err(error) => panic!("first start_screen_audio failed: {error}"),
+        };
+        let second = match super::start_screen_audio() {
+            Ok(capture) => capture,
+            Err(error) => panic!("second start_screen_audio failed: {error}"),
+        };
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let (mut a, mut b) = (0u64, 0u64);
+        while Instant::now() < deadline {
+            if first.rx.recv_timeout(Duration::from_millis(50)).is_ok() {
+                a += 1;
+            }
+            if second.rx.recv_timeout(Duration::from_millis(50)).is_ok() {
+                b += 1;
+            }
+        }
+        println!("first={a} second={b}");
+        assert!(a > 0 && b > 0, "one of the two streams went silent");
+    }
+
+    #[test]
+    #[ignore]
+    fn system_audio_capture_delivers_samples() {
+        let capture = match super::start_screen_audio() {
+            Ok(capture) => capture,
+            Err(error) => panic!("start_screen_audio failed: {error}"),
+        };
+        let deadline = Instant::now() + Duration::from_secs(4);
+        let mut buffers = 0u64;
+        let mut samples = 0u64;
+        let mut peak = 0i32;
+        while Instant::now() < deadline {
+            if let Ok(chunk) = capture.rx.recv_timeout(Duration::from_millis(250)) {
+                buffers += 1;
+                samples += chunk.len() as u64;
+                for value in chunk {
+                    peak = peak.max(value.unsigned_abs() as i32);
+                }
+            }
+        }
+        println!("buffers={buffers} samples={samples} peak={peak}");
+    }
+}

--- a/crates/vendor/gpui_windows/src/platform.rs
+++ b/crates/vendor/gpui_windows/src/platform.rs
@@ -294,6 +294,18 @@ impl WindowsPlatform {
             .map(|hwnd| hwnd.as_raw())
     }
 
+    /// A shell dialog with no owner can come up *behind* the app, which reads to
+    /// the user as "the dialog never opened". Fall back to any window we own so
+    /// it is always modal to something visible.
+    fn dialog_owner_window(&self) -> Option<HWND> {
+        self.find_current_active_window().or_else(|| {
+            self.raw_window_handles
+                .read()
+                .first()
+                .map(|hwnd| hwnd.as_raw())
+        })
+    }
+
     fn begin_vsync_thread(&self) {
         let Some(directx_devices) = self.inner.state.directx_devices.borrow().clone() else {
             return;
@@ -560,7 +572,7 @@ impl Platform for WindowsPlatform {
         options: PathPromptOptions,
     ) -> Receiver<Result<Option<Vec<PathBuf>>>> {
         let (tx, rx) = oneshot::channel();
-        let window = self.find_current_active_window();
+        let window = self.dialog_owner_window();
         self.foreground_executor()
             .spawn(async move {
                 let _ = tx.send(file_open_dialog(options, window));
@@ -578,7 +590,7 @@ impl Platform for WindowsPlatform {
         let directory = directory.to_owned();
         let suggested_name = suggested_name.map(|s| s.to_owned());
         let (tx, rx) = oneshot::channel();
-        let window = self.find_current_active_window();
+        let window = self.dialog_owner_window();
         self.foreground_executor()
             .spawn(async move {
                 let _ = tx.send(file_save_dialog(directory, suggested_name, window));
@@ -1135,6 +1147,17 @@ fn open_target_in_explorer(target: &Path) -> Result<()> {
     })
 }
 
+/// `IFileDialog::Show` reports a cancelled dialog as `ERROR_CANCELLED`. Every
+/// other failure means the dialog never came up, and reporting that as a cancel
+/// leaves the caller silently doing nothing at all.
+fn dialog_cancelled(error: windows::core::Error) -> Result<()> {
+    if error.code() == HRESULT::from_win32(ERROR_CANCELLED.0) {
+        Ok(())
+    } else {
+        Err(error).context("failed to show the file dialog")
+    }
+}
+
 fn file_open_dialog(
     options: PathPromptOptions,
     window: Option<HWND>,
@@ -1158,9 +1181,8 @@ fn file_open_dialog(
             folder_dialog.SetOkButtonLabel(&HSTRING::from(prompt))?;
         }
 
-        if folder_dialog.Show(window).is_err() {
-            // User cancelled
-            return Ok(None);
+        if let Err(error) = folder_dialog.Show(window) {
+            return dialog_cancelled(error).map(|()| None);
         }
     }
 
@@ -1218,9 +1240,8 @@ fn file_save_dialog(
             pszName: windows::core::w!("All files"),
             pszSpec: windows::core::w!("*.*"),
         }])?;
-        if dialog.Show(window).is_err() {
-            // User cancelled
-            return Ok(None);
+        if let Err(error) = dialog.Show(window) {
+            return dialog_cancelled(error).map(|()| None);
         }
     }
     let shell_item = unsafe { dialog.GetResult()? };


### PR DESCRIPTION
A Windows recording came back 80 bytes long — ftyp, Media Foundation's OS-version uuid box and an mdat with nothing in it, no moov anywhere — and the app still renamed the partial to its final name and reported it saved.

Check the file before claiming it: `container::is_playable` walks the top-level ISO-BMFF boxes and requires a `moov` for mp4/mov/m4a, and `Recorder::finish` keeps the `.part` and reports `Incomplete` rather than taking the final path.

Close the ways the Windows sink can end up encoding nothing:

- the PCM input type was incomplete (no MF_MT_AUDIO_AVG_BYTES_PER_SECOND, no MF_MT_ALL_SAMPLES_INDEPENDENT), which leaves the AAC encoder free to reject every sample handed to it;
- the sink writer is created on the background executor but fed from the audio worker and the compositor, and neither thread had joined a COM apartment;
- the MP4 sink interleaves by timestamp and writes nothing while one stream is behind, so tick the video stream for as long as it has no samples;
- count what was encoded and refuse to report success for a finalize that wrote no sample at all.

Stop `IFileDialog::Show` reporting every failure as a user cancel — only ERROR_CANCELLED is one — and give the shell dialogs an owner window so they cannot open behind the app, which reads as "the save dialog never appeared".

Add what would have made this visible from a log: frames mixed per source, the source of each remote audio track, whether the screen share was asked to carry system audio, and an error the user can see when that capture fails instead of a warning only the log ever held.