### PR TITLE
feat(chat): show a poster on YouTube and TikTok link cards

### DIFF
--- a/crates/mezon-client/src/lib.rs
+++ b/crates/mezon-client/src/lib.rs
@@ -17,6 +17,7 @@ pub mod ogp;
 pub mod search_message;
 pub mod server_clock;
 pub mod session;
+pub mod social;
 pub mod tls_crypto;
 pub mod transport;
 pub mod transport_adapter;

--- a/crates/mezon-client/src/social.rs
+++ b/crates/mezon-client/src/social.rs
@@ -1,0 +1,247 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use futures::AsyncReadExt as _;
+use http_client::{AsyncBody, HttpClient, HttpRequestExt as _, RedirectPolicy, http};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+
+use crate::transport_runtime::{http_client, runtime};
+
+const SOCIAL_TIMEOUT: Duration = Duration::from_secs(10);
+const OEMBED_MAX_BYTES: usize = 64 * 1024;
+const TIKTOK_MAX_REDIRECTS: usize = 3;
+const SOCIAL_USER_AGENT: &str =
+    "Mozilla/5.0 (compatible; MezonDesktop/1.0; +https://mezon.ai) LinkPreview";
+const YOUTUBE_ID_LEN: usize = 11;
+const YOUTUBE_POSTER_BASE: &str = "https://i.ytimg.com/vi/";
+const YOUTUBE_POSTER_QUALITIES: [&str; 2] = ["maxresdefault.jpg", "mqdefault.jpg"];
+const YOUTUBE_MARKERS: [&str; 6] = [
+    "youtube.com/watch?v=",
+    "youtube.com/embed/",
+    "youtube.com/shorts/",
+    "youtube.com/v/",
+    "youtube.com/e/",
+    "youtu.be/",
+];
+
+pub fn youtube_video_id(url: &str) -> Option<&str> {
+    let rest = YOUTUBE_MARKERS
+        .iter()
+        .find_map(|marker| url.split_once(marker).map(|(_, rest)| rest))?;
+    let id = rest
+        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '_'))
+        .next()?;
+    (id.len() >= YOUTUBE_ID_LEN).then(|| &id[..YOUTUBE_ID_LEN])
+}
+
+pub fn youtube_poster_url(video_id: &str) -> String {
+    format!(
+        "{YOUTUBE_POSTER_BASE}{video_id}/{}",
+        YOUTUBE_POSTER_QUALITIES[0]
+    )
+}
+
+pub fn youtube_poster_fallback(poster_url: &str) -> Option<String> {
+    let (video_id, quality) = poster_url
+        .strip_prefix(YOUTUBE_POSTER_BASE)?
+        .split_once('/')?;
+    let current = YOUTUBE_POSTER_QUALITIES
+        .iter()
+        .position(|candidate| *candidate == quality)?;
+    let next = YOUTUBE_POSTER_QUALITIES.get(current + 1)?;
+    Some(format!("{YOUTUBE_POSTER_BASE}{video_id}/{next}"))
+}
+
+pub fn is_youtube_shorts(url: &str) -> bool {
+    url.contains("youtube.com/shorts/")
+}
+
+pub fn is_tiktok_link(url: &str) -> bool {
+    url.contains("tiktok.com/")
+}
+
+fn is_tiktok_video_page(url: &str) -> bool {
+    url.split_once("tiktok.com/@")
+        .and_then(|(_, rest)| rest.split_once("/video/"))
+        .and_then(|(_, id)| id.chars().next())
+        .is_some_and(|first| first.is_ascii_digit())
+}
+
+fn tiktok_oembed_url(video_url: &str) -> String {
+    format!(
+        "https://www.tiktok.com/oembed?url={}",
+        utf8_percent_encode(video_url, NON_ALPHANUMERIC)
+    )
+}
+
+fn tiktok_poster_from_oembed(body: &[u8]) -> Option<String> {
+    let payload: serde_json::Value = serde_json::from_slice(body).ok()?;
+    let url = payload.get("thumbnail_url")?.as_str()?.trim();
+    url.starts_with("https://").then(|| url.to_string())
+}
+
+pub async fn fetch_tiktok_poster(url: &str) -> Result<String> {
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        anyhow::bail!("unsupported url scheme");
+    }
+    let url = url.to_string();
+    runtime()
+        .spawn(async move {
+            let outcome = tokio::time::timeout(SOCIAL_TIMEOUT, async move {
+                let page = resolve_tiktok_page(url).await?;
+                let request = http::Request::builder()
+                    .method(http::Method::GET)
+                    .uri(tiktok_oembed_url(&page))
+                    .header(http::header::USER_AGENT, SOCIAL_USER_AGENT)
+                    .header(http::header::ACCEPT, "application/json")
+                    .body(AsyncBody::empty())?;
+                let mut response = http_client().send(request).await?;
+                if !response.status().is_success() {
+                    anyhow::bail!("tiktok oembed failed with status {}", response.status());
+                }
+                let mut bytes = Vec::new();
+                response
+                    .body_mut()
+                    .take(OEMBED_MAX_BYTES as u64)
+                    .read_to_end(&mut bytes)
+                    .await?;
+                tiktok_poster_from_oembed(&bytes)
+                    .ok_or_else(|| anyhow::anyhow!("tiktok oembed carried no thumbnail"))
+            })
+            .await;
+            match outcome {
+                Ok(inner) => inner,
+                Err(_) => anyhow::bail!(
+                    "tiktok poster fetch timed out after {}s",
+                    SOCIAL_TIMEOUT.as_secs()
+                ),
+            }
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("tiktok poster fetch task failed: {e}"))?
+}
+
+async fn resolve_tiktok_page(url: String) -> Result<String> {
+    let mut current = url;
+    for _ in 0..TIKTOK_MAX_REDIRECTS {
+        if is_tiktok_video_page(&current) {
+            return Ok(current);
+        }
+        let request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri(&current)
+            .header(http::header::USER_AGENT, SOCIAL_USER_AGENT)
+            .follow_redirects(RedirectPolicy::NoFollow)
+            .body(AsyncBody::empty())?;
+        let response = http_client().send(request).await?;
+        if !response.status().is_redirection() {
+            break;
+        }
+        let Some(location) = response
+            .headers()
+            .get(http::header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+        else {
+            break;
+        };
+        current = location.to_string();
+    }
+    if is_tiktok_video_page(&current) {
+        Ok(current)
+    } else {
+        anyhow::bail!("not a tiktok video url")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn youtube_ids_come_from_every_link_shape() {
+        assert_eq!(
+            youtube_video_id("https://www.youtube.com/watch?v=lHW3fsJQ1sg"),
+            Some("lHW3fsJQ1sg")
+        );
+        assert_eq!(
+            youtube_video_id("https://youtu.be/lHW3fsJQ1sg?t=42"),
+            Some("lHW3fsJQ1sg")
+        );
+        assert_eq!(
+            youtube_video_id("https://m.youtube.com/shorts/lHW3fsJQ1sg"),
+            Some("lHW3fsJQ1sg")
+        );
+        assert_eq!(
+            youtube_video_id("https://www.youtube.com/embed/lHW3fsJQ1sg?rel=0"),
+            Some("lHW3fsJQ1sg")
+        );
+        assert_eq!(
+            youtube_video_id("https://www.youtube.com/watch?v=lHW3fsJQ1sg&list=PL1"),
+            Some("lHW3fsJQ1sg")
+        );
+    }
+
+    #[test]
+    fn youtube_id_needs_a_full_length_id() {
+        assert_eq!(youtube_video_id("https://youtu.be/abc"), None);
+        assert_eq!(youtube_video_id("https://example.com/watch?v=abc"), None);
+    }
+
+    #[test]
+    fn youtube_poster_is_the_hq_still() {
+        assert_eq!(
+            youtube_poster_url("lHW3fsJQ1sg"),
+            "https://i.ytimg.com/vi/lHW3fsJQ1sg/maxresdefault.jpg"
+        );
+        assert_eq!(
+            youtube_poster_fallback("https://i.ytimg.com/vi/lHW3fsJQ1sg/maxresdefault.jpg")
+                .as_deref(),
+            Some("https://i.ytimg.com/vi/lHW3fsJQ1sg/mqdefault.jpg")
+        );
+        assert_eq!(
+            youtube_poster_fallback("https://i.ytimg.com/vi/lHW3fsJQ1sg/mqdefault.jpg"),
+            None
+        );
+        assert_eq!(
+            youtube_poster_fallback("https://p16.tiktokcdn.com/a.image"),
+            None
+        );
+        assert!(is_youtube_shorts(
+            "https://www.youtube.com/shorts/lHW3fsJQ1sg"
+        ));
+        assert!(!is_youtube_shorts(
+            "https://www.youtube.com/watch?v=lHW3fsJQ1sg"
+        ));
+    }
+
+    #[test]
+    fn tiktok_video_pages_need_a_numeric_id() {
+        assert!(is_tiktok_video_page(
+            "https://www.tiktok.com/@user/video/123"
+        ));
+        assert!(!is_tiktok_video_page(
+            "https://www.tiktok.com/@user/video/١٢٣"
+        ));
+        assert!(!is_tiktok_video_page("https://vm.tiktok.com/ZSjnnkQeP/"));
+        assert!(is_tiktok_link("https://vm.tiktok.com/ZSjnnkQeP/"));
+    }
+
+    #[test]
+    fn tiktok_oembed_url_encodes_the_video_url() {
+        assert_eq!(
+            tiktok_oembed_url("https://www.tiktok.com/@user/video/123"),
+            "https://www.tiktok.com/oembed?url=https%3A%2F%2Fwww%2Etiktok%2Ecom%2F%40user%2Fvideo%2F123"
+        );
+    }
+
+    #[test]
+    fn tiktok_poster_reads_the_oembed_thumbnail() {
+        let body = br#"{"type":"video","thumbnail_url":"https://p16.tiktokcdn.com/a.image?x=1"}"#;
+        assert_eq!(
+            tiktok_poster_from_oembed(body).as_deref(),
+            Some("https://p16.tiktokcdn.com/a.image?x=1")
+        );
+        assert_eq!(tiktok_poster_from_oembed(br#"{"type":"video"}"#), None);
+        assert_eq!(tiktok_poster_from_oembed(b"not json"), None);
+    }
+}

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -1273,6 +1273,7 @@ pub struct ChannelMessages {
     small_avatar_image_cache: Entity<LruImageCache>,
     icon_image_cache: Entity<LruImageCache>,
     ogp_image_cache: Entity<LruImageCache>,
+    social_image_cache: Entity<LruImageCache>,
     active_videos: Rc<HashMap<(MessageId, usize), Entity<VideoPlayerView>>>,
     active_audios: Rc<indexmap::IndexMap<(MessageId, usize), Entity<AudioPlayerView>>>,
     gif_videos: Rc<HashMap<(MessageId, usize), Entity<GifVideoView>>>,
@@ -1854,6 +1855,7 @@ impl ChannelMessages {
             )
         });
         let ogp_image_cache = crate::image_cache::ogp_timeline_cache("message-ogp", cx);
+        let social_image_cache = crate::image_cache::social_thumb_cache("message-social", cx);
         let last_cold_inputs = Self::cold_inputs(cx);
         let (welcome, onboarding) = Self::compute_indicator_contexts(cx);
         let cached_unread_boundary = unread_boundary(&MessagesStore::global(cx), None, cx);
@@ -1934,6 +1936,7 @@ impl ChannelMessages {
             small_avatar_image_cache,
             icon_image_cache,
             ogp_image_cache,
+            social_image_cache,
             active_videos: Rc::new(HashMap::new()),
             active_audios: Rc::new(indexmap::IndexMap::new()),
             gif_videos: Rc::new(HashMap::new()),
@@ -4618,6 +4621,7 @@ impl ChannelMessages {
         let avatar_image_cache = self.avatar_image_cache.clone();
         let small_avatar_image_cache = self.small_avatar_image_cache.clone();
         let ogp_image_cache = self.ogp_image_cache.clone();
+        let social_image_cache = self.social_image_cache.clone();
         let icon_image_cache = self.icon_image_cache.clone();
         let reply_highlight_id = TopicsStore::global(cx)
             .read(cx)
@@ -4682,6 +4686,7 @@ impl ChannelMessages {
                         large_avatar_cache: avatar_image_cache.clone(),
                         icon_cache: icon_image_cache.clone(),
                         ogp_cache: ogp_image_cache.clone(),
+                        social_cache: social_image_cache.clone(),
                         unread_boundary_id: None,
                         highlight_id: None,
                         reply_highlight_id,
@@ -4887,6 +4892,7 @@ impl Render for ChannelMessages {
         let avatar_image_cache = self.avatar_image_cache.clone();
         let small_avatar_image_cache = self.small_avatar_image_cache.clone();
         let ogp_image_cache = self.ogp_image_cache.clone();
+        let social_image_cache = self.social_image_cache.clone();
         let icon_image_cache = self.icon_image_cache.clone();
         let unread_boundary_id = self.cached_unread_boundary;
         let highlight_id = self.highlight_id;
@@ -4959,6 +4965,7 @@ impl Render for ChannelMessages {
                         large_avatar_cache: avatar_image_cache.clone(),
                         icon_cache: icon_image_cache.clone(),
                         ogp_cache: ogp_image_cache.clone(),
+                        social_cache: social_image_cache.clone(),
                         unread_boundary_id,
                         highlight_id,
                         reply_highlight_id,

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -4,8 +4,8 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use gpui::{
-    AnyElement, App, Bounds, FontWeight, HighlightStyle, Hsla, InteractiveText, ObjectFit, Pixels,
-    SharedString, StyledText, TextLayout, UnderlineStyle, canvas, div, fill, img, point,
+    AnyElement, App, Bounds, Entity, FontWeight, HighlightStyle, Hsla, InteractiveText, ObjectFit,
+    Pixels, SharedString, StyledText, TextLayout, UnderlineStyle, canvas, div, fill, img, point,
     prelude::*, px, relative, rems, rgb, rgba, size,
 };
 use mezon_store::{
@@ -24,6 +24,7 @@ use super::selection::{
 use crate::app::shell::Shell;
 use crate::chat::user_profile_popover::{ClickableContainer, UserProfilePopover};
 use crate::components::primitives::{CopyButton, Icon, IconName};
+use crate::image_cache::LruImageCache;
 use crate::router::{Route, navigate};
 use crate::theme::Theme;
 
@@ -36,6 +37,9 @@ const YOUTUBE_ACCENT: u32 = 0xff_00_1f;
 const TIKTOK_ACCENT: u32 = 0xff_00_50;
 const FACEBOOK_ACCENT: u32 = 0x18_77_f2;
 const SOCIAL_CARD_BG: u32 = 0x2b_2d_31;
+const SOCIAL_POSTER_BG: u32 = 0x1e_1f_22;
+const SOCIAL_CARD_WIDTH: f32 = 400.;
+const SOCIAL_CARD_PADDING: f32 = 16.;
 const EMOJI_SIZE: f32 = 24.;
 const EMOJI_JUMBO_SIZE: f32 = 48.;
 
@@ -865,12 +869,15 @@ fn render_selectable_segmented_spans(
                 }
                 let card_key = link_part_index;
                 link_part_index += 1;
+                let poster = social_poster(*kind, resolved.as_ref())
+                    .map(|poster| (poster, ctx.social_cache.clone()));
                 row = row.child(render_social_link_card(
                     *kind,
                     &ctx.selection,
                     resolved,
                     card_key,
                     url_col,
+                    poster,
                 ));
                 base += text.len();
             }
@@ -1701,6 +1708,7 @@ fn append_span(
                 SharedString::from(resolve_link_url(url, text)),
                 key,
                 render_social_link_url_row(text, theme),
+                None,
             ))
         }
         MessageSpan::Link { text, url, .. } => {
@@ -1838,6 +1846,87 @@ fn render_social_link_url_row(text: &SharedString, theme: &Theme) -> AnyElement 
         .into_any_element()
 }
 
+struct SocialPoster {
+    source: SharedString,
+    width: f32,
+    height: f32,
+}
+
+fn social_poster(kind: LinkKind, url: &str) -> Option<SocialPoster> {
+    match kind {
+        LinkKind::YouTube => {
+            let video_id = mezon_client::social::youtube_video_id(url)?;
+            let (width, height) = if mezon_client::social::is_youtube_shorts(url) {
+                (169., 300.)
+            } else {
+                (400., 225.)
+            };
+            Some(SocialPoster {
+                source: mezon_client::social::youtube_poster_url(video_id).into(),
+                width,
+                height,
+            })
+        }
+        LinkKind::TikTok => Some(SocialPoster {
+            source: SharedString::from(url.to_string()),
+            width: 253.,
+            height: 450.,
+        }),
+        LinkKind::Facebook | LinkKind::Plain => None,
+    }
+}
+
+fn render_social_poster(poster: SocialPoster, cache: Entity<LruImageCache>) -> AnyElement {
+    div()
+        .relative()
+        .w_full()
+        .max_w(px(poster.width))
+        .h(px(poster.height))
+        .flex_shrink_0()
+        .mt_1()
+        .rounded(px(8.))
+        .overflow_hidden()
+        .bg(rgb(SOCIAL_POSTER_BG))
+        .image_cache(cache)
+        .child(
+            div().absolute().inset_0().overflow_hidden().child(
+                img(poster.source)
+                    .w_full()
+                    .h_full()
+                    .object_fit(ObjectFit::Cover)
+                    .with_fallback(|| div().w_full().h_full().into_any_element()),
+            ),
+        )
+        .child(
+            div()
+                .absolute()
+                .inset_0()
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .size(px(48.))
+                        .rounded_full()
+                        .bg(gpui::Rgba {
+                            r: 0.,
+                            g: 0.,
+                            b: 0.,
+                            a: 0.5,
+                        })
+                        .child(
+                            Icon::new(IconName::PlayButton)
+                                .size(px(20.))
+                                .text_color(gpui::white()),
+                        ),
+                ),
+        )
+        .into_any_element()
+}
+
 fn render_social_link_card(
     kind: LinkKind,
     selection: &SharedSelection,
@@ -1846,6 +1935,7 @@ fn render_social_link_card(
     // hash to one id and the two cards would share their interactive state.
     key: usize,
     url_row: impl IntoElement,
+    poster: Option<(SocialPoster, Entity<LruImageCache>)>,
 ) -> AnyElement {
     let (accent, label) = match kind {
         LinkKind::YouTube => (YOUTUBE_ACCENT, "YouTube"),
@@ -1855,6 +1945,9 @@ fn render_social_link_card(
     };
     let id = ("msg-social", key);
     let selection = selection.clone();
+    let card_width = poster.as_ref().map_or(SOCIAL_CARD_WIDTH, |(poster, _)| {
+        (poster.width + SOCIAL_CARD_PADDING * 2.).max(SOCIAL_CARD_WIDTH)
+    });
     div()
         .flex()
         .flex_row()
@@ -1869,9 +1962,9 @@ fn render_social_link_card(
                 .gap_1()
                 .w_full()
                 .min_w_0()
-                .max_w(px(400.))
+                .max_w(px(card_width))
                 .my_1()
-                .p(px(16.))
+                .p(px(SOCIAL_CARD_PADDING))
                 .rounded(px(4.))
                 .border_l_4()
                 .border_color(rgb(accent))
@@ -1880,7 +1973,7 @@ fn render_social_link_card(
                 .cursor_pointer()
                 .on_click(move |_, _, cx| {
                     if !selection.borrow().has_selection() {
-                        open_message_link(resolved.to_string(), cx);
+                        PlatformStore::open_app_window(resolved.to_string(), cx);
                     }
                 })
                 .child(
@@ -1890,7 +1983,10 @@ fn render_social_link_card(
                         .text_color(rgb(accent))
                         .child(label),
                 )
-                .child(url_row),
+                .child(url_row)
+                .when_some(poster, |card, (poster, cache)| {
+                    card.child(render_social_poster(poster, cache))
+                }),
         )
         .into_any_element()
 }

--- a/crates/mezon-ui/src/chat/message/context.rs
+++ b/crates/mezon-ui/src/chat/message/context.rs
@@ -71,6 +71,7 @@ pub struct RowCtx<'a> {
     pub large_avatar_cache: Entity<LruImageCache>,
     pub icon_cache: Entity<LruImageCache>,
     pub ogp_cache: Entity<LruImageCache>,
+    pub social_cache: Entity<LruImageCache>,
     pub unread_boundary_id: Option<MessageId>,
     pub highlight_id: Option<MessageId>,
     pub reply_highlight_id: Option<MessageId>,

--- a/crates/mezon-ui/src/image_cache.rs
+++ b/crates/mezon-ui/src/image_cache.rs
@@ -174,6 +174,9 @@ const OGP_TIMELINE_CACHE_BYTES: u64 = 6 * 1024 * 1024;
 const OGP_AUX_CACHE_CAPACITY: usize = 4;
 const OGP_AUX_CACHE_BYTES: u64 = 2 * 1024 * 1024;
 const OGP_ENTRY_MAX_BYTES: u64 = 1024 * 1024;
+const SOCIAL_THUMB_CACHE_CAPACITY: usize = 12;
+const SOCIAL_THUMB_CACHE_BYTES: u64 = 12 * 1024 * 1024;
+const SOCIAL_THUMB_ENTRY_MAX_BYTES: u64 = 3 * 1024 * 1024 / 2;
 
 pub fn ogp_timeline_cache(label: &'static str, cx: &mut App) -> Entity<LruImageCache> {
     ogp_preview_cache(
@@ -195,6 +198,18 @@ fn ogp_preview_cache(
     cx: &mut App,
 ) -> Entity<LruImageCache> {
     cx.new(|cx| LruImageCache::ogp_thumbnail(label, capacity, bytes, OGP_ENTRY_MAX_BYTES, cx))
+}
+
+pub fn social_thumb_cache(label: &'static str, cx: &mut App) -> Entity<LruImageCache> {
+    cx.new(|cx| {
+        LruImageCache::social_thumbnail(
+            label,
+            SOCIAL_THUMB_CACHE_CAPACITY,
+            SOCIAL_THUMB_CACHE_BYTES,
+            SOCIAL_THUMB_ENTRY_MAX_BYTES,
+            cx,
+        )
+    })
 }
 
 /// Shared decode cache for role icons. They render at 12-20px everywhere, so
@@ -636,6 +651,7 @@ enum LoaderKind {
     /// Aspect-preserving thumbnail for OGP link previews, capped at
     /// [`OGP_THUMB_DECODE_MAX_PX`].
     OgpThumbnail,
+    SocialThumbnail,
     /// Aspect-preserving thumbnail for Timeline/Events/Event-Detail preview
     /// cards, capped at [`GALLERY_PREVIEW_DECODE_MAX_PX`].
     GalleryPreview,
@@ -816,6 +832,23 @@ impl LruImageCache {
         Self::with_loader(
             label,
             LoaderKind::OgpThumbnail,
+            max_items,
+            max_bytes,
+            max_entry_bytes,
+            cx,
+        )
+    }
+
+    pub fn social_thumbnail(
+        label: &'static str,
+        max_items: usize,
+        max_bytes: u64,
+        max_entry_bytes: u64,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self::with_loader(
+            label,
+            LoaderKind::SocialThumbnail,
             max_items,
             max_bytes,
             max_entry_bytes,
@@ -1234,6 +1267,9 @@ impl LruImageCache {
             LoaderKind::OgpThumbnail => {
                 AssetLogger::<OgpImageLoader>::load(resource.clone(), cx).boxed()
             }
+            LoaderKind::SocialThumbnail => {
+                AssetLogger::<SocialPosterLoader>::load(resource.clone(), cx).boxed()
+            }
             LoaderKind::GalleryPreview => {
                 AssetLogger::<GalleryPreviewLoader>::load(resource.clone(), cx).boxed()
             }
@@ -1343,6 +1379,8 @@ const GALLERY_THUMB_DECODE_MAX_PX: u32 = 320;
 /// side (aspect-preserving, ~2x for retina) so a large external OG image
 /// (typically 1200×630) can never decode oversized in the preview card.
 const OGP_THUMB_DECODE_MAX_PX: u32 = 512;
+const SOCIAL_THUMB_DECODE_MAX_PX: u32 = 640;
+const SOCIAL_POSTER_FETCH_MAX_BYTES: usize = 4 * 1024 * 1024;
 /// Timeline/Events/Event-Detail preview cards render up to ~900px wide
 /// (featured banner) at aspect ratio; decode to this longest side so the
 /// featured image stays sharp while grid/card thumbnails (much smaller on
@@ -2069,6 +2107,84 @@ impl Asset for OgpImageLoader {
         cx: &mut App,
     ) -> impl Future<Output = Self::Output> + Send + 'static {
         load_scaled_aspect(source, OGP_THUMB_DECODE_MAX_PX, cx)
+    }
+}
+
+fn load_social_poster(
+    source: Resource,
+    max_px: u32,
+    cx: &mut App,
+) -> impl Future<Output = Result<Arc<RenderImage>, ImageCacheError>> + Send + 'static {
+    let client = cx.http_client();
+    async move {
+        let _permit = acquire_image_pipeline_permit().await?;
+        use anyhow::Context as _;
+        let Resource::Uri(uri) = source else {
+            return Err(ImageCacheError::Asset(
+                "a social poster needs a link url".into(),
+            ));
+        };
+        let poster = if mezon_client::social::is_tiktok_link(uri.as_ref()) {
+            mezon_client::social::fetch_tiktok_poster(uri.as_ref())
+                .await
+                .with_context(|| format!("resolving a tiktok poster for {uri:?}"))?
+        } else {
+            uri.to_string()
+        };
+        let mut candidate = poster;
+        let bytes = loop {
+            match fetch_social_poster_bytes(&client, &candidate).await {
+                Ok(bytes) => break bytes,
+                Err(err) => match mezon_client::social::youtube_poster_fallback(&candidate) {
+                    Some(next) => candidate = next,
+                    None => return Err(err),
+                },
+            }
+        };
+        let decoded = match decode_scaled_dynamic(&bytes, max_px) {
+            Some(image) => image,
+            None => image::load_from_memory(&bytes)?,
+        };
+        Ok(Arc::new(RenderImage::new(vec![downscaled_static_frame(
+            decoded, max_px,
+        )])))
+    }
+}
+
+async fn fetch_social_poster_bytes(
+    client: &Arc<dyn gpui::http_client::HttpClient>,
+    poster: &str,
+) -> Result<Vec<u8>, ImageCacheError> {
+    use anyhow::Context as _;
+    let mut response = client
+        .get(poster, ().into(), true)
+        .await
+        .with_context(|| format!("loading a social poster from {poster:?}"))?;
+    let bytes = read_body_limited(&mut response, SOCIAL_POSTER_FETCH_MAX_BYTES).await?;
+    if !response.status().is_success() {
+        let mut body = String::from_utf8_lossy(&bytes).into_owned();
+        let first_line = body.lines().next().unwrap_or("").trim_end();
+        body.truncate(first_line.len());
+        return Err(ImageCacheError::BadStatus {
+            uri: poster.to_string().into(),
+            status: response.status(),
+            body,
+        });
+    }
+    Ok(bytes)
+}
+
+pub enum SocialPosterLoader {}
+
+impl Asset for SocialPosterLoader {
+    type Source = Resource;
+    type Output = Result<Arc<RenderImage>, ImageCacheError>;
+
+    fn load(
+        source: Self::Source,
+        cx: &mut App,
+    ) -> impl Future<Output = Self::Output> + Send + 'static {
+        load_social_poster(source, SOCIAL_THUMB_DECODE_MAX_PX, cx)
     }
 }
 


### PR DESCRIPTION
A social link card now renders the video's thumbnail with a play badge, and clicking it opens the link in the browser's app-window mode — the same path channel apps take. Nothing is embedded or played in-app.

YouTube posters are derived from the video id (maxresdefault, falling back to mqdefault for videos that have no HD still). TikTok has neither a derivable poster nor og:image on its page, so it resolves through the public oEmbed endpoint, following one redirect hop for vm.tiktok.com short links. Both load through a dedicated bounded cache (12 entries / 12 MB, decoded at 640px) and only in the message body: reply, pin and inbox previews stay text-only, as in React.

The poster image sits in an absolutely positioned layer because an in-flow img() feeds its intrinsic size into the row measurement and inflates the message row by ~185px even when its box has a fixed height.