### PR TITLE
fix(topic): show the picture being sent, and tools to prove it

### DIFF
--- a/ATTACHMENT_TEST_CHECKLIST.md
+++ b/ATTACHMENT_TEST_CHECKLIST.md
@@ -90,7 +90,11 @@ regresses independently of the channel path. Test it separately, every time.
 
 - [ ] Single image into a topic → `kind="local-file"`
 - [ ] **Album (3 images) into a topic** → three `local-file` lines. This is the
-      case that exercises the index-aligned `local_source` guard
+      case that exercises the name-matched `local_source` guard
+- [ ] Album into a topic where the **socket echo beats the ack** (the common case
+      for a batch): the paths land on the row the socket already created, and the
+      topic list has to be told — check the rendered row, not the store, since a
+      store that is right behind a stale view looks like a pass
 - [ ] Image + document together → both settle, only the image renders locally
 - [ ] Receiver sees the topic reply and its reply-count badge on the parent
 
@@ -223,8 +227,11 @@ Video:
 ## 7. Reading the numbers
 
 The `img_render` lines come from a temporary instrumentation in
-`MessageImageLoader` (`crates/mezon-ui/src/image_cache.rs`) — **not committed**.
-Re-add it when a run needs render sources, drop it before committing.
+`MessageImageLoader` (`crates/mezon-ui/src/image_cache.rs`) — **not committed**,
+and it must stay that way: it logs the absolute local path and the full remote
+url of every image the app loads, on the hot path. Add it for a measuring run,
+then `git checkout origin/develop -- crates/mezon-ui/src/image_cache.rs` before
+committing anything.
 
 Healthy ranges measured on a working build:
 

--- a/ATTACHMENT_TEST_CHECKLIST.md
+++ b/ATTACHMENT_TEST_CHECKLIST.md
@@ -29,7 +29,7 @@ TMPDIR=/tmp/mz2 ./target/debug/mezon mcp call open_channel \
 - [ ] A second instance needs a *different* `TMPDIR` (e.g. `/tmp/mz3`), otherwise
       the single-instance guard kills it and MCP answers from the old process.
 - [ ] `RUST_LOG` includes `img_render` only if the build carries the temporary
-      render instrumentation (see §6). `mezon_store=debug` is what prints
+      render instrumentation (see §7). `mezon_store=debug` is what prints
       `presign probe` and `presign gate`.
 
 ### Web
@@ -137,13 +137,37 @@ Send in one message: `png jpg gif mp4 mp3 webm pdf txt`.
 
 ---
 
-## 5. Other paths
+## 5. Opening the viewer, pressing play
+
+A tile is inert until its bytes are up. The row gates the click on
+`!sending && !upload_failed && !presign_pending && !url.is_empty()`
+(`parts.rs`), and `open_image_viewer` refuses on the same conditions — a tool
+that opened a viewer the user cannot open would report a pass for nothing.
+
+Image viewer:
+
+- [ ] Sender clicks their **own image while it is uploading** → nothing opens
+      (`open_image_viewer` answers `still uploading`)
+- [ ] Sender clicks after it settles → viewer opens on the CDN url
+- [ ] Receiver clicks → viewer opens, and paging walks the channel's other media
+- [ ] A failed upload's tile does not open the viewer
+- [ ] Web: `canOpenViewer` checks only `isPresignPending` — confirm a row that is
+      merely *sending* is inert there too
+
+Video:
+
+- [ ] Sender presses play while uploading → nothing happens
+- [ ] Sender presses play after it settles → plays
+- [ ] Receiver presses play: `readyState=4`, `error=none`, `currentTime`
+      advances. The video streams straight from the CDN; only the poster goes
+      through imgproxy
+
+---
+
+## 6. Other paths
 
 - [ ] Reply carrying an attachment (`reply_begin` → drop → `composer_submit`):
       the reply reference survives the presign patch — check the *receiver's* UI
-- [ ] Receiver presses play on a video: `readyState=4`, `error=none`,
-      `currentTime` advances. The video streams straight from the CDN; only the
-      poster goes through imgproxy
 - [ ] Large file — desktop ≥16 MB takes the multipart path (etag ends `-N`);
       web ~9 MB single PUT
 - [ ] Reload the page: the sender's local preview is gone, so the row must fall
@@ -151,7 +175,7 @@ Send in one message: `png jpg gif mp4 mp3 webm pdf txt`.
 
 ---
 
-## 6. Reading the numbers
+## 7. Reading the numbers
 
 The `img_render` lines come from a temporary instrumentation in
 `MessageImageLoader` (`crates/mezon-ui/src/image_cache.rs`) — **not committed**.
@@ -171,7 +195,7 @@ Healthy ranges measured on a working build:
 
 ---
 
