### PR TITLE
fix(attachments): heal messages stuck on "Uploading..." and mark undecodable video

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -2997,6 +2997,7 @@
   "message.actions.topicDiscussion": "Themen-Diskussion",
   "message.actions.unPinMessage": "Anpinnen aufheben",
   "message.addAMessage": "Eine Nachricht hinzufügen (optional)",
+  "message.attachment.uploading": "Wird hochgeladen...",
   "message.attachments.attachment": "Anhang",
   "message.attachments.audio": "Sprachnachricht",
   "message.attachments.contact": "Visitenkarte",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -3130,6 +3130,7 @@
   "message.actions.topicDiscussion": "Topic Discussion",
   "message.actions.unPinMessage": "Unpin Message",
   "message.addAMessage": "Add a message (Optional)",
+  "message.attachment.uploading": "Uploading...",
   "message.attachments.attachment": "Attachment",
   "message.attachments.audio": "Voice",
   "message.attachments.contact": "Contact",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -3007,6 +3007,7 @@
   "message.actions.unPinMessage": "Desfijar mensaje",
   "message.addAMessage": "Añadir un mensaje (Opcional)",
   "message.addReaction": "Añadir reacción",
+  "message.attachment.uploading": "Subiendo...",
   "message.attachments.attachment": "Adjunto",
   "message.attachments.audio": "Voz",
   "message.attachments.contact": "Contacto",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -2997,6 +2997,7 @@
   "message.actions.topicDiscussion": "Discussione argomento",
   "message.actions.unPinMessage": "Rimuovi fissaggio",
   "message.addAMessage": "Aggiungi un messaggio (opzionale)",
+  "message.attachment.uploading": "Caricamento in corso...",
   "message.attachments.attachment": "Allegato",
   "message.attachments.audio": "Messaggio vocale",
   "message.attachments.contact": "Contatto",

--- a/assets/i18n/jpn.json
+++ b/assets/i18n/jpn.json
@@ -2997,6 +2997,7 @@
   "message.actions.topicDiscussion": "スレッドディスカッション",
   "message.actions.unPinMessage": "メッセージのピン留めを解除",
   "message.addAMessage": "メッセージを追加（オプション）",
+  "message.attachment.uploading": "アップロード中...",
   "message.attachments.attachment": "添付ファイル",
   "message.attachments.audio": "音声メッセージ",
   "message.attachments.contact": "名刺",

--- a/assets/i18n/kr.json
+++ b/assets/i18n/kr.json
@@ -2990,6 +2990,7 @@
   "message.actions.topicDiscussion": "토론 주제",
   "message.actions.unPinMessage": "메시지 고정 해제",
   "message.addAMessage": "메시지 추가 (선택 사항)",
+  "message.attachment.uploading": "업로드 중...",
   "message.attachments.attachment": "첨부 파일",
   "message.attachments.audio": "음성 메시지",
   "message.attachments.contact": "명함",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -2997,6 +2997,7 @@
   "message.actions.topicDiscussion": "Discussão de tópico",
   "message.actions.unPinMessage": "Desafixar mensagem",
   "message.addAMessage": "Adicionar uma mensagem (Opcional)",
+  "message.attachment.uploading": "Enviando...",
   "message.attachments.attachment": "Anexo",
   "message.attachments.audio": "Mensagem de voz",
   "message.attachments.contact": "Contato",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -3005,6 +3005,7 @@
   "message.actions.topicDiscussion": "Дискуссия в топике",
   "message.actions.unPinMessage": "Открепить сообщение",
   "message.addAMessage": "Добавить сообщение (опционально)",
+  "message.attachment.uploading": "Загрузка...",
   "message.attachments.attachment": "Вложение",
   "message.attachments.audio": "Аудио",
   "message.attachments.contact": "Контакт",

--- a/assets/i18n/swe.json
+++ b/assets/i18n/swe.json
@@ -2997,6 +2997,7 @@
   "message.actions.topicDiscussion": "Ämnesdiskussion",
   "message.actions.unPinMessage": "Avspika meddelande",
   "message.addAMessage": "Lägg till ett meddelande (Valfritt)",
+  "message.attachment.uploading": "Laddar upp...",
   "message.attachments.attachment": "Bilaga",
   "message.attachments.audio": "Röstmeddelande",
   "message.attachments.contact": "Visitekort",

--- a/assets/i18n/tt.json
+++ b/assets/i18n/tt.json
@@ -2568,6 +2568,7 @@
   "message.actions.topicDiscussion": "Топикта дискуссия",
   "message.actions.unPinMessage": "Хәбәрне төяп куюдан алу",
   "message.addAMessage": "Хәбәр өстәү (мәҗбүри түгел)",
+  "message.attachment.uploading": "Йөкләү...",
   "message.attachments.attachment": "Кушымта",
   "message.attachments.audio": "Аудио",
   "message.attachments.contact": "Контакт",

--- a/assets/i18n/vi.json
+++ b/assets/i18n/vi.json
@@ -3118,6 +3118,7 @@
   "message.actions.topicDiscussion": "Thảo luận chủ đề",
   "message.actions.unPinMessage": "Bỏ ghim tin nhắn",
   "message.addAMessage": "Thêm một tin nhắn (Không bắt buộc)",
+  "message.attachment.uploading": "Đang tải lên...",
   "message.attachments.attachment": "Tệp đính kèm",
   "message.attachments.audio": "Tin nhắn thoại",
   "message.attachments.contact": "Danh thiếp",

