### PR TITLE
fix(poll): render pinned and searched polls as read-only cards

### DIFF
--- a/crates/mezon-store/src/message_search.rs
+++ b/crates/mezon-store/src/message_search.rs
@@ -17,10 +17,11 @@ use crate::AppConfig;
 use crate::cache::KeyedCache;
 use crate::ids::{ChannelId, ClanId, MessageId, UserId};
 use crate::message::{
-    Embed, MessageAttachment, MessageSpan, OgpPreview, RichLayout, build_rich_layout, parse_spans,
+    Embed, MessageAttachment, MessageSpan, OgpPreview, PollData, RichLayout, build_rich_layout,
+    parse_spans,
 };
 use crate::message_time::{format_local_time_hhmm, local_datetime};
-use crate::messages::{MessagesStore, build_embeds, build_ogp_preview};
+use crate::messages::{MessagesStore, build_embeds, build_ogp_preview, build_poll_data};
 
 #[derive(Debug, Clone, Default)]
 pub struct ChannelSearchState {
@@ -59,6 +60,7 @@ pub struct SearchHit {
     pub rich_layout: Option<Arc<RichLayout>>,
     pub ogp: Option<Box<OgpPreview>>,
     pub embeds: Arc<[Embed]>,
+    pub poll: Option<Box<PollData>>,
     pub channel_label: SharedString,
     pub create_time_seconds: i64,
     pub time_hhmm: SharedString,
@@ -567,6 +569,7 @@ pub fn search_hit_from_document(
         rich_layout: parsed.rich_layout,
         ogp: parsed.ogp,
         embeds: parsed.embeds,
+        poll: parsed.poll,
         channel_label: SharedString::from(doc.channel_label.clone()),
         create_time_seconds,
         time_hhmm,
@@ -617,6 +620,7 @@ struct ParsedSearchContent {
     rich_layout: Option<Arc<RichLayout>>,
     ogp: Option<Box<OgpPreview>>,
     embeds: Arc<[Embed]>,
+    poll: Option<Box<PollData>>,
 }
 
 fn parse_search_hit_content(
@@ -640,7 +644,10 @@ fn parse_search_hit_content(
     let rich_layout = build_rich_layout(&spans);
     let ogp = build_ogp_preview(&tokens, cfg);
     let embeds = build_embeds(&tokens, cfg);
-    let preview = if tokens.t.is_empty() {
+    let poll = build_poll_data(&tokens, &tokens.t, cfg);
+    let preview = if poll.is_some() {
+        String::new()
+    } else if tokens.t.is_empty() {
         content_preview_from_raw(content_raw)
     } else {
         crate::message::reply_preview_line(tokens.t.trim())
@@ -651,6 +658,7 @@ fn parse_search_hit_content(
         rich_layout,
         ogp,
         embeds,
+        poll,
     }
 }
 
@@ -837,6 +845,19 @@ mod tests {
             content_preview_from_raw(r#"{"t":"hello world"}"#),
             "hello world"
         );
+    }
+
+    #[test]
+    fn search_hit_content_parses_poll_and_leaves_no_preview() {
+        let raw = r#"{"poll_id":7,"question":"gg","answers":["1","2"],"answer_counts":[1,1],"total_votes":2}"#;
+
+        let parsed = parse_search_hit_content(raw, "", None);
+
+        assert!(parsed.preview.is_empty());
+        let poll = parsed.poll.expect("poll parsed from search hit");
+        assert_eq!(poll.question.as_ref(), "gg");
+        assert_eq!(poll.answers.len(), 2);
+        assert_eq!(poll.total_votes, 2);
     }
 
     #[test]

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -29,13 +29,14 @@ use mezon_client::{
 use crate::AppConfig;
 use crate::KeyedCache;
 use crate::Settings;
-use crate::account::AccountStore;
+use crate::account::{AccountStore, UserAccount};
 use crate::album_layout::{AlbumLayout, calculate_album_layout};
 use crate::badge::BadgeService;
 use crate::channel::{ChannelEvent, ChannelList, ChannelType, STREAM_MODE_THREAD};
 use crate::channel_members::ChannelMembersStore;
 use crate::clan_members::ClanMembersStore;
-use crate::direct::{DirectKind, DirectMessageStore};
+use crate::direct::{DirectChannel, DirectKind, DirectMessageStore};
+use crate::group_members::GroupMembersStore;
 use crate::inbox::{GLOBAL_INBOX_BUCKET_CLAN_ID, InboxStore};
 use crate::message::{
     CallLog, CallLogType, Embed, EmbedAnimation, EmbedAuthor, EmbedDatePicker, EmbedField,
@@ -6114,11 +6115,15 @@ impl MessagesStore {
     ) -> Task<anyhow::Result<PollDetail>> {
         let api = self.api.clone();
         let cid = self.active_channel_id.map_or(0, |c| c.get());
-        let clan_id = self.active_clan_id.unwrap_or(ClanId(0));
+        let is_dm = self.is_dm;
+        let clan_id = (!is_dm).then_some(self.active_clan_id).flatten();
+        let dm_channel_id = is_dm.then_some(self.active_channel_id).flatten();
         let mid = message_id.get();
         cx.spawn(async move |this, cx| {
             let resp = api.get_poll(poll_id, mid, cid).await?;
-            let detail = this.update(cx, |_store, cx| map_poll_detail(&resp, clan_id, cx))?;
+            let detail = this.update(cx, |_store, cx| {
+                map_poll_detail(&resp, clan_id, dm_channel_id, cx)
+            })?;
             Ok(detail)
         })
     }
@@ -7767,12 +7772,17 @@ fn message_from_api(m: ApiMessage, cfg: Option<&AppConfig>, viewer_id: Option<Us
 
 fn map_poll_detail(
     resp: &mezon_proto::api::GetPollResponse,
-    clan_id: ClanId,
+    clan_id: Option<ClanId>,
+    dm_channel_id: Option<ChannelId>,
     cx: &App,
 ) -> PollDetail {
-    let members_entity = ClanMembersStore::global(cx);
-    let members = members_entity.read(cx);
     let cfg = AppConfig::try_global(cx);
+    let clan = clan_id.map(|clan_id| (clan_id, ClanMembersStore::global(cx).read(cx)));
+    let group =
+        dm_channel_id.map(|channel_id| (channel_id, GroupMembersStore::global(cx).read(cx)));
+    let dm_channel = dm_channel_id
+        .and_then(|channel_id| DirectMessageStore::global(cx).read(cx).find(channel_id));
+    let account = AccountStore::try_global(cx).and_then(|store| store.read(cx).account.as_ref());
     let answer_count = resp.answers.len().max(resp.answer_counts.len());
     let mut voters_by_answer: Vec<Vec<PollVoter>> = vec![Vec::new(); answer_count];
     for detail in &resp.voter_details {
@@ -7781,34 +7791,85 @@ fn map_poll_detail(
             continue;
         };
         for &uid in &detail.user_ids {
-            let user_id = UserId(uid);
-            let voter = match members.member(clan_id, user_id) {
-                Some(member) => {
-                    let avatar = member.avatar();
-                    let avatar_proxied = cfg
-                        .map(|c| c.avatar_proxy(avatar))
-                        .unwrap_or_else(|| avatar.to_string());
-                    PollVoter {
-                        user_id,
-                        display_name: member.name().to_string().into(),
-                        username: member.user.username.clone().into(),
-                        avatar_proxied: avatar_proxied.into(),
-                    }
-                }
-                None => PollVoter {
-                    user_id,
-                    display_name: uid.to_string().into(),
-                    username: SharedString::default(),
-                    avatar_proxied: SharedString::default(),
-                },
-            };
-            slot.push(voter);
+            slot.push(resolve_poll_voter(
+                UserId(uid),
+                clan,
+                group,
+                dm_channel,
+                account,
+                cfg,
+            ));
         }
     }
     PollDetail {
         total_votes: resp.total_votes,
         answer_counts: resp.answer_counts.clone(),
         voters_by_answer,
+    }
+}
+
+fn resolve_poll_voter(
+    user_id: UserId,
+    clan: Option<(ClanId, &ClanMembersStore)>,
+    group: Option<(ChannelId, &GroupMembersStore)>,
+    dm_channel: Option<&DirectChannel>,
+    account: Option<&UserAccount>,
+    cfg: Option<&AppConfig>,
+) -> PollVoter {
+    let proxy = |avatar: &str| {
+        cfg.map(|c| c.avatar_proxy(avatar))
+            .unwrap_or_else(|| avatar.to_string())
+    };
+    if let Some((clan_id, members)) = clan
+        && let Some(member) = members.member(clan_id, user_id)
+    {
+        return PollVoter {
+            user_id,
+            display_name: member.name().to_string().into(),
+            username: member.user.username.clone().into(),
+            avatar_proxied: proxy(member.avatar()).into(),
+        };
+    }
+    if let Some((channel_id, members)) = group
+        && let Some(member) = members.member(channel_id, user_id)
+    {
+        return PollVoter {
+            user_id,
+            display_name: member.name().to_string().into(),
+            username: member.user.username.clone().into(),
+            avatar_proxied: proxy(member.avatar()).into(),
+        };
+    }
+    if let Some(dm) = dm_channel
+        && dm.peer_user_id == Some(user_id)
+    {
+        return PollVoter {
+            user_id,
+            display_name: dm.label.clone().into(),
+            username: dm.peer_username.clone().into(),
+            avatar_proxied: proxy(&dm.avatar).into(),
+        };
+    }
+    if let Some(account) = account
+        && account.user_id == user_id.get()
+    {
+        let display_name = if account.display_name.is_empty() {
+            &account.username
+        } else {
+            &account.display_name
+        };
+        return PollVoter {
+            user_id,
+            display_name: display_name.clone().into(),
+            username: account.username.clone().into(),
+            avatar_proxied: proxy(account.avatar_url.as_deref().unwrap_or_default()).into(),
+        };
+    }
+    PollVoter {
+        user_id,
+        display_name: user_id.get().to_string().into(),
+        username: SharedString::default(),
+        avatar_proxied: SharedString::default(),
     }
 }
 
@@ -8487,7 +8548,7 @@ fn poll_label_segments(label: &str, cfg: Option<&AppConfig>) -> Vec<PollLabelSeg
     segments
 }
 
-fn build_poll_data(
+pub(crate) fn build_poll_data(
     content: &ApiMessageContent,
     text: &str,
     cfg: Option<&AppConfig>,

--- a/crates/mezon-store/src/pinned.rs
+++ b/crates/mezon-store/src/pinned.rs
@@ -13,10 +13,12 @@ use mezon_proto::realtime::LastPinMessageEvent;
 use crate::AppConfig;
 use crate::ids::{ChannelId, ClanId, MessageId, UserId};
 use crate::message::{
-    Embed, Message, MessageAttachment, MessageSpan, OgpPreview, RichLayout, build_rich_layout,
-    link_marker_from_kind, parse_spans,
+    Embed, Message, MessageAttachment, MessageSpan, OgpPreview, PollData, RichLayout,
+    build_rich_layout, link_marker_from_kind, parse_spans,
 };
-use crate::messages::{MessagesEvent, MessagesStore, build_embeds, build_ogp_preview};
+use crate::messages::{
+    MessagesEvent, MessagesStore, build_embeds, build_ogp_preview, build_poll_data,
+};
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
 use crate::user_profile::{ProfileContext, resolve_avatar_url};
 
@@ -35,6 +37,7 @@ pub struct PinnedMessage {
     pub ogp: Option<Box<OgpPreview>>,
     pub embeds: Arc<[Embed]>,
     pub attachments: Vec<MessageAttachment>,
+    pub poll: Option<Box<PollData>>,
     pub create_time: i64,
 }
 
@@ -447,6 +450,7 @@ impl PinnedMessagesStore {
                 ogp: body.ogp,
                 embeds: body.embeds,
                 attachments: body.attachments,
+                poll: body.poll,
                 create_time,
             },
         );
@@ -676,13 +680,19 @@ fn enrich_pin_body(
     let ogp = build_ogp_preview(&tokens, cfg);
     let embeds = build_embeds(&tokens, cfg);
     let text = if tokens.t.is_empty() {
-        serde_json::from_str::<serde_json::Value>(trimmed)
-            .ok()
-            .and_then(|v| v.get("t").and_then(|t| t.as_str().map(|s| s.to_string())))
-            .unwrap_or_else(|| trimmed.to_string())
+        match serde_json::from_str::<serde_json::Value>(trimmed) {
+            Ok(serde_json::Value::Object(fields)) => fields
+                .get("t")
+                .and_then(|t| t.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            _ => trimmed.to_string(),
+        }
     } else {
-        tokens.t
+        tokens.t.clone()
     };
+    let poll = build_poll_data(&tokens, &text, cfg);
+    let text = if poll.is_some() { String::new() } else { text };
     EnrichedPinBody {
         text,
         spans: spans.into(),
@@ -690,6 +700,7 @@ fn enrich_pin_body(
         ogp,
         embeds,
         attachments,
+        poll,
     }
 }
 
@@ -700,6 +711,7 @@ struct EnrichedPinBody {
     ogp: Option<Box<OgpPreview>>,
     embeds: Arc<[Embed]>,
     attachments: Vec<MessageAttachment>,
+    poll: Option<Box<PollData>>,
 }
 
 fn pinned_from_api(m: ApiPinMessage, cfg: Option<&AppConfig>) -> PinnedMessage {
@@ -719,7 +731,9 @@ fn pinned_from_api(m: ApiPinMessage, cfg: Option<&AppConfig>) -> PinnedMessage {
         sender_name: m.sender_name,
         avatar_url: m.avatar,
         avatar_proxied: avatar_proxied.into(),
-        content: if body.text.is_empty() {
+        content: if body.poll.is_some() {
+            String::new()
+        } else if body.text.is_empty() {
             m.content_text
         } else {
             body.text
@@ -730,6 +744,7 @@ fn pinned_from_api(m: ApiPinMessage, cfg: Option<&AppConfig>) -> PinnedMessage {
         ogp: body.ogp,
         embeds: body.embeds,
         attachments: body.attachments,
+        poll: body.poll,
         create_time: m.create_time,
     }
 }
@@ -764,6 +779,7 @@ fn pinned_from_last_pin_event(pin: &LastPinMessageEvent, cfg: Option<&AppConfig>
         ogp: body.ogp,
         embeds: body.embeds,
         attachments: body.attachments,
+        poll: body.poll,
         create_time,
     }
 }
@@ -845,5 +861,44 @@ mod tests {
             )),
             "a pinned social link must stay classified when the message also carries markdown"
         );
+    }
+
+    #[test]
+    fn poll_pin_body_parses_poll_and_drops_raw_json() {
+        let raw = r#"{"poll_id":123,"question":"gg","answers":[{"index":0,"label":"1"},{"index":1,"label":"2"}],"answer_counts":[1,1],"total_votes":2,"type":1,"expire_at":0}"#;
+
+        let body = enrich_pin_body(raw, Vec::new(), None);
+
+        assert!(body.text.is_empty());
+        let poll = body.poll.expect("poll parsed from pin content");
+        assert_eq!(poll.question.as_ref(), "gg");
+        assert_eq!(poll.answers.len(), 2);
+        assert_eq!(poll.total_votes, 2);
+        assert!(poll.allow_multiple);
+    }
+
+    #[test]
+    fn embed_only_pin_body_never_shows_raw_json() {
+        let raw = r#"{"embed":[{"title":"hi","description":"there"}]}"#;
+
+        let body = enrich_pin_body(raw, Vec::new(), None);
+
+        assert!(body.text.is_empty());
+        assert_eq!(body.embeds.len(), 1);
+    }
+
+    #[test]
+    fn plain_text_pin_body_keeps_non_json_content() {
+        let body = enrich_pin_body("hello", Vec::new(), None);
+
+        assert_eq!(body.text, "hello");
+    }
+
+    #[test]
+    fn text_pin_body_keeps_text_and_has_no_poll() {
+        let body = enrich_pin_body(r#"{"t":"hello"}"#, Vec::new(), None);
+
+        assert_eq!(body.text, "hello");
+        assert!(body.poll.is_none());
     }
 }

--- a/crates/mezon-ui/src/chat/message/mod.rs
+++ b/crates/mezon-ui/src/chat/message/mod.rs
@@ -52,6 +52,7 @@ pub use forward_modal::{ShareContactModal, share_contact_subject};
 pub use gif_video::VideoThumbView;
 pub(crate) use message_buzz_modal::MessageBuzzModal;
 pub(crate) use ogp_embed::render_ogp_preview;
+pub(crate) use poll_card::render_poll_card_readonly;
 pub(crate) use reaction_picker::{ReactionPicker, ReactionPickerEvent};
 pub(crate) use send_token_modal::SendTokenModal;
 pub(crate) use share_location_modal::ShareLocationModal;

--- a/crates/mezon-ui/src/chat/message/pin_confirm_modals.rs
+++ b/crates/mezon-ui/src/chat/message/pin_confirm_modals.rs
@@ -348,7 +348,7 @@ fn preview_from_message(
         sender_label,
         avatar_src,
         avatar_fallback,
-        body: render_pin_message_preview(msg, theme, image_cache, ogp_cache),
+        body: render_pin_message_preview(msg, theme, locale, image_cache, ogp_cache),
         timestamp,
     }
 }
@@ -358,7 +358,7 @@ fn preview_from_pin(
     clan_id: Option<ClanId>,
     channel_id: Option<ChannelId>,
     fallback_sender_label: &SharedString,
-    _locale: &str,
+    locale: &str,
     image_cache: Entity<LruImageCache>,
     ogp_cache: Entity<LruImageCache>,
     cx: &App,
@@ -398,7 +398,7 @@ fn preview_from_pin(
         sender_label,
         avatar_src,
         avatar_fallback,
-        body: render_pinned_message_preview(pin, theme, image_cache, ogp_cache),
+        body: render_pinned_message_preview(pin, theme, locale, image_cache, ogp_cache),
         timestamp: None,
     }
 }

--- a/crates/mezon-ui/src/chat/message/poll_card.rs
+++ b/crates/mezon-ui/src/chat/message/poll_card.rs
@@ -3,8 +3,8 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use gpui::{
-    Animation, AnimationExt as _, AnyElement, Bounds, FontWeight, ObjectFit, Pixels, SharedString,
-    div, img, prelude::*, px, relative, rgb, rgba,
+    Animation, AnimationExt as _, AnyElement, Bounds, Entity, FontWeight, ObjectFit, Pixels,
+    SharedString, div, img, prelude::*, px, relative, rgb, rgba,
 };
 use mezon_store::{Message, MessageId, MessagesStore, PollAnswerView, PollData, PollLabelSegment};
 
@@ -15,6 +15,8 @@ use super::context::RowCtx;
 use super::poll_detail_modal::PollDetailModal;
 use super::selection::{SelectableRegion, TextSegment};
 use crate::components::primitives::{Icon, IconName};
+use crate::image_cache::LruImageCache;
+use crate::theme::Theme;
 
 const BLUE_600: u32 = 0x2563eb;
 const BLUE_500: u32 = 0x3b82f6;
@@ -622,11 +624,213 @@ fn render_footer(
 }
 
 fn vote_word(ctx: &RowCtx, count: i32) -> &'static str {
+    vote_word_for(ctx.locale, count)
+}
+
+fn vote_word_for(locale: &str, count: i32) -> &'static str {
     if count < 2 {
-        mezon_i18n::t(ctx.locale, "message.poll.vote")
+        mezon_i18n::t(locale, "message.poll.vote")
     } else {
-        mezon_i18n::t(ctx.locale, "message.poll.votes")
+        mezon_i18n::t(locale, "message.poll.votes")
     }
+}
+
+pub(crate) fn render_poll_card_readonly(
+    poll: &PollData,
+    voted: &[i32],
+    theme: &Theme,
+    locale: &str,
+    now_secs: i64,
+    image_cache: &Entity<LruImageCache>,
+) -> AnyElement {
+    let is_expired = poll.is_expired(now_secs);
+    let is_closed = poll.is_closed;
+    let tokens = &theme.tokens;
+
+    let mut header = div().flex().flex_row().items_center().gap_2().mb_1().child(
+        div()
+            .flex_1()
+            .min_w_0()
+            .text_size(px(15.))
+            .font_weight(FontWeight::SEMIBOLD)
+            .text_color(tokens.text_secondary)
+            .child(poll.question.clone()),
+    );
+    if is_closed || is_expired {
+        header = header.child(
+            div()
+                .flex_shrink_0()
+                .px_2()
+                .py_0p5()
+                .text_xs()
+                .font_weight(FontWeight::SEMIBOLD)
+                .rounded(px(4.))
+                .bg(rgba(RED_500_10))
+                .text_color(rgb(RED_500))
+                .child(mezon_i18n::t(locale, "message.poll.ended")),
+        );
+    }
+
+    let mut answers = div().flex().flex_col().gap_2().mb_3();
+    for (position, answer) in poll.answers.iter().enumerate() {
+        let count = poll.answer_counts.get(position).copied().unwrap_or(0);
+        let percentage = poll.percentages.get(position).copied().unwrap_or(0);
+        let is_voted = voted.contains(&(position as i32));
+
+        let mut right = div()
+            .relative()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap_3()
+            .flex_shrink_0()
+            .pl_2()
+            .child(
+                div()
+                    .text_xs()
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(tokens.text_secondary)
+                    .child(format!(
+                        "{percentage}% {count} {}",
+                        vote_word_for(locale, count)
+                    )),
+            );
+        if is_voted {
+            right = right.child(
+                div()
+                    .size_5()
+                    .rounded_full()
+                    .bg(tokens.text_theme_primary)
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .flex_shrink_0()
+                    .child(
+                        Icon::new(IconName::Check)
+                            .size(px(12.))
+                            .text_color(tokens.text_secondary),
+                    ),
+            );
+        }
+
+        answers = answers.child(
+            div()
+                .relative()
+                .flex()
+                .flex_row()
+                .items_center()
+                .justify_between()
+                .flex_shrink_0()
+                .px_3()
+                .py(px(10.))
+                .rounded(px(4.))
+                .border_1()
+                .border_color(tokens.border_primary)
+                .overflow_hidden()
+                .bg(tokens.bg_item_hover)
+                .child(
+                    div()
+                        .absolute()
+                        .left_0()
+                        .top_0()
+                        .bottom_0()
+                        .w(relative(percentage as f32 / 100.0))
+                        .bg(rgb(BLUE_600)),
+                )
+                .child(
+                    div()
+                        .relative()
+                        .flex_1()
+                        .min_w_0()
+                        .overflow_hidden()
+                        .text_size(px(14.))
+                        .font_weight(FontWeight::MEDIUM)
+                        .text_color(tokens.text_secondary)
+                        .child(render_poll_label_plain(
+                            answer,
+                            poll.poll_id,
+                            position,
+                            image_cache,
+                        )),
+                )
+                .child(right),
+        );
+    }
+
+    let mut footer = div()
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap_1()
+        .w_full()
+        .min_w_0()
+        .pt_1()
+        .text_xs()
+        .text_color(tokens.text_theme_primary)
+        .child(div().child(format!(
+            "{} {}",
+            poll.total_votes,
+            vote_word_for(locale, poll.total_votes)
+        )));
+    if !is_closed
+        && !is_expired
+        && let Some(time_label) = time_remaining_label(poll.expire_at, now_secs, locale)
+    {
+        footer = footer.child(div().child(format!(
+            "• {time_label} {}",
+            mezon_i18n::t(locale, "message.poll.left")
+        )));
+    }
+
+    div()
+        .w_full()
+        .min_w_0()
+        .child(
+            div()
+                .w_full()
+                .max_w(px(420.))
+                .rounded(px(4.))
+                .p_3()
+                .border_1()
+                .border_color(tokens.border_primary)
+                .bg(tokens.bg_active_member_channel)
+                .child(header)
+                .child(answers)
+                .child(footer),
+        )
+        .into_any_element()
+}
+
+fn render_poll_label_plain(
+    answer: &PollAnswerView,
+    poll_id: i64,
+    position: usize,
+    image_cache: &Entity<LruImageCache>,
+) -> AnyElement {
+    let mut row = div().flex().flex_row().items_center().overflow_hidden();
+    for (segment_index, segment) in answer.segments.iter().enumerate() {
+        match segment {
+            PollLabelSegment::Text(text) => {
+                row = row.child(div().overflow_hidden().child(text.clone()));
+            }
+            PollLabelSegment::Emoji(src) => {
+                if src.is_empty() {
+                    continue;
+                }
+                row = row.child(
+                    img(src.clone())
+                        .w(px(20.))
+                        .h(px(20.))
+                        .object_fit(ObjectFit::Contain)
+                        .image_cache(image_cache)
+                        .id(format!(
+                            "pin-poll-emoji-{poll_id}-{position}-{segment_index}"
+                        )),
+                );
+            }
+        }
+    }
+    row.into_any_element()
 }
 
 fn time_remaining_label(expire_at: Option<i64>, now_secs: i64, locale: &str) -> Option<String> {

--- a/crates/mezon-ui/src/chat/message_search.rs
+++ b/crates/mezon-ui/src/chat/message_search.rs
@@ -25,7 +25,7 @@ use crate::chat::layout::ChatLayout;
 use crate::chat::member_list::{MentionMemberRaw, mention_member_pool};
 use crate::chat::message::{
     RichRunPalette, code_block_copy_overlay, format_message_time, open_message_link,
-    render_ogp_preview, rich_run_highlight_with_link_underline,
+    render_ogp_preview, render_poll_card_readonly, rich_run_highlight_with_link_underline,
 };
 use crate::chat::role_style::message_sender_color;
 use crate::components::primitives::{Icon, IconName, Input, InputState, Sizable, Size, Spinner};
@@ -827,6 +827,24 @@ fn render_search_row(
         )
     });
     let ogp = resolve_search_hit_ogp(hit, cx);
+    let poll_card = hit.poll.as_deref().map(|poll| {
+        let voted = MessagesStore::try_global(cx)
+            .and_then(|store| {
+                store
+                    .read(cx)
+                    .poll_my_vote(hit.message_id)
+                    .map(<[i32]>::to_vec)
+            })
+            .unwrap_or_default();
+        render_poll_card_readonly(
+            poll,
+            &voted,
+            theme,
+            locale,
+            now.timestamp(),
+            &attachment_image_cache,
+        )
+    });
 
     let group_header =
         (show_channel_label && show_group_header && resolved_channel_label.is_some()).then(|| {
@@ -896,6 +914,7 @@ fn render_search_row(
                                             )),
                                     )
                                 })
+                                .children(poll_card)
                                 .children(ogp.as_ref().and_then(|ogp| {
                                     let preview = render_ogp_preview(
                                         ogp,

--- a/crates/mezon-ui/src/chat/pinned_popover.rs
+++ b/crates/mezon-ui/src/chat/pinned_popover.rs
@@ -9,7 +9,7 @@ use gpui::{
 use mezon_store::{
     AccountStore, ChannelId, ClanMembersStore, DirectMessageStore, Embed, Message,
     MessageAttachment, MessageId, MessageSpan, MessagesStore, PinnedMessage, PinnedMessagesStore,
-    RichLayout, Settings, UsersByUserStore, strip_code_fence,
+    PollData, RichLayout, Settings, UsersByUserStore, strip_code_fence,
 };
 use ui::{PopoverMenuHandle, ScrollAxes, Scrollbars, WithScrollbar};
 
@@ -19,8 +19,8 @@ use crate::chat::message::parts::{
 };
 use crate::chat::message::{
     ConfirmUnpinMessageModal, code_block_copy_overlay, heading_line_height, heading_size,
-    pin_link_element, render_ogp_preview, render_pin_rich_layout_element, resolve_message_link_url,
-    text_wrap_children,
+    pin_link_element, render_ogp_preview, render_pin_rich_layout_element,
+    render_poll_card_readonly, resolve_message_link_url, text_wrap_children,
 };
 use crate::components::primitives::{
     Avatar, Button, ButtonVariants, Icon, IconName, Sizable, Size, Spinner, h_flex, v_flex,
@@ -54,6 +54,8 @@ struct PinCardVm {
     avatar_fallback: Option<SharedString>,
     pin: Arc<PinnedMessage>,
     text_spans: Arc<[MessageSpan]>,
+    poll: Option<Arc<PollData>>,
+    poll_my_vote: Arc<[i32]>,
 }
 
 impl PinCardVm {
@@ -72,6 +74,7 @@ impl PinCardVm {
             cx,
         );
         let (avatar_src, avatar_fallback) = resolve_pin_avatar_urls(msg, clan_id, channel_id, cx);
+        let (poll, poll_my_vote) = resolve_pin_poll(msg, channel_id, cx);
         Self {
             pin_id: msg.id.clone().into(),
             message_id: msg.message_id.clone().into(),
@@ -82,18 +85,52 @@ impl PinCardVm {
             avatar_fallback,
             pin: Arc::new(msg.clone()),
             text_spans: prepare_pin_text_spans(msg),
+            poll,
+            poll_my_vote,
         }
     }
+}
+
+fn resolve_pin_poll(
+    pin: &PinnedMessage,
+    channel_id: Option<ChannelId>,
+    cx: &App,
+) -> (Option<Arc<PollData>>, Arc<[i32]>) {
+    if pin.poll.is_none() {
+        return (None, Arc::default());
+    }
+    let Ok(message_id) = pin.message_id.parse::<MessageId>() else {
+        return (pin.poll.clone().map(Arc::from), Arc::default());
+    };
+    let store = MessagesStore::global(cx).read(cx);
+    let live = channel_id
+        .and_then(|channel_id| store.message_in_channel(channel_id, message_id))
+        .and_then(|msg| msg.poll.clone());
+    let my_vote: Arc<[i32]> = store
+        .poll_my_vote(message_id)
+        .map(Arc::from)
+        .unwrap_or_default();
+    (live.or_else(|| pin.poll.clone()).map(Arc::from), my_vote)
 }
 
 pub(crate) fn render_pinned_message_preview(
     pin: &PinnedMessage,
     theme: &Theme,
+    locale: &str,
     image_cache: Entity<LruImageCache>,
     ogp_cache: Entity<LruImageCache>,
 ) -> gpui::AnyElement {
     let text_spans = prepare_pin_text_spans(pin);
-    render_pin_body(pin, &text_spans, theme, image_cache, ogp_cache)
+    let poll = pin.poll.as_deref().map(|poll| (poll, &[] as &[i32]));
+    render_pin_body(
+        pin,
+        &text_spans,
+        poll,
+        theme,
+        locale,
+        image_cache,
+        ogp_cache,
+    )
 }
 
 fn pinned_message_from_chat_message(msg: &Message) -> PinnedMessage {
@@ -111,6 +148,7 @@ fn pinned_message_from_chat_message(msg: &Message) -> PinnedMessage {
         ogp: msg.ogp.clone(),
         embeds: msg.embeds.clone(),
         attachments: msg.attachments.clone(),
+        poll: msg.poll.clone(),
         create_time: msg.create_time,
     }
 }
@@ -118,12 +156,14 @@ fn pinned_message_from_chat_message(msg: &Message) -> PinnedMessage {
 pub(crate) fn render_pin_message_preview(
     msg: &Message,
     theme: &Theme,
+    locale: &str,
     image_cache: Entity<LruImageCache>,
     ogp_cache: Entity<LruImageCache>,
 ) -> gpui::AnyElement {
     render_pinned_message_preview(
         &pinned_message_from_chat_message(msg),
         theme,
+        locale,
         image_cache,
         ogp_cache,
     )
@@ -537,7 +577,19 @@ fn pin_card(
                 .child(format_pin_time(vm.create_time, locale)),
         );
 
-    let content = render_pin_body(&vm.pin, &vm.text_spans, theme, message_cache, ogp_cache);
+    let poll = vm
+        .poll
+        .as_deref()
+        .map(|poll| (poll, vm.poll_my_vote.as_ref()));
+    let content = render_pin_body(
+        &vm.pin,
+        &vm.text_spans,
+        poll,
+        theme,
+        locale,
+        message_cache,
+        ogp_cache,
+    );
 
     let jump_message_id = vm.message_id.clone();
     let jump_handle = popover_handle.clone();
@@ -613,12 +665,24 @@ fn pin_card(
 fn render_pin_body(
     pin: &PinnedMessage,
     text_spans: &[MessageSpan],
+    poll: Option<(&PollData, &[i32])>,
     theme: &Theme,
+    locale: &str,
     image_cache: Entity<LruImageCache>,
     ogp_cache: Entity<LruImageCache>,
 ) -> gpui::AnyElement {
     let message_id = pin.message_id.parse::<MessageId>().unwrap_or(MessageId(0));
-    let text_body = render_pin_text_body(pin, text_spans, theme);
+    let text_body = match poll {
+        Some((poll, voted)) => render_poll_card_readonly(
+            poll,
+            voted,
+            theme,
+            locale,
+            mezon_store::message_time::unix_now_seconds(),
+            &image_cache,
+        ),
+        None => render_pin_text_body(pin, text_spans, theme),
+    };
     let image_preview = pin
         .attachments
         .iter()


### PR DESCRIPTION
A pinned poll showed the raw content JSON: enrich_pin_body kept only the `t` field and fell back to the whole trimmed content when that key was missing, and PinnedMessage carried no poll at all. Pins and search hits now build poll data with the same build_poll_data the message body uses, and render a read-only poll card - results always shown, no vote or show-results controls - mirroring the React <PollMessage interactionDisabled /> used by ItemPinMessage and by search results.

A content JSON object without a `t` key (bot embeds) no longer leaks its raw JSON into the pin body either.

Poll voters in a group DM rendered as raw numeric ids: map_poll_detail only looked them up in ClanMembersStore, which holds nothing outside a clan. Resolution now walks clan -> group members -> DM peer -> self, with every store read hoisted out of the per-voter loop.