### PR TITLE
feat(clan): wire up the category actions and channel favorite

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -2172,6 +2172,7 @@
   "contextMenu.copyUserId": "Copy User ID",
   "contextMenu.createThread": "Create Thread",
   "contextMenu.deleteCategory": "Delete Category",
+  "contextMenu.deleteCategoryFailed": "Failed to delete category. Please try again.",
   "contextMenu.deleteMessage": "Delete Message",
   "contextMenu.editCategory": "Edit Category",
   "contextMenu.editClanProfile": "Edit Clan Profile",

--- a/assets/i18n/vi.json
+++ b/assets/i18n/vi.json
@@ -2163,6 +2163,7 @@
   "contextMenu.copyUserId": "Sao chép ID người dùng",
   "contextMenu.createThread": "Tạo chủ đề",
   "contextMenu.deleteCategory": "Xóa danh mục",
+  "contextMenu.deleteCategoryFailed": "Xóa danh mục thất bại. Vui lòng thử lại.",
   "contextMenu.deleteMessage": "Xóa tin nhắn",
   "contextMenu.editCategory": "Chỉnh sửa danh mục",
   "contextMenu.editClanProfile": "Chỉnh sửa hồ sơ Clan",

--- a/crates/mezon-app/src/mcp.rs
+++ b/crates/mezon-app/src/mcp.rs
@@ -429,6 +429,104 @@ impl McpRuntime {
                             .update(|cx| mezon_ui::app::capture::clan_menu_pick(cx, index, value));
                         let _ = reply.send(result);
                     }
+                    McpCommand::ListCategories { clan_id, reply } => {
+                        let result = cx.update(|cx| {
+                            mezon_ui::app::capture::list_categories(
+                                cx,
+                                mezon_store::ClanId(clan_id),
+                            )
+                        });
+                        let _ = reply.send(result);
+                    }
+                    McpCommand::CreateCategory {
+                        clan_id,
+                        name,
+                        reply,
+                    } => {
+                        let task = cx.update(|cx| {
+                            mezon_ui::app::capture::create_category_task(
+                                cx,
+                                mezon_store::ClanId(clan_id),
+                                name,
+                            )
+                        });
+                        let _ = reply.send(task.await);
+                    }
+                    McpCommand::ChannelMenuState { reply } => {
+                        let result = cx.update(|cx| mezon_ui::app::capture::channel_menu_state(cx));
+                        let _ = reply.send(result);
+                    }
+                    McpCommand::ChannelMenuOpen {
+                        clan_id,
+                        channel_id,
+                        x,
+                        y,
+                        in_favorites,
+                        reply,
+                    } => {
+                        let result = cx.update(|cx| {
+                            mezon_ui::app::capture::channel_menu_open(
+                                cx,
+                                mezon_store::ClanId(clan_id),
+                                mezon_store::ChannelId(channel_id),
+                                x,
+                                y,
+                                in_favorites,
+                            )
+                        });
+                        let _ = reply.send(result);
+                    }
+                    McpCommand::ChannelMenuClose { reply } => {
+                        let result = cx.update(mezon_ui::app::capture::channel_menu_close);
+                        let _ = reply.send(result);
+                    }
+                    McpCommand::ChannelMenuPick {
+                        index,
+                        value,
+                        reply,
+                    } => {
+                        let result = cx.update(|cx| {
+                            mezon_ui::app::capture::channel_menu_pick(cx, index, value)
+                        });
+                        let _ = reply.send(result);
+                    }
+                    McpCommand::CategoryMenuState { reply } => {
+                        let result =
+                            cx.update(|cx| mezon_ui::app::capture::category_menu_state(cx));
+                        let _ = reply.send(result);
+                    }
+                    McpCommand::CategoryMenuOpen {
+                        clan_id,
+                        category_id,
+                        x,
+                        y,
+                        reply,
+                    } => {
+                        let result = cx.update(|cx| {
+                            mezon_ui::app::capture::category_menu_open(
+                                cx,
+                                mezon_store::ClanId(clan_id),
+                                category_id,
+                                x,
+                                y,
+                            )
+                        });
+                        let _ = reply.send(result);
+                    }
+                    McpCommand::CategoryMenuClose { reply } => {
+                        let result = cx.update(mezon_ui::app::capture::category_menu_close);
+                        let _ = reply.send(result);
+                    }
+                    McpCommand::CategoryMenuPick {
+                        index,
+                        value,
+                        reply,
+                    } => {
+                        let result = cx.update(|cx| {
+                            mezon_ui::app::capture::category_menu_pick(cx, index, value)
+                        });
+                        let _ = reply.send(result);
+                    }
                     McpCommand::CreateClan { name, logo, reply } => {
                         let task = cx
                             .update(|cx| mezon_ui::app::capture::create_clan_task(cx, name, logo));

--- a/crates/mezon-client/src/app_api.rs
+++ b/crates/mezon-client/src/app_api.rs
@@ -1735,6 +1735,23 @@ impl AppApi {
         })
     }
 
+    pub async fn update_category(
+        &self,
+        clan_id: i64,
+        category_id: i64,
+        category_name: &str,
+    ) -> Result<()> {
+        self.transport
+            .update_category(category_id, category_name, clan_id)
+            .await
+    }
+
+    pub async fn delete_category(&self, clan_id: i64, category_id: i64) -> Result<()> {
+        self.transport
+            .delete_category_desc(category_id, clan_id)
+            .await
+    }
+
     pub async fn add_channel_users(&self, channel_id: i64, user_ids: Vec<String>) -> Result<()> {
         self.transport.add_channel_users(channel_id, user_ids).await
     }

--- a/crates/mezon-client/src/transport_runtime.rs
+++ b/crates/mezon-client/src/transport_runtime.rs
@@ -2905,6 +2905,34 @@ impl TransportClient {
             .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
     }
 