--- a/crates/mezon-client/src/app_api.rs
+++ b/crates/mezon-client/src/app_api.rs
@@ -2314,7 +2314,15 @@ impl AppApi {
         let filename = sanitize_upload_filename(&thumbnail.filename);
         let size = clamp_i32(thumbnail.data.len());
         match self
-            .upload_bytes(&filename, "image/jpeg", size, 0, 0, thumbnail.data)
+            .upload_bytes(
+                &filename,
+                "image/jpeg",
+                "image/jpeg",
+                size,
+                0,
+                0,
+                thumbnail.data,
+            )
             .await
         {
             Ok(url) => url,
@@ -2325,10 +2333,17 @@ impl AppApi {
         }
     }
 
+    /// `filetype` is what the attachment is registered as; `content_type` is the
+    /// MIME the object is stored under. They are the same for a caller that knows
+    /// the real type, but not for one that only has a category ("image"), and S3
+    /// serves the Content-Type of the PUT back forever after — so a category here
+    /// would leave the CDN handing out an unusable type for the file's whole life.
+    #[allow(clippy::too_many_arguments)]
     async fn upload_bytes(
         &self,
         filename: &str,
         filetype: &str,
+        content_type: &str,
         size: i32,
         width: i32,
         height: i32,
@@ -2338,7 +2353,8 @@ impl AppApi {
             .transport
             .upload_attachment_file(filename, filetype, size, width, height)
             .await?;
-        crate::transport_runtime::put_bytes_to_content_type(&upload.url, data, filetype).await?;
+        crate::transport_runtime::put_bytes_to_content_type(&upload.url, data, content_type)
+            .await?;
         attachment_cdn_url(&self.base_img_url, &upload.filename)
     }
 
@@ -2376,7 +2392,15 @@ impl AppApi {
 
         let upload_type = upload_attachment_type(&filetype);
         let url = self
-            .upload_bytes(&upload_name, upload_type, size, width, height, data)
+            .upload_bytes(
+                &upload_name,
+                upload_type,
+                &filetype,
+                size,
+                width,
+                height,
+                data,
+            )
             .await?;
 
         Ok(mezon_proto::api::MessageAttachment {
@@ -2544,7 +2568,7 @@ impl AppApi {
         );
 
         let permanent_url = self
-            .upload_bytes(&filename, filetype, size, width, height, data)
+            .upload_bytes(&filename, filetype, filetype, size, width, height, data)
             .await?;
 
         tracing::info!("Avatar upload complete: url={}", permanent_url);

--- a/crates/mezon-client/src/app_api.rs
+++ b/crates/mezon-client/src/app_api.rs
@@ -108,6 +108,13 @@ const MULTIPART_PART_SIZE: u64 = 10 * 1024 * 1024;
 const MULTIPART_MIN_FILE_SIZE: u64 = 16 * 1024 * 1024;
 const MULTIPART_PART_CONCURRENCY: usize = 2;
 const ATTACHMENT_UPLOAD_CONCURRENCY: usize = 4;
+/// Delay AFTER each failed presign_finish attempt; the last entry is zero
+/// because there is no attempt left to wait for.
+const PRESIGN_SYNC_BACKOFF: [std::time::Duration; 3] = [
+    std::time::Duration::from_secs(1),
+    std::time::Duration::from_secs(3),
+    std::time::Duration::ZERO,
+];
 const PRESIGN_EDIT_BATCH_SIZE: usize = 4;
 
 #[derive(Debug, Clone)]
@@ -136,6 +143,7 @@ enum UploadPlan {
     Single {
         put_url: String,
         path: PathBuf,
+        content_type: String,
     },
     Multipart {
         upload_id: String,
@@ -1859,6 +1867,7 @@ impl AppApi {
                 UploadPlan::Single {
                     put_url: upload.url,
                     path,
+                    content_type: filetype,
                 },
             )
         };
@@ -1890,9 +1899,19 @@ impl AppApi {
 
     pub async fn execute_upload(&self, presigned: PresignedAttachment) -> Result<()> {
         match presigned.plan {
-            UploadPlan::Single { put_url, path } => {
+            UploadPlan::Single {
+                put_url,
+                path,
+                content_type,
+            } => {
                 let data = crate::transport_runtime::read_file(path).await?;
-                crate::transport_runtime::put_bytes_to_url(&put_url, data).await?;
+                // S3 stores whatever Content-Type the PUT carries and the CDN
+                // serves it back forever after, so sending the placeholder here
+                // is how every attachment under MULTIPART_MIN_FILE_SIZE ended up
+                // as application/octet-stream — the multipart arm always got
+                // this right.
+                crate::transport_runtime::put_bytes_to_content_type(&put_url, data, &content_type)
+                    .await?;
                 Ok(())
             }
             UploadPlan::Multipart {
@@ -2137,16 +2156,16 @@ impl AppApi {
                     let _ = on_complete.send(AttachmentUploadOutcome::Failed(key));
                 }
             }
-            if finished.len() - synced >= PRESIGN_EDIT_BATCH_SIZE {
-                if let Err(e) = self
-                    .update_presign_finish(
+            if finished.len() - synced >= PRESIGN_EDIT_BATCH_SIZE
+                && self
+                    .sync_presign_finish_with_retry(
                         clan_id,
                         channel_id,
                         message_id,
                         content,
-                        mentions.clone(),
-                        hashtags.clone(),
-                        emojis.clone(),
+                        &mentions,
+                        &hashtags,
+                        &emojis,
                         finished.clone(),
                         create_time_seconds,
                         mode,
@@ -2155,24 +2174,62 @@ impl AppApi {
                         is_update_msg_topic,
                     )
                     .await
-                {
-                    tracing::error!("presign_finish sync failed: {e}");
-                } else {
-                    synced = finished.len();
-                }
+            {
+                synced = finished.len();
             }
         }
-        if finished.len() > synced
-            && let Err(e) = self
+        if finished.len() > synced {
+            self.sync_presign_finish_with_retry(
+                clan_id,
+                channel_id,
+                message_id,
+                content,
+                &mentions,
+                &hashtags,
+                &emojis,
+                finished,
+                create_time_seconds,
+                mode,
+                is_public,
+                topic_id,
+                is_update_msg_topic,
+            )
+            .await;
+        }
+    }
+
+    /// One lost presign_finish patch leaves the attachment loading on EVERY
+    /// recipient until the 10-minute expiry, so a single socket hiccup here is
+    /// worth a few retries. Each call re-sends the cumulative key list, so a
+    /// late success still carries everything an earlier attempt would have.
+    #[allow(clippy::too_many_arguments)]
+    async fn sync_presign_finish_with_retry(
+        &self,
+        clan_id: i64,
+        channel_id: i64,
+        message_id: i64,
+        content: &str,
+        mentions: &[crate::transport::OutgoingMention],
+        hashtags: &[crate::transport::OutgoingHashtag],
+        emojis: &[crate::transport::OutgoingEmoji],
+        finished: Vec<String>,
+        create_time_seconds: u32,
+        mode: i32,
+        is_public: bool,
+        topic_id: i64,
+        is_update_msg_topic: bool,
+    ) -> bool {
+        for (attempt, backoff) in PRESIGN_SYNC_BACKOFF.iter().enumerate() {
+            match self
                 .update_presign_finish(
                     clan_id,
                     channel_id,
                     message_id,
                     content,
-                    mentions,
-                    hashtags,
-                    emojis,
-                    finished,
+                    mentions.to_vec(),
+                    hashtags.to_vec(),
+                    emojis.to_vec(),
+                    finished.clone(),
                     create_time_seconds,
                     mode,
                     is_public,
@@ -2180,9 +2237,21 @@ impl AppApi {
                     is_update_msg_topic,
                 )
                 .await
-        {
-            tracing::error!("presign_finish final sync failed: {e}");
+            {
+                Ok(_) => return true,
+                Err(e) => {
+                    tracing::error!(
+                        "presign_finish sync failed (attempt {}/{}): {e}",
+                        attempt + 1,
+                        PRESIGN_SYNC_BACKOFF.len()
+                    );
+                    if !backoff.is_zero() {
+                        crate::transport_runtime::sleep(*backoff).await;
+                    }
+                }
+            }
         }
+        false
     }
 
     pub async fn send_message_with_attachment_urls(
@@ -2257,23 +2326,6 @@ impl AppApi {
     }
 
     async fn upload_bytes(
-        &self,
-        filename: &str,
-        filetype: &str,
-        size: i32,
-        width: i32,
-        height: i32,
-        data: Vec<u8>,
-    ) -> Result<String> {
-        let upload = self
-            .transport
-            .upload_attachment_file(filename, filetype, size, width, height)
-            .await?;
-        crate::transport_runtime::put_bytes_to_url(&upload.url, data).await?;
-        attachment_cdn_url(&self.base_img_url, &upload.filename)
-    }
-
-    async fn upload_avatar_bytes(
         &self,
         filename: &str,
         filetype: &str,
@@ -2492,7 +2544,7 @@ impl AppApi {
         );
 
         let permanent_url = self
-            .upload_avatar_bytes(&filename, filetype, size, width, height, data)
+            .upload_bytes(&filename, filetype, size, width, height, data)
             .await?;
 
         tracing::info!("Avatar upload complete: url={}", permanent_url);

--- a/crates/mezon-client/src/transport_runtime.rs
+++ b/crates/mezon-client/src/transport_runtime.rs
@@ -17,6 +17,9 @@ use tokio::runtime::Runtime;
 static TRANSPORT_RUNTIME: OnceLock<Runtime> = OnceLock::new();
 static HTTP_CLIENT: OnceLock<Arc<ReqwestClient>> = OnceLock::new();
 
+/// A probe must never hold a slot the way a transfer does; it is a liveness
+/// check, not a download.
+const OBJECT_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const HTTP_TRANSFER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
 fn shared_http_client() -> &'static Arc<ReqwestClient> {
@@ -63,10 +66,6 @@ fn parse_optional_id(value: &str, field: &str) -> Result<i64> {
     value
         .parse::<i64>()
         .map_err(|e| anyhow::anyhow!("invalid {field}: {e}"))
-}
-
-pub async fn put_bytes_to_url(url: &str, data: Vec<u8>) -> Result<()> {
-    put_bytes_to_content_type(url, data, "application/octet-stream").await
 }
 
 pub async fn put_bytes_to_content_type(url: &str, data: Vec<u8>, content_type: &str) -> Result<()> {
@@ -147,6 +146,44 @@ pub async fn fetch_bytes(url: &str) -> Result<(Vec<u8>, Option<String>)> {
         })
         .await
         .map_err(|e| anyhow::anyhow!("fetch task failed: {e}"))?
+}
+
+/// Sleep on the transport runtime. Callers here are futures driven by that
+/// runtime, so they cannot reach for a GPUI timer.
+pub async fn sleep(duration: std::time::Duration) {
+    let _ = runtime()
+        .spawn(async move { tokio::time::sleep(duration).await })
+        .await;
+}
+
+/// HEAD the object and report whether it is already readable.
+///
+/// The presign_finish patch is a single realtime event: lose it — the sender's
+/// socket hiccuped, or the receiver was mid-reconnect — and the attachment sits
+/// in its loading state until the 10-minute expiry sweeps it, even though the
+/// bytes have been on the CDN the whole time. The object itself is the only
+/// authority on whether it can be rendered, so probe that instead of waiting.
+///
+/// The caller passes a cache-busting URL: a not-found answer is then cached
+/// under a key nothing else uses, so an early probe can never poison the clean
+/// URL the message renders with (imgproxy is never involved — this goes to the
+/// origin).
+pub async fn object_exists(url: &str) -> bool {
+    let url = url.to_string();
+    let task = runtime().spawn(async move {
+        let Ok(request) = http::Request::builder()
+            .method(http::Method::HEAD)
+            .uri(&url)
+            .body(AsyncBody::empty())
+        else {
+            return false;
+        };
+        match tokio::time::timeout(OBJECT_PROBE_TIMEOUT, http_client().send(request)).await {
+            Ok(Ok(response)) => response.status().is_success(),
+            _ => false,
+        }
+    });
+    task.await.unwrap_or(false)
 }
 
 const NOTIFICATION_ICON_MAX_PX: u32 = 64;

--- a/crates/mezon-store/src/message.rs
+++ b/crates/mezon-store/src/message.rs
@@ -94,6 +94,23 @@ impl MessageAttachment {
         Self::media_is_video(&self.filetype, &self.url)
     }
 
+    /// A Matroska video (`.webm`, and the `video/matroska` MIME a browser
+    /// recorder writes) rides on whatever demuxer the platform player has:
+    /// GStreamer reads it, AVFoundation (macOS) and Media Foundation (Windows)
+    /// do not. There the inline player can only mount, fail, and sit on a play
+    /// button that never does anything, so hand the file to the download box
+    /// instead. Audio `.webm` (voice messages) is decoded in-app by symphonia
+    /// and is deliberately left alone.
+    fn is_undecodable_matroska(&self, ext: Option<&str>) -> bool {
+        if cfg!(target_os = "linux") || self.filetype.contains("audio") {
+            return false;
+        }
+        matches!(
+            self.filetype.as_str(),
+            "video/webm" | "video/matroska" | "video/x-matroska"
+        ) || ext == Some("webm")
+    }
+
     pub fn is_unsupported_media(&self) -> bool {
         if matches!(
             self.filetype.as_str(),
@@ -113,6 +130,9 @@ impl MessageAttachment {
             return true;
         }
         let ext = url_extension(&self.filename).or_else(|| url_extension(&self.url));
+        if self.is_undecodable_matroska(ext.as_deref()) {
+            return true;
+        }
         matches!(
             ext.as_deref(),
             Some(
@@ -2628,6 +2648,32 @@ mod tests {
         let png = attachment("image/png", "https://cdn.example/x.png");
         assert!(!png.is_unsupported_media());
         assert!(png.is_image());
+    }
+
+    #[test]
+    fn matroska_video_is_unsupported_where_the_platform_cannot_demux_it() {
+        // GStreamer reads Matroska; AVFoundation and Media Foundation do not.
+        let expected = !cfg!(target_os = "linux");
+
+        let webm = attachment("video/webm", "https://cdn.example/x.webm");
+        assert_eq!(webm.is_unsupported_media(), expected);
+
+        // A browser recorder writes `video/matroska`, and the web client uploads
+        // the bare "video" category instead of a MIME, so the extension has to
+        // carry the decision on its own.
+        let matroska = attachment("video/matroska", "https://cdn.example/1234.webm");
+        assert_eq!(matroska.is_unsupported_media(), expected);
+        let uploaded = attachment("video", "https://cdn.example/1234.webm");
+        assert_eq!(uploaded.is_unsupported_media(), expected);
+    }
+
+    #[test]
+    fn webm_voice_messages_stay_playable_audio() {
+        // Voice messages are WebM/Opus decoded in-app by symphonia, not by the
+        // platform video player, so the container gate must not swallow them.
+        let voice = attachment("audio/webm", "https://cdn.example/1234.webm");
+        assert!(!voice.is_unsupported_media());
+        assert!(voice.is_audio());
     }
 
     #[test]

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -994,6 +994,14 @@ impl MessagesStore {
         self.last_typing_sent = None;
         self.buzz_player = None;
         self.buzz_sound_loading = false;
+        // A probe round outlives the session it was started for: dropping the task
+        // stops it from spending requests on the previous account's CDN objects,
+        // and clearing the flag is what lets the next session arm a probe at all
+        // (the scheduler treats a set flag as "a round is already in flight").
+        self.presign_probe.clear();
+        self.presign_probe_task = None;
+        self.presign_probe_running = false;
+        self.presign_expiry_task = None;
         cx.notify();
     }
 
@@ -3829,11 +3837,10 @@ impl MessagesStore {
     /// Urls whose turn it is, with their backoff already advanced so a slow
     /// probe cannot be started twice.
     ///
-    /// Capped: the round runs the requests one after another, so a channel that
-    /// somehow has many stuck attachments would otherwise queue every HEAD (each
-    /// able to burn the probe timeout) behind the first. Whatever is left over
-    /// stays due and the next round — scheduled the moment this one lands —
-    /// picks it up.
+    /// Capped: the round fires its requests together, so a channel that somehow
+    /// has many stuck attachments would otherwise open a connection per
+    /// attachment at once. Whatever is left over stays due and the next round —
+    /// scheduled the moment this one lands — picks it up.
     fn take_due_probe_urls(&mut self) -> Vec<String> {
         let now = std::time::Instant::now();
         let mut due = Vec::new();
@@ -3911,17 +3918,26 @@ impl MessagesStore {
             let due = this
                 .update(cx, |this, _| this.take_due_probe_urls())
                 .unwrap_or_default();
-            let mut found = Vec::new();
-            for (index, url) in due.into_iter().enumerate() {
+            // Together, not one after another: a HEAD that goes unanswered burns the
+            // full probe timeout, and a serial round would stack one timeout per
+            // attachment before the next round — and before a channel the user has
+            // since switched to — gets a turn.
+            let probes = due.into_iter().enumerate().map(|(index, url)| {
                 let nonce = unix_now_seconds() as u64 ^ ((index as u64) << 32);
-                let exists =
-                    mezon_client::transport_runtime::object_exists(&presign_probe_url(&url, nonce))
-                        .await;
-                tracing::debug!(url = %url, exists, "presign probe");
-                if exists {
-                    found.push(url);
+                async move {
+                    let exists = mezon_client::transport_runtime::object_exists(
+                        &presign_probe_url(&url, nonce),
+                    )
+                    .await;
+                    tracing::debug!(url = %url, exists, "presign probe");
+                    exists.then_some(url)
                 }
-            }
+            });
+            let found: Vec<String> = futures::future::join_all(probes)
+                .await
+                .into_iter()
+                .flatten()
+                .collect();
             let _ = this.update(cx, |this, cx| {
                 this.presign_probe_running = false;
                 this.settle_presign_probes(&found, cx);
@@ -7308,7 +7324,7 @@ fn apply_presign_gate(
 /// second or two after the message — costs no requests at all.
 const PRESIGN_PROBE_BACKOFF_SECS: [u64; 5] = [8, 15, 30, 30, 30];
 
-/// How many objects one probe round asks about, since it asks in sequence.
+/// How many objects one probe round asks about at once.
 const PRESIGN_PROBE_BATCH: usize = 6;
 
 /// One attachment's probe schedule.
@@ -11630,11 +11646,11 @@ mod tests {
     }
 
     #[test]
-    fn presign_probe_batch_is_bounded_so_one_round_cannot_serialise_every_head() {
-        // The round awaits its requests one at a time, so the cap is what keeps a
-        // channel full of stuck attachments from queueing them all behind the first.
-        assert!(PRESIGN_PROBE_BATCH > 0);
-        assert!(PRESIGN_PROBE_BATCH <= 8);
+    fn presign_probe_batch_is_bounded_so_one_round_cannot_flood_the_cdn() {
+        // The round fires its requests together, so the cap is what keeps a channel
+        // full of stuck attachments from opening a connection per attachment.
+        const { assert!(PRESIGN_PROBE_BATCH > 0) };
+        const { assert!(PRESIGN_PROBE_BATCH <= 8) };
     }
 
     #[test]

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -616,6 +616,12 @@ pub struct MessagesStore {
     forward_task: Option<Task<()>>,
     forward_in_flight: bool,
     presign_expiry_task: Option<Task<()>>,
+    /// Per-attachment-url backoff for the CDN existence probe. Keyed by url
+    /// because that is what uniquely identifies an object across the message
+    /// copies the caches may hold.
+    presign_probe: HashMap<String, PresignProbe>,
+    presign_probe_task: Option<Task<()>>,
+    presign_probe_running: bool,
     pending_send_payloads: HashMap<MessageId, PendingSendPayload>,
     anonymous_clans: HashSet<ClanId>,
     topic_anonymous_mode: bool,
@@ -1050,6 +1056,9 @@ impl MessagesStore {
             embed_form: HashMap::new(),
             forward_task: None,
             presign_expiry_task: None,
+            presign_probe: HashMap::new(),
+            presign_probe_task: None,
+            presign_probe_running: false,
             forward_in_flight: false,
             pending_send_payloads: HashMap::new(),
             anonymous_clans: HashSet::new(),
@@ -3765,6 +3774,145 @@ impl MessagesStore {
             cx.notify();
         }
         self.schedule_presign_expiry(cx);
+        self.schedule_presign_probe(cx);
+    }
+
+    /// Buckets a probe may look at: whatever the user is actually looking at.
+    /// Probing the whole cache would turn every scrollback message into CDN
+    /// traffic, and an attachment nobody can see does not need healing.
+    fn probe_buckets(&self) -> Vec<ChannelId> {
+        [self.active_channel_id, self.active_topic_id]
+            .into_iter()
+            .flatten()
+            .collect()
+    }
+
+    /// Refresh the probe table from what is currently pending, then report how
+    /// long until the next attachment is due. `None` means nothing to probe.
+    fn refresh_presign_probes(&mut self) -> Option<std::time::Duration> {
+        let now = std::time::Instant::now();
+        let mut pending: Vec<String> = Vec::new();
+        for bucket in self.probe_buckets() {
+            let Some(channel) = self.cache.get(&bucket) else {
+                continue;
+            };
+            for message in channel.messages.items.iter() {
+                for att in message.attachments.iter() {
+                    // `uploading` means this client is still PUTting the bytes; it
+                    // knows the answer already and asking the CDN would only add
+                    // traffic to every message we send ourselves.
+                    if att.presign_pending && !att.uploading && !att.url.is_empty() {
+                        pending.push(att.url.clone());
+                    }
+                }
+            }
+        }
+        self.presign_probe.retain(|url, _| pending.contains(url));
+        for url in pending {
+            self.presign_probe.entry(url).or_insert(PresignProbe {
+                attempts: 0,
+                next_at: now + presign_probe_delay(0),
+            });
+        }
+        self.presign_probe
+            .values()
+            .map(|probe| probe.next_at.saturating_duration_since(now))
+            .min()
+    }
+
+    /// Urls whose turn it is, with their backoff already advanced so a slow
+    /// probe cannot be started twice.
+    fn take_due_probe_urls(&mut self) -> Vec<String> {
+        let now = std::time::Instant::now();
+        let mut due = Vec::new();
+        for (url, probe) in self.presign_probe.iter_mut() {
+            if probe.next_at <= now {
+                probe.attempts = probe.attempts.saturating_add(1);
+                probe.next_at = now + presign_probe_delay(probe.attempts);
+                due.push(url.clone());
+            }
+        }
+        due
+    }
+
+    /// The object answered, so the attachment can render even though the
+    /// presign_finish patch never reached us.
+    fn settle_presign_probes(&mut self, found: &[String], cx: &mut Context<Self>) {
+        if found.is_empty() {
+            return;
+        }
+        let mut touched: Vec<MessageId> = Vec::new();
+        for channel in self.cache.values_mut() {
+            for message in channel.messages.items.iter_mut() {
+                let mut hit = false;
+                for att in message.attachments.iter_mut() {
+                    if att.presign_pending && found.iter().any(|url| url == &att.url) {
+                        att.presign_pending = false;
+                        hit = true;
+                    }
+                }
+                if hit {
+                    touched.push(message.id);
+                }
+            }
+        }
+        for url in found {
+            self.presign_probe.remove(url);
+        }
+        if !touched.is_empty() {
+            tracing::info!(
+                count = found.len(),
+                "presign probe cleared pending attachments"
+            );
+            // The message list repaints on MessagesEvent, not on a bare notify: an
+            // Updated event per row is what re-measures and re-renders it, so the
+            // placeholder gives way to the image without waiting for some unrelated
+            // change to force a frame.
+            for message_id in touched {
+                cx.emit(MessagesEvent::Updated {
+                    message_id: Some(message_id),
+                });
+            }
+            cx.notify();
+        }
+    }
+
+    /// Ask the CDN whether the objects exist yet, for attachments still waiting
+    /// on a presign_finish that may never arrive. Runs only while something is
+    /// pending in the open channel or topic.
+    fn schedule_presign_probe(&mut self, cx: &mut Context<Self>) {
+        if self.presign_probe_running {
+            // A probe is in flight; it re-schedules itself when it lands. Restarting
+            // here would cancel it, and the busy callers below fire on every message.
+            return;
+        }
+        let Some(delay) = self.refresh_presign_probes() else {
+            self.presign_probe_task = None;
+            return;
+        };
+        self.presign_probe_running = true;
+        self.presign_probe_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(delay).await;
+            let due = this
+                .update(cx, |this, _| this.take_due_probe_urls())
+                .unwrap_or_default();
+            let mut found = Vec::new();
+            for (index, url) in due.into_iter().enumerate() {
+                let nonce = unix_now_seconds() as u64 ^ ((index as u64) << 32);
+                let exists =
+                    mezon_client::transport_runtime::object_exists(&presign_probe_url(&url, nonce))
+                        .await;
+                tracing::debug!(url = %url, exists, "presign probe");
+                if exists {
+                    found.push(url);
+                }
+            }
+            let _ = this.update(cx, |this, cx| {
+                this.presign_probe_running = false;
+                this.settle_presign_probes(&found, cx);
+                this.schedule_presign_probe(cx);
+            });
+        }));
     }
 
     fn schedule_presign_expiry(&mut self, cx: &mut Context<Self>) {
@@ -5086,6 +5234,7 @@ impl MessagesStore {
                     prepare_messages(page.messages, AppConfig::try_global(cx), viewer_user_id(cx));
                 self.set_channel(channel_id, messages);
                 self.schedule_presign_expiry(cx);
+                self.schedule_presign_probe(cx);
                 if is_current && self.messages().is_empty() {
                     self.mark_empty_channel_seen(channel_id, cx);
                 }
@@ -5300,6 +5449,7 @@ impl MessagesStore {
         self.set_last_message(storage_id, last_id);
         if arms_expiry {
             self.schedule_presign_expiry(cx);
+            self.schedule_presign_probe(cx);
         }
         if is_buzz && appended {
             self.play_buzz_sound(cx);
@@ -5353,6 +5503,7 @@ impl MessagesStore {
         patch_reply_previews_after_update(&mut channel.messages, message_id, &preview);
         if arms_expiry {
             self.schedule_presign_expiry(cx);
+            self.schedule_presign_probe(cx);
         }
         if self.active_topic_id == Some(storage_id) {
             cx.emit(MessagesEvent::TopicUpdated {
@@ -6339,6 +6490,9 @@ impl MessagesStore {
             });
             cx.notify();
         }
+        // Our own upload just finished, so the row is now pending on nothing but the
+        // presign_finish patch — which is exactly what can go missing.
+        self.schedule_presign_probe(cx);
     }
 
     pub fn apply_topic_attachment_outcome(
@@ -6355,6 +6509,7 @@ impl MessagesStore {
             cx.emit(MessagesEvent::TopicUpdated { topic_id });
             cx.notify();
         }
+        self.schedule_presign_probe(cx);
     }
 
     fn resync(&mut self, cx: &mut Context<Self>) {
@@ -7133,6 +7288,32 @@ fn apply_presign_gate(
 /// sweep would not touch it. It must agree with `sweep_expired_presign`: a
 /// message the sweep skips but this counts would be rescheduled at zero delay
 /// forever.
+/// Backoff between CDN existence probes for one attachment. The first wait is
+/// long enough that the normal path — the presign_finish update arriving a
+/// second or two after the message — costs no requests at all.
+const PRESIGN_PROBE_BACKOFF_SECS: [u64; 5] = [8, 15, 30, 30, 30];
+
+/// One attachment's probe schedule.
+#[derive(Debug, Clone, Copy)]
+struct PresignProbe {
+    attempts: u32,
+    next_at: std::time::Instant,
+}
+
+fn presign_probe_delay(attempts: u32) -> std::time::Duration {
+    let last = PRESIGN_PROBE_BACKOFF_SECS.len() - 1;
+    let idx = (attempts as usize).min(last);
+    std::time::Duration::from_secs(PRESIGN_PROBE_BACKOFF_SECS[idx])
+}
+
+/// The probe URL carries a nonce so that a not-found answer is cached under a
+/// key nothing renders from. Without it an early probe could pin a 404 onto the
+/// very URL the message is about to use.
+fn presign_probe_url(url: &str, nonce: u64) -> String {
+    let sep = if url.contains('?') { '&' } else { '?' };
+    format!("{url}{sep}probe={nonce:x}")
+}
+
 fn presign_expiry_deadline(message: &Message) -> Option<i64> {
     if message.create_time <= 0 || !message.attachments.iter().any(|a| a.presign_pending) {
         return None;
@@ -11412,6 +11593,37 @@ mod tests {
         // counting it here would re-arm the timer at zero delay forever.
         pending.content = r#"{"t":"hi"}"#.to_string();
         assert_eq!(presign_expiry_deadline(&pending), None);
+    }
+
+    #[test]
+    fn presign_probe_backoff_stretches_then_holds_at_thirty_seconds() {
+        let secs = |attempts| presign_probe_delay(attempts).as_secs();
+        // The first wait outlasts a healthy presign_finish, so the normal path
+        // never spends a request.
+        assert_eq!(secs(0), 8);
+        assert_eq!(secs(1), 15);
+        assert_eq!(secs(2), 30);
+        assert_eq!(secs(3), 30);
+        // A genuinely slow upload must not turn into a request storm: the delay
+        // stops growing but never shrinks back down.
+        assert_eq!(secs(4), 30);
+        assert_eq!(secs(50), 30);
+        assert_eq!(secs(u32::MAX), 30);
+    }
+
+    #[test]
+    fn presign_probe_url_never_reuses_the_clean_url() {
+        // A 404 must be cached under a key nothing renders from, otherwise an
+        // early probe poisons the URL the message is about to use.
+        let probed = presign_probe_url("https://cdn.mezon.ai/a/b.png", 0xdead);
+        assert_eq!(probed, "https://cdn.mezon.ai/a/b.png?probe=dead");
+        assert!(probed.starts_with("https://cdn.mezon.ai/a/b.png?"));
+
+        // An url that already carries a query keeps it.
+        assert_eq!(
+            presign_probe_url("https://cdn.mezon.ai/a/b.png?v=2", 1),
+            "https://cdn.mezon.ai/a/b.png?v=2&probe=1"
+        );
     }
 
     #[test]

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -3791,7 +3791,7 @@ impl MessagesStore {
     /// long until the next attachment is due. `None` means nothing to probe.
     fn refresh_presign_probes(&mut self) -> Option<std::time::Duration> {
         let now = std::time::Instant::now();
-        let mut pending: Vec<String> = Vec::new();
+        let mut pending: HashSet<String> = HashSet::new();
         for bucket in self.probe_buckets() {
             let Some(channel) = self.cache.get(&bucket) else {
                 continue;
@@ -3800,9 +3800,15 @@ impl MessagesStore {
                 for att in message.attachments.iter() {
                     // `uploading` means this client is still PUTting the bytes; it
                     // knows the answer already and asking the CDN would only add
-                    // traffic to every message we send ourselves.
-                    if att.presign_pending && !att.uploading && !att.url.is_empty() {
-                        pending.push(att.url.clone());
+                    // traffic to every message we send ourselves. `upload_failed`
+                    // means the bytes never left, so the object will never appear
+                    // and probing for it just burns requests until the expiry.
+                    if att.presign_pending
+                        && !att.uploading
+                        && !att.upload_failed
+                        && !att.url.is_empty()
+                    {
+                        pending.insert(att.url.clone());
                     }
                 }
             }
@@ -3822,10 +3828,19 @@ impl MessagesStore {
 
     /// Urls whose turn it is, with their backoff already advanced so a slow
     /// probe cannot be started twice.
+    ///
+    /// Capped: the round runs the requests one after another, so a channel that
+    /// somehow has many stuck attachments would otherwise queue every HEAD (each
+    /// able to burn the probe timeout) behind the first. Whatever is left over
+    /// stays due and the next round — scheduled the moment this one lands —
+    /// picks it up.
     fn take_due_probe_urls(&mut self) -> Vec<String> {
         let now = std::time::Instant::now();
         let mut due = Vec::new();
         for (url, probe) in self.presign_probe.iter_mut() {
+            if due.len() >= PRESIGN_PROBE_BATCH {
+                break;
+            }
             if probe.next_at <= now {
                 probe.attempts = probe.attempts.saturating_add(1);
                 probe.next_at = now + presign_probe_delay(probe.attempts);
@@ -7292,6 +7307,9 @@ fn apply_presign_gate(
 /// long enough that the normal path — the presign_finish update arriving a
 /// second or two after the message — costs no requests at all.
 const PRESIGN_PROBE_BACKOFF_SECS: [u64; 5] = [8, 15, 30, 30, 30];
+
+/// How many objects one probe round asks about, since it asks in sequence.
+const PRESIGN_PROBE_BATCH: usize = 6;
 
 /// One attachment's probe schedule.
 #[derive(Debug, Clone, Copy)]
@@ -11609,6 +11627,14 @@ mod tests {
         assert_eq!(secs(4), 30);
         assert_eq!(secs(50), 30);
         assert_eq!(secs(u32::MAX), 30);
+    }
+
+    #[test]
+    fn presign_probe_batch_is_bounded_so_one_round_cannot_serialise_every_head() {
+        // The round awaits its requests one at a time, so the cap is what keeps a
+        // channel full of stuck attachments from queueing them all behind the first.
+        assert!(PRESIGN_PROBE_BATCH > 0);
+        assert!(PRESIGN_PROBE_BATCH <= 8);
     }
 
     #[test]

--- a/crates/mezon-ui/src/chat/message/audio_player.rs
+++ b/crates/mezon-ui/src/chat/message/audio_player.rs
@@ -351,7 +351,11 @@ pub(crate) fn audio_pill(
         .into_any_element()
 }
 
-pub(crate) fn audio_sending_pill(duration: f64) -> gpui::AnyElement {
+/// The pill a voice message shows while its bytes are still on their way — for
+/// the sender until the upload finishes, for everyone else until `presign_finish`
+/// names the key. Spelling out "Uploading…" beats a bare spinner: the row is
+/// otherwise indistinguishable from an audio player that simply will not start.
+pub(crate) fn audio_sending_pill(duration: f64, locale: &str) -> gpui::AnyElement {
     div()
         .flex()
         .w_full()
@@ -383,8 +387,16 @@ pub(crate) fn audio_sending_pill(duration: f64) -> gpui::AnyElement {
                         .ml_2()
                         .text_size(px(14.))
                         .whitespace_nowrap()
-                        .child(audio_time_label(0.0, duration)),
-                ),
+                        .child(mezon_i18n::t(locale, "message.attachment.uploading")),
+                )
+                .when(duration > 0.0, |d| {
+                    d.child(
+                        div()
+                            .text_size(px(14.))
+                            .whitespace_nowrap()
+                            .child(audio_time_label(0.0, duration)),
+                    )
+                }),
         )
         .into_any_element()
 }

--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use gpui::{
-    Anchor, AnyElement, App, ClickEvent, Entity, FontWeight, Hsla, MouseButton, ObjectFit, Pixels,
+    Anchor, AnyElement, App, ClickEvent, Entity, FontWeight, Hsla, MouseButton, ObjectFit,
     SharedString, Transformation, Window, div, img, prelude::*, px, radians, rems, rgba,
 };
 use mezon_store::{
@@ -759,26 +759,32 @@ struct Uploader {
     avatar: SharedString,
 }
 
-fn attachment_spinner(size: Pixels, theme: &Theme) -> impl IntoElement {
-    div()
-        .size(size)
-        .rounded_full()
-        .border_2()
-        .border_color(theme.text_secondary)
-}
+/// Width below which the label is dropped: an album tile can be ~100px and the
+/// text would spill out of it. The spinner alone still reads as "working".
+const SENDING_LABEL_MIN_WIDTH: f32 = 160.;
 
-fn attachment_sending_overlay(theme: &Theme) -> impl IntoElement {
+fn attachment_sending_overlay(theme: &Theme, locale: &str, box_width: f32) -> impl IntoElement {
     div()
         .absolute()
         .inset_0()
         .flex()
+        .flex_col()
         .items_center()
         .justify_center()
+        .gap_2()
         .child(
             Spinner::new()
                 .with_size(Size::Large)
                 .color(theme.text_secondary.into()),
         )
+        .when(box_width >= SENDING_LABEL_MIN_WIDTH, |d| {
+            d.child(
+                div()
+                    .text_size(px(12.))
+                    .text_color(theme.text_secondary)
+                    .child(mezon_i18n::t(locale, "message.attachment.uploading")),
+            )
+        })
 }
 
 fn attachment_failed_overlay(theme: &Theme) -> impl IntoElement {
@@ -812,11 +818,18 @@ fn render_audio(
     sending: bool,
 ) -> AnyElement {
     let duration = att.duration.max(0) as f64;
+    // `uploading` only ever covers OUR OWN outgoing message. A recipient sees
+    // the message the moment it is posted, with `presign_pending` set until the
+    // sender's upload lands — play it then and the player fetches an object the
+    // CDN does not have yet, and the not-found is what gets cached. React drops
+    // pending audio from the list entirely; the pill says the same thing and
+    // keeps the row's height.
+    let sending = sending || att.presign_pending;
     if att.upload_failed {
         return audio_failed_pill(duration);
     }
     if sending {
-        return audio_sending_pill(duration);
+        return audio_sending_pill(duration, ctx.locale);
     }
     if let Some(view) = ctx.active_audios.get(&(msg_id, index)) {
         return div().w_full().child(view.clone()).into_any_element();
@@ -933,7 +946,7 @@ fn render_album(
                 tile.height,
             ));
         } else if att.presign_pending {
-            tile_element = presign_child(tile_element, att, theme);
+            tile_element = presign_child(tile_element, att, theme, ctx.locale, tile.width);
         } else {
             let selection = ctx.selection.clone();
             let src = album_tile_src(cfg, att, tile.width, tile.height);
@@ -964,7 +977,8 @@ fn render_album(
         if att.upload_failed {
             tile_element = tile_element.child(attachment_failed_overlay(theme));
         } else if att.uploading {
-            tile_element = tile_element.child(attachment_sending_overlay(theme));
+            tile_element =
+                tile_element.child(attachment_sending_overlay(theme, ctx.locale, tile.width));
         }
         container = container.child(tile_element);
     }
@@ -1021,15 +1035,22 @@ fn presign_child(
     parent: gpui::Stateful<gpui::Div>,
     att: &MessageAttachment,
     theme: &Theme,
+    locale: &str,
+    box_width: f32,
 ) -> gpui::Stateful<gpui::Div> {
+    // A recipient never sees `uploading` — only `presign_pending` — so without
+    // this the whole upload window is a bare spinner on their side while the
+    // sender gets a labelled one.
     if att.thumbnail.is_empty() {
-        parent.child(attachment_spinner(px(30.), theme))
+        parent.child(attachment_sending_overlay(theme, locale, box_width))
     } else {
-        parent.child(
-            img(SharedString::from(att.thumbnail.clone()))
-                .size_full()
-                .object_fit(ObjectFit::Cover),
-        )
+        parent
+            .child(
+                img(SharedString::from(att.thumbnail.clone()))
+                    .size_full()
+                    .object_fit(ObjectFit::Cover),
+            )
+            .child(attachment_sending_overlay(theme, locale, box_width))
     }
 }
 
@@ -1117,7 +1138,11 @@ fn render_photo(
         if att.upload_failed {
             el = el.child(attachment_failed_overlay(theme));
         } else if sending {
-            el = el.child(attachment_sending_overlay(theme));
+            el = el.child(attachment_sending_overlay(
+                theme,
+                ctx.locale,
+                att.display_width,
+            ));
         }
         return el.into_any_element();
     }
@@ -1133,11 +1158,15 @@ fn render_photo(
             .items_center()
             .justify_center()
             .bg(theme.bg_tertiary);
-        placeholder = presign_child(placeholder, att, theme);
+        placeholder = presign_child(placeholder, att, theme, ctx.locale, att.display_width);
         if att.upload_failed {
             placeholder = placeholder.child(attachment_failed_overlay(theme));
         } else if sending {
-            placeholder = placeholder.child(attachment_sending_overlay(theme));
+            placeholder = placeholder.child(attachment_sending_overlay(
+                theme,
+                ctx.locale,
+                att.display_width,
+            ));
         }
         return placeholder.into_any_element();
     }
@@ -1166,7 +1195,10 @@ fn render_photo(
         .h(px(att.display_height))
         .rounded_md()
         .overflow_hidden();
-    el = el.when(!is_sticker && !att.upload_failed, |d| {
+    // `render_album` already refuses to open a tile that is still uploading;
+    // the single-image path is the same picture with the same half-written
+    // object behind it.
+    el = el.when(!is_sticker && !att.upload_failed && !sending, |d| {
         d.cursor_pointer().on_click(move |_, window, cx| {
             if !selection.borrow().has_selection() {
                 open_viewer_from_message(
@@ -1205,7 +1237,11 @@ fn render_photo(
     if att.upload_failed {
         el = el.child(attachment_failed_overlay(theme));
     } else if sending {
-        el = el.child(attachment_sending_overlay(theme));
+        el = el.child(attachment_sending_overlay(
+            theme,
+            ctx.locale,
+            att.display_width,
+        ));
     }
     el.into_any_element()
 }
@@ -1246,6 +1282,7 @@ fn render_video_poster(
     let width = att.display_width;
     let height = att.display_height;
     let host = ctx.video_host.clone();
+    let locale = SharedString::from(ctx.locale.to_string());
     let selection = ctx.selection.clone();
     let container = div()
         .id(("msg-video", index))
@@ -1273,11 +1310,16 @@ fn render_video_poster(
     }
     if sending {
         return container
-            .child(attachment_sending_overlay(theme))
+            .child(attachment_sending_overlay(
+                theme,
+                ctx.locale,
+                att.display_width,
+            ))
             .into_any_element();
     }
     if att.presign_pending {
-        return presign_child(container, att, theme).into_any_element();
+        return presign_child(container, att, theme, ctx.locale, att.display_width)
+            .into_any_element();
     }
     let overlay = div()
         .absolute()
@@ -1327,6 +1369,7 @@ fn render_video_poster(
                 fullscreen_mode: VideoFullscreenMode::default(),
                 layout: VideoLayout::default(),
                 decode_max_size: None,
+                locale: locale.clone(),
             };
             let _ = host.update(cx, |host, cx| {
                 host.activate_video((msg_id, index), activation, window, cx);
@@ -1379,7 +1422,11 @@ fn render_file_box(
     ctx: &RowCtx,
 ) -> AnyElement {
     let theme = ctx.theme;
-    let sending = att.uploading;
+    // Same reason as `render_audio`: a recipient's copy is never `uploading`,
+    // only `presign_pending`, and every button in this box (download, open PDF)
+    // hits the object URL directly. React filters pending documents out of the
+    // list; the spinner state already disables all of them.
+    let sending = att.uploading || att.presign_pending;
     let failed = att.upload_failed;
     let is_owner = ctx.current_user_id == msg.sender_id.as_str();
     let filename = if att.filename.is_empty() {
@@ -1390,7 +1437,14 @@ fn render_file_box(
     let is_pdf =
         att.filetype == "application/pdf" || att.filename.to_ascii_lowercase().ends_with(".pdf");
     let url = SharedString::from(att.url.clone());
-    let size_line = SharedString::from(format!("size: {}", att.size_label));
+    // While the object is not on the CDN yet the size we have is the sender's
+    // claim about a file nobody can fetch, so say what is actually happening
+    // instead — the spinner alone reads as a stuck row.
+    let size_line = if sending {
+        SharedString::from(mezon_i18n::t(ctx.locale, "message.attachment.uploading"))
+    } else {
+        SharedString::from(format!("size: {}", att.size_label))
+    };
     let group_name = SharedString::from(format!("file-box-{}-{}", msg.id.0, index));
 
     let download_url = url.clone();

--- a/crates/mezon-ui/src/chat/message/video_player.rs
+++ b/crates/mezon-ui/src/chat/message/video_player.rs
@@ -36,18 +36,6 @@ const TRACK_BG: Rgba = Rgba {
     b: 1.0,
     a: 0.3,
 };
-const OVERLAY_BG: Rgba = Rgba {
-    r: 0.0,
-    g: 0.0,
-    b: 0.0,
-    a: 0.3,
-};
-const PLAY_DISC_BG: Rgba = Rgba {
-    r: 0.0,
-    g: 0.0,
-    b: 0.0,
-    a: 0.5,
-};
 
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum VideoFullscreenMode {
@@ -72,6 +60,9 @@ pub struct VideoActivation {
     pub fullscreen_mode: VideoFullscreenMode,
     pub layout: VideoLayout,
     pub decode_max_size: Option<(u32, u32)>,
+    /// Locale for the "cannot play" card — the view has no settings entity of
+    /// its own, so the caller hands its own locale down.
+    pub locale: SharedString,
 }
 
 #[derive(Default)]
@@ -105,6 +96,7 @@ pub struct VideoPlayerView {
     url: SharedString,
     filename: SharedString,
     poster: SharedString,
+    locale: SharedString,
     width: f32,
     height: f32,
     player: Option<Rc<VideoPlayer>>,
@@ -126,6 +118,7 @@ impl VideoPlayerView {
             fullscreen_mode,
             layout,
             decode_max_size,
+            locale,
         } = activation;
         let player = VideoPlayer::open(url.as_ref(), decode_max_size)
             .ok()
@@ -146,6 +139,7 @@ impl VideoPlayerView {
             url,
             filename,
             poster,
+            locale,
             width,
             height,
             player,
@@ -163,6 +157,7 @@ impl VideoPlayerView {
         player: Rc<VideoPlayer>,
         shared: Shared,
         poster: SharedString,
+        locale: SharedString,
         width: f32,
         height: f32,
         window: &mut Window,
@@ -176,6 +171,7 @@ impl VideoPlayerView {
             url: SharedString::default(),
             filename: SharedString::default(),
             poster,
+            locale,
             width,
             height,
             player: Some(player),
@@ -256,10 +252,12 @@ impl VideoPlayerView {
             fullscreen_mode,
             layout,
             decode_max_size,
+            locale,
         } = activation;
         self.url = url;
         self.filename = filename;
         self.poster = poster;
+        self.locale = locale;
         self.width = width;
         self.height = height;
         self.fullscreen_mode = fullscreen_mode;
@@ -385,6 +383,7 @@ impl VideoPlayerView {
                         player,
                         self.shared.clone(),
                         self.poster.clone(),
+                        self.locale.clone(),
                         self.width,
                         self.height,
                         window,
@@ -623,6 +622,80 @@ impl VideoPlayerView {
             })
     }
 
+    /// Shown when the platform player cannot open the file at all. Without it
+    /// the failed state renders exactly like the untouched poster — same play
+    /// circle, same overlay — so a video the demuxer rejects just looks frozen
+    /// and clicking it appears to do nothing.
+    fn unplayable_card(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let (title_color, body_color, button_bg) = {
+            let theme = cx.theme();
+            (theme.text_primary, theme.text_secondary, theme.bg_floating)
+        };
+        let locale = self.locale.as_ref();
+        div()
+            .absolute()
+            .inset_0()
+            .flex()
+            .flex_col()
+            .items_center()
+            .justify_center()
+            .gap_2()
+            .p_4()
+            .bg(SCRIM)
+            .child(
+                Icon::new(IconName::TriangleAlert)
+                    .size(px(22.))
+                    .text_color(body_color),
+            )
+            .child(
+                div()
+                    .text_size(px(14.))
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_color(title_color)
+                    .child(mezon_i18n::t(locale, "media.video.error.title")),
+            )
+            .child(
+                div()
+                    .max_w(px(240.))
+                    .text_size(px(12.))
+                    .text_color(body_color)
+                    .child(mezon_i18n::t(
+                        locale,
+                        "media.video.error.formatNotSupported",
+                    )),
+            )
+            .child(
+                h_flex()
+                    .id("video-unplayable-download")
+                    .gap_1p5()
+                    .px_3()
+                    .py_1p5()
+                    .rounded_md()
+                    .bg(button_bg)
+                    .cursor_pointer()
+                    .hover(|s| s.opacity(0.85))
+                    .on_click(cx.listener(|view, _, _window, cx| {
+                        cx.stop_propagation();
+                        crate::util::download::save_with_progress_toast(
+                            view.url.clone(),
+                            view.filename.clone(),
+                            cx,
+                        );
+                    }))
+                    .child(
+                        Icon::new(IconName::Download)
+                            .size(px(14.))
+                            .text_color(title_color),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(12.))
+                            .text_color(title_color)
+                            .child(mezon_i18n::t(locale, "media.video.error.downloadButton")),
+                    ),
+            )
+    }
+
     fn download_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let (bg, icon_color) = {
             let theme = cx.theme();
@@ -775,7 +848,7 @@ impl Render for VideoPlayerView {
                 .when(!self.poster.is_empty(), |d| {
                     d.child(img(self.poster.clone()).size_full().object_fit(poster_fit))
                 })
-                .child(play_circle())
+                .child(self.unplayable_card(cx))
                 .on_click(cx.listener(|view, _, _window, cx| view.open_external(cx)))
                 .into_any_element();
         }
@@ -828,30 +901,6 @@ fn control_button(
         .hover(|s| s.bg(CONTROL_TINT))
         .on_click(on_click)
         .child(Icon::new(icon).size(px(16.)).text_color(gpui::white()))
-}
-
-fn play_circle() -> impl IntoElement {
-    div()
-        .absolute()
-        .inset_0()
-        .flex()
-        .items_center()
-        .justify_center()
-        .bg(OVERLAY_BG)
-        .child(
-            div()
-                .flex()
-                .items_center()
-                .justify_center()
-                .size(px(48.))
-                .rounded_full()
-                .bg(PLAY_DISC_BG)
-                .child(
-                    Icon::new(IconName::PlayButton)
-                        .size(px(20.))
-                        .text_color(gpui::white()),
-                ),
-        )
 }
 
 fn should_replay_from_start(playing: bool, current_time: f64, duration: f64) -> bool {

--- a/crates/mezon-ui/src/chat/message/video_player.rs
+++ b/crates/mezon-ui/src/chat/message/video_player.rs
@@ -153,9 +153,12 @@ impl VideoPlayerView {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn open_theater(
         player: Rc<VideoPlayer>,
         shared: Shared,
+        url: SharedString,
+        filename: SharedString,
         poster: SharedString,
         locale: SharedString,
         width: f32,
@@ -168,8 +171,12 @@ impl VideoPlayerView {
             fullscreen_mode: VideoFullscreenMode::ShellModal,
             layout: VideoLayout::Fixed,
             focus_handle: cx.focus_handle(),
-            url: SharedString::default(),
-            filename: SharedString::default(),
+            // The theater plays a player that is already open, so it never needed
+            // the source — until decoding fails mid-playback and the error card
+            // offers Download and Open externally, which have nothing to act on
+            // without it.
+            url,
+            filename,
             poster,
             locale,
             width,
@@ -382,6 +389,8 @@ impl VideoPlayerView {
                     Self::open_theater(
                         player,
                         self.shared.clone(),
+                        self.url.clone(),
+                        self.filename.clone(),
                         self.poster.clone(),
                         self.locale.clone(),
                         self.width,

--- a/crates/mezon-ui/src/image_viewer/mod.rs
+++ b/crates/mezon-ui/src/image_viewer/mod.rs
@@ -437,6 +437,7 @@ impl ImageViewer {
             fullscreen_mode: VideoFullscreenMode::InPlaceTheater,
             layout: VideoLayout::Fixed,
             decode_max_size: None,
+            locale: SharedString::from(self.locale(cx)),
         };
         if let Some(view) = self.active_video.clone() {
             view.update(cx, |player, cx| player.reopen(activation, window, cx));


### PR DESCRIPTION
## Problem

A message with attachments posts immediately and its files are patched in afterwards through `presign_finish`. Receivers leave that pending ("Uploading…") state on **one** realtime update, so a single lost event keeps the row spinning until the user reloads. Same report as on web.

Separately, `.webm`/Matroska video showed a play button that could never play: AVFoundation (macOS) and Media Foundation (Windows) have no demuxer for that container.

## What changes

**Stop losing the patch**
- `update_presign_finish` retries (1s, 3s, once more). It used to log the error and give up.
- Single-PUT uploads send the real `Content-Type` instead of an empty one.

**Heal the row when it is lost anyway**
- Whatever is still pending in the **open** channel or topic asks the CDN whether the object exists (HEAD, backoff 8/15/30s, stopping at the 10 minute expiry). A 200 clears the row.
- The probe URL carries a nonce, so a not-found answer is never cached against the URL the message renders from.
- Attachments this client is still uploading are skipped, so the healthy path spends **no** requests — measured: 0 probes across a 10-case send matrix.
- Clearing emits `MessagesEvent::Updated`: a bare `cx.notify()` does not repaint the list (`ChannelMessages` only subscribes), so the placeholder would otherwise sit there until some unrelated frame.

**Make the state legible while it lasts**
- "Uploading…" now covers images, video, audio and files, on sender and receiver, replacing the size line rather than showing a dead play button.

**Say so when a video cannot be played**
- Matroska/webm video is reported as unsupported on platforms whose demuxer cannot open it, with an error card and a Download action. Voice messages (audio/webm) stay playable and Linux (GStreamer) is unaffected.

## Testing

Against prod, two accounts in one channel, desktop ⇄ web both directions.

- Formats: png/jpg/webp/bmp/heic/gif, mp4/hevc/mov/webm/mkv/avi, mp3/wav/ogg, pdf/zip/txt, 3- and 6-image albums, mixed batches, 25MB multipart — 22/22 delivered, nothing left pending; re-run 10/10 on the final build.
- Failure cases, forced with temporary fault injection (removed before this commit):
  - patch fails twice then succeeds → `attempt 1/3`, `2/3` at 1s/3s, third lands;
  - patch fails permanently → the sender's own row heals from the CDN probe;
  - lost realtime update → probe clears the row ~8s later and the image appears without any user interaction (verified from screenshots of the pending → cleared transition);
  - object not on the CDN yet → probe answers `exists=false` at 8s, 15s, 30s and clears on the `exists=true`.
- `cargo test -p mezon-store -p mezon-client`: 1252 pass. clippy and fmt clean.

## Known gap

If the patch fails permanently the server never stores `presign_finish`, so a **web** reader stays pending until the 10 minute expiry — it cannot run this probe because the media CDN sends no `Access-Control-Allow-Origin`. Desktop recovers on its own. Tracked in the web PR (mezonai/mezon#13628).