### PR TITLE
fix(pdf): hand the page bitmap back the way the rules require

### DIFF
--- a/crates/mezon-ui/src/pdf_viewer/mod.rs
+++ b/crates/mezon-ui/src/pdf_viewer/mod.rs
@@ -336,8 +336,12 @@ impl PdfViewer {
 
     fn clear_page_image(&mut self, window: Option<&mut Window>, cx: &mut App) {
         self.rendered_key = None;
-        if let Some(image) = self.page_image.take() {
-            cx.drop_image(image, window);
+        let Some(image) = self.page_image.take() else {
+            return;
+        };
+        match window {
+            Some(window) => cx.drop_image(image, Some(window)),
+            None => crate::image_cache::queue_atlas_drop(cx, image),
         }
     }
 
@@ -351,6 +355,7 @@ impl PdfViewer {
         self._render_task = None;
         self.document = None;
         self.clear_page_image(window, cx);
+        crate::image_cache::release_freed_memory_to_os(cx);
     }
 
     fn close_window(&mut self, window: &mut Window, cx: &mut Context<Self>) {


### PR DESCRIPTION
Two memory-hygiene gaps in the viewer teardown, both caught while measuring what a close actually gives back.

`clear_page_image` passed its `Option<Window>` straight to `cx.drop_image`. With a window in hand that is right, but the `on_release` path has none, and a windowless `drop_image` misses any window checked out at that moment and leaks the atlas tile — the case `image_cache::queue_atlas_drop` exists for. In practice `release_resources` runs first and leaves nothing behind, so this is closing a hole rather than fixing a live leak, but it is the hole the guard in CLAUDE.md names.

`release_resources` also never asked the allocator to give the pages back, which `ImageViewer` does for the same reason: a page rasterised at full zoom is tens of megabytes, and freeing it is not the same as returning it.

Measured on macOS with a 3-page document, stepping zoom from 100% to 300%: footprint 104 MB with no viewer, 241 MB with it open, 524 MB at full zoom, and 122 MB once it is closed and settled. The atlas textures come back on their own — IOAccelerator 25.7 MB before, 71.6 MB at full zoom, 23.1 MB after — so the GPU side was already correct; this is about the host pages.