### PR TITLE
test(mcp): drop files on a topic, and report attachment delivery state

### DIFF
--- a/crates/mezon-app/src/mcp.rs
+++ b/crates/mezon-app/src/mcp.rs
@@ -329,9 +329,14 @@ impl McpRuntime {
                         let result = cx.update(|cx| load_more_messages(cx, older));
                         let _ = reply.send(result);
                     }
-                    McpCommand::ListLoadedMessages { limit, reply } => {
-                        let result =
-                            cx.update(|cx| mezon_ui::app::capture::list_loaded_messages(cx, limit));
+                    McpCommand::ListLoadedMessages {
+                        limit,
+                        topic,
+                        reply,
+                    } => {
+                        let result = cx.update(|cx| {
+                            mezon_ui::app::capture::list_loaded_messages(cx, limit, topic)
+                        });
                         let _ = reply.send(result);
                     }
                     McpCommand::JumpToMessage { message_id, reply } => {

--- a/crates/mezon-app/src/mcp.rs
+++ b/crates/mezon-app/src/mcp.rs
@@ -227,6 +227,11 @@ impl McpRuntime {
                         let result = cx.update(|cx| mezon_ui::app::capture::topic_type(cx, &text));
                         let _ = reply.send(result);
                     }
+                    McpCommand::TopicDropPaths { paths, reply } => {
+                        let result =
+                            cx.update(|cx| mezon_ui::app::capture::topic_drop_paths(cx, paths));
+                        let _ = reply.send(result);
+                    }
                     McpCommand::TopicSubmit { reply } => {
                         let result = cx.update(mezon_ui::app::capture::topic_submit);
                         let _ = reply.send(result);

--- a/crates/mezon-mcp/src/catalog.rs
+++ b/crates/mezon-mcp/src/catalog.rs
@@ -220,7 +220,10 @@ list_messages (which reads the server) to tell a delivery failure apart from a m
 the server accepted but the list never rendered.
 
 Parameters:
-- limit (optional, default 50): return at most this many rows from each end of the buffer.",
+- limit (optional, default 50): return at most this many rows from each end of the buffer.
+- topic (optional, default false): read the open topic panel's buffer instead. The topic is
+  a bucket of its own and the parent channel stays active while it is open, so a reply sent
+  into a topic only shows up here with this set.",
         write: false,
     },
     ToolSpec {
@@ -1167,6 +1170,10 @@ composer_drop_paths always targets the channel composer even while the topic
 panel is open, so use this one for attachments meant for a topic. Call
 open_topic first.
 
+Staging is asynchronous: this returns as soon as the paths are handed over, so
+poll topic_state until its `attachments` lists the files before topic_submit —
+submitting earlier sends the reply without them.
+
 Parameters:
 - paths (required): array of local file paths.",
         write: true,
@@ -1176,6 +1183,9 @@ Parameters:
         description: "\
 Drop local files onto the composer, like a drag-and-drop. They become pending
 attachments; send them with composer_submit.
+
+The file is read on a background task, so poll composer_state until its
+`attachments` lists it before composer_submit.
 
 Parameters:
 - paths (required): array of local file paths.",

--- a/crates/mezon-mcp/src/catalog.rs
+++ b/crates/mezon-mcp/src/catalog.rs
@@ -1159,6 +1159,19 @@ Parameters:
         write: true,
     },
     ToolSpec {
+        name: "topic_drop_paths",
+        description: "\
+Drop local files onto the TOPIC panel's composer; send them with topic_submit.
+
+composer_drop_paths always targets the channel composer even while the topic
+panel is open, so use this one for attachments meant for a topic. Call
+open_topic first.
+
+Parameters:
+- paths (required): array of local file paths.",
+        write: true,
+    },
+    ToolSpec {
         name: "composer_drop_paths",
         description: "\
 Drop local files onto the composer, like a drag-and-drop. They become pending

--- a/crates/mezon-mcp/src/command.rs
+++ b/crates/mezon-mcp/src/command.rs
@@ -182,6 +182,7 @@ pub enum McpCommand {
     },
     ListLoadedMessages {
         limit: usize,
+        topic: bool,
         reply: oneshot::Sender<anyhow::Result<Value>>,
     },
     JumpToMessage {

--- a/crates/mezon-mcp/src/command.rs
+++ b/crates/mezon-mcp/src/command.rs
@@ -117,6 +117,10 @@ pub enum McpCommand {
         text: String,
         reply: oneshot::Sender<anyhow::Result<Value>>,
     },
+    TopicDropPaths {
+        paths: Vec<String>,
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
     TopicSubmit {
         reply: oneshot::Sender<anyhow::Result<Value>>,
     },

--- a/crates/mezon-mcp/src/schemas.rs
+++ b/crates/mezon-mcp/src/schemas.rs
@@ -552,6 +552,7 @@ pub fn input_schema(name: &str) -> Arc<Map<String, Value>> {
         "list_loaded_messages" => Arc::new(object(
             json!({
                 "limit": integer("Max rows from each end of the buffer. Default 50.", Some(50)),
+                "topic": bool("Read the open topic panel's buffer instead of the channel's. Default false."),
             }),
             &[],
         )),

--- a/crates/mezon-mcp/src/schemas.rs
+++ b/crates/mezon-mcp/src/schemas.rs
@@ -483,6 +483,16 @@ pub fn input_schema(name: &str) -> Arc<Map<String, Value>> {
             }),
             &["kind", "url"],
         )),
+        "topic_drop_paths" => Arc::new(object(
+            json!({
+                "paths": json!({
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Local file paths to drop on the topic composer."
+                }),
+            }),
+            &["paths"],
+        )),
         "composer_drop_paths" => Arc::new(object(
             json!({
                 "paths": json!({

--- a/crates/mezon-mcp/src/tools.rs
+++ b/crates/mezon-mcp/src/tools.rs
@@ -519,6 +519,25 @@ impl McpBackend {
                 })
                 .await
             }
+            "topic_drop_paths" => {
+                self.require_write_mode("topic_drop_paths")?;
+                let paths: Vec<String> = arguments
+                    .get("paths")
+                    .and_then(Value::as_array)
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(str::to_string)
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                if paths.is_empty() {
+                    anyhow::bail!("topic_drop_paths requires a non-empty paths array");
+                }
+                self.send_ui_result(|reply| McpCommand::TopicDropPaths { paths, reply })
+                    .await
+            }
             "composer_drop_paths" => {
                 self.require_write_mode("composer_drop_paths")?;
                 let paths: Vec<String> = arguments

--- a/crates/mezon-mcp/src/tools.rs
+++ b/crates/mezon-mcp/src/tools.rs
@@ -224,8 +224,16 @@ impl McpBackend {
                     .and_then(Value::as_u64)
                     .unwrap_or(50)
                     .clamp(1, 500) as usize;
-                self.send_ui_result(|reply| McpCommand::ListLoadedMessages { limit, reply })
-                    .await
+                let topic = arguments
+                    .get("topic")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                self.send_ui_result(|reply| McpCommand::ListLoadedMessages {
+                    limit,
+                    topic,
+                    reply,
+                })
+                .await
             }
             "jump_to_message" => {
                 self.require_write_mode("jump_to_message")?;

--- a/crates/mezon-ui/src/app/capture.rs
+++ b/crates/mezon-ui/src/app/capture.rs
@@ -324,6 +324,9 @@ fn composer_snapshot(cx: &mut App) -> anyhow::Result<Value> {
     let (popup_open, selected, suggestions) = composer.probe_suggestions();
     Ok(json!({
         "text": composer.probe_text(cx).to_string(),
+        // Staged, not dropped: a dropped file is read on a background task, so
+        // submitting before it lands here sends the message without it.
+        "attachments": composer.probe_attachments(),
         "popup_open": popup_open,
         "selected": selected,
         "suggestions": suggestions,
@@ -443,6 +446,9 @@ fn topic_snapshot(cx: &App) -> anyhow::Result<Value> {
     let (item_count, first_visible, at_bottom) = topic_panel(cx)
         .map(|(_, timeline)| timeline.read(cx).viewport_state())
         .unwrap_or((0, 0, false));
+    let attachments = topic_panel(cx)
+        .map(|(composer, _)| composer.read(cx).probe_attachments())
+        .unwrap_or_default();
     Ok(json!({
         "panel_open": topics.is_panel_open(),
         "topic_id": topic_id.map(|id| id.to_string()),
@@ -455,6 +461,9 @@ fn topic_snapshot(cx: &App) -> anyhow::Result<Value> {
         "item_count": item_count,
         "first_visible_index": first_visible,
         "at_bottom": at_bottom,
+        // Same reason as composer_state: topic_drop_paths returns before the file
+        // is read, so this is what says the next topic_submit will carry it.
+        "attachments": attachments,
     }))
 }
 
@@ -657,7 +666,10 @@ pub fn topic_drop_paths(cx: &mut App, paths: Vec<String>) -> anyhow::Result<Valu
             composer.add_dropped_paths(paths.into_iter().map(Into::into).collect(), window, cx);
         });
     })?;
-    Ok(json!({ "ok": true, "dropped": count }))
+    // Staging is asynchronous: this reports what was handed over, not what is
+    // ready. Poll topic_state until `attachments` lists the files before calling
+    // topic_submit, or the reply goes out without them.
+    Ok(json!({ "ok": true, "dropped": count, "staged": false }))
 }
 
 pub const WHEEL_TICK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(16);
@@ -1010,10 +1022,27 @@ pub fn set_user_status(
     }))
 }
 
-pub fn list_loaded_messages(cx: &App, limit: usize) -> anyhow::Result<Value> {
+/// `topic` reads the open topic panel's buffer instead of the channel's. The
+/// two are separate buckets and the channel stays "active" while a topic is
+/// open, so without the switch a reply just sent into a topic is invisible here
+/// — the caller would be looking at the parent channel and see nothing arrive.
+pub fn list_loaded_messages(cx: &App, limit: usize, topic: bool) -> anyhow::Result<Value> {
     let store = mezon_store::MessagesStore::global(cx);
     let store = store.read(cx);
-    let rows = store.messages();
+    let topic_id = topic
+        .then(|| {
+            mezon_store::TopicsStore::global(cx)
+                .read(cx)
+                .active_topic_id()
+        })
+        .flatten();
+    if topic && topic_id.is_none() {
+        anyhow::bail!("no topic is open; call open_topic first");
+    }
+    let rows = match topic_id {
+        Some(id) => store.messages_in_channel(mezon_store::ChannelId(id)),
+        None => store.messages(),
+    };
     let row_json = |m: &mezon_store::Message| {
         json!({
             "message_id": m.id.to_string(),
@@ -1041,9 +1070,17 @@ pub fn list_loaded_messages(cx: &App, limit: usize) -> anyhow::Result<Value> {
         .map(row_json)
         .collect();
     Ok(json!({
-        "channel_id": store.active_channel_id().map(|id| id.to_string()),
+        "channel_id": match topic_id {
+            Some(id) => Some(id.to_string()),
+            None => store.active_channel_id().map(|id| id.to_string()),
+        },
+        "bucket": if topic_id.is_some() { "topic" } else { "channel" },
         "loaded_count": rows.len(),
-        "has_more_bottom": store.has_more_bottom(),
+        "has_more_bottom": if topic_id.is_some() {
+            store.topic_has_more_bottom()
+        } else {
+            store.has_more_bottom()
+        },
         "oldest": head,
         "newest": tail,
     }))

--- a/crates/mezon-ui/src/app/capture.rs
+++ b/crates/mezon-ui/src/app/capture.rs
@@ -638,6 +638,28 @@ pub fn composer_submit(cx: &mut App) -> anyhow::Result<Value> {
     Ok(json!({ "ok": true, "sent": before }))
 }
 
+/// Same as [`composer_drop_paths`] but onto the topic panel's own composer.
+/// `with_composer` resolves the ACTIVE composer, which stays the channel's even
+/// while the topic panel is open, so without this an attachment aimed at a topic
+/// silently lands in the parent channel instead.
+pub fn topic_drop_paths(cx: &mut App, paths: Vec<String>) -> anyhow::Result<Value> {
+    if let Some(path) = paths
+        .iter()
+        .find(|path| !std::path::Path::new(path).is_file())
+    {
+        anyhow::bail!("file not found: {path}");
+    }
+    let count = paths.len();
+    let (composer, _) = topic_panel(cx)?;
+    let main_handle = handle(cx).ok_or_else(|| anyhow::anyhow!("main window not found"))?;
+    cx.update_window(main_handle, |_, window, cx| {
+        composer.update(cx, |composer, cx| {
+            composer.add_dropped_paths(paths.into_iter().map(Into::into).collect(), window, cx);
+        });
+    })?;
+    Ok(json!({ "ok": true, "dropped": count }))
+}
+
 pub const WHEEL_TICK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(16);
 pub const WHEEL_MAX_TICKS: u32 = 500;
 
@@ -1000,6 +1022,16 @@ pub fn list_loaded_messages(cx: &App, limit: usize) -> anyhow::Result<Value> {
             "sender": m.sender_name,
             "send_failed": m.send_failed,
             "content": m.content.chars().take(60).collect::<String>(),
+            // Attachment delivery state, so a test can tell "still uploading" apart
+            // from "rendered" without reading pixels.
+            "attachments": m.attachments.iter().map(|a| json!({
+                "filetype": a.filetype,
+                "name": a.filename,
+                "uploading": a.uploading,
+                "presign_pending": a.presign_pending,
+                "upload_failed": a.upload_failed,
+                "url": a.url,
+            })).collect::<Vec<_>>(),
         })
     };
     let head: Vec<Value> = rows.iter().take(limit).map(row_json).collect();

--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -2147,6 +2147,17 @@ impl MentionInput {
         self.input.read(cx).value_shared()
     }
 
+    /// Names of the files staged on the composer, in the order they will be
+    /// sent. Reading a file off disk happens on a background task, so a drop
+    /// only shows up here once the attachment is actually staged — which is what
+    /// makes it the thing to poll before submitting.
+    pub(crate) fn probe_attachments(&self) -> Vec<String> {
+        self.pending_attachments
+            .iter()
+            .map(|att| att.filename.clone())
+            .collect()
+    }
+
     pub(crate) fn probe_suggestions(&self) -> (bool, usize, Vec<String>) {
         let labels = self
             .suggestions


### PR DESCRIPTION
Two gaps found while trying to reproduce "images sent into a topic stay loading for the receiver" through the control socket.

- `composer_drop_paths` always targets the channel composer, even with the topic panel open, so attachments meant for a topic could not be sent at all. `topic_drop_paths` does for the topic panel what that tool does for the channel; send with `topic_submit`.
- `list_loaded_messages` returned no attachment state, so a test could not tell "still uploading" apart from "rendered" without reading pixels. Each row now carries `filetype`, `name`, `uploading`, `presign_pending`, `upload_failed` and `url` — which is how the presign self-heal in #386 was measured.

Read-only additions apart from the drop tool, nothing outside the MCP surface.