### PR TITLE
feat(voice): open the finished call recording once it saves

### DIFF
--- a/crates/mezon-ui/src/app/root.rs
+++ b/crates/mezon-ui/src/app/root.rs
@@ -65,11 +65,9 @@ fn surface_recording_toast(
     let (kind, message) = match toast {
         mezon_store::RecordingToast::Saved(path) => {
             // Hand the finished file straight to the system player — the desktop can do what the
-            // web app cannot. An encoder that bailed can still leave a zero-byte container behind,
-            // and launching a player on that only surfaces its "cannot play" dialog, so skip those.
-            if std::fs::metadata(&path).is_ok_and(|file| file.len() > 0) {
-                cx.open_with_system(&path);
-            }
+            // web app cannot. `Saved` already means playable: the recorder only reports it after
+            // `container::is_playable`, so there is nothing left to check here.
+            cx.open_with_system(&path);
             (
                 crate::components::primitives::ToastKind::Success,
                 format!(

--- a/crates/mezon-ui/src/app/root.rs
+++ b/crates/mezon-ui/src/app/root.rs
@@ -63,16 +63,24 @@ fn surface_recording_toast(
         mezon_store::VoiceStoreEvent::RecordingFinished(toast) => toast.clone(),
     };
     let (kind, message) = match toast {
-        mezon_store::RecordingToast::Saved(path) => (
-            crate::components::primitives::ToastKind::Success,
-            format!(
-                "{} {}",
-                mezon_i18n::t(&locale, "channelVoice.recordingSaved"),
-                path.file_name()
-                    .map(|name| name.to_string_lossy().to_string())
-                    .unwrap_or_default()
-            ),
-        ),
+        mezon_store::RecordingToast::Saved(path) => {
+            // Hand the finished file straight to the system player — the desktop can do what the
+            // web app cannot. An encoder that bailed can still leave a zero-byte container behind,
+            // and launching a player on that only surfaces its "cannot play" dialog, so skip those.
+            if std::fs::metadata(&path).is_ok_and(|file| file.len() > 0) {
+                cx.open_with_system(&path);
+            }
+            (
+                crate::components::primitives::ToastKind::Success,
+                format!(
+                    "{} {}",
+                    mezon_i18n::t(&locale, "channelVoice.recordingSaved"),
+                    path.file_name()
+                        .map(|name| name.to_string_lossy().to_string())
+                        .unwrap_or_default()
+                ),
+            )
+        }
         mezon_store::RecordingToast::Failed(error) => (
             crate::components::primitives::ToastKind::Error,
             format!(


### PR DESCRIPTION
Stopping a recording only raised a toast naming the file; finding it was left to the user. The desktop can hand the file straight to the system player, which the web app has no way to do, so it now does.

A failed encoder can still leave a zero-byte container behind, and launching a player on one only surfaces its "cannot play" dialog, so those are skipped and the toast stands alone.