-## 7. Known open issues to check against
+## 8. Known open issues to check against
 
 - [ ] Web keeps showing "Uploading…" long past the 10-minute expiry for an
       attachment whose upload died (suspect: `getMessageCreateTimeSeconds`

--- a/ATTACHMENT_TEST_CHECKLIST.md
+++ b/ATTACHMENT_TEST_CHECKLIST.md
@@ -1,0 +1,184 @@
+# Attachment send/receive — test checklist
+
+Everything below is driven through the MCP control socket (desktop) and the
+browser (web), against **CLAN TEST 01 → #general**
+(`clan 2048775830980530176`, `channel 2048775831257354240`).
+
+A run is only meaningful with **two clients signed in as different accounts** —
+one is the sender, the other the receiver, and the interesting behaviour is
+almost always on the side that did *not* send.
+
+---
+
+## 0. Setup
+
+### Desktop
+
+```bash
+cd <worktree>
+cargo build --bin mezon
+mkdir -p /tmp/mz2
+TMPDIR=/tmp/mz2 RUST_LOG=img_render=info,mezon_store=debug,mezon=info \
+  ./target/debug/mezon > /tmp/mz2/run.log 2>&1 &
+TMPDIR=/tmp/mz2 ./target/debug/mezon mcp call open_channel \
+  --args '{"clan_id":"2048775830980530176","channel_id":"2048775831257354240"}'
+```
+
+- [ ] `TMPDIR` is short. The control socket lives under it and `sun_path` is
+      104 bytes — a long scratch path silently loses the socket.
+- [ ] A second instance needs a *different* `TMPDIR` (e.g. `/tmp/mz3`), otherwise
+      the single-instance guard kills it and MCP answers from the old process.
+- [ ] `RUST_LOG` includes `img_render` only if the build carries the temporary
+      render instrumentation (see §6). `mezon_store=debug` is what prints
+      `presign probe` and `presign gate`.
+
+### Web
+
+```bash
+npm run dev:chat            # never `yarn` — corepack gives Yarn 4, the repo lock is v1
+```
+
+- [ ] `apps/chat/.env` is the intended one (prod vs dev decides which backend a
+      pasted session token is valid for). Vite bakes it at **startup** — changing
+      `.env` needs a restart.
+- [ ] DevTools console filtered to `img-render`.
+
+### Traps that cost the most time
+
+- [ ] **The desktop window must be visible.** An occluded window stops rendering,
+      GPUI drops view entities, and every UI tool answers
+      `no composer is mounted` / `no topic panel is mounted`. Bring it to the
+      front, then re-check `topic_state.panel_mounted` — `panel_open` alone is
+      the store's flag and stays `true` after the view is gone.
+- [ ] **Staging a dropped file is asynchronous.** `composer_drop_paths` /
+      `topic_drop_paths` return before the file is read. Poll
+      `composer_state.attachments` / `topic_state.attachments` until the name
+      appears; submitting earlier sends the message with **no attachment** and no
+      error anywhere.
+- [ ] The web page has more than one file input when the topic panel is open —
+      uploading to the wrong one puts the file in the other composer.
+
+---
+
+## 1. Direction × receiver state
+
+For each: the sender's row must render from its **local copy** and issue **zero**
+proxy requests for the object it just uploaded; the receiver's row goes through
+imgproxy.
+
+- [ ] Desktop → web, web **has the channel open**
+- [ ] Web → desktop, desktop **has the channel open**
+- [ ] Desktop → web, web **in another channel** → 0 requests while away, renders
+      after switching back
+- [ ] Web → desktop, desktop **in another channel** → same
+- [ ] Web → desktop, desktop **closed**, reopened afterwards → backlog renders,
+      every attachment clean
+- [ ] After switching away and back, the sender's own rows still render locally
+
+Check on the sender:
+
+```bash
+grep img_render /tmp/mz2/run.log | grep -c "<object-id>"   # must be 0
+```
+
+---
+
+## 2. Topic
+
+The topic reply has no optimistic row — it is built from the server echo — so it
+regresses independently of the channel path. Test it separately, every time.
+
+- [ ] Single image into a topic → `kind="local-file"`
+- [ ] **Album (3 images) into a topic** → three `local-file` lines. This is the
+      case that exercises the index-aligned `local_source` guard
+- [ ] Image + document together → both settle, only the image renders locally
+- [ ] Receiver sees the topic reply and its reply-count badge on the parent
+
+---
+
+## 3. File types
+
+Send in one message: `png jpg gif mp4 mp3 webm pdf txt`.
+
+- [ ] All settle to `uploading=0 presign_pending=0 upload_failed=0`
+- [ ] Every object on the CDN carries its **real** Content-Type:
+      ```bash
+      curl -sSI "<url>" | grep -i content-type
+      ```
+      `image/png`, `image/jpeg`, `image/gif`, `audio/mpeg`, `video/mp4`,
+      `video/webm`, `application/pdf`, `text/plain`
+- [ ] The video renders as a poster with a play control on both clients
+- [ ] The extra `.jpg` object with no matching filename is the video poster the
+      desktop generates — it has no local file, so one proxy request for it is
+      expected
+- [ ] Documents show a named box while uploading, not an empty row
+
+---
+
+## 4. Failure and recovery
+
+- [ ] **Upload fails** — web: patch `fetch` to reject `PUT` to `/r2-upload`;
+      desktop: delete the file right after `composer_submit`
+  - [ ] Desktop sender marks `upload_failed` and shows the error overlay
+  - [ ] Receiver shows the box with "Uploading…" and makes **no** CDN request
+  - [ ] Exactly one PUT attempt — no retry storm
+- [ ] **CDN probe** on the receiver backs off `8s → 15s → 30s` then holds, one
+      request per round:
+      ```bash
+      grep "presign probe" /tmp/mz2/run.log
+      ```
+- [ ] **Expiry** at 10 minutes: the attachment is dropped from the row **in the
+      running session**, and the probe stops with it (count stops growing).
+      Verifying this after an app restart proves nothing — a fresh load gates
+      attachments from the API payload and hides the bug.
+- [ ] Send, then leave the channel immediately → upload and the `presign_finish`
+      patch still complete; the row is clean on return
+- [ ] Two sends back to back → both land, in order, each with its own attachment
+
+---
+
+## 5. Other paths
+
+- [ ] Reply carrying an attachment (`reply_begin` → drop → `composer_submit`):
+      the reply reference survives the presign patch — check the *receiver's* UI
+- [ ] Receiver presses play on a video: `readyState=4`, `error=none`,
+      `currentTime` advances. The video streams straight from the CDN; only the
+      poster goes through imgproxy
+- [ ] Large file — desktop ≥16 MB takes the multipart path (etag ends `-N`);
+      web ~9 MB single PUT
+- [ ] Reload the page: the sender's local preview is gone, so the row must fall
+      back to the proxy and still render
+
+---
+
+## 6. Reading the numbers
+
+The `img_render` lines come from a temporary instrumentation in
+`MessageImageLoader` (`crates/mezon-ui/src/image_cache.rs`) — **not committed**.
+Re-add it when a run needs render sources, drop it before committing.
+
+Healthy ranges measured on a working build:
+
+| | source | time |
+|---|---|---|
+| Sender, own image | `local-file` | 4–150 ms (capped to 1024 px) |
+| Receiver, warm rendition | `imgproxy` | 20–160 ms |
+| Receiver, first fetch of a new rendition | `imgproxy` | 500–1600 ms |
+
+- [ ] Sender rows never say `imgproxy` for their own object
+- [ ] Each client requests its own `rs:fill:W:H` — a rendition broken for one
+      client can be fine on another, so reproduce on the client that reported it
+
+---
+
+## 7. Known open issues to check against
+
+- [ ] Web keeps showing "Uploading…" long past the 10-minute expiry for an
+      attachment whose upload died (suspect: `getMessageCreateTimeSeconds`
+      returning nothing for a realtime message, so
+      `filterExpiredPresignAttachments` bails)
+- [ ] A failed upload on web leaves the **sender** on "Uploading…" with no error
+      state; the desktop shows a failure
+- [ ] imgproxy 5xx responses are cached by Cloudflare with
+      `public, max-age=604800` — one transient timeout breaks a rendition for a
+      week. Infrastructure fix; clients can only avoid triggering it

--- a/ATTACHMENT_TEST_CHECKLIST.md
+++ b/ATTACHMENT_TEST_CHECKLIST.md
@@ -98,20 +98,65 @@ regresses independently of the channel path. Test it separately, every time.
 
 ## 3. File types
 
-Send in one message: `png jpg gif mp4 mp3 webm pdf txt`.
+Not "does it upload" — every type below takes a **different branch**, and the
+branches are what break. Send them in batches and check the row, not just the
+state flags.
 
-- [ ] All settle to `uploading=0 presign_pending=0 upload_failed=0`
+### Renders inline
+
+| File | Path it exercises | Row must show |
+|---|---|---|
+| `png` `jpg` | static decode, capped to 1024 px | the picture |
+| `gif` | animation path (`message_path_maybe_animated`, frame budget) | plays, does not freeze on frame 1 |
+| `webp` | animation path too — animated webp is decoded frame by frame | the picture |
+| `heic` | ImageIO on macOS; the `image` crate cannot read it | the picture (verified on macOS) |
+| `mp4` | platform demuxer + generated poster | poster, then plays on click |
+| `mp3` | audio player | duration and a play control |
+| `webm` **audio** (voice message) | symphonia in-app — deliberately exempt from the Matroska block | plays |
+
+### Must fall back to a named file box, never a broken tile
+
+| File | Why |
+|---|---|
+| `bmp` `tiff` `psd` | in both blocklists; imgproxy cannot read them |
+| `avi` `wmv` `flv` `mkv` `rmvb` | in both blocklists |
+| `svg` | web excludes `svg+xml` from images on purpose |
+| `webm` **video** on macOS/Windows | AVFoundation and Media Foundation have no Matroska demuxer |
+| `wma` `ra` | blocked audio |
+
+- [ ] Renders-inline set: all settle to `uploading=0 presign_pending=0 upload_failed=0`
+- [ ] Fallback set: every one shows a file box with name and size — no broken
+      image, no play button that does nothing
 - [ ] Every object on the CDN carries its **real** Content-Type:
       ```bash
       curl -sSI "<url>" | grep -i content-type
       ```
-      `image/png`, `image/jpeg`, `image/gif`, `audio/mpeg`, `video/mp4`,
-      `video/webm`, `application/pdf`, `text/plain`
-- [ ] The video renders as a poster with a play control on both clients
+      `image/png`, `image/jpeg`, `image/gif`, `image/bmp`, `image/heic`,
+      `image/svg+xml`, `audio/mpeg`, `video/mp4`, `video/webm`,
+      `application/pdf`, `text/plain`
+- [ ] A type the sender cannot identify uploads as `application/octet-stream`
+      (measured for `.avi`) — the row still has to be a file box
 - [ ] The extra `.jpg` object with no matching filename is the video poster the
-      desktop generates — it has no local file, so one proxy request for it is
+      desktop generates; it has no local file, so one proxy request for it is
       expected
-- [ ] Documents show a named box while uploading, not an empty row
+- [ ] Documents show a named box **while uploading**, not an empty row
+
+### Names and sizes
+
+- [ ] A non-ASCII filename (`ảnh-tiếng-việt.png`) uploads and fetches back
+      — `sanitize_upload_filename` rewrites the object key, the display name keeps
+      its accents
+- [ ] A zero-byte file
+- [ ] A name long enough to wrap the file box
+
+### Still untested — carry these forward
+
+- [ ] `webp` (macOS `sips` cannot write one; produce it another way)
+- [ ] `avif` — known undecodable on desktop for avatars, unverified for messages
+- [ ] `mov` / QuickTime — the web has a probe path specifically for it
+- [ ] PDF preview on web (`PDFViewerModal`), not just the download box
+- [ ] A Tenor GIF — a url attachment, never uploaded, different code path
+- [ ] Voice message recorded in-app, as opposed to a `.webm` picked from disk
 
 ---
 

--- a/crates/mezon-app/src/mcp.rs
+++ b/crates/mezon-app/src/mcp.rs
@@ -339,6 +339,11 @@ impl McpRuntime {
                         });
                         let _ = reply.send(result);
                     }