+    pub async fn update_category(
+        &self,
+        category_id: i64,
+        category_name: &str,
+        clan_id: i64,
+    ) -> Result<()> {
+        let transport = self.inner.clone();
+        let category_name = category_name.to_string();
+
+        runtime()
+            .spawn(async move {
+                transport
+                    .update_category(category_id, &category_name, clan_id)
+                    .await
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
+    }
+
+    pub async fn delete_category_desc(&self, category_id: i64, clan_id: i64) -> Result<()> {
+        let transport = self.inner.clone();
+
+        runtime()
+            .spawn(async move { transport.delete_category_desc(category_id, clan_id).await })
+            .await
+            .map_err(|e| anyhow::anyhow!("transport task failed: {e}"))?
+    }
+
     pub async fn update_category_order(
         &self,
         clan_id: i64,

--- a/crates/mezon-mcp/src/catalog.rs
+++ b/crates/mezon-mcp/src/catalog.rs
@@ -381,6 +381,127 @@ Parameters:
         write: true,
     },
     ToolSpec {
+        name: "list_categories",
+        description: "\
+List the categories of a clan as the channel sidebar sees them, including EMPTY ones.
+
+list_channels only reveals categories that still hold a channel, so this is the only way to find an
+empty category — which is exactly the case category_menu_pick offers Delete Category for. The clan
+must already be loaded (open one of its channels first).
+
+Parameters:
+- clan_id (required): clan snowflake id.",
+        write: false,
+    },
+    ToolSpec {
+        name: "create_category",
+        description: "\
+Create a category in a clan through the same store path the Create Category modal uses.
+
+Useful for making a throwaway empty category to exercise the category context menu rows
+(Edit Category, Delete Category) without touching a real one.
+
+Parameters:
+- clan_id (required): clan snowflake id.
+- name (required): category name (letters, digits, space, - or _; must not start with a separator).",
+        write: true,
+    },
+    ToolSpec {
+        name: "channel_menu_state",
+        description: "\
+Return the channel context menu that is currently open in the channel sidebar, if any.
+
+Reports the target channel plus is_favorite (which decides the Mark/Unmark Favorite row) and
+can_manage_channel, alongside the item list whose indexes channel_menu_pick takes.
+
+Parameters: none.",
+        write: false,
+    },
+    ToolSpec {
+        name: "channel_menu_open",
+        description: "\
+Open the right-click context menu for one channel or thread in the channel sidebar.
+
+The channel must belong to the clan and be listed by list_channels. Returns the same shape as
+channel_menu_state.
+
+Parameters:
+- clan_id (required): clan snowflake id.
+- channel_id (required): channel snowflake id.
+- x, y (optional): anchor point in window points.
+- in_favorites (optional): right-click the row inside the Favorites section instead of its own
+  category; that row drops Mark As Read, exactly as React does.",
+        write: false,
+    },
+    ToolSpec {
+        name: "channel_menu_close",
+        description: "\
+Dismiss the channel context menu without running an action.
+
+Parameters: none.",
+        write: false,
+    },
+    ToolSpec {
+        name: "channel_menu_pick",
+        description: "\
+Run one row of the open channel context menu (Mark As Read, Copy Link, Mute, Notification,
+Mark/Unmark Favorite, Edit Channel, Delete Channel).
+
+Mark/Unmark Favorite writes straight through to the server; Delete Channel opens a confirmation
+modal instead of deleting immediately.
+
+Parameters:
+- index (required): item index from channel_menu_open/channel_menu_state.
+- value (optional): submenu option value (mute duration seconds, notification level).",
+        write: true,
+    },
+    ToolSpec {
+        name: "category_menu_state",
+        description: "\
+Return the category context menu that is currently open in the channel sidebar, if any.
+
+Reports collapsed, can_manage_category and category_is_empty (Delete Category only shows for an
+empty category), plus the item list for category_menu_pick.
+
+Parameters: none.",
+        write: false,
+    },
+    ToolSpec {
+        name: "category_menu_open",
+        description: "\
+Open the right-click context menu for one category header in the channel sidebar.
+
+The favourites pseudo-category has no menu and is rejected.
+
+Parameters:
+- clan_id (required): clan snowflake id.
+- category_id (required): category id string from list_channels.
+- x, y (optional): anchor point in window points.",
+        write: false,
+    },
+    ToolSpec {
+        name: "category_menu_close",
+        description: "\
+Dismiss the category context menu without running an action.
+
+Parameters: none.",
+        write: false,
+    },
+    ToolSpec {
+        name: "category_menu_pick",
+        description: "\
+Run one row of the open category context menu (Mark As Read, Collapse Category, Collapse All
+Categories, Mute, Notification Settings, Edit Category, Delete Category).
+
+Edit Category opens a rename modal and Delete Category opens a confirmation modal; the rest apply
+immediately.
+
+Parameters:
+- index (required): item index from category_menu_open/category_menu_state.
+- value (optional): submenu option value (mute duration seconds, notification level).",
+        write: true,
+    },
+    ToolSpec {
         name: "open_create_clan_modal",
         description: "\
 Open the Create Clan modal on its template-picker step.

--- a/crates/mezon-mcp/src/command.rs
+++ b/crates/mezon-mcp/src/command.rs
@@ -241,6 +241,52 @@ pub enum McpCommand {
         value: Option<i32>,
         reply: oneshot::Sender<anyhow::Result<Value>>,
     },
+    ListCategories {
+        clan_id: i64,
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
+    CreateCategory {
+        clan_id: i64,
+        name: String,
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
+    ChannelMenuState {
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
+    ChannelMenuOpen {
+        clan_id: i64,
+        channel_id: i64,
+        x: f32,
+        y: f32,
+        in_favorites: bool,
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
+    ChannelMenuClose {
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
+    ChannelMenuPick {
+        index: usize,
+        value: Option<i32>,
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
+    CategoryMenuState {
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
+    CategoryMenuOpen {
+        clan_id: i64,
+        category_id: String,
+        x: f32,
+        y: f32,
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
+    CategoryMenuClose {
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
+    CategoryMenuPick {
+        index: usize,
+        value: Option<i32>,
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
     CreateClan {
         name: String,
         logo: String,

--- a/crates/mezon-mcp/src/schemas.rs
+++ b/crates/mezon-mcp/src/schemas.rs
@@ -142,6 +142,56 @@ pub fn input_schema(name: &str) -> Arc<Map<String, Value>> {
             }),
             &["index"],
         )),
+        "list_categories" => Arc::new(object(
+            json!({ "clan_id": id("Clan snowflake id from list_clans.") }),
+            &["clan_id"],
+        )),
+        "create_category" => Arc::new(object(
+            json!({
+                "clan_id": id("Clan snowflake id from list_clans."),
+                "name": { "type": "string", "description": "Category name (letters, digits, space, - or _; must not start with a separator)." },
+            }),
+            &["clan_id", "name"],
+        )),
+        "channel_menu_open" => Arc::new(object(
+            json!({
+                "clan_id": id("Clan snowflake id from list_clans."),
+                "channel_id": id("Channel snowflake id from list_channels."),
+                "x": integer("Menu anchor x in window points (default 0).", Some(0)),
+                "y": integer("Menu anchor y in window points (default 0).", Some(0)),
+                "in_favorites": { "type": "boolean", "description": "Right-click the row inside the Favorites section instead of its own category (default false); the Favorites row drops Mark As Read." },
+            }),
+            &["clan_id", "channel_id"],
+        )),
+        "channel_menu_pick" => Arc::new(object(
+            json!({
+                "index": integer("Item index from channel_menu_open/channel_menu_state.", None),
+                "value": integer(
+                    "Submenu option value; required for the Mute and Notification rows.",
+                    None,
+                ),
+            }),
+            &["index"],
+        )),
+        "category_menu_open" => Arc::new(object(
+            json!({
+                "clan_id": id("Clan snowflake id from list_clans."),
+                "category_id": { "type": "string", "description": "Category id from list_channels." },
+                "x": integer("Menu anchor x in window points (default 0).", Some(0)),
+                "y": integer("Menu anchor y in window points (default 0).", Some(0)),
+            }),
+            &["clan_id", "category_id"],
+        )),
+        "category_menu_pick" => Arc::new(object(
+            json!({
+                "index": integer("Item index from category_menu_open/category_menu_state.", None),
+                "value": integer(
+                    "Submenu option value; required for the Mute and Notification Settings rows.",
+                    None,
+                ),
+            }),
+            &["index"],
+        )),
         "create_clan" => Arc::new(object(
             json!({
                 "name": { "type": "string", "description": "Clan name (letters, digits, space, - or _; must not start with a separator)." },

--- a/crates/mezon-mcp/src/tools.rs
+++ b/crates/mezon-mcp/src/tools.rs
@@ -248,6 +248,16 @@ impl McpBackend {
                 self.member_menu_pick(&arguments).await
             }
             "clan_menu_state" => self.clan_menu_state().await,
+            "list_categories" => self.list_categories(&arguments).await,
+            "create_category" => self.create_category(&arguments).await,
+            "channel_menu_state" => self.channel_menu_state().await,
+            "channel_menu_open" => self.channel_menu_open(&arguments).await,
+            "channel_menu_close" => self.channel_menu_close().await,
+            "channel_menu_pick" => self.channel_menu_pick(&arguments).await,
+            "category_menu_state" => self.category_menu_state().await,
+            "category_menu_open" => self.category_menu_open(&arguments).await,
+            "category_menu_close" => self.category_menu_close().await,
+            "category_menu_pick" => self.category_menu_pick(&arguments).await,
             "clan_menu_open" => self.clan_menu_open(&arguments).await,
             "clan_menu_close" => self.clan_menu_close().await,
             "clan_menu_pick" => {
@@ -721,6 +731,8 @@ impl McpBackend {
             id: i64,
             label: String,
             channel_type: u32,
+            category_id: i64,
+            category_name: String,
         }
         let items: Vec<ChannelSummary> = channels
             .into_iter()
@@ -728,6 +740,8 @@ impl McpBackend {
                 id: channel.channel_id,
                 label: channel.channel_label,
                 channel_type: channel.channel_type,
+                category_id: channel.category_id,
+                category_name: channel.category_name,
             })
             .collect();
         to_json(&items)
@@ -1260,6 +1274,130 @@ impl McpBackend {
             .and_then(Value::as_i64)
             .map(|value| value as i32);
         self.send_ui_result(|reply| McpCommand::ClanMenuPick {
+            index,
+            value,
+            reply,
+        })
+        .await
+    }
+
+    async fn list_categories(&self, arguments: &Value) -> anyhow::Result<Value> {
+        let clan_id = optional_i64_field(arguments, "clan_id")
+            .ok_or_else(|| anyhow::anyhow!("list_categories requires field clan_id"))?;
+        self.send_ui_result(|reply| McpCommand::ListCategories { clan_id, reply })
+            .await
+    }
+
+    async fn create_category(&self, arguments: &Value) -> anyhow::Result<Value> {
+        let clan_id = optional_i64_field(arguments, "clan_id")
+            .ok_or_else(|| anyhow::anyhow!("create_category requires field clan_id"))?;
+        let name = arguments
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .ok_or_else(|| anyhow::anyhow!("create_category requires string field name"))?;
+        self.send_ui_result(|reply| McpCommand::CreateCategory {
+            clan_id,
+            name,
+            reply,
+        })
+        .await
+    }
+
+    async fn channel_menu_state(&self) -> anyhow::Result<Value> {
+        self.send_ui_result(|reply| McpCommand::ChannelMenuState { reply })
+            .await
+    }
+
+    async fn channel_menu_open(&self, arguments: &Value) -> anyhow::Result<Value> {
+        let clan_id = optional_i64_field(arguments, "clan_id")
+            .ok_or_else(|| anyhow::anyhow!("channel_menu_open requires field clan_id"))?;
+        let channel_id = optional_i64_field(arguments, "channel_id")
+            .ok_or_else(|| anyhow::anyhow!("channel_menu_open requires field channel_id"))?;
+        let x = arguments.get("x").and_then(Value::as_f64).unwrap_or(0.0) as f32;
+        let y = arguments.get("y").and_then(Value::as_f64).unwrap_or(0.0) as f32;
+        let in_favorites = arguments
+            .get("in_favorites")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        self.send_ui_result(|reply| McpCommand::ChannelMenuOpen {
+            clan_id,
+            channel_id,
+            x,
+            y,
+            in_favorites,
+            reply,
+        })
+        .await
+    }
+
+    async fn channel_menu_close(&self) -> anyhow::Result<Value> {
+        self.send_ui_result(|reply| McpCommand::ChannelMenuClose { reply })
+            .await
+    }
+
+    async fn channel_menu_pick(&self, arguments: &Value) -> anyhow::Result<Value> {
+        let index = arguments
+            .get("index")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| anyhow::anyhow!("channel_menu_pick requires integer field index"))?
+            as usize;
+        let value = arguments
+            .get("value")
+            .and_then(Value::as_i64)
+            .map(|value| value as i32);
+        self.send_ui_result(|reply| McpCommand::ChannelMenuPick {
+            index,
+            value,
+            reply,
+        })
+        .await
+    }
+
+    async fn category_menu_state(&self) -> anyhow::Result<Value> {
+        self.send_ui_result(|reply| McpCommand::CategoryMenuState { reply })
+            .await
+    }
+
+    async fn category_menu_open(&self, arguments: &Value) -> anyhow::Result<Value> {
+        let clan_id = optional_i64_field(arguments, "clan_id")
+            .ok_or_else(|| anyhow::anyhow!("category_menu_open requires field clan_id"))?;
+        let category_id = arguments
+            .get("category_id")
+            .and_then(|raw| {
+                raw.as_str()
+                    .map(str::to_owned)
+                    .or_else(|| raw.as_i64().map(|id| id.to_string()))
+            })
+            .ok_or_else(|| anyhow::anyhow!("category_menu_open requires field category_id"))?;
+        let x = arguments.get("x").and_then(Value::as_f64).unwrap_or(0.0) as f32;
+        let y = arguments.get("y").and_then(Value::as_f64).unwrap_or(0.0) as f32;
+        self.send_ui_result(|reply| McpCommand::CategoryMenuOpen {
+            clan_id,
+            category_id,
+            x,
+            y,
+            reply,
+        })
+        .await
+    }
+
+    async fn category_menu_close(&self) -> anyhow::Result<Value> {
+        self.send_ui_result(|reply| McpCommand::CategoryMenuClose { reply })
+            .await
+    }
+
+    async fn category_menu_pick(&self, arguments: &Value) -> anyhow::Result<Value> {
+        let index = arguments
+            .get("index")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| anyhow::anyhow!("category_menu_pick requires integer field index"))?
+            as usize;
+        let value = arguments
+            .get("value")
+            .and_then(Value::as_i64)
+            .map(|value| value as i32);
+        self.send_ui_result(|reply| McpCommand::CategoryMenuPick {
             index,
             value,
             reply,

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -33,6 +33,7 @@ pub const FAVOR_CATE_ID: &str = "favorCate";
 pub const CATEGORY_NAME_MAX_CHARS: usize = 64;
 const CATEGORY_EVENT_CREATED: i32 = 1;
 const CATEGORY_EVENT_UPDATED: i32 = 2;
+const CATEGORY_EVENT_DELETED: i32 = 3;
 
 const PREVIOUS_CHANNELS_PERSIST_DEBOUNCE: Duration = Duration::from_millis(500);
 const BADGE_SEED_MAX_ATTEMPTS: u32 = 3;
@@ -1611,14 +1612,39 @@ impl ChannelList {
         if !self.cache.contains(&clan_id) {
             return;
         }
+        let category_id = category.id.clone();
+        let category_name = category.name.clone();
         let changed = self
             .cache
             .get_mut(&clan_id)
             .is_some_and(|categories| upsert_category(categories, category));
-        if changed {
+        let names_changed = self.sync_channel_category_names(clan_id, &category_id, &category_name);
+        if changed || names_changed {
             self.invalidate_channel_index(clan_id);
             self.notify_channel_list(clan_id, cx);
         }
+    }
+
+    fn sync_channel_category_names(
+        &mut self,
+        clan_id: ClanId,
+        category_id: &str,
+        name: &str,
+    ) -> bool {
+        let mut changed = false;
+        if let Some(categories) = self.cache.get_mut(&clan_id) {
+            for channel in categories
+                .iter_mut()
+                .flat_map(|category| category.channels.iter_mut())
+                .filter(|channel| channel.category_id.as_deref() == Some(category_id))
+            {
+                if channel.category_name != name {
+                    channel.category_name = name.to_string();
+                    changed = true;
+                }
+            }
+        }
+        changed
     }
 
     pub fn channel_badge_count(&self, clan_id: ClanId, channel_id: ChannelId) -> u32 {
@@ -2186,14 +2212,198 @@ impl ChannelList {
         .detach();
     }
 
+    pub fn mark_category_as_read(
+        &mut self,
+        clan_id: ClanId,
+        category_id: &str,
+        cx: &mut Context<Self>,
+    ) {
+        let Ok(category_id) = category_id.parse::<i64>() else {
+            return;
+        };
+        if category_id == 0 {
+            return;
+        }
+        let api = self.api.clone();
+        let generation = self.reset_generation;
+        cx.spawn(async move |this, cx| {
+            if let Err(e) = api.mark_as_read(0, category_id, clan_id.get()).await {
+                tracing::error!("mark category as read failed for category {category_id}: {e}");
+                return;
+            }
+            let _ = this.update(cx, |this, cx| {
+                if this.reset_generation != generation {
+                    return;
+                }
+                this.apply_mark_as_read_category(clan_id, category_id, cx);
+            });
+        })
+        .detach();
+    }
+
+    pub fn collapse_all_categories(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+        let Some(categories) = self.cache.get(&clan_id) else {
+            return;
+        };
+        let clan_key = clan_id.to_string();
+        let keys: Vec<(String, String)> = categories
+            .iter()
+            .map(|category| (clan_key.clone(), category.id.clone()))
+            .collect();
+        let mut changed = false;
+        for key in keys {
+            changed |= self.collapsed.insert(key);
+        }
+        if !changed {
+            return;
+        }
+        cx.notify();
+        let snapshot: Vec<(String, String)> = self.collapsed.iter().cloned().collect();
+        cx.background_executor()
+            .spawn(async move { save_collapse_state(snapshot) })
+            .detach();
+    }
+
     pub fn category_name_exists(&self, clan_id: ClanId, name: &str) -> bool {
-        let normalized = name.trim();
+        self.category_name_exists_excluding(clan_id, name, "")
+    }
+
+    pub fn category_name_exists_excluding(
+        &self,
+        clan_id: ClanId,
+        name: &str,
+        exclude_id: &str,
+    ) -> bool {
+        let normalized = name.trim().to_lowercase();
         self.cache.get(&clan_id).is_some_and(|categories| {
             categories.iter().any(|category| {
                 category.id != FAVOR_CATE_ID
-                    && category.name.trim().to_lowercase() == normalized.to_lowercase()
+                    && category.id != exclude_id
+                    && category.name.trim().to_lowercase() == normalized
             })
         })
+    }
+
+    pub fn category_name(&self, clan_id: ClanId, category_id: &str) -> Option<&str> {
+        self.cache.get(&clan_id).and_then(|categories| {
+            categories
+                .iter()
+                .find(|category| category.id == category_id)
+                .map(|category| category.name.as_str())
+        })
+    }
+
+    pub fn rename_category(
+        &mut self,
+        clan_id: ClanId,
+        category_id: String,
+        name: String,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<(), CreateCategoryError>> {
+        let trimmed = match validate_category_name(&name) {
+            Ok(trimmed) => trimmed,
+            Err(err) => return Task::ready(Err(err)),
+        };
+        if self.category_name_exists_excluding(clan_id, &trimmed, &category_id) {
+            return Task::ready(Err(CreateCategoryError::DuplicateName));
+        }
+        let Ok(category_id_num) = category_id.parse::<i64>() else {
+            return Task::ready(Err(CreateCategoryError::Other(
+                "category is not editable".into(),
+            )));
+        };
+        let api = self.api.clone();
+        cx.spawn(async move |this, cx| {
+            api.update_category(clan_id.get(), category_id_num, &trimmed)
+                .await
+                .map_err(|e| CreateCategoryError::Other(e.to_string()))?;
+            this.update(cx, |this, cx| {
+                this.apply_category_rename(clan_id, &category_id, trimmed, cx);
+            })
+            .map_err(|_| CreateCategoryError::Other("store dropped".into()))?;
+            Ok(())
+        })
+    }
+
+    fn apply_category_rename(
+        &mut self,
+        clan_id: ClanId,
+        category_id: &str,
+        name: String,
+        cx: &mut Context<Self>,
+    ) {
+        let mut changed = false;
+        if let Some(categories) = self.cache.get_mut(&clan_id) {
+            for category in categories
+                .iter_mut()
+                .filter(|category| category.id == category_id)
+            {
+                if category.name != name {
+                    category.name = name.clone();
+                    changed = true;
+                }
+            }
+        }
+        changed |= self.sync_channel_category_names(clan_id, category_id, &name);
+        if changed {
+            self.notify_channel_list(clan_id, cx);
+        }
+    }
+
+    pub fn delete_category(
+        &self,
+        clan_id: ClanId,
+        category_id: String,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<(), String>> {
+        let api = self.api.clone();
+        cx.spawn(async move |this, cx| {
+            let category_id_num = category_id
+                .parse::<i64>()
+                .map_err(|_| "category is not deletable".to_string())?;
+            api.delete_category(clan_id.get(), category_id_num)
+                .await
+                .map_err(|e| e.to_string())?;
+            let _ = this.update(cx, |this, cx| {
+                this.apply_category_removed(clan_id, &category_id, cx);
+            });
+            Ok(())
+        })
+    }
+
+    fn apply_category_removed(
+        &mut self,
+        clan_id: ClanId,
+        category_id: &str,
+        cx: &mut Context<Self>,
+    ) {
+        if category_id == FAVOR_CATE_ID {
+            return;
+        }
+        let doomed: Vec<(ChannelId, ChannelId)> = self
+            .cache
+            .get(&clan_id)
+            .into_iter()
+            .flatten()
+            .filter(|category| category.id == category_id)
+            .flat_map(|category| category.channels.iter())
+            .map(|ch| (ch.id, ch.parent_id.unwrap_or(ChannelId(0))))
+            .collect();
+        for (channel_id, parent_id) in doomed {
+            self.apply_local_delete(clan_id, channel_id, parent_id, cx);
+        }
+        let mut removed = false;
+        if let Some(categories) = self.cache.get_mut(&clan_id) {
+            let before = categories.len();
+            categories.retain(|category| category.id != category_id);
+            removed = categories.len() != before;
+        }
+        self.collapsed
+            .remove(&(clan_id.to_string(), category_id.to_string()));
+        if removed {
+            self.invalidate_channel_index(clan_id);
+            self.notify_channel_list(clan_id, cx);
+        }
     }
 
     pub fn update_categories_order(
@@ -2716,11 +2926,14 @@ impl ChannelList {
     fn handle_event(&mut self, event: &RealtimeEvent, cx: &mut Context<Self>) {
         match event {
             RealtimeEvent::CategoryEvent(e) => {
-                if e.id == 0 || e.category_name.trim().is_empty() {
+                if e.id == 0 {
                     return;
                 }
                 let clan_id = ClanId(e.clan_id);
                 match e.status {
+                    CATEGORY_EVENT_DELETED => {
+                        self.apply_category_removed(clan_id, &e.id.to_string(), cx);
+                    }
                     CATEGORY_EVENT_CREATED | CATEGORY_EVENT_UPDATED => {
                         let name = e.category_name.trim();
                         if name.is_empty() {
@@ -3827,6 +4040,12 @@ impl ChannelList {
         cx.background_executor()
             .spawn(async move { save_collapse_state(snapshot) })
             .detach();
+    }
+
+    pub fn is_channel_favorite(&self, clan_id: ClanId, channel_id: ChannelId) -> bool {
+        self.favorites
+            .get(&clan_id)
+            .is_some_and(|ids| ids.contains(&channel_id))
     }
 
     pub fn add_channel_favorite(
@@ -7991,6 +8210,141 @@ mod tests {
                     0,
                     "a later structure refetch must not resurrect a badge whose category was \
                      already explicitly marked as read"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn collapse_all_categories_collapses_every_category_of_the_clan(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[ChannelId(2)]),
+                    cx,
+                );
+                assert!(!channels.is_category_collapsed(ClanId(1), "1"));
+                assert!(!channels.is_category_collapsed(ClanId(1), FAVOR_CATE_ID));
+
+                channels.collapse_all_categories(ClanId(1), cx);
+
+                assert!(channels.is_category_collapsed(ClanId(1), "1"));
+                assert!(channels.is_category_collapsed(ClanId(1), FAVOR_CATE_ID));
+                assert!(!channels.is_category_collapsed(ClanId(2), "1"));
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn category_name_exists_excluding_ignores_the_renamed_category_itself(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
+
+                assert!(channels.category_name_exists(ClanId(1), "general"));
+                assert!(!channels.category_name_exists_excluding(ClanId(1), "general", "1"));
+                assert!(channels.category_name_exists_excluding(ClanId(1), "general", "2"));
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn apply_category_removed_drops_the_category_and_its_channels(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[ChannelId(2)]),
+                    cx,
+                );
+                channels.toggle_category(ClanId(1), "1", cx);
+                assert!(channels.is_category_collapsed(ClanId(1), "1"));
+
+                channels.apply_category_removed(ClanId(1), "1", cx);
+
+                assert!(
+                    channels
+                        .categories_for_clan(ClanId(1))
+                        .iter()
+                        .all(|category| category.id != "1")
+                );
+                assert!(channels.channel(ClanId(1), ChannelId(1)).is_none());
+                assert!(
+                    channels.channel(ClanId(1), ChannelId(2)).is_none(),
+                    "the favourites copy of a deleted channel must go too"
+                );
+                assert!(!channels.is_category_collapsed(ClanId(1), "1"));
+            });
+        });
+    }
+
+    fn category_event(clan_id: i64, id: i64, name: &str, status: i32) -> RealtimeEvent {
+        RealtimeEvent::CategoryEvent(mezon_proto::realtime::CategoryEvent {
+            clan_id,
+            id,
+            category_name: name.to_string(),
+            status,
+            ..Default::default()
+        })
+    }
+
+    #[gpui::test]
+    fn category_event_delete_drops_the_category_and_redirects_the_open_channel(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let channels = init_channel_list_with_threads(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
+                channels.select_channel(ChannelId(1), cx);
+
+                channels.handle_event(&category_event(1, 1, "", CATEGORY_EVENT_DELETED), cx);
+
+                assert!(
+                    channels
+                        .categories_for_clan(ClanId(1))
+                        .iter()
+                        .all(|category| category.id != "1")
+                );
+                assert!(channels.channel(ClanId(1), ChannelId(1)).is_none());
+                assert_eq!(
+                    channels.active_channel_id, None,
+                    "deleting the category of the open channel must clear the selection"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn category_event_update_renames_the_category_on_its_channels_too(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
+
+                channels.handle_event(&category_event(1, 1, "Renamed", CATEGORY_EVENT_UPDATED), cx);
+
+                assert_eq!(
+                    channels.category_name(ClanId(1), "1"),
+                    Some("Renamed"),
+                    "the sidebar header must follow a remote rename"
+                );
+                assert_eq!(
+                    channels
+                        .channel(ClanId(1), ChannelId(1))
+                        .map(|ch| ch.category_name.as_str()),
+                    Some("Renamed"),
+                    "channel.category_name is read by the channel settings tabs and mention rows"
                 );
             });
         });

--- a/crates/mezon-ui/src/app/capture.rs
+++ b/crates/mezon-ui/src/app/capture.rs
@@ -831,6 +831,105 @@ pub fn clan_menu_pick(cx: &mut App, index: usize, value: Option<i32>) -> anyhow:
     })?
 }
 
+pub fn list_categories(cx: &App, clan_id: mezon_store::ClanId) -> anyhow::Result<Value> {
+    let channels = mezon_store::ChannelList::try_global(cx)
+        .ok_or_else(|| anyhow::anyhow!("channel store unavailable"))?;
+    let channels = channels.read(cx);
+    let items: Vec<Value> = channels
+        .categories_for_clan(clan_id)
+        .iter()
+        .map(|category| {
+            json!({
+                "id": category.id,
+                "name": category.name,
+                "order": category.order,
+                "channel_count": category.channels.len(),
+                "collapsed": channels.is_category_collapsed(clan_id, &category.id),
+            })
+        })
+        .collect();
+    Ok(Value::Array(items))
+}
+
+pub fn create_category_task(
+    cx: &mut App,
+    clan_id: mezon_store::ClanId,
+    name: String,
+) -> gpui::Task<anyhow::Result<Value>> {
+    let Some(channels) = mezon_store::ChannelList::try_global(cx) else {
+        return gpui::Task::ready(Err(anyhow::anyhow!("channel store unavailable")));
+    };
+    let task = channels.update(cx, |list, cx| {
+        list.create_category(clan_id, name.clone(), cx)
+    });
+    cx.background_spawn(async move {
+        task.await.map_err(|e| anyhow::anyhow!("{e:?}"))?;
+        Ok(json!({ "ok": true, "name": name }))
+    })
+}
+
+pub fn channel_menu_state(cx: &App) -> anyhow::Result<Value> {
+    crate::sidebar::channel_sidebar::channel_menu_state(cx)
+}
+
+pub fn channel_menu_open(
+    cx: &mut App,
+    clan_id: mezon_store::ClanId,
+    channel_id: mezon_store::ChannelId,
+    x: f32,
+    y: f32,
+    in_favorites: bool,
+) -> anyhow::Result<Value> {
+    crate::sidebar::channel_sidebar::channel_menu_open(
+        clan_id,
+        channel_id,
+        gpui::point(gpui::px(x), gpui::px(y)),
+        in_favorites,
+        cx,
+    )
+}
+
+pub fn channel_menu_close(cx: &mut App) -> anyhow::Result<Value> {
+    crate::sidebar::channel_sidebar::channel_menu_close(cx)
+}
+
+pub fn channel_menu_pick(cx: &mut App, index: usize, value: Option<i32>) -> anyhow::Result<Value> {
+    let main_handle = handle(cx).ok_or_else(|| anyhow::anyhow!("main window not found"))?;
+    cx.update_window(main_handle, |_, window, cx| {
+        crate::sidebar::channel_sidebar::channel_menu_pick(index, value, window, cx)
+    })?
+}
+
+pub fn category_menu_state(cx: &App) -> anyhow::Result<Value> {
+    crate::sidebar::channel_sidebar::category_menu_state(cx)
+}
+
+pub fn category_menu_open(
+    cx: &mut App,
+    clan_id: mezon_store::ClanId,
+    category_id: String,
+    x: f32,
+    y: f32,
+) -> anyhow::Result<Value> {
+    crate::sidebar::channel_sidebar::category_menu_open(
+        clan_id,
+        category_id,
+        gpui::point(gpui::px(x), gpui::px(y)),
+        cx,
+    )
+}
+
+pub fn category_menu_close(cx: &mut App) -> anyhow::Result<Value> {
+    crate::sidebar::channel_sidebar::category_menu_close(cx)
+}
+
+pub fn category_menu_pick(cx: &mut App, index: usize, value: Option<i32>) -> anyhow::Result<Value> {
+    let main_handle = handle(cx).ok_or_else(|| anyhow::anyhow!("main window not found"))?;
+    cx.update_window(main_handle, |_, window, cx| {
+        crate::sidebar::channel_sidebar::category_menu_pick(index, value, window, cx)
+    })?
+}
+
 pub fn user_status_snapshot(cx: &App) -> anyhow::Result<Value> {
     let Some((user_id, status)) = mezon_store::current_user_status(cx) else {
         return Ok(json!({ "signed_in": false }));

--- a/crates/mezon-ui/src/app/shell/confirm_delete_category_modal.rs
+++ b/crates/mezon-ui/src/app/shell/confirm_delete_category_modal.rs
@@ -1,0 +1,142 @@
+use gpui::{Context, FocusHandle, SharedString, Window, div, prelude::*, px};
+use mezon_store::{ChannelList, ClanId};
+
+use super::Shell;
+use crate::components::primitives::{Button, ButtonVariants, h_flex, v_flex};
+use crate::theme::ActiveTheme;
+
+pub(super) struct ConfirmDeleteCategoryModal {
+    pub(super) focus_handle: FocusHandle,
+    pub(super) clan_id: ClanId,
+    pub(super) category_id: String,
+    pub(super) locale: String,
+    pub(super) title: SharedString,
+    pub(super) description: SharedString,
+    pub(super) cancel_label: SharedString,
+    pub(super) delete_label: SharedString,
+    pub(super) submitting: bool,
+}
+
+impl ConfirmDeleteCategoryModal {
+    fn delete(&mut self, cx: &mut Context<Self>) {
+        if self.submitting {
+            return;
+        }
+        self.submitting = true;
+        cx.notify();
+
+        let clan_id = self.clan_id;
+        let category_id = self.category_id.clone();
+        let locale = self.locale.clone();
+
+        cx.spawn(async move |this, cx| {
+            let task = this
+                .update(cx, |_, cx| {
+                    ChannelList::global(cx).update(cx, |store, cx| {
+                        store.delete_category(clan_id, category_id.clone(), cx)
+                    })
+                })
+                .ok();
+            let Some(task) = task else {
+                return;
+            };
+            let result = task.await;
+
+            cx.update(|cx| {
+                Shell::global(cx).update(cx, |shell, cx| match &result {
+                    Ok(()) => shell.close_modal(cx),
+                    Err(err) => {
+                        tracing::error!("delete_category failed for {category_id}: {err}");
+                        shell.error(
+                            mezon_i18n::t(&locale, "contextMenu.deleteCategoryFailed").to_string(),
+                            cx,
+                        );
+                    }
+                });
+            });
+
+            let _ = this.update(cx, |this, cx| {
+                this.submitting = false;
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+}
+
+impl Render for ConfirmDeleteCategoryModal {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let submitting = self.submitting;
+
+        v_flex()
+            .track_focus(&self.focus_handle)
+            .key_context("menu")
+            .on_action(cx.listener(|this, _: &::menu::Cancel, _window, cx| {
+                if this.submitting {
+                    return;
+                }
+                Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+            }))
+            .on_action(cx.listener(|this, _: &::menu::Confirm, _window, cx| {
+                this.delete(cx);
+            }))
+            .w(px(440.))
+            .overflow_hidden()
+            .rounded_lg()
+            .border_1()
+            .border_color(theme.border)
+            .bg(theme.bg_floating)
+            .shadow_lg()
+            .child(
+                v_flex()
+                    .px(px(16.))
+                    .pt(px(16.))
+                    .pb(px(20.))
+                    .gap_4()
+                    .child(
+                        div()
+                            .text_size(px(20.))
+                            .font_weight(gpui::FontWeight::SEMIBOLD)
+                            .text_color(theme.text_primary)
+                            .child(self.title.clone()),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(15.))
+                            .text_color(theme.text_primary)
+                            .child(self.description.clone()),
+                    ),
+            )
+            .child(
+                h_flex()
+                    .justify_end()
+                    .items_center()
+                    .gap_4()
+                    .p(px(16.))
+                    .bg(theme.bg_secondary)
+                    .child(
+                        Button::new("confirm-delete-category-cancel")
+                            .label(self.cancel_label.clone())
+                            .ghost()
+                            .disabled(submitting)
+                            .on_click(cx.listener(|this, _, _window, cx| {
+                                if this.submitting {
+                                    return;
+                                }
+                                Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+                            })),
+                    )
+                    .child(
+                        Button::new("confirm-delete-category-confirm")
+                            .label(self.delete_label.clone())
+                            .danger()
+                            .disabled(submitting)
+                            .loading(submitting)
+                            .on_click(cx.listener(|this, _, _window, cx| {
+                                this.delete(cx);
+                            })),
+                    ),
+            )
+    }
+}

--- a/crates/mezon-ui/src/app/shell/mod.rs
+++ b/crates/mezon-ui/src/app/shell/mod.rs
@@ -17,6 +17,7 @@ use crate::router::Route;
 mod coming_soon_modal;
 mod confirm_archive_channel_modal;
 mod confirm_delete_canvas_modal;
+mod confirm_delete_category_modal;
 mod confirm_delete_channel_modal;
 mod confirm_delete_clan_modal;
 mod confirm_delete_emoji_modal;
@@ -36,6 +37,7 @@ mod wallet_not_available_modal;
 use coming_soon_modal::ComingSoonModal;
 use confirm_archive_channel_modal::ConfirmArchiveChannelModal;
 use confirm_delete_canvas_modal::ConfirmDeleteCanvasModal;
+use confirm_delete_category_modal::ConfirmDeleteCategoryModal;
 use confirm_delete_channel_modal::ConfirmDeleteChannelModal;
 use confirm_delete_clan_modal::ConfirmDeleteClanModal;
 use confirm_delete_emoji_modal::ConfirmDeleteEmojiModal;
@@ -561,6 +563,47 @@ impl Shell {
             focus_handle: cx.focus_handle(),
             clan_id,
             channel_id,
+            locale: locale.to_string(),
+            title,
+            description,
+            cancel_label,
+            delete_label,
+            submitting: false,
+        });
+        let focus_handle = view.read(cx).focus_handle.clone();
+        window.focus(&focus_handle, cx);
+        self.show_modal(view.into(), cx);
+    }
+
+    pub fn confirm_delete_category(
+        &mut self,
+        clan_id: mezon_store::ClanId,
+        category_id: String,
+        locale: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let category_name = mezon_store::ChannelList::global(cx)
+            .read(cx)
+            .category_name(clan_id, &category_id)
+            .unwrap_or_default()
+            .to_string();
+        let title: SharedString = mezon_i18n::t(locale, "common.modalConfirm.deleteCategoryTitle")
+            .replace("{{name}}", &category_name)
+            .into();
+        let description: SharedString =
+            mezon_i18n::t(locale, "clan.categoryOverview.cannotBeUndone")
+                .to_string()
+                .into();
+        let cancel_label: SharedString = mezon_i18n::t(locale, "common.cancel").to_string().into();
+        let delete_label: SharedString =
+            mezon_i18n::t(locale, "clan.categoryOverview.deleteCategoryButton")
+                .to_string()
+                .into();
+        let view = cx.new(|cx| ConfirmDeleteCategoryModal {
+            focus_handle: cx.focus_handle(),
+            clan_id,
+            category_id,
             locale: locale.to_string(),
             title,
             description,

--- a/crates/mezon-ui/src/chat/member_list.rs
+++ b/crates/mezon-ui/src/chat/member_list.rs
@@ -1419,6 +1419,21 @@ struct MemberMenuArgs {
     permissions: MemberMenuPermissions,
 }
 
+fn close_member_submenus(
+    panel: WeakEntity<MemberListPanel>,
+) -> impl Fn(&mut Window, &mut App) + 'static {
+    move |_window: &mut Window, cx: &mut App| {
+        let _ = panel.update(cx, |this, cx| {
+            if let Some(menu) = this.open_menu.as_mut()
+                && menu.ban_sub_open
+            {
+                menu.ban_sub_open = false;
+                cx.notify();
+            }
+        });
+    }
+}
+
 fn close_member_menu(panel: &WeakEntity<MemberListPanel>, cx: &mut App) {
     if let Some(panel) = panel.upgrade() {
         panel.update(cx, |this, cx| {
@@ -1473,6 +1488,7 @@ fn build_member_menu(args: MemberMenuArgs) -> ContextMenu {
         .replace("{{username}}", display_name.as_ref());
 
     let mut menu = ContextMenu::new()
+        .on_submenu_close(close_member_submenus(panel.clone()))
         .on_dismiss(dismiss)
         .item(t("contextMenu.member.profile"), {
             let panel = panel.clone();

--- a/crates/mezon-ui/src/clan/edit_category_modal.rs
+++ b/crates/mezon-ui/src/clan/edit_category_modal.rs
@@ -1,0 +1,305 @@
+use crate::app::shell::Shell;
+use crate::components::primitives::{
+    Button, ButtonVariants, Icon, IconName, Input, InputEvent, InputState, h_flex, v_flex,
+};
+use crate::theme::ActiveTheme;
+use gpui::{
+    App, Context, Entity, FocusHandle, Focusable, FontWeight, SharedString, Subscription, Task,
+    Window, div, prelude::*, px,
+};
+use mezon_store::{ChannelList, ClanId, CreateCategoryError, validate_category_name};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Validation {
+    InvalidName,
+    DuplicateName,
+    Validated,
+}
+
+pub struct EditCategoryModal {
+    focus_handle: FocusHandle,
+    clan_id: ClanId,
+    category_id: String,
+    channel_list: Entity<ChannelList>,
+    locale: String,
+    initial_name: String,
+    name_input: Entity<InputState>,
+    validation: Validation,
+    validation_visible: bool,
+    saving: bool,
+    _input_sub: Subscription,
+    _save_task: Option<Task<()>>,
+}
+
+impl Focusable for EditCategoryModal {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl EditCategoryModal {
+    pub fn new(
+        clan_id: ClanId,
+        category_id: String,
+        channel_list: Entity<ChannelList>,
+        locale: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let initial_name = channel_list
+            .read(cx)
+            .category_name(clan_id, &category_id)
+            .unwrap_or_default()
+            .to_string();
+        let placeholder: SharedString =
+            mezon_i18n::t(&locale, "clan.categoryOverview.categoryNamePlaceholder")
+                .to_string()
+                .into();
+        let name_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(placeholder)
+                .height(px(40.))
+        });
+        name_input.update(cx, |input, cx| {
+            input.set_value(initial_name.clone(), window, cx);
+        });
+        let input_sub = cx.subscribe(&name_input, |this, _, event: &InputEvent, cx| match event {
+            InputEvent::Change => this.revalidate(cx),
+            InputEvent::PressEnter => this.save(cx),
+        });
+        name_input.update(cx, |input, cx| input.focus(window, cx));
+
+        Self {
+            focus_handle: cx.focus_handle(),
+            clan_id,
+            category_id,
+            channel_list,
+            locale,
+            initial_name,
+            name_input,
+            validation: Validation::Validated,
+            validation_visible: false,
+            saving: false,
+            _input_sub: input_sub,
+            _save_task: None,
+        }
+    }
+
+    fn revalidate(&mut self, cx: &mut Context<Self>) {
+        let value = self.name_input.read(cx).value();
+        self.validation_visible = !value.is_empty();
+        self.validation = match validate_category_name(value) {
+            Ok(name)
+                if self.channel_list.read(cx).category_name_exists_excluding(
+                    self.clan_id,
+                    &name,
+                    &self.category_id,
+                ) =>
+            {
+                Validation::DuplicateName
+            }
+            Ok(_) => Validation::Validated,
+            Err(_) => Validation::InvalidName,
+        };
+        cx.notify();
+    }
+
+    fn has_changes(&self, cx: &App) -> bool {
+        self.name_input.read(cx).value().trim() != self.initial_name.trim()
+    }
+
+    fn save(&mut self, cx: &mut Context<Self>) {
+        if self.saving {
+            return;
+        }
+        if !self.has_changes(cx) {
+            Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+            return;
+        }
+        if self.validation != Validation::Validated {
+            self.validation_visible = true;
+            cx.notify();
+            return;
+        }
+        let name = self.name_input.read(cx).value().to_string();
+        let category_id = self.category_id.clone();
+        self.saving = true;
+        cx.notify();
+
+        let task = self.channel_list.update(cx, |store, cx| {
+            store.rename_category(self.clan_id, category_id, name, cx)
+        });
+        self._save_task = Some(cx.spawn(async move |this, cx| match task.await {
+            Ok(()) => {
+                cx.update(|cx| {
+                    Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+                });
+            }
+            Err(CreateCategoryError::InvalidName) => {
+                let _ = this.update(cx, |this, cx| {
+                    this.validation = Validation::InvalidName;
+                    this.validation_visible = true;
+                    this.saving = false;
+                    cx.notify();
+                });
+            }
+            Err(CreateCategoryError::DuplicateName) => {
+                let _ = this.update(cx, |this, cx| {
+                    this.validation = Validation::DuplicateName;
+                    this.validation_visible = true;
+                    this.saving = false;
+                    cx.notify();
+                });
+            }
+            Err(CreateCategoryError::Other(msg)) => {
+                tracing::error!("rename category failed: {msg}");
+                let _ = this.update(cx, |this, cx| {
+                    this.saving = false;
+                    cx.notify();
+                });
+                cx.update(|cx| {
+                    Shell::global(cx).update(cx, |shell, cx| shell.error(msg, cx));
+                });
+            }
+        }));
+    }
+}
+
+impl Render for EditCategoryModal {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let theme_setting_primary = cx.theme().tokens.theme_setting_primary;
+        let title: SharedString = mezon_i18n::t(&self.locale, "contextMenu.editCategory")
+            .to_string()
+            .to_uppercase()
+            .into();
+        let name_label: SharedString =
+            mezon_i18n::t(&self.locale, "clan.categoryOverview.categoryName")
+                .to_string()
+                .into();
+        let invalid_msg: SharedString =
+            mezon_i18n::t(&self.locale, "clan.createCategoryModal.invalidName")
+                .to_string()
+                .into();
+        let duplicate_msg: SharedString =
+            mezon_i18n::t(&self.locale, "clan.createCategoryModal.duplicateName")
+                .to_string()
+                .into();
+        let cancel_label: SharedString = mezon_i18n::t(&self.locale, "common.cancel")
+            .to_string()
+            .into();
+        let save_label: SharedString = mezon_i18n::t(&self.locale, "common.saveChanges")
+            .to_string()
+            .into();
+
+        let name_input = self.name_input.clone();
+        let show_invalid = self.validation_visible && self.validation == Validation::InvalidName;
+        let show_duplicate =
+            self.validation_visible && self.validation == Validation::DuplicateName;
+        let can_save =
+            self.validation == Validation::Validated && !self.saving && self.has_changes(cx);
+
+        v_flex()
+            .track_focus(&self.focus_handle)
+            .key_context("menu")
+            .on_action(cx.listener(|this, _: &::menu::Cancel, _window, cx| {
+                if this.saving {
+                    return;
+                }
+                Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+            }))
+            .w(px(455.))
+            .max_w(px(455.))
+            .rounded(px(12.))
+            .bg(theme_setting_primary)
+            .shadow_lg()
+            .p(px(20.))
+            .child(
+                h_flex()
+                    .w_full()
+                    .justify_between()
+                    .items_center()
+                    .mb(px(20.))
+                    .child(
+                        div()
+                            .text_size(px(18.))
+                            .font_weight(gpui::FontWeight::BOLD)
+                            .text_color(theme.tokens.text_theme_primary)
+                            .child(title),
+                    )
+                    .child(
+                        div()
+                            .id("edit-category-close")
+                            .w(px(28.))
+                            .h(px(28.))
+                            .rounded_full()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .cursor_pointer()
+                            .opacity(0.65)
+                            .hover(|s| s.opacity(1.0))
+                            .on_click(|_, _, cx| {
+                                Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+                            })
+                            .child(
+                                Icon::new(IconName::Close)
+                                    .size(px(22.))
+                                    .text_color(theme.text_secondary),
+                            ),
+                    ),
+            )
+            .child(
+                div()
+                    .w_full()
+                    .child(
+                        div()
+                            .mb(px(8.))
+                            .text_sm()
+                            .font_weight(gpui::FontWeight::BOLD)
+                            .text_color(theme.tokens.text_theme_primary)
+                            .child(name_label),
+                    )
+                    .child(Input::new(&name_input))
+                    .child(
+                        div()
+                            .mt(px(4.))
+                            .h(px(18.))
+                            .text_xs()
+                            .italic()
+                            .font_weight(FontWeight::MEDIUM)
+                            .text_color(theme.danger_text)
+                            .when(show_invalid, |el| el.child(invalid_msg))
+                            .when(show_duplicate, |el| el.child(duplicate_msg)),
+                    ),
+            )
+            .child(
+                h_flex()
+                    .w_full()
+                    .justify_end()
+                    .gap_3()
+                    .mt(px(20.))
+                    .font_weight(FontWeight(900.))
+                    .child(
+                        Button::new("edit-category-cancel")
+                            .label(cancel_label)
+                            .ghost()
+                            .text_color(gpui::Hsla::from(theme.text_secondary))
+                            .on_click(|_, _, cx| {
+                                Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+                            }),
+                    )
+                    .child(
+                        Button::new("edit-category-submit")
+                            .label(save_label)
+                            .primary()
+                            .min_w(px(128.))
+                            .disabled(!can_save)
+                            .loading(self.saving)
+                            .on_click(cx.listener(|this, _, _window, cx| {
+                                this.save(cx);
+                            })),
+                    ),
+            )
+    }
+}

--- a/crates/mezon-ui/src/clan/mod.rs
+++ b/crates/mezon-ui/src/clan/mod.rs
@@ -2,6 +2,7 @@ pub mod clan_menu;
 pub mod create_category_modal;
 pub mod create_channel_modal;
 pub mod create_clan_modal;
+pub mod edit_category_modal;
 pub mod invite_people_modal;
 pub mod settings;
 mod templates;

--- a/crates/mezon-ui/src/components/primitives/context_menu.rs
+++ b/crates/mezon-ui/src/components/primitives/context_menu.rs
@@ -70,6 +70,7 @@ pub struct ContextMenu {
     quick_reactions: Vec<QuickReaction>,
     on_quick_reaction: Option<QuickReactionHandler>,
     on_reaction_close: Option<MenuHandler>,
+    on_submenu_close: Option<MenuHandler>,
     on_dismiss: Option<DismissHandler>,
     anchor: Point<Pixels>,
 }
@@ -193,6 +194,14 @@ impl ContextMenu {
 
     pub fn separator(mut self) -> Self {
         self.items.push(Item::Separator);
+        self
+    }
+
+    pub fn on_submenu_close(
+        mut self,
+        on_submenu_close: impl Fn(&mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_submenu_close = Some(Rc::new(on_submenu_close));
         self
     }
 
@@ -501,6 +510,27 @@ impl RenderOnce for ContextMenu {
         let brand = theme.brand;
         let dismiss = self.on_dismiss.clone();
         let on_reaction_close = self.on_reaction_close;
+        let on_submenu_close = self.on_submenu_close;
+        let flyout_open = self.items.iter().any(|item| {
+            matches!(
+                item,
+                Item::Submenu { open: true, .. } | Item::ReactionSubmenu { open: true, .. }
+            )
+        });
+        let close_open_flyouts: Option<MenuHandler> = (flyout_open
+            && (on_reaction_close.is_some() || on_submenu_close.is_some()))
+        .then(|| {
+            let on_reaction_close = on_reaction_close.clone();
+            let on_submenu_close = on_submenu_close.clone();
+            Rc::new(move |window: &mut Window, cx: &mut App| {
+                if let Some(close) = &on_reaction_close {
+                    close(window, cx);
+                }
+                if let Some(close) = &on_submenu_close {
+                    close(window, cx);
+                }
+            }) as MenuHandler
+        });
         let on_quick_reaction = self.on_quick_reaction;
         // Flip the reaction submenu to the left of the menu when it would overflow
         // the window's right edge.
@@ -624,7 +654,7 @@ impl RenderOnce for ContextMenu {
                                     }
                                 })
                             })
-                            .when_some(on_reaction_close.clone(), |row, close| {
+                            .when_some(close_open_flyouts.clone(), |row, close| {
                                 row.on_hover(move |hovered, window, cx| {
                                     if *hovered {
                                         close(window, cx);
@@ -769,9 +799,15 @@ impl RenderOnce for ContextMenu {
                                     s.bg(hover)
                                 }
                             })
-                            .on_hover(move |hovered, window, cx| {
-                                if *hovered {
-                                    on_open(window, cx);
+                            .on_hover({
+                                let close = close_open_flyouts.clone();
+                                move |hovered, window, cx| {
+                                    if *hovered {
+                                        if !open && let Some(close) = &close {
+                                            close(window, cx);
+                                        }
+                                        on_open(window, cx);
+                                    }
                                 }
                             })
                             .when_some(on_parent_click, |row, on_parent_click| {
@@ -806,6 +842,13 @@ impl RenderOnce for ContextMenu {
                             .text_color(text)
                             .cursor_pointer()
                             .hover(|s| s.bg(hover))
+                            .when_some(close_open_flyouts.clone(), |row, close| {
+                                row.on_hover(move |hovered, window, cx| {
+                                    if *hovered {
+                                        close(window, cx);
+                                    }
+                                })
+                            })
                             .child(
                                 div()
                                     .w(px(16.))
@@ -954,9 +997,15 @@ impl RenderOnce for ContextMenu {
                             .text_color(text)
                             .cursor_pointer()
                             .hover(|s| s.bg(hover))
-                            .on_hover(move |hovered, window, cx| {
-                                if *hovered {
-                                    on_open(window, cx);
+                            .on_hover({
+                                let close = close_open_flyouts.clone();
+                                move |hovered, window, cx| {
+                                    if *hovered {
+                                        if !open && let Some(close) = &close {
+                                            close(window, cx);
+                                        }
+                                        on_open(window, cx);
+                                    }
                                 }
                             })
                             .child(div().flex_1().child(label))

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/menu.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/menu.rs
@@ -1,12 +1,13 @@
-use gpui::{App, ClickEvent, ClipboardItem, Entity, Pixels, Point, WeakEntity, Window};
+use gpui::{App, AppContext, ClickEvent, ClipboardItem, Entity, Pixels, Point, WeakEntity, Window};
 use mezon_store::{
     AppConfig, BadgeService, ChannelId, ChannelList, ChannelType, ClanId, PERMISSION_ADMINISTRATOR,
     PERMISSION_CLAN_OWNER, PERMISSION_MANAGE_CHANNEL, PERMISSION_MANAGE_CLAN, PermissionStore,
     archive_menu_hidden, can_archive_channel,
 };
 
-use super::ChannelSidebar;
+use super::{CategoryMenuData, ChannelMenuData, ChannelSidebar};
 use crate::app::shell::Shell;
+use crate::clan::edit_category_modal::EditCategoryModal;
 use crate::components::primitives::{ContextMenu, SubmenuOption};
 
 #[derive(Clone, Copy, Default)]
@@ -17,6 +18,7 @@ pub(super) struct ChannelMenuPermissions {
     pub(super) is_channel_creator: bool,
     pub(super) is_welcome_channel: bool,
     pub(super) hide_archive: bool,
+    pub(super) is_favorite: bool,
 }
 
 impl ChannelMenuPermissions {
@@ -55,6 +57,7 @@ impl ChannelMenuPermissions {
             is_channel_creator,
             is_welcome_channel,
             hide_archive: archive_menu_hidden(channel_type, is_welcome_channel),
+            is_favorite: channel_list.is_channel_favorite(clan_id, channel_id),
         }
     }
 }
@@ -100,10 +103,19 @@ pub(super) struct OpenMenu {
     pub(super) noti_sub_open: bool,
 }
 
-fn coming_soon_toast(message: String) -> impl Fn(&mut Window, &mut App) + 'static {
+fn toggle_channel_favorite(
+    clan_id: ClanId,
+    channel_id: ChannelId,
+    is_favorite: bool,
+) -> impl Fn(&mut Window, &mut App) + 'static {
     move |_window: &mut Window, cx: &mut App| {
-        let message = message.clone();
-        Shell::global(cx).update(cx, move |shell, cx| shell.info(message, cx));
+        ChannelList::global(cx).update(cx, |channels, cx| {
+            if is_favorite {
+                channels.remove_channel_favorite(channel_id, clan_id, cx);
+            } else {
+                channels.add_channel_favorite(channel_id, clan_id, cx);
+            }
+        });
     }
 }
 
@@ -303,6 +315,38 @@ fn set_submenu_open(
     }
 }
 
+fn close_channel_submenus(
+    sidebar: WeakEntity<ChannelSidebar>,
+) -> impl Fn(&mut Window, &mut App) + 'static {
+    move |_window: &mut Window, cx: &mut App| {
+        let _ = sidebar.update(cx, |this, cx| {
+            if let Some(menu) = this.open_menu.as_mut()
+                && (menu.mute_sub_open || menu.noti_sub_open)
+            {
+                menu.mute_sub_open = false;
+                menu.noti_sub_open = false;
+                cx.notify();
+            }
+        });
+    }
+}
+
+fn close_category_submenus(
+    sidebar: WeakEntity<ChannelSidebar>,
+) -> impl Fn(&mut Window, &mut App) + 'static {
+    move |_window: &mut Window, cx: &mut App| {
+        let _ = sidebar.update(cx, |this, cx| {
+            if let Some(menu) = this.category_menu.as_mut()
+                && (menu.mute_sub_open || menu.noti_sub_open)
+            {
+                menu.mute_sub_open = false;
+                menu.noti_sub_open = false;
+                cx.notify();
+            }
+        });
+    }
+}
+
 pub(crate) fn apply_mute(
     channel_id: ChannelId,
     clan_id: ClanId,
@@ -407,37 +451,41 @@ fn push_mute_and_notification(
     menu
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(super) fn build_channel_menu(
     sidebar: WeakEntity<ChannelSidebar>,
-    locale: &str,
-    channel_type: ChannelType,
-    is_thread: bool,
-    channel_id: ChannelId,
-    clan_id: ClanId,
-    muted: bool,
-    muted_until: Option<String>,
-    level: i32,
-    mute_sub_open: bool,
-    noti_sub_open: bool,
-    clan_default: Option<i32>,
-    in_favorites: bool,
-    permissions: ChannelMenuPermissions,
+    data: &ChannelMenuData,
 ) -> ContextMenu {
+    let ChannelMenuData {
+        channel_type,
+        is_thread,
+        channel_id,
+        clan_id,
+        muted,
+        level,
+        mute_sub_open,
+        noti_sub_open,
+        clan_default,
+        in_favorites,
+        permissions,
+        ..
+    } = *data;
+    let locale = data.locale.as_str();
+    let muted_until = data.muted_until.clone();
     let t = |key: &'static str| mezon_i18n::t(locale, key).to_string();
-    let coming_soon = t("common.comingSoon");
     let locale_owned = locale.to_string();
     let sidebar_dismiss = sidebar.clone();
     let show_notification = matches!(channel_type, ChannelType::Text) || is_thread;
 
-    let mut menu = ContextMenu::new().on_dismiss(move |_window, cx| {
-        if let Some(view) = sidebar_dismiss.upgrade() {
-            view.update(cx, |this, cx| {
-                this.open_menu = None;
-                cx.notify();
-            });
-        }
-    });
+    let mut menu = ContextMenu::new()
+        .on_submenu_close(close_channel_submenus(sidebar.clone()))
+        .on_dismiss(move |_window, cx| {
+            if let Some(view) = sidebar_dismiss.upgrade() {
+                view.update(cx, |this, cx| {
+                    this.open_menu = None;
+                    cx.notify();
+                });
+            }
+        });
 
     if !in_favorites {
         menu = menu
@@ -525,9 +573,14 @@ pub(super) fn build_channel_menu(
             noti_sub_open,
             show_notification,
         );
+        let favorite_label = if permissions.is_favorite {
+            t("channelMenu.menu.inviteMenu.unMarkFavorite")
+        } else {
+            t("channelMenu.menu.inviteMenu.markFavorite")
+        };
         menu = menu.item(
-            t("channelMenu.menu.inviteMenu.markFavorite"),
-            coming_soon_toast(coming_soon.clone()),
+            favorite_label,
+            toggle_channel_favorite(clan_id, channel_id, permissions.is_favorite),
         );
 
         if permissions.can_manage_channel {
@@ -675,41 +728,50 @@ fn apply_category_mute_forever(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(super) fn build_category_menu(
     sidebar: WeakEntity<ChannelSidebar>,
     channel_list: Entity<ChannelList>,
-    locale: &str,
-    category_id: String,
-    clan_id: ClanId,
-    collapsed: bool,
-    time_muted: bool,
-    muted_until: Option<String>,
-    level: i32,
-    mute_sub_open: bool,
-    noti_sub_open: bool,
-    can_manage_category: bool,
-    category_is_empty: bool,
+    data: &CategoryMenuData,
 ) -> ContextMenu {
+    let CategoryMenuData {
+        clan_id,
+        collapsed,
+        time_muted,
+        level,
+        mute_sub_open,
+        noti_sub_open,
+        can_manage_category,
+        category_is_empty,
+        ..
+    } = *data;
+    let locale = data.locale.as_str();
+    let category_id = data.category_id.clone();
+    let muted_until = data.muted_until.clone();
     let t = |key: &'static str| mezon_i18n::t(locale, key).to_string();
-    let coming_soon = t("common.comingSoon");
     let locale_owned = locale.to_string();
     let sidebar_dismiss = sidebar.clone();
 
-    let mut menu = ContextMenu::new().on_dismiss(move |_window, cx| {
-        if let Some(view) = sidebar_dismiss.upgrade() {
-            view.update(cx, |this, cx| {
-                this.category_menu = None;
-                cx.notify();
-            });
-        }
-    });
+    let mut menu = ContextMenu::new()
+        .on_submenu_close(close_category_submenus(sidebar.clone()))
+        .on_dismiss(move |_window, cx| {
+            if let Some(view) = sidebar_dismiss.upgrade() {
+                view.update(cx, |this, cx| {
+                    this.category_menu = None;
+                    cx.notify();
+                });
+            }
+        });
 
     menu = menu
-        .item(
-            t("contextMenu.markAsRead"),
-            coming_soon_toast(coming_soon.clone()),
-        )
+        .item(t("contextMenu.markAsRead"), {
+            let channel_list = channel_list.clone();
+            let category_id = category_id.clone();
+            move |_window, cx| {
+                channel_list.update(cx, |list, cx| {
+                    list.mark_category_as_read(clan_id, &category_id, cx);
+                });
+            }
+        })
         .separator()
         .checkbox_item(t("contextMenu.collapseCategory"), collapsed, {
             let channel_list = channel_list.clone();
@@ -720,10 +782,14 @@ pub(super) fn build_category_menu(
                 });
             }
         })
-        .item(
-            t("contextMenu.collapseAllCategories"),
-            coming_soon_toast(coming_soon.clone()),
-        )
+        .item(t("contextMenu.collapseAllCategories"), {
+            let channel_list = channel_list.clone();
+            move |_window, cx| {
+                channel_list.update(cx, |list, cx| {
+                    list.collapse_all_categories(clan_id, cx);
+                });
+            }
+        })
         .separator();
 
     menu = if time_muted {
@@ -750,23 +816,62 @@ pub(super) fn build_category_menu(
         submenu_options(locale, CATEGORY_NOTI_LEVELS, level),
         noti_sub_open,
         set_category_submenu_open(sidebar, false),
-        apply_category_level(category_id, clan_id),
+        apply_category_level(category_id.clone(), clan_id),
     );
 
     if can_manage_category {
         let edit_label = t("contextMenu.editCategory");
         let delete_label = t("contextMenu.deleteCategory");
         menu = menu.separator().item(
-            edit_label.clone(),
-            coming_soon_modal(edit_label, locale_owned.clone()),
+            edit_label,
+            open_edit_category(
+                clan_id,
+                category_id.clone(),
+                channel_list,
+                locale_owned.clone(),
+            ),
         );
         if category_is_empty {
             menu = menu.danger_item(
-                delete_label.clone(),
-                coming_soon_modal(delete_label, locale_owned),
+                delete_label,
+                open_delete_category_confirm(clan_id, category_id, locale_owned),
             );
         }
     }
 
     menu
+}
+
+fn open_edit_category(
+    clan_id: ClanId,
+    category_id: String,
+    channel_list: Entity<ChannelList>,
+    locale: String,
+) -> impl Fn(&mut Window, &mut App) + 'static {
+    move |window: &mut Window, cx: &mut App| {
+        let modal = cx.new(|cx| {
+            EditCategoryModal::new(
+                clan_id,
+                category_id.clone(),
+                channel_list.clone(),
+                locale.clone(),
+                window,
+                cx,
+            )
+        });
+        Shell::global(cx).update(cx, |shell, cx| shell.show_modal(modal.into(), cx));
+    }
+}
+
+fn open_delete_category_confirm(
+    clan_id: ClanId,
+    category_id: String,
+    locale: String,
+) -> impl Fn(&mut Window, &mut App) + 'static {
+    move |window: &mut Window, cx: &mut App| {
+        let category_id = category_id.clone();
+        Shell::global(cx).update(cx, |shell, cx| {
+            shell.confirm_delete_category(clan_id, category_id, &locale, window, cx);
+        });
+    }
 }

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
@@ -127,7 +127,122 @@ pub struct ChannelSidebar {
     _notification_setting_observe: Subscription,
 }
 
+struct ActiveChannelSidebar(gpui::WeakEntity<ChannelSidebar>);
+impl gpui::Global for ActiveChannelSidebar {}
+
+struct ChannelMenuData {
+    position: gpui::Point<gpui::Pixels>,
+    channel_type: mezon_store::ChannelType,
+    is_thread: bool,
+    locale: String,
+    channel_id: ChannelId,
+    clan_id: ClanId,
+    muted: bool,
+    muted_until: Option<String>,
+    level: i32,
+    mute_sub_open: bool,
+    noti_sub_open: bool,
+    clan_default: Option<i32>,
+    in_favorites: bool,
+    permissions: ChannelMenuPermissions,
+}
+
+struct CategoryMenuData {
+    position: gpui::Point<gpui::Pixels>,
+    locale: String,
+    category_id: String,
+    clan_id: ClanId,
+    collapsed: bool,
+    time_muted: bool,
+    muted_until: Option<String>,
+    level: i32,
+    mute_sub_open: bool,
+    noti_sub_open: bool,
+    can_manage_category: bool,
+    category_is_empty: bool,
+}
+
 impl ChannelSidebar {
+    fn channel_menu_data(&self, locale: &str, cx: &App) -> Option<ChannelMenuData> {
+        let menu = self.open_menu.as_ref()?;
+        let store = mezon_store::NotificationSettingStore::try_global(cx);
+        Some(ChannelMenuData {
+            position: menu.position,
+            channel_type: menu.channel_type,
+            is_thread: menu.is_thread,
+            locale: locale.to_string(),
+            channel_id: menu.channel_id,
+            clan_id: menu.clan_id,
+            muted: store
+                .as_ref()
+                .is_some_and(|s| s.read(cx).is_time_muted(menu.channel_id)),
+            muted_until: store
+                .as_ref()
+                .and_then(|s| s.read(cx).muted_until_ms(menu.channel_id))
+                .map(|ms| {
+                    format!(
+                        "{} {}",
+                        mezon_i18n::t(locale, "channelMenu.menu.notification.mutedUntil"),
+                        crate::chat::notification_setting_popover::format_muted_until(ms)
+                    )
+                }),
+            level: store
+                .as_ref()
+                .map(|s| s.read(cx).level(menu.channel_id))
+                .unwrap_or(0),
+            mute_sub_open: menu.mute_sub_open,
+            noti_sub_open: menu.noti_sub_open,
+            clan_default: store
+                .as_ref()
+                .and_then(|s| s.read(cx).clan_default(menu.clan_id)),
+            in_favorites: menu.in_favorites,
+            permissions: ChannelMenuPermissions::resolve(menu.clan_id, menu.channel_id, cx),
+        })
+    }
+
+    fn category_menu_data(&self, locale: &str, cx: &App) -> Option<CategoryMenuData> {
+        let menu = self.category_menu.as_ref()?;
+        let store = mezon_store::NotificationSettingStore::try_global(cx);
+        Some(CategoryMenuData {
+            position: menu.position,
+            locale: locale.to_string(),
+            category_id: menu.category_id.clone(),
+            clan_id: menu.clan_id,
+            collapsed: menu.collapsed,
+            time_muted: store
+                .as_ref()
+                .is_some_and(|s| s.read(cx).category_is_time_muted(&menu.category_id)),
+            muted_until: store
+                .as_ref()
+                .and_then(|s| s.read(cx).category_muted_until_ms(&menu.category_id))
+                .map(|ms| {
+                    format!(
+                        "{} {}",
+                        mezon_i18n::t(locale, "channelMenu.menu.notification.mutedUntil"),
+                        crate::chat::notification_setting_popover::format_muted_until(ms)
+                    )
+                }),
+            level: store
+                .as_ref()
+                .and_then(|s| s.read(cx).category_default(&menu.category_id))
+                .unwrap_or(0),
+            mute_sub_open: menu.mute_sub_open,
+            noti_sub_open: menu.noti_sub_open,
+            can_manage_category: PermissionStore::try_global(cx).is_some_and(|permissions| {
+                permissions
+                    .read(cx)
+                    .check(menu.clan_id, None, PERMISSION_MANAGE_CLAN, cx)
+            }),
+            category_is_empty: self
+                .channel_list
+                .read(cx)
+                .categories_for_clan(menu.clan_id)
+                .iter()
+                .find(|category| category.id == menu.category_id)
+                .is_some_and(|category| category.channels.is_empty()),
+        })
+    }
+
     pub fn new(
         clan_list: Entity<ClanList>,
         channel_list: Entity<ChannelList>,
@@ -263,6 +378,7 @@ impl ChannelSidebar {
             _channel_permissions_observe: channel_permissions_observe,
             _notification_setting_observe: notification_setting_observe,
         };
+        cx.set_global(ActiveChannelSidebar(cx.entity().downgrade()));
         this.rebuild_items(cx);
         this
     }
@@ -640,6 +756,26 @@ impl ChannelSidebar {
         }
     }
 
+    fn clear_overlays(&mut self) {
+        self.open_menu = None;
+        self.category_menu = None;
+        self.clan_menu_open = false;
+        self.app_list_open = false;
+        self.app_list_apps.clear();
+    }
+
+    fn open_channel_menu(&mut self, menu: OpenMenu, cx: &mut Context<Self>) {
+        self.clear_overlays();
+        self.open_menu = Some(menu);
+        cx.notify();
+    }
+
+    fn open_category_menu(&mut self, menu: CategoryMenu, cx: &mut Context<Self>) {
+        self.clear_overlays();
+        self.category_menu = Some(menu);
+        cx.notify();
+    }
+
     pub(crate) fn dismiss_clan_menu(&mut self, cx: &mut Context<Self>) {
         if self.clan_menu_open {
             self.clan_menu_open = false;
@@ -660,6 +796,7 @@ impl ChannelSidebar {
             self.dismiss_app_list(cx);
             return;
         }
+        self.clear_overlays();
         self.app_list_open = true;
         self.app_list_apps = apps;
         cx.notify();
@@ -713,82 +850,8 @@ impl Render for ChannelSidebar {
                         .check_permission(clan_id, PERMISSION_MANAGE_CLAN, cx)
                 })
             });
-        let menu_overlay = self.open_menu.as_ref().map(|menu| {
-            (
-                menu.position,
-                menu.channel_type,
-                menu.is_thread,
-                locale.clone(),
-                menu.channel_id,
-                menu.clan_id,
-                mezon_store::NotificationSettingStore::try_global(cx)
-                    .is_some_and(|store| store.read(cx).is_time_muted(menu.channel_id)),
-                mezon_store::NotificationSettingStore::try_global(cx)
-                    .and_then(|store| store.read(cx).muted_until_ms(menu.channel_id))
-                    .map(|ms| {
-                        format!(
-                            "{} {}",
-                            mezon_i18n::t(&locale, "channelMenu.menu.notification.mutedUntil"),
-                            crate::chat::notification_setting_popover::format_muted_until(ms)
-                        )
-                    }),
-                mezon_store::NotificationSettingStore::try_global(cx)
-                    .map(|store| store.read(cx).level(menu.channel_id))
-                    .unwrap_or(0),
-                menu.mute_sub_open,
-                menu.noti_sub_open,
-                mezon_store::NotificationSettingStore::try_global(cx)
-                    .and_then(|store| store.read(cx).clan_default(menu.clan_id)),
-                menu.in_favorites,
-                ChannelMenuPermissions::resolve(menu.clan_id, menu.channel_id, cx),
-            )
-        });
-        let category_menu_overlay = self.category_menu.as_ref().map(|menu| {
-            let store = mezon_store::NotificationSettingStore::try_global(cx);
-            let level = store
-                .as_ref()
-                .and_then(|s| s.read(cx).category_default(&menu.category_id))
-                .unwrap_or(0);
-            let time_muted = store
-                .as_ref()
-                .is_some_and(|s| s.read(cx).category_is_time_muted(&menu.category_id));
-            let muted_until = store
-                .as_ref()
-                .and_then(|s| s.read(cx).category_muted_until_ms(&menu.category_id))
-                .map(|ms| {
-                    format!(
-                        "{} {}",
-                        mezon_i18n::t(&locale, "channelMenu.menu.notification.mutedUntil"),
-                        crate::chat::notification_setting_popover::format_muted_until(ms)
-                    )
-                });
-            let can_manage_category = PermissionStore::try_global(cx).is_some_and(|permissions| {
-                permissions
-                    .read(cx)
-                    .check(menu.clan_id, None, PERMISSION_MANAGE_CLAN, cx)
-            });
-            let category_is_empty = self
-                .channel_list
-                .read(cx)
-                .categories_for_clan(menu.clan_id)
-                .iter()
-                .find(|category| category.id == menu.category_id)
-                .is_some_and(|category| category.channels.is_empty());
-            (
-                menu.position,
-                locale.clone(),
-                menu.category_id.clone(),
-                menu.clan_id,
-                menu.collapsed,
-                time_muted,
-                muted_until,
-                level,
-                menu.mute_sub_open,
-                menu.noti_sub_open,
-                can_manage_category,
-                category_is_empty,
-            )
-        });
+        let menu_overlay = self.channel_menu_data(&locale, cx);
+        let category_menu_overlay = self.category_menu_data(&locale, cx);
         let clan_menu_data = self.clan_menu_open.then(|| {
             let active_clan_for_menu = self.clan_list.read(cx).active_clan().map(|clan| {
                 (
@@ -940,7 +1003,9 @@ impl Render for ChannelSidebar {
                                     move |_: &MouseDownEvent, _window, cx| {
                                         if let Some(view) = sidebar.upgrade() {
                                             view.update(cx, |this, cx| {
-                                                this.clan_menu_open = !this.clan_menu_open;
+                                                let opening = !this.clan_menu_open;
+                                                this.clear_overlays();
+                                                this.clan_menu_open = opening;
                                                 cx.notify();
                                             });
                                         }
@@ -1022,83 +1087,22 @@ impl Render for ChannelSidebar {
                         cx,
                     ),
             )
-            .when_some(
-                menu_overlay,
-                move |el,
-                      (
-                    position,
-                    channel_type,
-                    is_thread,
-                    locale,
-                    channel_id,
-                    clan_id,
-                    muted,
-                    muted_until,
-                    level,
-                    mute_sub_open,
-                    noti_sub_open,
-                    clan_default,
-                    in_favorites,
-                    channel_permissions,
-                )| {
-                    el.child(context_menu_at(
-                        position,
-                        build_channel_menu(
-                            sidebar_for_channel_menu.clone(),
-                            &locale,
-                            channel_type,
-                            is_thread,
-                            channel_id,
-                            clan_id,
-                            muted,
-                            muted_until,
-                            level,
-                            mute_sub_open,
-                            noti_sub_open,
-                            clan_default,
-                            in_favorites,
-                            channel_permissions,
-                        ),
-                    ))
-                },
-            )
-            .when_some(
-                category_menu_overlay,
-                move |el,
-                      (
-                    position,
-                    locale,
-                    category_id,
-                    clan_id,
-                    collapsed,
-                    time_muted,
-                    muted_until,
-                    level,
-                    mute_sub_open,
-                    noti_sub_open,
-                    can_manage_category,
-                    category_is_empty,
-                )| {
-                    el.child(context_menu_at(
-                        position,
-                        build_category_menu(
-                            sidebar_for_category_menu.clone(),
-                            channel_list_for_category_menu.clone(),
-                            &locale,
-                            category_id,
-                            clan_id,
-                            collapsed,
-                            time_muted,
-                            muted_until,
-                            level,
-                            mute_sub_open,
-                            noti_sub_open,
-                            can_manage_category,
-                            category_is_empty,
-                        ),
-                    ))
-                },
-            )
+            .when_some(menu_overlay, move |el, data| {
+                el.child(context_menu_at(
+                    data.position,
+                    build_channel_menu(sidebar_for_channel_menu.clone(), &data),
+                ))
+            })
+            .when_some(category_menu_overlay, move |el, data| {
+                el.child(context_menu_at(
+                    data.position,
+                    build_category_menu(
+                        sidebar_for_category_menu.clone(),
+                        channel_list_for_category_menu.clone(),
+                        &data,
+                    ),
+                ))
+            })
             .when_some(app_list_overlay, move |el, (apps, locale)| {
                 el.child(app_list_popover_overlay(
                     &apps,
@@ -1110,6 +1114,242 @@ impl Render for ChannelSidebar {
                 ))
             })
     }
+}
+
+fn active_channel_sidebar(cx: &App) -> anyhow::Result<Entity<ChannelSidebar>> {
+    cx.try_global::<ActiveChannelSidebar>()
+        .and_then(|active| active.0.upgrade())
+        .ok_or_else(|| anyhow::anyhow!("no channel sidebar is mounted; sign in first"))
+}
+
+fn probe_items_json(menu: &crate::components::primitives::ContextMenu) -> serde_json::Value {
+    serde_json::Value::Array(
+        menu.probe_items()
+            .into_iter()
+            .enumerate()
+            .map(|(index, item)| {
+                serde_json::json!({
+                    "index": index,
+                    "kind": item.kind,
+                    "label": item.label,
+                    "disabled": item.disabled,
+                    "options": item
+                        .options
+                        .into_iter()
+                        .map(|(value, label)| serde_json::json!({ "value": value, "label": label }))
+                        .collect::<Vec<_>>(),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn channel_menu_json(sidebar: &Entity<ChannelSidebar>, cx: &App) -> serde_json::Value {
+    let this = sidebar.read(cx);
+    let locale = this.settings.read(cx).language.clone();
+    let Some(data) = this.channel_menu_data(&locale, cx) else {
+        return serde_json::json!({ "open": false, "items": [] });
+    };
+    let menu = build_channel_menu(sidebar.downgrade(), &data);
+    serde_json::json!({
+        "open": true,
+        "clan_id": data.clan_id.to_string(),
+        "channel_id": data.channel_id.to_string(),
+        "is_thread": data.is_thread,
+        "in_favorites": data.in_favorites,
+        "is_favorite": data.permissions.is_favorite,
+        "can_manage_channel": data.permissions.can_manage_channel,
+        "mute_submenu_open": data.mute_sub_open,
+        "noti_submenu_open": data.noti_sub_open,
+        "items": probe_items_json(&menu),
+    })
+}
+
+fn category_menu_json(sidebar: &Entity<ChannelSidebar>, cx: &App) -> serde_json::Value {
+    let this = sidebar.read(cx);
+    let locale = this.settings.read(cx).language.clone();
+    let Some(data) = this.category_menu_data(&locale, cx) else {
+        return serde_json::json!({ "open": false, "items": [] });
+    };
+    let menu = build_category_menu(sidebar.downgrade(), this.channel_list_handle.clone(), &data);
+    serde_json::json!({
+        "open": true,
+        "clan_id": data.clan_id.to_string(),
+        "category_id": data.category_id,
+        "collapsed": data.collapsed,
+        "can_manage_category": data.can_manage_category,
+        "category_is_empty": data.category_is_empty,
+        "mute_submenu_open": data.mute_sub_open,
+        "noti_submenu_open": data.noti_sub_open,
+        "items": probe_items_json(&menu),
+    })
+}
+
+pub fn channel_menu_state(cx: &App) -> anyhow::Result<serde_json::Value> {
+    let sidebar = active_channel_sidebar(cx)?;
+    Ok(channel_menu_json(&sidebar, cx))
+}
+
+pub fn channel_menu_open(
+    clan_id: ClanId,
+    channel_id: ChannelId,
+    position: gpui::Point<gpui::Pixels>,
+    in_favorites: bool,
+    cx: &mut App,
+) -> anyhow::Result<serde_json::Value> {
+    let sidebar = active_channel_sidebar(cx)?;
+    let channels = ChannelList::global(cx);
+    let channel = channels
+        .read(cx)
+        .channel(clan_id, channel_id)
+        .cloned()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "channel {channel_id} is not in clan {clan_id}; call list_channels first"
+            )
+        })?;
+    sidebar.update(cx, |this, cx| {
+        this.open_channel_menu(
+            OpenMenu {
+                channel_type: channel.channel_type,
+                is_thread: channel.parent_id.is_some(),
+                position,
+                channel_id,
+                clan_id,
+                in_favorites,
+                mute_sub_open: false,
+                noti_sub_open: false,
+            },
+            cx,
+        );
+    });
+    Ok(channel_menu_json(&sidebar, cx))
+}
+
+pub fn channel_menu_close(cx: &mut App) -> anyhow::Result<serde_json::Value> {
+    let sidebar = active_channel_sidebar(cx)?;
+    sidebar.update(cx, |this, cx| {
+        this.open_menu = None;
+        cx.notify();
+    });
+    Ok(channel_menu_json(&sidebar, cx))
+}
+
+pub fn channel_menu_pick(
+    index: usize,
+    value: Option<i32>,
+    window: &mut Window,
+    cx: &mut App,
+) -> anyhow::Result<serde_json::Value> {
+    let sidebar = active_channel_sidebar(cx)?;
+    let locale = sidebar.read(cx).settings.read(cx).language.clone();
+    let data = sidebar
+        .read(cx)
+        .channel_menu_data(&locale, cx)
+        .ok_or_else(|| anyhow::anyhow!("channel menu is not open; call channel_menu_open first"))?;
+    let menu = build_channel_menu(sidebar.downgrade(), &data);
+    let picked = menu
+        .probe_items()
+        .get(index)
+        .map(|item| (item.kind, item.label.clone()))
+        .ok_or_else(|| anyhow::anyhow!("no menu item at index {index}"))?;
+    menu.probe_activate(index, value, window, cx)?;
+    Ok(serde_json::json!({
+        "ok": true,
+        "index": index,
+        "kind": picked.0,
+        "label": picked.1,
+        "value": value,
+        "menu_open": sidebar.read(cx).open_menu.is_some(),
+    }))
+}
+
+pub fn category_menu_state(cx: &App) -> anyhow::Result<serde_json::Value> {
+    let sidebar = active_channel_sidebar(cx)?;
+    Ok(category_menu_json(&sidebar, cx))
+}
+
+pub fn category_menu_open(
+    clan_id: ClanId,
+    category_id: String,
+    position: gpui::Point<gpui::Pixels>,
+    cx: &mut App,
+) -> anyhow::Result<serde_json::Value> {
+    let sidebar = active_channel_sidebar(cx)?;
+    anyhow::ensure!(
+        category_id != FAVOR_CATE_ID,
+        "the favourites category has no context menu"
+    );
+    let channels = ChannelList::global(cx);
+    anyhow::ensure!(
+        channels
+            .read(cx)
+            .categories_for_clan(clan_id)
+            .iter()
+            .any(|category| category.id == category_id),
+        "category {category_id} is not in clan {clan_id}; call list_channels first"
+    );
+    let collapsed = channels
+        .read(cx)
+        .is_category_collapsed(clan_id, &category_id);
+    sidebar.update(cx, |this, cx| {
+        this.open_category_menu(
+            CategoryMenu {
+                position,
+                category_id: category_id.clone(),
+                clan_id,
+                collapsed,
+                mute_sub_open: false,
+                noti_sub_open: false,
+            },
+            cx,
+        );
+        if let Some(store) = mezon_store::NotificationSettingStore::try_global(cx) {
+            store.update(cx, |store, cx| store.ensure_category(category_id, cx));
+        }
+    });
+    Ok(category_menu_json(&sidebar, cx))
+}
+
+pub fn category_menu_close(cx: &mut App) -> anyhow::Result<serde_json::Value> {
+    let sidebar = active_channel_sidebar(cx)?;
+    sidebar.update(cx, |this, cx| {
+        this.category_menu = None;
+        cx.notify();
+    });
+    Ok(category_menu_json(&sidebar, cx))
+}
+
+pub fn category_menu_pick(
+    index: usize,
+    value: Option<i32>,
+    window: &mut Window,
+    cx: &mut App,
+) -> anyhow::Result<serde_json::Value> {
+    let sidebar = active_channel_sidebar(cx)?;
+    let locale = sidebar.read(cx).settings.read(cx).language.clone();
+    let data = sidebar
+        .read(cx)
+        .category_menu_data(&locale, cx)
+        .ok_or_else(|| {
+            anyhow::anyhow!("category menu is not open; call category_menu_open first")
+        })?;
+    let channel_list = sidebar.read(cx).channel_list_handle.clone();
+    let menu = build_category_menu(sidebar.downgrade(), channel_list, &data);
+    let picked = menu
+        .probe_items()
+        .get(index)
+        .map(|item| (item.kind, item.label.clone()))
+        .ok_or_else(|| anyhow::anyhow!("no menu item at index {index}"))?;
+    menu.probe_activate(index, value, window, cx)?;
+    Ok(serde_json::json!({
+        "ok": true,
+        "index": index,
+        "kind": picked.0,
+        "label": picked.1,
+        "value": value,
+        "menu_open": sidebar.read(cx).category_menu.is_some(),
+    }))
 }
 
 fn sk_bar(sk: gpui::Rgba, w: gpui::Pixels, h: gpui::Pixels) -> gpui::Div {
@@ -1626,17 +1866,23 @@ fn render_sidebar_item(
                     let sidebar = sidebar.clone();
                     let category_id = category_id.clone();
                     move |event: &MouseDownEvent, _window, cx| {
+                        if category_id == FAVOR_CATE_ID {
+                            return;
+                        }
                         let position = event.position;
                         if let Some(view) = sidebar.upgrade() {
                             view.update(cx, |this, cx| {
-                                this.category_menu = Some(CategoryMenu {
-                                    position,
-                                    category_id: category_id.clone(),
-                                    clan_id: clan_id_for_toggle,
-                                    collapsed: menu_collapsed,
-                                    mute_sub_open: false,
-                                    noti_sub_open: false,
-                                });
+                                this.open_category_menu(
+                                    CategoryMenu {
+                                        position,
+                                        category_id: category_id.clone(),
+                                        clan_id: clan_id_for_toggle,
+                                        collapsed: menu_collapsed,
+                                        mute_sub_open: false,
+                                        noti_sub_open: false,
+                                    },
+                                    cx,
+                                );
                                 if let Some(store) =
                                     mezon_store::NotificationSettingStore::try_global(cx)
                                 {
@@ -1843,16 +2089,19 @@ fn render_sidebar_item(
                     .on_right_click(move |position, _window, cx| {
                         if let Some(view) = menu_sidebar.upgrade() {
                             view.update(cx, |this, cx| {
-                                this.open_menu = Some(OpenMenu {
-                                    channel_type: menu_channel_type,
-                                    is_thread: menu_is_thread,
-                                    position,
-                                    channel_id: menu_channel_id,
-                                    clan_id: menu_clan_id,
-                                    in_favorites,
-                                    mute_sub_open: false,
-                                    noti_sub_open: false,
-                                });
+                                this.open_channel_menu(
+                                    OpenMenu {
+                                        channel_type: menu_channel_type,
+                                        is_thread: menu_is_thread,
+                                        position,
+                                        channel_id: menu_channel_id,
+                                        clan_id: menu_clan_id,
+                                        in_favorites,
+                                        mute_sub_open: false,
+                                        noti_sub_open: false,
+                                    },
+                                    cx,
+                                );
                                 if let Some(store) =
                                     mezon_store::NotificationSettingStore::try_global(cx)
                                 {
@@ -1990,16 +2239,19 @@ fn render_sidebar_item(
                     let position = event.position;
                     if let Some(view) = sidebar.upgrade() {
                         view.update(cx, |this, cx| {
-                            this.open_menu = Some(OpenMenu {
-                                channel_type,
-                                is_thread,
-                                position,
-                                channel_id: menu_channel_id,
-                                clan_id: menu_clan_id,
-                                in_favorites,
-                                mute_sub_open: false,
-                                noti_sub_open: false,
-                            });
+                            this.open_channel_menu(
+                                OpenMenu {
+                                    channel_type,
+                                    is_thread,
+                                    position,
+                                    channel_id: menu_channel_id,
+                                    clan_id: menu_clan_id,
+                                    in_favorites,
+                                    mute_sub_open: false,
+                                    noti_sub_open: false,
+                                },
+                                cx,
+                            );
                             if let Some(store) =
                                 mezon_store::NotificationSettingStore::try_global(cx)
                             {

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/clan_row.rs
@@ -97,14 +97,19 @@ pub(super) fn build_clan_rail_menu(
     let locale_owned = locale.to_string();
     let sidebar_dismiss = sidebar.clone();
 
-    let mut menu = ContextMenu::new().on_dismiss(move |_window, cx| {
-        if let Some(view) = sidebar_dismiss.upgrade() {
-            view.update(cx, |this, cx| {
-                this.clan_menu = None;
-                cx.notify();
-            });
-        }
-    });
+    let sidebar_close = sidebar.clone();
+    let mut menu = ContextMenu::new()
+        .on_submenu_close(move |_window, cx| {
+            let _ = sidebar_close.update(cx, |this, cx| this.close_clan_submenus(cx));
+        })
+        .on_dismiss(move |_window, cx| {
+            if let Some(view) = sidebar_dismiss.upgrade() {
+                view.update(cx, |this, cx| {
+                    this.clan_menu = None;
+                    cx.notify();
+                });
+            }
+        });
 
     menu = menu
         .item(t("contextMenu.markAsRead"), move |_window, cx| {

--- a/crates/mezon-ui/src/sidebar/clan_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/clan_sidebar/mod.rs
@@ -239,6 +239,15 @@ impl ClanSidebar {
         }
     }
 
+    pub(super) fn close_clan_submenus(&mut self, cx: &mut Context<Self>) {
+        if let Some(menu) = self.clan_menu.as_mut()
+            && menu.noti_sub_open
+        {
+            menu.noti_sub_open = false;
+            cx.notify();
+        }
+    }
+
     fn sync_chrome(&mut self, cx: &App) {
         let locale = self.settings.read(cx).language.clone();
         self.discover_title = mezon_i18n::t(&locale, "common.discover").to_string().into();

--- a/crates/mezon-ui/src/sidebar/direct_sidebar.rs
+++ b/crates/mezon-ui/src/sidebar/direct_sidebar.rs
@@ -147,6 +147,21 @@ fn dm_set_mute_submenu_open(
     }
 }
 
+fn dm_close_submenus(
+    sidebar: WeakEntity<DirectSidebar>,
+) -> impl Fn(&mut Window, &mut App) + 'static {
+    move |_window: &mut Window, cx: &mut App| {
+        let _ = sidebar.update(cx, |this, cx| {
+            if let Some(menu) = this.open_menu.as_mut()
+                && menu.mute_sub_open
+            {
+                menu.mute_sub_open = false;
+                cx.notify();
+            }
+        });
+    }
+}
+
 fn build_dm_menu(
     sidebar: WeakEntity<DirectSidebar>,
     locale: &str,
@@ -158,6 +173,7 @@ fn build_dm_menu(
     let t = |key: &'static str| mezon_i18n::t(locale, key).to_string();
     let sidebar_dismiss = sidebar.clone();
     let mut menu = ContextMenu::new()
+        .on_submenu_close(dm_close_submenus(sidebar.clone()))
         .on_dismiss(move |_window, cx| {
             let _ = sidebar_dismiss.update(cx, |this, cx| {
                 this.open_menu = None;


### PR DESCRIPTION
## What

Replaces the coming-soon placeholders on the channel and category context menus with the real actions, mirroring React's `PanelChannel` / `PanelCategory`.

**Channel menu**
- **Mark / Unmark Favorite** — label follows the channel's real favorite state; `add/remove_channel_favorite` already existed in the store and simply had no caller.

**Category menu**
- **Mark As Read** — category-scoped `mark_as_read` (channel id 0).
- **Collapse All Categories** — one-way collapse of every category in the clan, matching `setCollapseAllCategory`.
- **Edit Category** — rename modal. React opens the whole `CategorySetting` screen, whose only editable field is the name, so it collapses into one modal here.
- **Delete Category** — confirm modal (`Delete {name}` / *This cannot be undone*), offered only for an empty category, same as React.

## Two things that came with it

- **`CategoryEvent` status 3 (DELETE) is now handled.** Without it, a category deleted from another client stayed in the sidebar forever. Its channels go through `apply_local_delete`, so badge counts, thread cleanup and the redirect away from an open channel are handled by the audited path.
- **A remote rename now updates `channel.category_name`.** The socket path only changed `Category.name`, leaving the stale name visible in the Channel Settings *Category* / *Permissions* tabs, the mention popup sub-text and the inbox breadcrumb.

## Behaviour changes worth flagging

- **Right-clicking the FAVORITE CHANNEL header no longer opens a menu**, matching React (`handleMouseClick` returns early on `FAVORITE_CATEGORY_ID`). Nothing is lost: that category's id is `"favorCate"`, which never parses as an `i64`, so `ensure_category` / `set_category_level` / mute all returned early — the menu there was already a silent no-op, and the new Edit / Delete rows would have errored.
- **Only one sidebar overlay is visible at a time.** Opening a channel or category context menu dismisses the other one, plus the clan dropdown and the app-list popover, and vice versa.

## Context-menu submenu fix

Reported alongside: hovering an item with a submenu and then moving to another item left the submenu open — in several menus, not just this one.

The bug was in the `ContextMenu` primitive, not in any single menu: the submenu row had `on_hover -> on_open` but nothing ever closed it, and plain / checkbox rows had no hover handler at all. Switching between two submenu rows worked only because each `on_open` cleared its sibling.

Added `ContextMenu::on_submenu_close`, merged with the existing `on_reaction_close` into one handler attached to every row (GPUI keeps a single `on_hover` listener per element, so a second registration would have silently replaced the reaction one). Wired for the **channel, category, clan rail, DM and member** menus.

## Perf

The only render-path addition is that hover listener, so it is registered **only while a flyout is actually open** — the menu knows this at build time from its own items. With no flyout open, zero listeners and zero allocation, i.e. the same element tree as before this PR.

Measured on a debug build with `RUST_LOG=render=trace`, 40 synthetic pointer moves per run, 3 runs each:

| Scenario | renders / 40 moves | CPU |
|---|---|---|
| Control — no menu, hover two sidebar rows *(path untouched by this PR)* | 45 · 41 · 41 | 0.44 · 0.40 · 0.40 s |
| Channel menu open, **no** flyout | 40 · 41 · 40 | 0.39 · 0.39 · 0.37 s |
| Flyout **open** | 40 · 40 · 40 | 0.40 · 0.38 · 0.38 s |
| Menu open, pointer idle 6 s | **0** | 0.04 s |

Message list, same method, counting `ChannelMessages` renders:

| Scenario | renders / 40 moves | CPU |
|---|---|---|
| Hover two message rows, no menu *(path untouched)* | 42 · 46 · 46 | 0.39 · 0.41 · 0.40 s |
| Message context menu open, reaction flyout closed | 48 · 51 · 50 | 0.48 · 0.49 · 0.49 s |
| Message context menu open, reaction flyout open | 49 · 49 · 50 | 0.48 · 0.48 · 0.49 s |

The ~1 render per pointer transition is the app's pre-existing cost from GPUI's `.hover()` styling — the control run, which this PR does not touch, shows the same. Flyout open vs closed is identical, so the change adds nothing measurable. No file under `chat/message/` or the channel-list row builder (`rebuild_items`) is touched, and every `ContextMenu` is built once behind a "menu is open" guard, never per row or per message.

CPU figures are from a debug build (`trace_render!` is `debug_assertions`-only), so only the comparison between rows is meaningful.

## MCP

`channel_menu_*`, `category_menu_*` (open / state / pick / close), `list_categories`, `create_category`, and category ids on `list_channels` — the same shape as the existing `clan_menu_*` / `member_menu_*` probes.

`list_categories` is not a convenience: `list_channels` derives categories from channels, so an empty category is invisible to it, and an empty category is exactly what Delete Category applies to.

The probes also settled the perf question above — `capture_window` returned stale frames twice during this work and nearly had me report a bug that did not exist.

## Test

`just lint` clean (fmt + clippy `--all-targets --all-features --locked -D warnings` over all 19 crates), `cargo test` green, `cargo build -p mezon-app` links.

Five store tests added: collapse-all, duplicate-name-excluding-self, category removal, and the two realtime `CategoryEvent` paths (delete clears the open channel, update renames the channel's `category_name`).

Verified end to end against the real backend: Mark/Unmark Favorite both directions with the sidebar Favorites section following; Collapse All; rename persisted across a soft reload; delete persisted across a soft reload; Edit/Delete correctly hidden without manage-clan and Delete hidden for a non-empty category. Category **Mark As Read** was only confirmed as far as the API returning OK — I could not stage a real unread category to watch the badges clear.
