### PR TITLE
fix(markdown): let the copy button block the selection, copy the source

### DIFF
--- a/crates/mezon-ui/src/chat/inbox/row.rs
+++ b/crates/mezon-ui/src/chat/inbox/row.rs
@@ -1189,7 +1189,9 @@ fn render_inbox_message_spans(
                 children.push(element);
             }
             if let MessageSpan::CodeBlock {
-                text: code_text, ..
+                text: code_text,
+                fenced_source,
+                ..
             } = span
             {
                 if let Some(rel) = text[offset..].find(code_text.as_ref()) {
@@ -1198,7 +1200,12 @@ fn render_inbox_message_spans(
                 let copy_id =
                     SharedString::from(format!("inbox-code-copy-{notification_id}-{code_key}"));
                 code_key += 1;
-                children.push(render_inbox_code_block(theme, code_text, copy_id));
+                children.push(render_inbox_code_block(
+                    theme,
+                    code_text,
+                    copy_id,
+                    fenced_source.clone(),
+                ));
             }
             continue;
         }
@@ -1263,9 +1270,9 @@ fn render_inbox_code_block(
     theme: &Theme,
     text: &SharedString,
     copy_id: SharedString,
+    copy_source: SharedString,
 ) -> gpui::AnyElement {
     div()
-        .relative()
         .w_full()
         .min_w_0()
         .my_1()
@@ -1277,7 +1284,7 @@ fn render_inbox_code_block(
         .text_size(px(14.))
         .text_color(theme.tokens.text_theme_message)
         .child(text.clone())
-        .child(code_block_copy_overlay(copy_id, text.clone(), theme))
+        .child(code_block_copy_overlay(copy_id, copy_source, theme))
         .into_any_element()
 }
 

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -757,13 +757,16 @@ fn render_selectable_segmented_spans(
                 );
                 base = end;
             }
-            MessageSpan::CodeBlock { text, .. } => {
+            MessageSpan::CodeBlock {
+                text,
+                fenced_source,
+                ..
+            } => {
                 let end = base + text.len();
                 let styled = selectable_segment(text, base, selected.as_ref());
                 segments.push(TextSegment::text(styled.layout().clone(), base..end));
                 row = row.child(
                     div()
-                        .relative()
                         .flex_basis(relative(1.))
                         .w_full()
                         .min_w_0()
@@ -777,8 +780,8 @@ fn render_selectable_segmented_spans(
                         .text_color(ctx.theme.tokens.text_theme_message)
                         .child(styled)
                         .child(code_block_copy_overlay(
-                            SharedString::from(format!("code-copy-{}-{base}", msg.id.0)),
-                            text.clone(),
+                            SharedString::from(format!("code-copy-{}-{base}", msg.row_anchor_id.0)),
+                            fenced_source.clone(),
                             ctx.theme,
                         )),
                 );
@@ -1105,36 +1108,16 @@ pub(crate) fn selectable_spans_text(spans: &[MessageSpan], locale: &str, cx: &Ap
     text
 }
 
-/// Copy affordance pinned to the top-right of a markdown code block, matching
-/// React `TripleBackticks`. Callers own the element id: it has to stay unique
-/// across every code block alive on screen, because a duplicate id kills the
-/// click and makes two blocks share one copied state.
-pub(crate) fn code_block_copy_button(
-    id: impl Into<gpui::ElementId>,
-    text: SharedString,
-    theme: &Theme,
-) -> CopyButton {
-    CopyButton::new(
-        id,
-        text,
-        theme.tokens.text_theme_message,
-        theme.tokens.bg_item_theme_hover,
-    )
-    .size(px(14.))
-}
-
-/// Absolutely-positioned wrapper for [`code_block_copy_button`]; the code block
-/// itself must be `relative()`.
 pub(crate) fn code_block_copy_overlay(
     id: impl Into<gpui::ElementId>,
     text: SharedString,
     theme: &Theme,
 ) -> gpui::Div {
-    div()
-        .absolute()
-        .top(px(4.))
-        .right(px(4.))
-        .child(code_block_copy_button(id, text, theme))
+    let overlay = div().absolute().top(px(8.)).right(px(8.));
+    if text.is_empty() {
+        return overlay;
+    }
+    overlay.child(CopyButton::new(id, text, theme.tokens.text_theme_message))
 }
 
 fn append_selectable_section(text: &mut String, section: &str) {

--- a/crates/mezon-ui/src/chat/message_search.rs
+++ b/crates/mezon-ui/src/chat/message_search.rs
@@ -1040,13 +1040,16 @@ fn render_search_spans(
             MessageSpan::Emoji { name, .. } => {
                 row = row.child(div().max_w_full().min_w_0().child(name.to_string()));
             }
-            MessageSpan::CodeBlock { text, .. } => {
+            MessageSpan::CodeBlock {
+                text,
+                fenced_source,
+                ..
+            } => {
                 let copy_id =
                     SharedString::from(format!("search-code-copy-{}-{code_key}", message_id.get()));
                 code_key += 1;
                 row = row.child(
                     div()
-                        .relative()
                         .w_full()
                         .min_w_0()
                         .my_1()
@@ -1054,7 +1057,11 @@ fn render_search_spans(
                         .rounded_md()
                         .bg(code_bg)
                         .child(text.to_string())
-                        .child(code_block_copy_overlay(copy_id, text.clone(), theme)),
+                        .child(code_block_copy_overlay(
+                            copy_id,
+                            fenced_source.clone(),
+                            theme,
+                        )),
                 );
             }
             MessageSpan::Canvas { title, .. } | MessageSpan::Heading { text: title, .. } => {

--- a/crates/mezon-ui/src/chat/pinned_popover.rs
+++ b/crates/mezon-ui/src/chat/pinned_popover.rs
@@ -968,7 +968,11 @@ fn render_pin_spans(spans: &[MessageSpan], message_id: &str, theme: &Theme) -> g
                         .child(text.clone()),
                 );
             }
-            MessageSpan::CodeBlock { text, .. } => {
+            MessageSpan::CodeBlock {
+                text,
+                fenced_source,
+                ..
+            } => {
                 if has_inline {
                     col = col.child(row);
                     row = pin_inline_row();
@@ -995,7 +999,6 @@ fn render_pin_spans(spans: &[MessageSpan], message_id: &str, theme: &Theme) -> g
                 code_key += 1;
                 col = col.child(
                     div()
-                        .relative()
                         .w_full()
                         .min_w_0()
                         .max_w_full()
@@ -1007,7 +1010,11 @@ fn render_pin_spans(spans: &[MessageSpan], message_id: &str, theme: &Theme) -> g
                         .border_color(theme.tokens.border_primary)
                         .bg(code_bg)
                         .child(code_col)
-                        .child(code_block_copy_overlay(copy_id, text.clone(), theme)),
+                        .child(code_block_copy_overlay(
+                            copy_id,
+                            fenced_source.clone(),
+                            theme,
+                        )),
                 );
             }
         }

--- a/crates/mezon-ui/src/components/primitives/copy_button.rs
+++ b/crates/mezon-ui/src/components/primitives/copy_button.rs
@@ -1,39 +1,49 @@
 use std::time::{Duration, Instant};
 
 use gpui::{
-    App, ClipboardItem, Context, ElementId, Hsla, IntoElement, MouseButton, MouseDownEvent, Pixels,
-    RenderOnce, SharedString, Window, div, prelude::*, px,
+    App, ClipboardItem, Context, ElementId, Hsla, IntoElement, Pixels, RenderOnce, SharedString,
+    Task, Window, div, prelude::*, px,
 };
 
 use crate::components::primitives::{Icon, IconName};
 
-/// React resets the copied state after 5s (`MarkdownContent.tsx`, `TripleBackticks`).
 const COPIED_DURATION: Duration = Duration::from_secs(5);
+const COPY_ICON_SIZE: Pixels = px(16.);
+const COPIED_ICON_SIZE: Pixels = px(20.);
 
 pub struct CopyButtonState {
     copied_at: Option<Instant>,
+    _reset: Option<Task<()>>,
 }
 
 impl CopyButtonState {
     fn new(_window: &mut Window, _cx: &mut Context<Self>) -> Self {
-        Self { copied_at: None }
+        Self {
+            copied_at: None,
+            _reset: None,
+        }
     }
 
     fn is_copied(&self) -> bool {
         self.copied_at
             .is_some_and(|at| at.elapsed() < COPIED_DURATION)
     }
+
+    fn mark_copied(&mut self, cx: &mut Context<Self>) {
+        self.copied_at = Some(Instant::now());
+        self._reset = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(COPIED_DURATION).await;
+            this.update(cx, |_, cx| cx.notify()).ok();
+        }));
+        cx.notify();
+    }
 }
 
-/// Copy-to-clipboard icon button. React shows `CopyIcon`, swapping to `PasteIcon`
-/// (a check mark) for five seconds after a copy.
 #[derive(IntoElement)]
 pub struct CopyButton {
     id: ElementId,
     text: SharedString,
     color: Hsla,
-    hover_bg: Hsla,
-    size: Pixels,
 }
 
 impl CopyButton {
@@ -41,32 +51,23 @@ impl CopyButton {
         id: impl Into<ElementId>,
         text: impl Into<SharedString>,
         color: impl Into<Hsla>,
-        hover_bg: impl Into<Hsla>,
     ) -> Self {
         Self {
             id: id.into(),
             text: text.into(),
             color: color.into(),
-            hover_bg: hover_bg.into(),
-            size: px(16.),
         }
-    }
-
-    pub fn size(mut self, size: Pixels) -> Self {
-        self.size = size;
-        self
     }
 }
 
 impl RenderOnce for CopyButton {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let state = window.use_keyed_state(self.id.clone(), cx, CopyButtonState::new);
-        let icon = if state.read(cx).is_copied() {
-            IconName::PasteIcon
+        let (icon, size) = if state.read(cx).is_copied() {
+            (IconName::PasteIcon, COPIED_ICON_SIZE)
         } else {
-            IconName::CopyIcon
+            (IconName::CopyIcon, COPY_ICON_SIZE)
         };
-        let hover_bg = self.hover_bg;
         let text = self.text;
 
         div()
@@ -74,28 +75,15 @@ impl RenderOnce for CopyButton {
             .flex()
             .items_center()
             .justify_center()
-            .p_1()
-            .rounded(px(4.))
             .cursor_pointer()
-            .hover(move |s| s.bg(hover_bg))
-            // Without this the press starts a text selection drag over the block.
-            .on_mouse_down(MouseButton::Left, |_: &MouseDownEvent, _, cx| {
-                cx.stop_propagation();
-            })
+            .occlude()
             .on_click(move |_, _, cx| {
-                cx.stop_propagation();
+                if text.is_empty() {
+                    return;
+                }
                 cx.write_to_clipboard(ClipboardItem::new_string(text.to_string()));
-                state.update(cx, |state, cx| {
-                    state.copied_at = Some(Instant::now());
-                    cx.notify();
-                });
-                let state_id = state.entity_id();
-                cx.spawn(async move |cx| {
-                    cx.background_executor().timer(COPIED_DURATION).await;
-                    cx.update(|cx| cx.notify(state_id))
-                })
-                .detach();
+                state.update(cx, |state, cx| state.mark_copied(cx));
             })
-            .child(Icon::new(icon).size(self.size).text_color(self.color))
+            .child(Icon::new(icon).size(size).text_color(self.color))
     }
 }


### PR DESCRIPTION
Review follow-up on the code-block copy affordance.

`on_mouse_down` + `stop_propagation` could not keep the press off the timeline: it is a bubble-phase listener, while the selection host reads mouse-down in the capture phase and only checks whether its hitbox is hovered. Pressing Copy therefore cleared the live selection, re-anchored inside the block and pulled focus off the composer. `.occlude()` takes the hitbox out of the hit test instead, which is what actually stops it.

The button copied the span's display text, which `strip_code_fence` has already trimmed twice and stripped the language line from — so pasted code came back missing the first line's indentation. It now copies `fenced_source`, the raw fence body React hands to `writeText`.

An empty fence still rendered a button that wrote an empty string, and `ClipboardItem` clears the pasteboard before writing: one click on someone else's ```` `````` ```` and whatever the user had copied was gone. The overlay now renders nothing when there is nothing to copy.

Also: key the element id on `row_anchor_id` so the checkmark survives the optimistic-to-echo id swap; hold the five-second reset in the state so a re-click replaces it instead of parking another detached timer; drop the four `relative()` calls (GPUI positions relative by default); and match React's geometry — `right-2 top-3` over the block, a 16px copy icon that grows to 20px on copy, and no invented hover pill.