+                    McpCommand::ReplyBegin { message_id, reply } => {
+                        let result =
+                            cx.update(|cx| mezon_ui::app::capture::reply_begin(cx, message_id));
+                        let _ = reply.send(result);
+                    }
                     McpCommand::JumpToMessage { message_id, reply } => {
                         let result =
                             cx.update(|cx| mezon_ui::app::capture::jump_to_message(cx, message_id));

--- a/crates/mezon-mcp/src/catalog.rs
+++ b/crates/mezon-mcp/src/catalog.rs
@@ -227,6 +227,20 @@ Parameters:
         write: false,
     },
     ToolSpec {
+        name: "reply_begin",
+        description: "\
+Aim the composer at a message, the way the row's Reply action does. Nothing is sent.
+
+Use this when the reply must carry something the composer holds — an attachment from
+composer_drop_paths, a mention picked with composer_pick. `reply_to_message` posts a
+text-only reply in one call and cannot carry either. Send with composer_submit;
+composer_state reports the pending target under `reply_target`.
+
+Parameters:
+- message_id (required): must be in the open channel's loaded history.",
+        write: true,
+    },
+    ToolSpec {
         name: "jump_to_present",
         description: "\
 Return the open channel's message list to the live tail after a jump_to_message.

--- a/crates/mezon-mcp/src/command.rs
+++ b/crates/mezon-mcp/src/command.rs
@@ -185,6 +185,10 @@ pub enum McpCommand {
         topic: bool,
         reply: oneshot::Sender<anyhow::Result<Value>>,
     },
+    ReplyBegin {
+        message_id: i64,
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
     JumpToMessage {
         message_id: i64,
         reply: oneshot::Sender<anyhow::Result<Value>>,

--- a/crates/mezon-mcp/src/schemas.rs
+++ b/crates/mezon-mcp/src/schemas.rs
@@ -556,6 +556,12 @@ pub fn input_schema(name: &str) -> Arc<Map<String, Value>> {
             }),
             &[],
         )),
+        "reply_begin" => Arc::new(object(
+            json!({
+                "message_id": id("Message to reply to; must be in the open channel's loaded history."),
+            }),
+            &["message_id"],
+        )),
         "jump_to_message" => Arc::new(object(
             json!({
                 "message_id": id("Message snowflake id to centre the window on."),

--- a/crates/mezon-mcp/src/tools.rs
+++ b/crates/mezon-mcp/src/tools.rs
@@ -235,6 +235,12 @@ impl McpBackend {
                 })
                 .await
             }
+            "reply_begin" => {
+                self.require_write_mode("reply_begin")?;
+                let message_id = parse_i64_field(&arguments, "message_id")?;
+                self.send_ui_result(|reply| McpCommand::ReplyBegin { message_id, reply })
+                    .await
+            }
             "jump_to_message" => {
                 self.require_write_mode("jump_to_message")?;
                 let message_id = parse_i64_field(&arguments, "message_id")?;
@@ -2031,12 +2037,28 @@ fn parse_search_content(raw: &str) -> String {
 struct MessageDetail {
     id: i64,
     content: String,
+    /// The content JSON as the server stored it. This is where `presign_finish`
+    /// lives, and comparing its keys against the attachment urls below is the
+    /// only way to see why a receiver still treats an attachment as pending.
+    content_raw: String,
     sender_id: i64,
     sender_name: String,
     create_time: i64,
     has_attachments: bool,
+    attachments: Vec<AttachmentSummary>,
     embeds: Vec<EmbedSummary>,
     components: Vec<ComponentRowSummary>,
+}
+
+#[derive(Serialize)]
+struct AttachmentSummary {
+    filename: String,
+    filetype: String,
+    size: i32,
+    url: String,
+    thumbnail: String,
+    width: i32,
+    height: i32,
 }
 
 #[derive(Serialize)]
@@ -2097,10 +2119,24 @@ fn message_detail(message: &ApiMessage) -> MessageDetail {
     MessageDetail {
         id: message.message_id,
         content: message.content.clone(),
+        content_raw: message.content_raw.clone(),
         sender_id: message.sender_id,
         sender_name: message.sender_name.clone(),
         create_time: message.create_time,
         has_attachments: !message.attachments.is_empty(),
+        attachments: message
+            .attachments
+            .iter()
+            .map(|a| AttachmentSummary {
+                filename: a.filename.clone(),
+                filetype: a.filetype.clone(),
+                size: a.size,
+                url: a.url.clone(),
+                thumbnail: a.thumbnail.clone(),
+                width: a.width,
+                height: a.height,
+            })
+            .collect(),
         embeds: message
             .content_tokens
             .embed

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -3606,16 +3606,7 @@ impl MessagesStore {
         let masked = anonymous && anonymize_sender(&mut msg, cfg);
         enrich_sparse_topic_ack(&mut msg, viewer_id, self.active_clan_id, masked, cx);
         mark_pending_attachments_uploading(&mut msg.attachments);
-        // Only when they line up: a mismatch means this echo is not the one those
-        // files belong to, and pointing a row at the wrong local file is worse than
-        // going to the network for it.
-        if local_sources.len() == msg.attachments.len() {
-            for (att, path) in msg.attachments.iter_mut().zip(local_sources) {
-                if att.local_source.is_none() {
-                    att.local_source = path;
-                }
-            }
-        }
+        apply_local_sources(&mut msg.attachments, &local_sources);
         let message_id = msg.id;
         let create_time = if msg.create_time > 0 {
             msg.create_time
@@ -3625,6 +3616,14 @@ impl MessagesStore {
         if self.cache.contains(&topic_key) {
             if let Some(channel) = self.cache.get_mut(&topic_key) {
                 if channel.messages.contains_id(msg.id) {
+                    // The socket delivered this reply before its own ack came back —
+                    // with a batch of attachments it usually does. Dropping the paths
+                    // here is what sent the sender to the proxy for files it is
+                    // holding: the row that survives is the socket's, and that one
+                    // never had them.
+                    if let Some(existing) = channel.messages.get_mut_by_id(msg.id) {
+                        apply_local_sources(&mut existing.attachments, &local_sources);
+                    }
                     return TopicAppend::default();
                 }
                 channel.messages.push_grouped(msg);
@@ -6694,6 +6693,23 @@ fn carries_topic_marker(m: &mezon_proto::api::ChannelMessage) -> bool {
         .and_then(|content| content.tp)
         .and_then(|tp| tp.parse::<i64>().ok())
         .is_some_and(|id| id != 0)
+}
+
+/// Point a row's attachments at the sender's own copies, by position. Only when
+/// the counts line up: a mismatch means these paths belong to a different send,
+/// and aiming a row at the wrong local file is worse than going to the network.
+fn apply_local_sources(
+    attachments: &mut [MessageAttachment],
+    local_sources: &[Option<std::path::PathBuf>],
+) {
+    if local_sources.len() != attachments.len() {
+        return;
+    }
+    for (att, path) in attachments.iter_mut().zip(local_sources) {
+        if att.local_source.is_none() {
+            att.local_source = path.clone();
+        }
+    }
 }
 
 fn mark_pending_attachments_uploading(attachments: &mut [MessageAttachment]) {

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -3621,8 +3621,20 @@ impl MessagesStore {
                     // here is what sent the sender to the proxy for files it is
                     // holding: the row that survives is the socket's, and that one
                     // never had them.
+                    let mut changed = false;
                     if let Some(existing) = channel.messages.get_mut_by_id(msg.id) {
-                        apply_local_sources(&mut existing.attachments, &local_sources);
+                        changed = apply_local_sources(&mut existing.attachments, &local_sources);
+                    }
+                    if changed {
+                        // The topic list renders from a clone it only refreshes on
+                        // an event, so a silent change here is a store that is
+                        // right behind a view that is not. Measured, the row still
+                        // comes out right — it is uploading at this point, so
+                        // nothing is fetched, and the presign patch that follows
+                        // refreshes the view in time. This is here so that stays
+                        // true when the order those two arrive in changes.
+                        cx.emit(MessagesEvent::TopicUpdated { topic_id });
+                        cx.notify();
                     }
                     return TopicAppend::default();
                 }
@@ -6702,18 +6714,22 @@ fn carries_topic_marker(m: &mezon_proto::api::ChannelMessage) -> bool {
 ///
 /// The count check stays as the outer guard: a different length means this echo
 /// is not the send those files belong to at all.
+/// Returns whether any attachment actually gained a path — the caller has to
+/// know, because a row that changed under a view holding its own clone is only
+/// redrawn if the store says so.
 fn apply_local_sources(
     attachments: &mut [MessageAttachment],
     local_sources: &[(String, Option<std::path::PathBuf>)],
-) {
+) -> bool {
     if local_sources.len() != attachments.len() {
-        return;
+        return false;
     }
     let mut by_name: HashMap<&str, std::collections::VecDeque<&Option<std::path::PathBuf>>> =
         HashMap::new();
     for (name, path) in local_sources {
         by_name.entry(name.as_str()).or_default().push_back(path);
     }
+    let mut changed = false;
     for att in attachments.iter_mut() {
         if att.local_source.is_some() {
             continue;
@@ -6721,9 +6737,11 @@ fn apply_local_sources(
         if let Some(queue) = by_name.get_mut(att.filename.as_str())
             && let Some(path) = queue.pop_front()
         {
+            changed |= path.is_some();
             att.local_source = path.clone();
         }
     }
+    changed
 }
 
 fn mark_pending_attachments_uploading(attachments: &mut [MessageAttachment]) {
@@ -8543,6 +8561,109 @@ mod tests {
     use super::*;
     use crate::ids::UserId;
     use crate::message::MessageSpan;
+
+    fn attachment(filename: &str) -> MessageAttachment {
+        MessageAttachment {
+            filename: filename.into(),
+            ..Default::default()
+        }
+    }
+
+    fn source(filename: &str, path: &str) -> (String, Option<std::path::PathBuf>) {
+        (filename.into(), Some(std::path::PathBuf::from(path)))
+    }
+
+    #[test]
+    fn local_sources_follow_the_filename_not_the_position() {
+        // The echo is the server's ordering of the batch, and nothing promises it
+        // matches the order they were handed to the upload.
+        let mut attachments = vec![
+            attachment("c.png"),
+            attachment("a.png"),
+            attachment("b.png"),
+        ];
+        let changed = apply_local_sources(
+            &mut attachments,
+            &[
+                source("a.png", "/disk/a.png"),
+                source("b.png", "/disk/b.png"),
+                source("c.png", "/disk/c.png"),
+            ],
+        );
+
+        assert!(changed);
+        let got: Vec<_> = attachments
+            .iter()
+            .map(|a| {
+                a.local_source
+                    .as_ref()
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        assert_eq!(got, vec!["/disk/c.png", "/disk/a.png", "/disk/b.png"]);
+    }
+
+    #[test]
+    fn repeated_filenames_keep_their_order_within_the_name() {
+        // Two files of the same name are indistinguishable, so the only sane rule
+        // is first-come inside that name.
+        let mut attachments = vec![attachment("shot.png"), attachment("shot.png")];
+        apply_local_sources(
+            &mut attachments,
+            &[
+                source("shot.png", "/disk/one/shot.png"),
+                source("shot.png", "/disk/two/shot.png"),
+            ],
+        );
+
+        assert_eq!(
+            attachments[0].local_source.as_ref().unwrap(),
+            &std::path::PathBuf::from("/disk/one/shot.png")
+        );
+        assert_eq!(
+            attachments[1].local_source.as_ref().unwrap(),
+            &std::path::PathBuf::from("/disk/two/shot.png")
+        );
+    }
+
+    #[test]
+    fn a_short_echo_applies_nothing_and_reports_no_change() {
+        let mut attachments = vec![attachment("a.png"), attachment("b.png")];
+        let changed = apply_local_sources(&mut attachments, &[source("a.png", "/disk/a.png")]);
+
+        assert!(
+            !changed,
+            "a count mismatch means the batch cannot be trusted"
+        );
+        assert!(attachments.iter().all(|a| a.local_source.is_none()));
+    }
+
+    #[test]
+    fn applying_paths_that_are_already_there_reports_no_change() {
+        // The caller redraws on `true`; saying so when nothing moved would repaint
+        // the topic list on every echo.
+        let mut attachments = vec![attachment("a.png")];
+        attachments[0].local_source = Some(std::path::PathBuf::from("/disk/a.png"));
+        let changed = apply_local_sources(&mut attachments, &[source("a.png", "/disk/other.png")]);
+
+        assert!(!changed);
+        assert_eq!(
+            attachments[0].local_source.as_ref().unwrap(),
+            &std::path::PathBuf::from("/disk/a.png"),
+            "a path already on the row wins over a late one"
+        );
+    }
+
+    #[test]
+    fn a_url_attachment_with_no_file_behind_it_is_not_a_change() {
+        let mut attachments = vec![attachment("tenor.gif")];
+        let changed = apply_local_sources(&mut attachments, &[("tenor.gif".into(), None)]);
+
+        assert!(!changed);
+        assert!(attachments[0].local_source.is_none());
+    }
 
     #[test]
     fn thread_send_joins_sender_when_not_a_member() {

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -3596,7 +3596,7 @@ impl MessagesStore {
         topic_id: i64,
         api_msg: mezon_client::transport::ApiMessage,
         anonymous: bool,
-        local_sources: Vec<Option<std::path::PathBuf>>,
+        local_sources: Vec<(String, Option<std::path::PathBuf>)>,
         cx: &mut Context<Self>,
     ) -> TopicAppend {
         let topic_key = ChannelId(topic_id);
@@ -6695,18 +6695,32 @@ fn carries_topic_marker(m: &mezon_proto::api::ChannelMessage) -> bool {
         .is_some_and(|id| id != 0)
 }
 
-/// Point a row's attachments at the sender's own copies, by position. Only when
-/// the counts line up: a mismatch means these paths belong to a different send,
-/// and aiming a row at the wrong local file is worse than going to the network.
+/// Point a row's attachments at the sender's own copies. Matched by filename,
+/// because the echo is the server's list and nothing promises it comes back in
+/// the order it was sent — an index would then aim a row at the wrong picture.
+/// The same name twice in one message keeps its order within that name.
+///
+/// The count check stays as the outer guard: a different length means this echo
+/// is not the send those files belong to at all.
 fn apply_local_sources(
     attachments: &mut [MessageAttachment],
-    local_sources: &[Option<std::path::PathBuf>],
+    local_sources: &[(String, Option<std::path::PathBuf>)],
 ) {
     if local_sources.len() != attachments.len() {
         return;
     }
-    for (att, path) in attachments.iter_mut().zip(local_sources) {
-        if att.local_source.is_none() {
+    let mut by_name: HashMap<&str, std::collections::VecDeque<&Option<std::path::PathBuf>>> =
+        HashMap::new();
+    for (name, path) in local_sources {
+        by_name.entry(name.as_str()).or_default().push_back(path);
+    }
+    for att in attachments.iter_mut() {
+        if att.local_source.is_some() {
+            continue;
+        }
+        if let Some(queue) = by_name.get_mut(att.filename.as_str())
+            && let Some(path) = queue.pop_front()
+        {
             att.local_source = path.clone();
         }
     }

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -3586,11 +3586,17 @@ impl MessagesStore {
         true
     }
 
+    /// `local_sources` is the sender's own copy of each attachment, in the order
+    /// they were sent — empty for a reply arriving from anyone else. A topic reply
+    /// has no optimistic row: it is built from the server's echo, which carries no
+    /// path, so without this the sender would fetch a proxied copy of the file
+    /// still sitting on their disk.
     pub fn append_topic_message(
         &mut self,
         topic_id: i64,
         api_msg: mezon_client::transport::ApiMessage,
         anonymous: bool,
+        local_sources: Vec<Option<std::path::PathBuf>>,
         cx: &mut Context<Self>,
     ) -> TopicAppend {
         let topic_key = ChannelId(topic_id);
@@ -3600,6 +3606,16 @@ impl MessagesStore {
         let masked = anonymous && anonymize_sender(&mut msg, cfg);
         enrich_sparse_topic_ack(&mut msg, viewer_id, self.active_clan_id, masked, cx);
         mark_pending_attachments_uploading(&mut msg.attachments);
+        // Only when they line up: a mismatch means this echo is not the one those
+        // files belong to, and pointing a row at the wrong local file is worse than
+        // going to the network for it.
+        if local_sources.len() == msg.attachments.len() {
+            for (att, path) in msg.attachments.iter_mut().zip(local_sources) {
+                if att.local_source.is_none() {
+                    att.local_source = path;
+                }
+            }
+        }
         let message_id = msg.id;
         let create_time = if msg.create_time > 0 {
             msg.create_time

--- a/crates/mezon-store/src/topics.rs
+++ b/crates/mezon-store/src/topics.rs
@@ -790,6 +790,14 @@ impl TopicsStore {
             message_code: 0,
         };
         let has_attachments = !attachments.is_empty();
+        // The reply row is built from the server's echo, which knows nothing about
+        // the file on this disk. Keep the paths so the sender sees the picture they
+        // just sent instead of fetching a proxied copy of it back — the same thing
+        // `MessageAttachment::optimistic_local` does for a channel send.
+        let local_sources: Vec<Option<std::path::PathBuf>> = attachments
+            .iter()
+            .map(|att| att.filetype.starts_with("image/").then(|| att.path.clone()))
+            .collect();
         let reply_ref =
             self.reply_target
                 .take()
@@ -1000,6 +1008,7 @@ impl TopicsStore {
                     generation,
                     ack,
                     anonymous,
+                    local_sources,
                     cx,
                 );
             });
@@ -1097,6 +1106,7 @@ impl TopicsStore {
         generation: u64,
         ack: mezon_client::transport::ApiMessage,
         anonymous: bool,
+        local_sources: Vec<Option<std::path::PathBuf>>,
         cx: &mut Context<Self>,
     ) {
         if self.compose_generation != generation {
@@ -1108,7 +1118,7 @@ impl TopicsStore {
         let creator_id = viewer_user_id(cx);
         let append = MessagesStore::global(cx).update(cx, |store, cx| {
             store.set_active_topic(Some(topic_id), cx);
-            let append = store.append_topic_message(topic_id, ack, anonymous, cx);
+            let append = store.append_topic_message(topic_id, ack, anonymous, local_sources, cx);
             if is_new_topic {
                 store.mark_message_as_topic(
                     ChannelId(parent_channel_id),
@@ -1251,6 +1261,9 @@ impl TopicsStore {
                     generation,
                     ack,
                     anonymous,
+                    // A url attachment (Tenor, a pasted link) has no file on this
+                    // disk to show.
+                    Vec::new(),
                     cx,
                 );
             });

--- a/crates/mezon-store/src/topics.rs
+++ b/crates/mezon-store/src/topics.rs
@@ -794,9 +794,14 @@ impl TopicsStore {
         // the file on this disk. Keep the paths so the sender sees the picture they
         // just sent instead of fetching a proxied copy of it back — the same thing
         // `MessageAttachment::optimistic_local` does for a channel send.
-        let local_sources: Vec<Option<std::path::PathBuf>> = attachments
+        let local_sources: Vec<(String, Option<std::path::PathBuf>)> = attachments
             .iter()
-            .map(|att| att.filetype.starts_with("image/").then(|| att.path.clone()))
+            .map(|att| {
+                (
+                    att.filename.clone(),
+                    att.filetype.starts_with("image/").then(|| att.path.clone()),
+                )
+            })
             .collect();
         let reply_ref =
             self.reply_target
@@ -1106,7 +1111,7 @@ impl TopicsStore {
         generation: u64,
         ack: mezon_client::transport::ApiMessage,
         anonymous: bool,
-        local_sources: Vec<Option<std::path::PathBuf>>,
+        local_sources: Vec<(String, Option<std::path::PathBuf>)>,
         cx: &mut Context<Self>,
     ) {
         if self.compose_generation != generation {

--- a/crates/mezon-ui/src/app/capture.rs
+++ b/crates/mezon-ui/src/app/capture.rs
@@ -461,7 +461,12 @@ fn topic_snapshot(cx: &App) -> anyhow::Result<Value> {
         .map(|(composer, _)| composer.read(cx).probe_attachments())
         .unwrap_or_default();
     Ok(json!({
+        // The store's flag and the mounted view are two different things: an
+        // occluded window drops the panel entity while the store still says the
+        // topic is open, and every write tool then fails with "no topic panel is
+        // mounted". Report both so a caller can tell those apart.
         "panel_open": topics.is_panel_open(),
+        "panel_mounted": topic_panel(cx).is_ok(),
         "topic_id": topic_id.map(|id| id.to_string()),
         "origin_message_id": topics.origin_message().map(|m| m.id.get().to_string()),
         "loaded_count": loaded,

--- a/crates/mezon-ui/src/app/capture.rs
+++ b/crates/mezon-ui/src/app/capture.rs
@@ -322,11 +322,22 @@ fn composer_snapshot(cx: &mut App) -> anyhow::Result<Value> {
         .ok_or_else(|| anyhow::anyhow!("no composer is mounted; open a channel first"))?;
     let composer = composer.read(cx);
     let (popup_open, selected, suggestions) = composer.probe_suggestions();
+    let reply_target = mezon_store::MessagesStore::global(cx)
+        .read(cx)
+        .reply_target()
+        .map(|draft| {
+            json!({
+                "message_id": draft.message_ref_id.get().to_string(),
+                "sender": draft.sender_name,
+            })
+        });
     Ok(json!({
         "text": composer.probe_text(cx).to_string(),
         // Staged, not dropped: a dropped file is read on a background task, so
         // submitting before it lands here sends the message without it.
         "attachments": composer.probe_attachments(),
+        // What the next submit will answer, if anything.
+        "reply_target": reply_target,
         "popup_open": popup_open,
         "selected": selected,
         "suggestions": suggestions,
@@ -670,6 +681,29 @@ pub fn topic_drop_paths(cx: &mut App, paths: Vec<String>) -> anyhow::Result<Valu
     // ready. Poll topic_state until `attachments` lists the files before calling
     // topic_submit, or the reply goes out without them.
     Ok(json!({ "ok": true, "dropped": count, "staged": false }))
+}
+
+/// Aim the composer at a message without sending anything, the way the row's
+/// "Reply" action does. `reply_to_message` posts a text reply in one shot, so it
+/// cannot carry a staged attachment — this is what lets a caller build a reply
+/// that has one.
+pub fn reply_begin(cx: &mut App, message_id: i64) -> anyhow::Result<Value> {
+    let store = mezon_store::MessagesStore::global(cx);
+    store.update(cx, |store, cx| {
+        store.set_reply_to(mezon_store::MessageId::new(message_id), cx)
+    });
+    let target = store.read(cx).reply_target().map(|draft| {
+        json!({
+            "message_id": draft.message_ref_id.get().to_string(),
+            "sender": draft.sender_name,
+        })
+    });
+    let Some(target) = target else {
+        anyhow::bail!(
+            "message {message_id} is not in the open channel's loaded history; open_channel and load_more_messages first"
+        );
+    };
+    Ok(json!({ "ok": true, "reply_target": target }))
 }
 
 pub const WHEEL_TICK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(16);

--- a/crates/mezon-ui/src/app/capture.rs
+++ b/crates/mezon-ui/src/app/capture.rs
@@ -1146,14 +1146,29 @@ pub fn open_message_image_viewer(
     cx: &mut App,
 ) -> anyhow::Result<Value> {
     let store = mezon_store::MessagesStore::global(cx);
+    let topic_id = mezon_store::TopicsStore::global(cx)
+        .read(cx)
+        .active_topic_id();
     let (seed, id, create_time, uploader_id) = {
         let store = store.read(cx);
+        // A reply lives in the topic's own bucket, not the channel's, so looking
+        // only at the channel makes every topic attachment unreachable from here.
         let message = store
             .messages()
             .iter()
             .find(|message| message.id.0 == message_id)
+            .or_else(|| {
+                topic_id.and_then(|id| {
+                    store
+                        .messages_in_channel(mezon_store::ChannelId(id))
+                        .iter()
+                        .find(|message| message.id.0 == message_id)
+                })
+            })
             .ok_or_else(|| {
-                anyhow::anyhow!("message {message_id} is not in the open channel's loaded history")
+                anyhow::anyhow!(
+                    "message {message_id} is not in the open channel's loaded history, nor in the open topic's"
+                )
             })?;
         let attachment = message.attachments.get(attachment_index).ok_or_else(|| {
             anyhow::anyhow!("message {message_id} has no attachment at index {attachment_index}")

--- a/crates/mezon-ui/src/app/capture.rs
+++ b/crates/mezon-ui/src/app/capture.rs
@@ -1158,11 +1158,30 @@ pub fn open_message_image_viewer(
         let attachment = message.attachments.get(attachment_index).ok_or_else(|| {
             anyhow::anyhow!("message {message_id} has no attachment at index {attachment_index}")
         })?;
+        // Mirror the row's own click gate (`parts.rs`): the tile is inert while the
+        // bytes are still going up, after they failed, or before the url exists.
+        // Without these the tool opens a viewer on an empty url and answers ok,
+        // which is a pass for something a user cannot do.
+        if attachment.uploading {
+            anyhow::bail!(
+                "attachment {attachment_index} of message {message_id} is still uploading; the row \
+                 does not open the viewer yet"
+            );
+        }
+        if attachment.upload_failed {
+            anyhow::bail!(
+                "attachment {attachment_index} of message {message_id} failed to upload, so there \
+                 is nothing to view"
+            );
+        }
         if attachment.presign_pending {
             anyhow::bail!(
                 "attachment {attachment_index} of message {message_id} is still waiting for its \
                  presign to finish, so its url does not resolve yet"
             );
+        }
+        if attachment.url.is_empty() {
+            anyhow::bail!("attachment {attachment_index} of message {message_id} has no url yet");
         }
         (
             mezon_store::AttachmentSeedInput::from_message(attachment),

--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -762,8 +762,17 @@ struct Uploader {
 /// Width below which the label is dropped: an album tile can be ~100px and the
 /// text would spill out of it. The spinner alone still reads as "working".
 const SENDING_LABEL_MIN_WIDTH: f32 = 160.;
+/// The spinner is 32px and the caption another ~16 above the gap. In a box
+/// shorter than this the stack does not fit and spills out of the tile, which is
+/// what makes a wide, short picture look broken rather than busy.
+const SENDING_LABEL_MIN_HEIGHT: f32 = 92.;
 
-fn attachment_sending_overlay(theme: &Theme, locale: &str, box_width: f32) -> impl IntoElement {
+fn attachment_sending_overlay(
+    theme: &Theme,
+    locale: &str,
+    box_width: f32,
+    box_height: f32,
+) -> impl IntoElement {
     div()
         .absolute()
         .inset_0()
@@ -771,20 +780,24 @@ fn attachment_sending_overlay(theme: &Theme, locale: &str, box_width: f32) -> im
         .flex_col()
         .items_center()
         .justify_center()
+        .overflow_hidden()
         .gap_2()
         .child(
             Spinner::new()
                 .with_size(Size::Large)
                 .color(theme.text_secondary.into()),
         )
-        .when(box_width >= SENDING_LABEL_MIN_WIDTH, |d| {
-            d.child(
-                div()
-                    .text_size(px(12.))
-                    .text_color(theme.text_secondary)
-                    .child(mezon_i18n::t(locale, "message.attachment.uploading")),
-            )
-        })
+        .when(
+            box_width >= SENDING_LABEL_MIN_WIDTH && box_height >= SENDING_LABEL_MIN_HEIGHT,
+            |d| {
+                d.child(
+                    div()
+                        .text_size(px(12.))
+                        .text_color(theme.text_secondary)
+                        .child(mezon_i18n::t(locale, "message.attachment.uploading")),
+                )
+            },
+        )
 }
 
 fn attachment_failed_overlay(theme: &Theme) -> impl IntoElement {
@@ -946,7 +959,14 @@ fn render_album(
                 tile.height,
             ));
         } else if att.presign_pending {
-            tile_element = presign_child(tile_element, att, theme, ctx.locale, tile.width);
+            tile_element = presign_child(
+                tile_element,
+                att,
+                theme,
+                ctx.locale,
+                tile.width,
+                tile.height,
+            );
         } else {
             let selection = ctx.selection.clone();
             let src = album_tile_src(cfg, att, tile.width, tile.height);
@@ -977,8 +997,12 @@ fn render_album(
         if att.upload_failed {
             tile_element = tile_element.child(attachment_failed_overlay(theme));
         } else if att.uploading {
-            tile_element =
-                tile_element.child(attachment_sending_overlay(theme, ctx.locale, tile.width));
+            tile_element = tile_element.child(attachment_sending_overlay(
+                theme,
+                ctx.locale,
+                tile.width,
+                tile.height,
+            ));
         }
         container = container.child(tile_element);
     }
@@ -1037,12 +1061,15 @@ fn presign_child(
     theme: &Theme,
     locale: &str,
     box_width: f32,
+    box_height: f32,
 ) -> gpui::Stateful<gpui::Div> {
     // A recipient never sees `uploading` — only `presign_pending` — so without
     // this the whole upload window is a bare spinner on their side while the
     // sender gets a labelled one.
     if att.thumbnail.is_empty() {
-        parent.child(attachment_sending_overlay(theme, locale, box_width))
+        parent.child(attachment_sending_overlay(
+            theme, locale, box_width, box_height,
+        ))
     } else {
         parent
             .child(
@@ -1050,7 +1077,9 @@ fn presign_child(
                     .size_full()
                     .object_fit(ObjectFit::Cover),
             )
-            .child(attachment_sending_overlay(theme, locale, box_width))
+            .child(attachment_sending_overlay(
+                theme, locale, box_width, box_height,
+            ))
     }
 }
 
@@ -1142,6 +1171,7 @@ fn render_photo(
                 theme,
                 ctx.locale,
                 att.display_width,
+                att.display_height,
             ));
         }
         return el.into_any_element();
@@ -1158,7 +1188,14 @@ fn render_photo(
             .items_center()
             .justify_center()
             .bg(theme.bg_tertiary);
-        placeholder = presign_child(placeholder, att, theme, ctx.locale, att.display_width);
+        placeholder = presign_child(
+            placeholder,
+            att,
+            theme,
+            ctx.locale,
+            att.display_width,
+            att.display_height,
+        );
         if att.upload_failed {
             placeholder = placeholder.child(attachment_failed_overlay(theme));
         } else if sending {
@@ -1166,6 +1203,7 @@ fn render_photo(
                 theme,
                 ctx.locale,
                 att.display_width,
+                att.display_height,
             ));
         }
         return placeholder.into_any_element();
@@ -1241,6 +1279,7 @@ fn render_photo(
             theme,
             ctx.locale,
             att.display_width,
+            att.display_height,
         ));
     }
     el.into_any_element()
@@ -1314,12 +1353,20 @@ fn render_video_poster(
                 theme,
                 ctx.locale,
                 att.display_width,
+                att.display_height,
             ))
             .into_any_element();
     }
     if att.presign_pending {
-        return presign_child(container, att, theme, ctx.locale, att.display_width)
-            .into_any_element();
+        return presign_child(
+            container,
+            att,
+            theme,
+            ctx.locale,
+            att.display_width,
+            att.display_height,
+        )
+        .into_any_element();
     }
     let overlay = div()
         .absolute()

--- a/crates/mezon-ui/src/image_cache.rs
+++ b/crates/mezon-ui/src/image_cache.rs
@@ -2080,19 +2080,6 @@ impl Asset for MessageImageLoader {
         let svg_renderer = cx.svg_renderer();
         let asset_source = cx.asset_source().clone();
         async move {
-            // TEMP DEBUG (img-render): not for commit.
-            let render_started = std::time::Instant::now();
-            let render_kind = match &source {
-                Resource::Path(_) => "local-file",
-                Resource::Uri(uri) if uri.contains("imgproxy") => "imgproxy",
-                Resource::Uri(_) => "cdn-direct",
-                Resource::Embedded(_) => "embedded",
-            };
-            let render_src = match &source {
-                Resource::Path(p) => p.to_string_lossy().into_owned(),
-                Resource::Uri(uri) => uri.to_string(),
-                Resource::Embedded(p) => p.to_string(),
-            };
             let _permit = acquire_image_pipeline_permit().await?;
             let bytes = match source.clone() {
                 Resource::Path(uri) => {
@@ -2100,15 +2087,10 @@ impl Asset for MessageImageLoader {
                         && let Some(decoded) =
                             decode_scaled_dynamic_path(uri.as_ref(), MESSAGE_STATIC_MAX_PX)
                     {
-                        let frame = downscaled_static_frame(decoded, MESSAGE_STATIC_MAX_PX);
-                        tracing::info!(
-                            target: "img_render",
-                            kind = render_kind,
-                            ms = render_started.elapsed().as_millis() as u64,
-                            src = %render_src,
-                            "message image ready"
-                        );
-                        return Ok(Arc::new(RenderImage::new(vec![frame])));
+                        return Ok(Arc::new(RenderImage::new(vec![downscaled_static_frame(
+                            decoded,
+                            MESSAGE_STATIC_MAX_PX,
+                        )])));
                     }
                     std::fs::read(uri.as_ref())?
                 }
@@ -2142,8 +2124,7 @@ impl Asset for MessageImageLoader {
                 },
             };
 
-            let fetched = bytes.len();
-            let out = if image::guess_format(&bytes).is_ok() {
+            if image::guess_format(&bytes).is_ok() {
                 decode_message_image(
                     &bytes,
                     MESSAGE_ANIMATION_MAX_PX,
@@ -2154,17 +2135,7 @@ impl Asset for MessageImageLoader {
                 svg_renderer
                     .render_single_frame(&bytes, 1.0)
                     .map_err(Into::into)
-            };
-            tracing::info!(
-                target: "img_render",
-                kind = render_kind,
-                ms = render_started.elapsed().as_millis() as u64,
-                bytes = fetched,
-                ok = out.is_ok(),
-                src = %render_src,
-                "message image ready"
-            );
-            out
+            }
         }
     }
 }

--- a/crates/mezon-ui/src/image_cache.rs
+++ b/crates/mezon-ui/src/image_cache.rs
@@ -2080,6 +2080,19 @@ impl Asset for MessageImageLoader {
         let svg_renderer = cx.svg_renderer();
         let asset_source = cx.asset_source().clone();
         async move {
+            // TEMP DEBUG (img-render): not for commit.
+            let render_started = std::time::Instant::now();
+            let render_kind = match &source {
+                Resource::Path(_) => "local-file",
+                Resource::Uri(uri) if uri.contains("imgproxy") => "imgproxy",
+                Resource::Uri(_) => "cdn-direct",
+                Resource::Embedded(_) => "embedded",
+            };
+            let render_src = match &source {
+                Resource::Path(p) => p.to_string_lossy().into_owned(),
+                Resource::Uri(uri) => uri.to_string(),
+                Resource::Embedded(p) => p.to_string(),
+            };
             let _permit = acquire_image_pipeline_permit().await?;
             let bytes = match source.clone() {
                 Resource::Path(uri) => {
@@ -2087,10 +2100,15 @@ impl Asset for MessageImageLoader {
                         && let Some(decoded) =
                             decode_scaled_dynamic_path(uri.as_ref(), MESSAGE_STATIC_MAX_PX)
                     {
-                        return Ok(Arc::new(RenderImage::new(vec![downscaled_static_frame(
-                            decoded,
-                            MESSAGE_STATIC_MAX_PX,
-                        )])));
+                        let frame = downscaled_static_frame(decoded, MESSAGE_STATIC_MAX_PX);
+                        tracing::info!(
+                            target: "img_render",
+                            kind = render_kind,
+                            ms = render_started.elapsed().as_millis() as u64,
+                            src = %render_src,
+                            "message image ready"
+                        );
+                        return Ok(Arc::new(RenderImage::new(vec![frame])));
                     }
                     std::fs::read(uri.as_ref())?
                 }
@@ -2124,7 +2142,8 @@ impl Asset for MessageImageLoader {
                 },
             };
 
-            if image::guess_format(&bytes).is_ok() {
+            let fetched = bytes.len();
+            let out = if image::guess_format(&bytes).is_ok() {
                 decode_message_image(
                     &bytes,
                     MESSAGE_ANIMATION_MAX_PX,
@@ -2135,7 +2154,17 @@ impl Asset for MessageImageLoader {
                 svg_renderer
                     .render_single_frame(&bytes, 1.0)
                     .map_err(Into::into)
-            }
+            };
+            tracing::info!(
+                target: "img_render",
+                kind = render_kind,
+                ms = render_started.elapsed().as_millis() as u64,
+                bytes = fetched,
+                ok = out.is_ok(),
+                src = %render_src,
+                "message image ready"
+            );
+            out
         }
     }
 }


### PR DESCRIPTION
## The bug

Send a picture into a topic and the sender's own row fetches a proxied copy of the file it just uploaded. Measured on the same image:

| | render |
|---|---|
| channel send | `local-file` **16-22ms** |
| topic send | `imgproxy` **592ms**, and **1631ms** on a second run |

Worse than the latency: that request is the *first* fetch of a fresh rendition, seconds after the object was written. A proxy timeout there is cached as a failure for a week — for every viewer — triggered by the one person who did not need the request at all.

## Why

A channel send builds an optimistic row through `MessageAttachment::optimistic_local`, which keeps the path to the file on this disk. A topic reply has no optimistic row at all: `TopicsStore::apply_reply_sent` waits for the ack and appends `message_from_api(...)`, and that always sets `local_source: None`.

## The change

`submit_reply` keeps the paths before the outgoing attachments are consumed, and `append_topic_message` attaches them to the echo — by index, and only when the counts line up. A mismatch means the echo is not the one those files belong to, and pointing a row at the wrong local file is worse than going to the network for it. A url attachment (Tenor, a pasted link) passes an empty list; it has no local file to show.

After: the same send logs `kind="local-file" ms=21 px="560x420"`, no proxy request.

## Tools

Both came out of testing this, and both close a gap that made a case untestable:

- **`reply_begin`** aims the composer at a message without sending anything, the way the row's Reply action does. `reply_to_message` posts a text reply in one call and cannot carry a staged attachment, so "reply with a picture" — the flow that once dropped its reply reference — could not be driven at all. `composer_state` now also reports `reply_target`.
- **`get_message`** returns the attachment list and the raw content JSON. Comparing `presign_finish` against the attachment urls is the only way to tell "a key never landed" apart from "the receiver mis-classified the attachment"; without it both look identical from outside.

## Testing

Driven through the MCP socket against CLAN TEST 01 #general, two clients (desktop + web) signed in as different accounts:

- Topic send before/after the change, timings above.
- Channel sends stay on `local-file`; receivers still go through the proxy (42-164ms warm, 525-636ms cold).
- Reply carrying an attachment: reference survives the presign patch, verified in the other client's UI.
- Eight file types in one message (png/jpg/gif/mp4/mp3/webm/pdf/txt): all settle clean, and every object lands on the CDN with its real Content-Type.
- `cargo test -p mezon-store -p mezon-mcp`: 1038 + 8 pass. Format clean. Clippy clean for the touched crates (the one error on develop, `integrations_tab.rs:661`, is untouched by this branch).