### PR TITLE
fix(unread): join the clan chat before any channel join

### DIFF
--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -342,10 +342,13 @@ fn log_dir() -> std::path::PathBuf {
 /// Initialise tracing to stdout **and** a daily-rotated log file. Uses a blocking file writer
 /// (not `non_blocking`) so a panic is flushed to disk before the process aborts.
 fn init_logging() {
+    // `noti` is an explicit target rather than a module path, so it needs its own
+    // directive — the whole notification chain logs there and has to stay readable in
+    // release, where `mezon=info` alone would drop it to the global `warn` floor.
     let default_filter = if cfg!(debug_assertions) {
-        "mezon=debug,info"
+        "mezon=debug,noti=debug,info"
     } else {
-        "mezon=info,warn"
+        "mezon=info,noti=info,warn"
     };
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter));

--- a/crates/mezon-app/src/mcp.rs
+++ b/crates/mezon-app/src/mcp.rs
@@ -309,6 +309,10 @@ impl McpRuntime {
                         let result = cx.update(|cx| mezon_ui::app::capture::topic_type(cx, &text));
                         let _ = reply.send(result);
                     }
+                    McpCommand::TopicPick { index, reply } => {
+                        let result = cx.update(|cx| mezon_ui::app::capture::topic_pick(cx, index));
+                        let _ = reply.send(result);
+                    }
                     McpCommand::TopicDropPaths { paths, reply } => {
                         let result =
                             cx.update(|cx| mezon_ui::app::capture::topic_drop_paths(cx, paths));

--- a/crates/mezon-client/src/gotify.rs
+++ b/crates/mezon-client/src/gotify.rs
@@ -82,6 +82,7 @@ pub async fn run_once(
     tx: &mpsc::UnboundedSender<GotifyNotification>,
 ) -> StreamEnd {
     let url = format!("{}/stream?token={token}", ws_base.trim_end_matches('/'));
+    tracing::info!(target: "noti", host = %ws_base, "gotify: connecting to the notification stream");
     let stream = match tokio_tungstenite::connect_async(&url).await {
         Ok((stream, _)) => stream,
         Err(e) => {
@@ -92,6 +93,8 @@ pub async fn run_once(
             );
             // The error may embed the URL, which carries the auth token — redact it.
             tracing::warn!(
+                target: "noti",
+                rejected,
                 "gotify: connect failed: {}",
                 e.to_string().replace(token, "***")
             );
@@ -102,7 +105,7 @@ pub async fn run_once(
             };
         }
     };
-    tracing::debug!("gotify: stream connected");
+    tracing::info!(target: "noti", "gotify: stream connected — listening for notifications");
     let (mut write, mut read) = stream.split();
 
     // The 60s watchdog advances only on a received `ping`, mirroring React's
@@ -112,13 +115,13 @@ pub async fn run_once(
     loop {
         let frame = tokio::select! {
             () = tokio::time::sleep_until(deadline) => {
-                tracing::debug!("gotify: ping timeout, reconnecting");
+                tracing::warn!(target: "noti", secs = PING_TIMEOUT.as_secs(), "gotify: no ping within the watchdog window, reconnecting");
                 return StreamEnd::Dropped;
             }
             frame = read.next() => match frame {
                 None => return StreamEnd::ClosedByServer,
                 Some(Err(e)) => {
-                    tracing::warn!("gotify: read error: {e}");
+                    tracing::warn!(target: "noti", "gotify: read error: {e}");
                     return StreamEnd::Dropped;
                 }
                 Some(Ok(frame)) => frame,
@@ -148,11 +151,25 @@ pub async fn run_once(
 
         match serde_json::from_str::<GotifyNotification>(trimmed) {
             Ok(notification) => {
+                tracing::info!(
+                    target: "noti",
+                    title = %notification.title,
+                    channel_id = %notification.channel_id,
+                    sender_id = %notification.sender_id,
+                    date = %notification.date,
+                    bytes = trimmed.len(),
+                    "gotify: frame received from the server"
+                );
                 if tx.send(notification).is_err() {
+                    tracing::warn!(target: "noti", "gotify: nobody is consuming notifications any more");
                     return StreamEnd::ReceiverGone;
                 }
             }
-            Err(e) => tracing::debug!("gotify: unparseable frame: {e}"),
+            Err(e) => tracing::warn!(
+                target: "noti",
+                bytes = trimmed.len(),
+                "gotify: could not parse a frame the server sent: {e}"
+            ),
         }
     }
 }

--- a/crates/mezon-mcp/src/catalog.rs
+++ b/crates/mezon-mcp/src/catalog.rs
@@ -424,6 +424,17 @@ Parameters:
         write: true,
     },
     ToolSpec {
+        name: "mute_channel",
+        description: "\
+Mute or unmute a channel for the signed-in user (backend SetMuteChannel).
+
+Parameters:
+- clan_id (required): clan snowflake id. Use 0 for direct messages.
+- channel_id (required): channel snowflake id.
+- mute_minutes (optional): minutes to mute (-1 = forever, 0 = unmute, default 0).",
+        write: true,
+    },
+    ToolSpec {
         name: "channel_menu_state",
         description: "\
 Return the channel context menu that is currently open in the channel sidebar, if any.
@@ -609,9 +620,27 @@ Parameters: none.",
         description: "\
 Replace the topic composer's text, the way typing into the panel does.
 
+Drives the real MentionInput, so trigger characters open their popup: @ (member/role),
+# (channel), : (emoji). Returns the composer state including the suggestion list; follow
+with topic_pick to accept one, then topic_submit to send.
+
 Parameters:
 - text (required)",
         write: false,
+    },
+    ToolSpec {
+        name: "topic_pick",
+        description: "\
+Accept one entry of the topic composer's suggestion popup.
+
+Typing `@name` on its own only produces literal text. A real mention needs the picked
+entry, because that is what writes the id into the message's `mentions` field — and the
+receiving client detects mentions from that field, never from the text. So a topic
+mention can only be exercised end to end through topic_type + topic_pick + topic_submit.
+
+Parameters:
+- index (optional, default 0): suggestion index from topic_type/topic_state.",
+        write: true,
     },
     ToolSpec {
         name: "topic_submit",
@@ -679,28 +708,10 @@ Parameters:
     ToolSpec {
         name: "scroll_wheel",
         description: "\
-Drives the real MentionInput, so trigger characters open their popup: @ (member/role),
-# (channel), : (emoji). Returns the composer state including the suggestion list; follow
-with topic_pick to accept one, then topic_submit to send.
-
 Send wheel events to the message list, the way a mouse wheel does.
 
 scroll_messages jumps the viewport, which cancels the wheel animation and never sets
 the list's scroll-active flag. That flag matters: while it is set the chat suppresses
-    ToolSpec {
-        name: "topic_pick",
-        description: "\
-Accept one entry of the topic composer's suggestion popup.
-
-Typing `@name` on its own only produces literal text. A real mention needs the picked
-entry, because that is what writes the id into the message's `mentions` field — and the
-receiving client detects mentions from that field, never from the text. So a topic
-mention can only be exercised end to end through topic_type + topic_pick + topic_submit.
-
-Parameters:
-- index (optional, default 0): suggestion index from topic_type/topic_state.",
-        write: true,
-    },
 its image-cache sweep, so a jump measures the app under lighter memory pressure than
 real scrolling does. Use this when the run has to reproduce scrolling behaviour, and
 scroll_messages when you only need to land at an edge.

--- a/crates/mezon-mcp/src/catalog.rs
+++ b/crates/mezon-mcp/src/catalog.rs
@@ -679,10 +679,28 @@ Parameters:
     ToolSpec {
         name: "scroll_wheel",
         description: "\
+Drives the real MentionInput, so trigger characters open their popup: @ (member/role),
+# (channel), : (emoji). Returns the composer state including the suggestion list; follow
+with topic_pick to accept one, then topic_submit to send.
+
 Send wheel events to the message list, the way a mouse wheel does.
 
 scroll_messages jumps the viewport, which cancels the wheel animation and never sets
 the list's scroll-active flag. That flag matters: while it is set the chat suppresses
+    ToolSpec {
+        name: "topic_pick",
+        description: "\
+Accept one entry of the topic composer's suggestion popup.
+
+Typing `@name` on its own only produces literal text. A real mention needs the picked
+entry, because that is what writes the id into the message's `mentions` field — and the
+receiving client detects mentions from that field, never from the text. So a topic
+mention can only be exercised end to end through topic_type + topic_pick + topic_submit.
+
+Parameters:
+- index (optional, default 0): suggestion index from topic_type/topic_state.",
+        write: true,
+    },
 its image-cache sweep, so a jump measures the app under lighter memory pressure than
 real scrolling does. Use this when the run has to reproduce scrolling behaviour, and
 scroll_messages when you only need to land at an edge.

--- a/crates/mezon-mcp/src/command.rs
+++ b/crates/mezon-mcp/src/command.rs
@@ -140,6 +140,10 @@ pub enum McpCommand {
         text: String,
         reply: oneshot::Sender<anyhow::Result<Value>>,
     },
+    TopicPick {
+        index: usize,
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
     TopicDropPaths {
         paths: Vec<String>,
         reply: oneshot::Sender<anyhow::Result<Value>>,

--- a/crates/mezon-mcp/src/schemas.rs
+++ b/crates/mezon-mcp/src/schemas.rs
@@ -502,6 +502,16 @@ pub fn input_schema(name: &str) -> Arc<Map<String, Value>> {
                 "index": json!({
                     "type": "integer",
                     "minimum": 0,
+        "topic_pick" => Arc::new(object(
+            json!({
+                "index": json!({
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Index into the suggestion list (default 0)."
+                }),
+            }),
+            &[],
+        )),
                     "description": "Suggestion index (default 0)."
                 }),
             }),

--- a/crates/mezon-mcp/src/schemas.rs
+++ b/crates/mezon-mcp/src/schemas.rs
@@ -153,6 +153,14 @@ pub fn input_schema(name: &str) -> Arc<Map<String, Value>> {
             }),
             &["clan_id", "name"],
         )),
+        "mute_channel" => Arc::new(object(
+            json!({
+                "clan_id": id("Clan snowflake id. Use 0 for direct messages."),
+                "channel_id": id("Channel snowflake id."),
+                "mute_minutes": integer("Minutes to mute. Use -1 forever or 0 to unmute.", Some(0)),
+            }),
+            &["clan_id", "channel_id"],
+        )),
         "channel_menu_open" => Arc::new(object(
             json!({
                 "clan_id": id("Clan snowflake id from list_clans."),
@@ -479,6 +487,16 @@ pub fn input_schema(name: &str) -> Arc<Map<String, Value>> {
             json!({ "text": string("Full composer text to set.") }),
             &["text"],
         )),
+        "topic_pick" => Arc::new(object(
+            json!({
+                "index": json!({
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Index into the suggestion list (default 0)."
+                }),
+            }),
+            &[],
+        )),
         "composer_pick" => Arc::new(object(
             json!({
                 "index": json!({
@@ -502,16 +520,6 @@ pub fn input_schema(name: &str) -> Arc<Map<String, Value>> {
                 "index": json!({
                     "type": "integer",
                     "minimum": 0,
-        "topic_pick" => Arc::new(object(
-            json!({
-                "index": json!({
-                    "type": "integer",
-                    "minimum": 0,
-                    "description": "Index into the suggestion list (default 0)."
-                }),
-            }),
-            &[],
-        )),
                     "description": "Suggestion index (default 0)."
                 }),
             }),

--- a/crates/mezon-mcp/src/tools.rs
+++ b/crates/mezon-mcp/src/tools.rs
@@ -185,13 +185,13 @@ impl McpBackend {
                 self.send_ui_result(|reply| McpCommand::TopicType { text, reply })
                     .await
             }
-            "topic_submit" => {
             "topic_pick" => {
                 self.require_write_mode("topic_pick")?;
                 let index = arguments.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
                 self.send_ui_result(|reply| McpCommand::TopicPick { index, reply })
                     .await
             }
+            "topic_submit" => {
                 self.send_ui_result(|reply| McpCommand::TopicSubmit { reply })
                     .await
             }
@@ -289,6 +289,10 @@ impl McpBackend {
             "clan_menu_state" => self.clan_menu_state().await,
             "list_categories" => self.list_categories(&arguments).await,
             "create_category" => self.create_category(&arguments).await,
+            "mute_channel" => {
+                self.require_write_mode("mute_channel")?;
+                self.mute_channel(&arguments).await
+            }
             "channel_menu_state" => self.channel_menu_state().await,
             "channel_menu_open" => self.channel_menu_open(&arguments).await,
             "channel_menu_close" => self.channel_menu_close().await,
@@ -1405,6 +1409,26 @@ impl McpBackend {
         .await
     }
 
+    async fn mute_channel(&self, arguments: &Value) -> anyhow::Result<Value> {
+        let clan_id = optional_i64_field(arguments, "clan_id")
+            .ok_or_else(|| anyhow::anyhow!("mute_channel requires field clan_id"))?;
+        let channel_id = optional_i64_field(arguments, "channel_id")
+            .ok_or_else(|| anyhow::anyhow!("mute_channel requires field channel_id"))?;
+        let mute_minutes = arguments
+            .get("mute_minutes")
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+        let mute_seconds = mute_seconds_from_minutes(mute_minutes)?;
+        self.api
+            .set_mute_channel(channel_id, mute_seconds, clan_id)
+            .await?;
+        to_json(&serde_json::json!({
+            "ok": true,
+            "channel_id": channel_id,
+            "mute_minutes": mute_minutes,
+        }))
+    }
+
     async fn channel_menu_state(&self) -> anyhow::Result<Value> {
         self.send_ui_result(|reply| McpCommand::ChannelMenuState { reply })
             .await
@@ -2365,6 +2389,18 @@ fn optional_i64_field(arguments: &Value, field: &str) -> Option<i64> {
     })
 }
 
+fn mute_seconds_from_minutes(minutes: i64) -> anyhow::Result<i32> {
+    match minutes {
+        -1 => Ok(-1),
+        0 => Ok(0),
+        1.. => minutes
+            .checked_mul(60)
+            .and_then(|seconds| i32::try_from(seconds).ok())
+            .ok_or_else(|| anyhow::anyhow!("mute_minutes is too large")),
+        _ => anyhow::bail!("mute_minutes must be -1, 0, or positive"),
+    }
+}
+
 fn validate_navigate_path(path: &str) -> anyhow::Result<()> {
     let path = path.trim();
     if path.is_empty() {
@@ -2546,5 +2582,14 @@ mod tests {
                 .expect("spans")
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn mute_minutes_are_converted_to_wire_seconds() {
+        assert_eq!(mute_seconds_from_minutes(-1).unwrap(), -1);
+        assert_eq!(mute_seconds_from_minutes(0).unwrap(), 0);
+        assert_eq!(mute_seconds_from_minutes(15).unwrap(), 900);
+        assert!(mute_seconds_from_minutes(-2).is_err());
+        assert!(mute_seconds_from_minutes(i64::MAX).is_err());
     }
 }

--- a/crates/mezon-mcp/src/tools.rs
+++ b/crates/mezon-mcp/src/tools.rs
@@ -168,8 +168,14 @@ impl McpBackend {
                 self.send_ui_result(|reply| McpCommand::OpenTopic { message_id, reply })
                     .await
             }
-            "close_topic" => self.send_ui_result(|reply| McpCommand::CloseTopic { reply }).await,
-            "topic_state" => self.send_ui_result(|reply| McpCommand::TopicState { reply }).await,
+            "close_topic" => {
+                self.send_ui_result(|reply| McpCommand::CloseTopic { reply })
+                    .await
+            }
+            "topic_state" => {
+                self.send_ui_result(|reply| McpCommand::TopicState { reply })
+                    .await
+            }
             "topic_type" => {
                 let text = arguments
                     .get("text")
@@ -180,6 +186,12 @@ impl McpBackend {
                     .await
             }
             "topic_submit" => {
+            "topic_pick" => {
+                self.require_write_mode("topic_pick")?;
+                let index = arguments.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
+                self.send_ui_result(|reply| McpCommand::TopicPick { index, reply })
+                    .await
+            }
                 self.send_ui_result(|reply| McpCommand::TopicSubmit { reply })
                     .await
             }

--- a/crates/mezon-native/src/notifications.rs
+++ b/crates/mezon-native/src/notifications.rs
@@ -280,7 +280,11 @@ fn init_macos() {
     use objc::{class, msg_send, sel, sel_impl};
 
     if !has_bundle_identifier() {
-        tracing::debug!("skipping notification setup: not running from an app bundle");
+        tracing::warn!(
+            target: "noti",
+            "notification setup skipped: not running from an app bundle, so macOS will \
+             refuse every notification this process posts"
+        );
         return;
     }
 
@@ -294,10 +298,14 @@ fn init_macos() {
         let options: usize = AUTH_OPTIONS_BADGE_SOUND_ALERT;
         let handler = ConcreteBlock::new(move |granted: BOOL, _error: *mut Object| {
             if granted == YES {
-                tracing::info!("notification authorisation granted");
+                tracing::info!(target: "noti", "macOS notification authorisation granted");
                 NOTIFICATION_AUTH.store(AUTH_GRANTED, std::sync::atomic::Ordering::Relaxed);
             } else {
-                tracing::warn!("notification authorisation denied; notifications will not appear");
+                tracing::warn!(
+                    target: "noti",
+                    "macOS notification authorisation DENIED — no notification will appear. \
+                     Enable it in System Settings > Notifications > Mezon, then restart the app."
+                );
                 NOTIFICATION_AUTH.store(AUTH_DENIED, std::sync::atomic::Ordering::Relaxed);
             }
         });
@@ -317,7 +325,11 @@ fn show_macos(n: &Notification) {
     use objc::{class, msg_send, sel, sel_impl};
 
     if !has_bundle_identifier() {
-        tracing::debug!("skipping notification: not running from an app bundle");
+        tracing::warn!(
+            target: "noti",
+            title = %n.title,
+            "notification dropped: not running from an app bundle"
+        );
         return;
     }
 
@@ -368,11 +380,29 @@ fn show_macos(n: &Notification) {
         let _: () = msg_send![ns_identifier, release];
         let _: () = msg_send![content, release];
 
+        // A null completion handler throws the OS's verdict away; with one we learn
+        // whether macOS actually accepted the request, which is otherwise invisible.
+        let title = n.title.clone();
+        let handler = block::ConcreteBlock::new(move |error: *mut Object| {
+            if error.is_null() {
+                tracing::info!(target: "noti", title = %title, "macOS accepted the notification");
+            } else {
+                let description: *mut Object = msg_send![error, localizedDescription];
+                let reason = nsstring_to_string(description).unwrap_or_default();
+                tracing::warn!(
+                    target: "noti",
+                    title = %title,
+                    "macOS rejected the notification: {reason}"
+                );
+            }
+        });
+        let handler = handler.copy();
         let _: () = msg_send![
             center,
             addNotificationRequest: request
-            withCompletionHandler: std::ptr::null::<Object>()
+            withCompletionHandler: &*handler
         ];
+        leak_for_async_objc_callback(handler);
     }
 }
 

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -468,6 +468,13 @@ pub struct ChannelList {
     extras_loading: HashSet<ClanId>,
     badge_seeding: HashSet<ClanId>,
     badge_seeded: HashSet<ClanId>,
+    joined_clans: HashSet<ClanId>,
+    joining_clans: HashMap<ClanId, Shared<Task<()>>>,
+    /// Bumped by `resync` only. Every fetch that owns an in-flight guard captures
+    /// it and abandons its bookkeeping when it no longer matches, so a reconnect
+    /// can drop those guards and re-issue without a task from the dead socket
+    /// clearing the replacement's guard behind it.
+    socket_generation: u64,
     forgotten_clans: HashSet<ClanId>,
     user_channels: HashMap<ChannelId, Channel>,
     user_channels_order: Vec<ChannelId>,
@@ -639,6 +646,8 @@ impl ChannelList {
         self.extras_loading.clear();
         self.badge_seeding.clear();
         self.badge_seeded.clear();
+        self.joined_clans.clear();
+        self.joining_clans.clear();
         self.forgotten_clans.clear();
         self.user_channels.clear();
         self.user_channels_order.clear();
@@ -731,6 +740,9 @@ impl ChannelList {
             extras_loading: HashSet::new(),
             badge_seeding: HashSet::new(),
             badge_seeded: HashSet::new(),
+            joined_clans: HashSet::new(),
+            joining_clans: HashMap::new(),
+            socket_generation: 0,
             forgotten_clans: HashSet::new(),
             user_channels: HashMap::new(),
             user_channels_order: Vec::new(),
@@ -784,6 +796,7 @@ impl ChannelList {
             .or_else(|| ClanList::global(cx).read(cx).active_clan_id);
         if active == Some(clan_id) {
             self.load_for_clan(clan_id, cx);
+            drop(self.ensure_clan_joined(clan_id, cx));
             self.seed_badges(clan_id, cx).detach();
         }
     }
@@ -812,6 +825,8 @@ impl ChannelList {
         self.extras_loading.remove(&clan_id);
         self.badge_seeding.remove(&clan_id);
         self.badge_seeded.remove(&clan_id);
+        self.joined_clans.remove(&clan_id);
+        self.joining_clans.remove(&clan_id);
         self.loading.remove(&clan_id);
         self.show_empty_categories.remove(&clan_id);
         self.remembered_channels.remove(&clan_id);
@@ -895,6 +910,81 @@ impl ChannelList {
         self.badge_seeding.remove(&clan_id);
     }
 
+    /// Subscribe the socket to a clan's channel streams — and never before the
+    /// clan's `ListChannelDescs` has been served.
+    ///
+    /// The gateway builds the per-channel subscriptions of a `clan_join` from the
+    /// server-side listing cache for this `(clan, user)`; on a cache miss it
+    /// tracks the clan stream alone, and every later `clan_join` for that clan is
+    /// answered from the tracker without re-running the fan-out. Public channels
+    /// ride the clan stream and keep working, so a join that lands too early goes
+    /// unnoticed except that **private channels and threads stop pushing** — no
+    /// `ChannelMessage`, so their sidebar rows never turn unread until the channel
+    /// is opened (opening one subscribes it on its own). Fetching the listing
+    /// first is what populates that cache.
+    pub fn ensure_clan_joined(
+        &mut self,
+        clan_id: ClanId,
+        cx: &mut Context<Self>,
+    ) -> Shared<Task<()>> {
+        if clan_id.is_zero() || self.forgotten_clans.contains(&clan_id) {
+            return Task::ready(()).shared();
+        }
+        if let Some(in_flight) = self.joining_clans.get(&clan_id) {
+            return in_flight.clone();
+        }
+        if self.joined_clans.contains(&clan_id) {
+            return Task::ready(()).shared();
+        }
+        // Callers reach this from two directions — the clan load, which has already
+        // started the listing, and a channel being opened, which may not have. Kick the
+        // listing here so the join is never skipped merely because nobody fetched yet.
+        self.load_structure_for_clan(clan_id, cx);
+        let api = self.api.clone();
+        let generation = self.reset_generation;
+        let socket_generation = self.socket_generation;
+        let structure_ready = self.clan_structure_ready(clan_id);
+        let task = cx
+            .spawn(async move |this, cx| {
+                structure_ready.await;
+                let ready = this
+                    .update(cx, |this, _| {
+                        this.reset_generation == generation
+                            && this.socket_generation == socket_generation
+                            && !this.forgotten_clans.contains(&clan_id)
+                            && this.cache.contains(&clan_id)
+                    })
+                    .unwrap_or(false);
+                // No listing means the gateway's cache may still be cold, and the
+                // one join it acts on would be wasted; leave the clan unjoined so
+                // the next entry retries.
+                if ready {
+                    match api.join_clan_chat(clan_id.get()).await {
+                        Ok(()) => {
+                            tracing::debug!(target: "clan_load", "clan {clan_id} subscribed (clan_join)");
+                            let _ = this.update(cx, |this, _| {
+                                if this.socket_generation == socket_generation {
+                                    this.joined_clans.insert(clan_id);
+                                }
+                            });
+                        }
+                        Err(e) => tracing::error!(
+                            target: "clan_load",
+                            "join_clan_chat failed for clan {clan_id}: {e}"
+                        ),
+                    }
+                }
+                let _ = this.update(cx, |this, _| {
+                    if this.socket_generation == socket_generation {
+                        this.joining_clans.remove(&clan_id);
+                    }
+                });
+            })
+            .shared();
+        self.joining_clans.insert(clan_id, task.clone());
+        task
+    }
+
     pub fn seed_badges(&mut self, clan_id: ClanId, cx: &mut Context<Self>) -> Task<()> {
         if self.forgotten_clans.contains(&clan_id)
             || self.badge_seeded.contains(&clan_id)
@@ -904,19 +994,19 @@ impl ChannelList {
         }
         let api = self.api.clone();
         let generation = self.reset_generation;
+        let socket_generation = self.socket_generation;
         let structure_ready = self.clan_structure_ready(clan_id);
         cx.spawn(async move |this, cx| {
             structure_ready.await;
             let still_current = this
                 .update(cx, |this, _| {
-                    this.reset_generation == generation && !this.forgotten_clans.contains(&clan_id)
+                    this.reset_generation == generation
+                        && this.socket_generation == socket_generation
+                        && !this.forgotten_clans.contains(&clan_id)
                 })
                 .unwrap_or(false);
             if !still_current {
                 return;
-            }
-            if let Err(e) = api.join_clan_chat(clan_id.get()).await {
-                tracing::error!(target: "clan_load", "join_clan_chat failed for clan {clan_id}: {e}");
             }
             let mut attempt = 0u32;
             let descs = loop {
@@ -940,10 +1030,12 @@ impl ChannelList {
                 }
             };
             let _ = this.update(cx, |this, cx| {
-                this.badge_seeding.remove(&clan_id);
-                if this.reset_generation != generation {
+                if this.reset_generation != generation
+                    || this.socket_generation != socket_generation
+                {
                     return;
                 }
+                this.badge_seeding.remove(&clan_id);
                 let Some(descs) = descs else {
                     return;
                 };
@@ -1079,13 +1171,16 @@ impl ChannelList {
         }
         let api = self.api.clone();
         let generation = self.reset_generation;
+        let socket_generation = self.socket_generation;
         cx.spawn(async move |this, cx| {
             let extras = Self::fetch_clan_extras(&api, clan_id).await;
             let _ = this.update(cx, |this, cx| {
-                this.extras_loading.remove(&clan_id);
-                if this.reset_generation != generation {
+                if this.reset_generation != generation
+                    || this.socket_generation != socket_generation
+                {
                     return;
                 }
+                this.extras_loading.remove(&clan_id);
                 this.finish_extras(clan_id, extras, cx);
             });
         })
@@ -1325,6 +1420,7 @@ impl ChannelList {
         }
         let api = self.api.clone();
         let generation = self.reset_generation;
+        let socket_generation = self.socket_generation;
         let executor = cx.background_executor().clone();
         let task = cx
             .spawn(async move |this, cx| {
@@ -1332,7 +1428,9 @@ impl ChannelList {
                 match result {
                     Ok((categories, favorite_ids)) => {
                         let _ = this.update(cx, |this, cx| {
-                            if this.reset_generation != generation {
+                            if this.reset_generation != generation
+                                || this.socket_generation != socket_generation
+                            {
                                 return;
                             }
                             this.apply_clan_structure(clan_id, categories, favorite_ids, cx);
@@ -1342,7 +1440,9 @@ impl ChannelList {
                     Err(e) => {
                         tracing::error!("Failed to load channels for clan {clan_id}: {e}");
                         let _ = this.update(cx, |this, cx| {
-                            if this.reset_generation != generation {
+                            if this.reset_generation != generation
+                                || this.socket_generation != socket_generation
+                            {
                                 return;
                             }
                             this.loading.remove(&clan_id);
@@ -3334,13 +3434,29 @@ impl ChannelList {
 
     fn resync(&mut self, cx: &mut Context<Self>) {
         tracing::info!("ChannelList resync — invalidating channel cache");
+        // Everything issued on the socket that just died is abandoned: the
+        // adapter drops its pending waiters, so those tasks resolve as failures
+        // whose only remaining effect would be to clear the guard belonging to
+        // their replacement. Bumping the generation makes them no-ops, which is
+        // what lets the guards below be cleared safely.
+        self.socket_generation = self.socket_generation.wrapping_add(1);
         self.cache.mark_all_stale();
         self.invalidate_channel_index_all();
         self.badge_seeded.clear();
+        self.badge_seeding.clear();
         self.extras_loaded.clear();
+        self.extras_loading.clear();
+        self.loading.clear();
+        // A reconnect is a new gateway session: every `clan_join` we sent is gone
+        // with the old one, so the clans have to be re-subscribed from scratch.
+        self.joined_clans.clear();
+        self.joining_clans.clear();
+        self.user_channels_generation = self.user_channels_generation.wrapping_add(1);
+        self.user_channels_loading = false;
         self.fetch_user_channels(cx);
         if let Some(clan_id) = self.active_clan_id {
             self.load_for_clan(clan_id, cx);
+            drop(self.ensure_clan_joined(clan_id, cx));
             self.seed_badges(clan_id, cx).detach();
         }
     }
@@ -8396,6 +8512,105 @@ mod tests {
     }
 
     #[gpui::test]
+    fn clan_join_waits_for_the_channel_listing(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.load_for_clan(ClanId(1), cx);
+
+                let join = channels.ensure_clan_joined(ClanId(1), cx);
+                assert!(
+                    join.now_or_never().is_none(),
+                    "clan_join must not be sent while the channel listing is still in flight — \
+                     the gateway would fan out over a cold cache and silently subscribe to \
+                     none of the clan's private channels or threads"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn opening_a_channel_waits_for_the_clan_join(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                // Nobody has loaded the clan yet — the path a deep link or a restored
+                // route takes. The join must still be reachable, because a public
+                // channel_join landing first would resolve to the clan stream and make
+                // the gateway skip the fan-out for the whole session.
+                let join = channels.ensure_clan_joined(ClanId(1), cx);
+                assert!(
+                    channels.is_loading_clan(ClanId(1)),
+                    "ensure_clan_joined must start the listing itself, not give up"
+                );
+                assert!(
+                    join.now_or_never().is_none(),
+                    "and it must not resolve until that listing lands"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn clan_join_is_sent_once_per_gateway_session(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_two_channels(),
+                    favor_ids(&[]),
+                    cx,
+                );
+
+                let first = channels.ensure_clan_joined(ClanId(1), cx);
+                assert!(
+                    Shared::ptr_eq(&first, &channels.ensure_clan_joined(ClanId(1), cx)),
+                    "a second entry must reuse the in-flight join, not send another"
+                );
+
+                channels.resync(cx);
+                assert!(
+                    channels.joined_clans.is_empty() && channels.joining_clans.is_empty(),
+                    "a reconnect starts a new gateway session, so every clan has to be \
+                     re-subscribed"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn resync_re_issues_the_fetches_a_dead_socket_left_in_flight(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.active_clan_id = Some(ClanId(1));
+                channels.load_for_clan(ClanId(1), cx);
+                channels.seed_badges(ClanId(1), cx).detach();
+                assert!(channels.is_loading_clan(ClanId(1)));
+                assert!(channels.badge_seeding.contains(&ClanId(1)));
+
+                let before = channels.socket_generation;
+                channels.resync(cx);
+
+                assert_ne!(
+                    channels.socket_generation, before,
+                    "the tasks of the dead socket must be fenced off"
+                );
+                assert!(
+                    channels.is_loading_clan(ClanId(1)),
+                    "resync must re-issue ListChannelDescs, not sit behind the guard the \
+                     dead socket's fetch still holds"
+                );
+                assert!(
+                    channels.badge_seeding.contains(&ClanId(1)),
+                    "resync must re-issue ListChannelBadgeCount for the active clan"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
     fn seed_badges_waits_on_the_in_flight_structure_fetch(cx: &mut gpui::TestAppContext) {
         cx.update(|cx| {
             let channels = init_channel_list(cx);
@@ -8409,7 +8624,7 @@ mod tests {
                 let listing = channels.clan_structure_ready(ClanId(1));
                 assert!(
                     listing.clone().now_or_never().is_none(),
-                    "seed_badges must not reach join_clan_chat while the listing is in flight"
+                    "seed_badges must not reach ListChannelBadgeCount while the listing is in flight"
                 );
 
                 channels.refresh_clan(ClanId(1), cx);

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -2998,6 +2998,30 @@ impl ChannelList {
         }
     }
 
+    pub fn set_channels_muted_any_clan(
+        &mut self,
+        channel_ids: &HashSet<ChannelId>,
+        muted: bool,
+        cx: &mut Context<Self>,
+    ) {
+        let mut changed = false;
+        for categories in self.cache.values_mut() {
+            for ch in categories
+                .iter_mut()
+                .flat_map(|c| c.channels.iter_mut())
+                .filter(|ch| channel_ids.contains(&ch.id))
+            {
+                if ch.muted != muted {
+                    ch.muted = muted;
+                    changed = true;
+                }
+            }
+        }
+        if changed {
+            cx.notify();
+        }
+    }
+
     pub fn apply_last_seen(
         &mut self,
         clan_id: ClanId,
@@ -5041,6 +5065,7 @@ fn merge_previous_voice_members(
 
 struct LiveUnreadState {
     badge_count: u32,
+    muted: bool,
     last_seen_timestamp: i64,
     last_seen_message_id: MessageId,
     last_sent_timestamp: i64,
@@ -5062,6 +5087,7 @@ fn collect_channel_badges(
                         ch.id,
                         LiveUnreadState {
                             badge_count: ch.badge_count,
+                            muted: ch.muted,
                             last_seen_timestamp: ch.last_seen_timestamp,
                             last_seen_message_id: ch.last_seen_message_id,
                             last_sent_timestamp: ch.last_sent_timestamp,
@@ -5091,6 +5117,7 @@ fn carry_live_channel_badges(
         let Some(live) = previous.get(&ch.id) else {
             continue;
         };
+        ch.muted = live.muted;
         ch.badge_count = ch.badge_count.max(live.badge_count);
         if live.last_seen_timestamp > ch.last_seen_timestamp
             || (live.last_seen_timestamp == ch.last_seen_timestamp
@@ -8763,6 +8790,42 @@ mod tests {
                      badge forward instead of resetting it, exactly like ClanList::carry_live_badges \
                      does for the clan-icon aggregate"
                 );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn live_channel_mute_survives_a_structure_refetch(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
+                channels.set_channel_muted(ClanId(1), ChannelId(1), true, cx);
+                assert!(channels.channel(ClanId(1), ChannelId(1)).unwrap().muted);
+
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
+                assert!(
+                    channels.channel(ClanId(1), ChannelId(1)).unwrap().muted,
+                    "a stale structure response must not erase a newer realtime mute"
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn bulk_channel_mute_updates_matching_rows(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
+                channels.set_channels_muted_any_clan(
+                    &HashSet::from([ChannelId(1), ChannelId(2)]),
+                    true,
+                    cx,
+                );
+
+                assert!(channels.channel(ClanId(1), ChannelId(1)).unwrap().muted);
+                assert!(channels.channel(ClanId(1), ChannelId(2)).unwrap().muted);
             });
         });
     }

--- a/crates/mezon-store/src/clan.rs
+++ b/crates/mezon-store/src/clan.rs
@@ -365,8 +365,14 @@ impl ClanOverviewDraft {
     }
 }
 
-fn carry_live_badges(previous: &[Clan], next: &mut [Clan]) {
-    if previous.is_empty() {
+/// Keep the live rail counts across a clan-list refetch.
+///
+/// `ListClanDescs` carries no badge, so a plain reload would paint every clan
+/// read. `authoritative` says the incoming rows came from `ListClanBadgeCount`
+/// instead — server truth, which also knows about reads made on other devices —
+/// and then it must win, or a reconnect could never correct a stale count.
+fn carry_live_badges(previous: &[Clan], next: &mut [Clan], authoritative: bool) {
+    if previous.is_empty() || authoritative {
         return;
     }
     let live: std::collections::HashMap<ClanId, (u32, bool)> = previous
@@ -552,7 +558,7 @@ impl ClanList {
             }
             dispatch.on_lagged(&entity, |this, cx| {
                 tracing::warn!("ClanList realtime lagged — reloading clans");
-                this.reload(cx);
+                this.reload_badges(cx);
             });
         });
     }
@@ -570,7 +576,7 @@ impl ClanList {
                     was_connected = true;
                     // Reconnected — realtime pushes were missed while offline, so the cached list
                     // is stale: always refetch (not just when empty).
-                    if this.update(cx, |this, cx| this.reload(cx)).is_err() {
+                    if this.update(cx, |this, cx| this.reload_badges(cx)).is_err() {
                         break;
                     }
                 } else if !connected {
@@ -578,6 +584,20 @@ impl ClanList {
                 }
             }
         })
+    }
+
+    /// `reload` plus a fresh `ListClanBadgeCount`, for the paths where the rail's
+    /// own counts are suspect and not just the clan list.
+    ///
+    /// The per-clan `ListChannelBadgeCount` re-seed is lazy — entering a clan
+    /// after a reconnect refetches it — but the rail is user-scoped and nothing
+    /// re-seeds it lazily, so an unvisited clan would keep a count from before
+    /// the drop for the rest of the session. Live traffic can't fill the gap
+    /// either: the rail's unread dot rides `ChannelMessage`, which needs the
+    /// clan to be joined.
+    pub fn reload_badges(&mut self, cx: &mut Context<Self>) {
+        self.badges_loaded = false;
+        self.reload(cx);
     }
 
     pub fn reload(&mut self, cx: &mut Context<Self>) {
@@ -651,12 +671,12 @@ impl ClanList {
                 }
                 this.loading = false;
                 this.badges_loaded = this.badges_loaded || badges_fetched;
-                this.update_clans(mapped, cx);
-                if let Some(clan_id) = this.active_clan_id {
-                    this.fire_join_clan_chat(clan_id, cx);
-                } else if let Some(clan_id) = this.clans.first().map(|clan| clan.id) {
-                    this.fire_join_clan_chat(clan_id, cx);
-                }
+                this.update_clans_inner(mapped, badges_fetched, cx);
+                // No `clan_join` from here. The clan listing has not been fetched
+                // yet at this point, and a join that lands before it leaves the
+                // clan's private channels and threads unsubscribed for the whole
+                // gateway session — `ChannelList::ensure_clan_joined` owns the
+                // join and waits for the structure first.
                 if this.reload_pending {
                     this.reload_pending = false;
                     this.reload(cx);
@@ -899,19 +919,16 @@ impl ClanList {
             .and_then(|c| c.welcome_channel_id)
     }
 
-    fn fire_join_clan_chat(&self, clan_id: ClanId, cx: &mut Context<Self>) {
-        let api = self.api.clone();
-        let id = clan_id.get();
-        cx.spawn(async move |_, _| {
-            if let Err(e) = api.join_clan_chat(id).await {
-                tracing::error!("join_clan_chat failed for clan {id}: {e}");
-            }
-        })
-        .detach();
-    }
-
+    /// `clan_join` has exactly one owner — [`ChannelList::ensure_clan_joined`] —
+    /// because the gateway only fans the join out to the clan's private channels
+    /// and threads when it already holds that user's channel listing, and it
+    /// answers every later join for the clan from the tracker instead of
+    /// re-running the fan-out. A join sent from here, before the listing, would
+    /// be the one that counts.
     pub fn subscribe_clan_realtime(&self, clan_id: ClanId, cx: &mut Context<Self>) {
-        self.fire_join_clan_chat(clan_id, cx);
+        crate::channel::ChannelList::global(cx).update(cx, |channels, cx| {
+            drop(channels.ensure_clan_joined(clan_id, cx));
+        });
     }
 
     pub fn is_joining_invite(&self, invite_url: &str) -> bool {
@@ -963,8 +980,9 @@ impl ClanList {
                 match &result {
                     Ok(accept) => {
                         this.invite_join_failed_urls.remove(&invite_url_for_task);
+                        // `select_clan` runs the clan load, which joins the chat
+                        // once the channel listing has landed.
                         this.select_clan(accept.clan_id, cx);
-                        this.fire_join_clan_chat(accept.clan_id, cx);
                         this.reload(cx);
                     }
                     Err(AcceptInviteError::AlreadyJoining) => {}
@@ -994,14 +1012,23 @@ impl ClanList {
         }
     }
 
-    pub fn update_clans(&mut self, mut clans: Vec<Clan>, cx: &mut Context<Self>) {
+    pub fn update_clans(&mut self, clans: Vec<Clan>, cx: &mut Context<Self>) {
+        self.update_clans_inner(clans, false, cx);
+    }
+
+    fn update_clans_inner(
+        &mut self,
+        mut clans: Vec<Clan>,
+        authoritative_badges: bool,
+        cx: &mut Context<Self>,
+    ) {
         let prev_active = self.active_clan_id;
         let previous: HashMap<ClanId, UserId> = self
             .clans
             .iter()
             .map(|clan| (clan.id, clan.creator_id))
             .collect();
-        carry_live_badges(&self.clans, &mut clans);
+        carry_live_badges(&self.clans, &mut clans, authoritative_badges);
         self.clans = clans;
         self.apply_saved_order_internal();
         let active_missing = self
@@ -1878,7 +1905,7 @@ mod tests {
         previous[0].badge_count = 4;
         previous[0].has_unread = true;
         let mut refetched = clans();
-        carry_live_badges(&previous, &mut refetched);
+        carry_live_badges(&previous, &mut refetched, false);
         assert_eq!(refetched[0].badge_count, 4);
         assert!(refetched[0].has_unread);
         assert_eq!(refetched[1].badge_count, 0);
@@ -1889,9 +1916,23 @@ mod tests {
         let mut fresh = clans();
         fresh[0].badge_count = 7;
         fresh[0].has_unread = true;
-        carry_live_badges(&[], &mut fresh);
+        carry_live_badges(&[], &mut fresh, false);
         assert_eq!(fresh[0].badge_count, 7);
         assert!(fresh[0].has_unread);
+    }
+
+    #[test]
+    fn a_badge_count_refetch_outranks_the_live_carry() {
+        let mut previous = clans();
+        previous[0].badge_count = 4;
+        previous[0].has_unread = true;
+        let mut refetched = clans();
+        refetched[0].badge_count = 1;
+        refetched[0].has_unread = true;
+        // Reconnect: ListClanBadgeCount ran, so the rows are server truth and must
+        // land — otherwise a count read on another device could never clear here.
+        carry_live_badges(&previous, &mut refetched, true);
+        assert_eq!(refetched[0].badge_count, 1);
     }
 
     #[test]
@@ -1899,7 +1940,7 @@ mod tests {
         let previous = vec![make_clan(1, "One", None)];
         let mut refetched = clans();
         refetched[1].badge_count = 9;
-        carry_live_badges(&previous, &mut refetched);
+        carry_live_badges(&previous, &mut refetched, false);
         assert_eq!(refetched[0].badge_count, 0);
         assert_eq!(refetched[1].badge_count, 9);
     }

--- a/crates/mezon-store/src/clan_load.rs
+++ b/crates/mezon-store/src/clan_load.rs
@@ -85,6 +85,19 @@ impl ClanLoadScheduler {
                     .update(cx, |channels, cx| channels.load_for_clan(clan_id, cx));
             });
 
+            // The gate: `clan_join` fans out to the clan's private channels and
+            // threads only if the gateway already has the channel listing cached
+            // for this user, so it has to follow the structure fetch, never race
+            // it. See `ChannelList::ensure_clan_joined`.
+            cx.update(|cx| {
+                ChannelList::global(cx)
+                    .update(cx, |channels, cx| channels.ensure_clan_joined(clan_id, cx))
+            })
+            .await;
+            if !is_current(&this, cx, generation) {
+                return;
+            }
+
             cx.update(|cx| {
                 ChannelList::global(cx).update(cx, |channels, cx| channels.seed_badges(clan_id, cx))
             })

--- a/crates/mezon-store/src/connection.rs
+++ b/crates/mezon-store/src/connection.rs
@@ -433,16 +433,11 @@ impl ConnectionStore {
                         ));
                     }
 
-                    let api_for_join = api.clone();
-                    exec.spawn(async move {
-                        match api_for_join.join_clan_chat(0).await {
-                            Ok(()) => tracing::info!("DM-space subscribed (clan_join clan_id=0)"),
-                            Err(e) => {
-                                tracing::warn!("DM-space join (clan_join clan_id=0) failed: {e}")
-                            }
-                        }
-                    })
-                    .detach();
+                    // The DM-space join (`clan_join{clan_id: 0}`) is owned by
+                    // `DirectMessageStore`: the gateway derives the DM and group
+                    // stream subscriptions from its cached channel listing for
+                    // this user, so the join has to follow the DM listing fetch
+                    // instead of racing it from here.
                     cx.update(|cx| {
                         auth_state.update(cx, |state, cx| {
                             if let AuthState::Connecting(s) = state {

--- a/crates/mezon-store/src/direct.rs
+++ b/crates/mezon-store/src/direct.rs
@@ -84,6 +84,8 @@ pub enum DirectEvent {
 }
 
 const DM_PAGE_SIZE: i32 = 500;
+const DM_FETCH_MAX_ATTEMPTS: u32 = 3;
+const DM_FETCH_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(400);
 const MESSAGE_CODE_SEND_TOKEN: i32 = 11;
 /// Incoming DM traffic bumps last-message/unread state per message; the
 /// sidebar and unread rail only need to converge, not animate every packet,
@@ -254,6 +256,12 @@ pub struct DirectMessageStore {
     current: Option<(ChannelId, i32)>,
     pending_changed: Vec<ChannelId>,
     changed_notify_task: Option<Task<()>>,
+    dm_space_joined: bool,
+    /// Bumped when the socket comes back. A listing issued on the socket that
+    /// died carries the old value and drops its result, so the reconnect can
+    /// clear `loading` and re-issue without the dead fetch clearing the flag —
+    /// or applying its stale page — behind the replacement.
+    socket_generation: u64,
     api: Arc<AppApi>,
     _conn_watch: Task<()>,
 }
@@ -282,6 +290,9 @@ impl DirectMessageStore {
 
     pub fn reset(&mut self, cx: &mut Context<Self>) {
         self.channels = DirectChannelList::default();
+        // Same fence as a reconnect: a listing still in flight must not repopulate
+        // the store, or re-join the DM space, for the account that just left.
+        self.socket_generation = self.socket_generation.wrapping_add(1);
         self.loading = false;
         self.freshness.mark_stale();
         self.has_more = true;
@@ -291,6 +302,7 @@ impl DirectMessageStore {
         self.persist_pinned(cx);
         self.pending_changed.clear();
         self.changed_notify_task = None;
+        self.dm_space_joined = false;
         cx.emit(DirectEvent::Changed { channel_id: None });
         cx.notify();
     }
@@ -308,6 +320,8 @@ impl DirectMessageStore {
             current: None,
             pending_changed: Vec::new(),
             changed_notify_task: None,
+            dm_space_joined: false,
+            socket_generation: 0,
             api,
             _conn_watch: conn_watch,
         }
@@ -342,6 +356,9 @@ impl DirectMessageStore {
                     was_connected = true;
                     if this
                         .update(cx, |this, cx| {
+                            this.socket_generation = this.socket_generation.wrapping_add(1);
+                            this.dm_space_joined = false;
+                            this.loading = false;
                             this.freshness.mark_stale();
                             this.fetch(cx);
                         })
@@ -351,6 +368,7 @@ impl DirectMessageStore {
                     }
                 } else if !connected {
                     was_connected = false;
+                    let _ = this.update(cx, |this, _| this.dm_space_joined = false);
                 }
             }
         })
@@ -687,6 +705,7 @@ impl DirectMessageStore {
         let next_page = self.current_page + 1;
         self.loading = true;
         let api = self.api.clone();
+        let socket_generation = self.socket_generation;
         cx.spawn(async move |this, cx| {
             let (result, badges) = tokio::join!(
                 api.list_dm_channels(next_page as i32),
@@ -699,6 +718,9 @@ impl DirectMessageStore {
             }
             let badge_map = badge_map_from_descs(badges.unwrap_or_default());
             let _ = this.update(cx, |this, cx| {
+                if this.socket_generation != socket_generation {
+                    return;
+                }
                 this.loading = false;
                 match result {
                     Ok(list) => {
@@ -725,25 +747,81 @@ impl DirectMessageStore {
         .detach();
     }
 
+    /// Subscribe the socket to the DM space, once per gateway session.
+    ///
+    /// `clan_join{clan_id: 0}` fans out to the DM and group streams from the
+    /// gateway's cached channel listing for this user, and the listing is only
+    /// cached once `ListChannelDescs` has been served — a join that runs first
+    /// subscribes to nothing, so unopened conversations stop pushing
+    /// `ChannelMessage` for the rest of the session. Hence: only ever called
+    /// after the DM listing round-trip has completed.
+    fn join_dm_space(&mut self, cx: &mut Context<Self>) {
+        if self.dm_space_joined {
+            return;
+        }
+        self.dm_space_joined = true;
+        let api = self.api.clone();
+        let socket_generation = self.socket_generation;
+        cx.spawn(async move |this, cx| match api.join_clan_chat(0).await {
+            Ok(()) => tracing::info!("DM-space subscribed (clan_join clan_id=0)"),
+            Err(e) => {
+                tracing::warn!("DM-space join (clan_join clan_id=0) failed: {e}");
+                let _ = this.update(cx, |this, _| {
+                    if this.socket_generation == socket_generation {
+                        this.dm_space_joined = false;
+                    }
+                });
+            }
+        })
+        .detach();
+    }
+
     fn fetch(&mut self, cx: &mut Context<Self>) {
         if self.loading {
             return;
         }
         self.loading = true;
         let api = self.api.clone();
+        let socket_generation = self.socket_generation;
+        let timer = cx.background_executor().clone();
         cx.spawn(async move |this, cx| {
-            let (result, badges) =
-                tokio::join!(api.list_dm_channels(1), api.list_channel_badge_counts(0),);
+            // Retried, because a failure here does more than leave the list stale:
+            // the DM-space `clan_join` hangs off this call landing, and nothing
+            // else re-triggers it while the socket stays up.
+            let mut attempt = 1u32;
+            let (result, badges) = loop {
+                let pair = tokio::join!(api.list_dm_channels(1), api.list_channel_badge_counts(0));
+                if pair.0.is_ok() || attempt >= DM_FETCH_MAX_ATTEMPTS {
+                    break pair;
+                }
+                if let Err(e) = &pair.0 {
+                    tracing::warn!("list_dm_channels failed (attempt {attempt}): {e}, retrying");
+                }
+                timer.timer(DM_FETCH_RETRY_BACKOFF * attempt).await;
+                let current = this
+                    .update(cx, |this, _| this.socket_generation == socket_generation)
+                    .unwrap_or(false);
+                if !current {
+                    return;
+                }
+                attempt += 1;
+            };
             let badges_complete = badges.is_ok();
             if let Err(e) = &badges {
                 tracing::warn!("list_channel_badge_counts failed alongside the DM list: {e}");
             }
             let badge_map = badge_map_from_descs(badges.unwrap_or_default());
             let _ = this.update(cx, |this, cx| {
+                if this.socket_generation != socket_generation {
+                    return;
+                }
                 this.loading = false;
                 match result {
                     Ok(list) => {
                         tracing::info!("DirectMessageStore: fetched {} DM channels", list.len());
+                        // The gateway has just served this user's clan-0 channel
+                        // listing, so its cache is warm and the join can fan out.
+                        this.join_dm_space(cx);
                         let has_more = list.len() >= DM_PAGE_SIZE as usize;
                         let channels: Vec<DirectChannel> =
                             list.into_iter().map(direct_from_api).collect();

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -5297,7 +5297,6 @@ impl MessagesStore {
         self.spawn_initial_fetch(clan_id, channel_id, generation, cx);
     }
 
-    fn spawn_join(
     /// Subscribe the socket to one channel — but never before the clan itself is joined.
     ///
     /// A `channel_join` for a **public** channel resolves to the clan-wide stream, not a
@@ -5308,6 +5307,7 @@ impl MessagesStore {
     /// reads as "some channels stopped going unread". Awaiting the clan join first is what
     /// keeps the fan-out reachable. React gets this ordering for free: its clan route loader
     /// dispatches `joinClan` before the channel loader dispatches `joinChannel`.
+    fn spawn_join(
         &self,
         clan_id: ClanId,
         channel_id: ChannelId,
@@ -5316,15 +5316,15 @@ impl MessagesStore {
         cx: &mut Context<Self>,
     ) {
         let api = self.api.clone();
-        cx.spawn(async move |_this, _cx| {
         let clan_joined = (!clan_id.is_zero()).then(|| {
             ChannelList::global(cx)
                 .update(cx, |channels, cx| channels.ensure_clan_joined(clan_id, cx))
         });
-            if let Err(e) = api
+        cx.spawn(async move |_this, _cx| {
             if let Some(clan_joined) = clan_joined {
                 clan_joined.await;
             }
+            if let Err(e) = api
                 .join_chat(clan_id.get(), channel_id.get(), join_type, is_public)
                 .await
             {

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -5298,6 +5298,16 @@ impl MessagesStore {
     }
 
     fn spawn_join(
+    /// Subscribe the socket to one channel — but never before the clan itself is joined.
+    ///
+    /// A `channel_join` for a **public** channel resolves to the clan-wide stream, not a
+    /// per-channel one, so the gateway ends up with the clan stream already tracked. Its
+    /// `clan_join` handler answers an already-tracked clan from the tracker and skips the
+    /// fan-out entirely, which silently leaves every **private** channel and thread in that
+    /// clan unsubscribed for the rest of the session — public rows keep updating, so it
+    /// reads as "some channels stopped going unread". Awaiting the clan join first is what
+    /// keeps the fan-out reachable. React gets this ordering for free: its clan route loader
+    /// dispatches `joinClan` before the channel loader dispatches `joinChannel`.
         &self,
         clan_id: ClanId,
         channel_id: ChannelId,
@@ -5307,7 +5317,14 @@ impl MessagesStore {
     ) {
         let api = self.api.clone();
         cx.spawn(async move |_this, _cx| {
+        let clan_joined = (!clan_id.is_zero()).then(|| {
+            ChannelList::global(cx)
+                .update(cx, |channels, cx| channels.ensure_clan_joined(clan_id, cx))
+        });
             if let Err(e) = api
+            if let Some(clan_joined) = clan_joined {
+                clan_joined.await;
+            }
                 .join_chat(clan_id.get(), channel_id.get(), join_type, is_public)
                 .await
             {

--- a/crates/mezon-store/src/notification_setting.rs
+++ b/crates/mezon-store/src/notification_setting.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Subscription, Task};
@@ -261,7 +261,7 @@ impl NotificationSettingStore {
             let _ = this.update(cx, |store, cx| {
                 store.clan_prefetch.remove(&clan_id);
                 match muted {
-                    Ok(ids) => store.seed_muted_channels(&ids),
+                    Ok(ids) => store.seed_muted_channels(&ids, cx),
                     Err(e) => tracing::warn!(
                         clan_id = clan_id.get(),
                         "failed to list muted channels: {e}"
@@ -283,7 +283,8 @@ impl NotificationSettingStore {
     /// `list_muted_channels` returns ids only, so it can establish that a channel is
     /// muted but not when the mute expires; the exact expiry arrives with
     /// [`Self::ensure_loaded`] for the channel actually being opened.
-    fn seed_muted_channels(&mut self, muted_ids: &[String]) {
+    fn seed_muted_channels(&mut self, muted_ids: &[String], cx: &mut Context<Self>) {
+        let mut seeded = HashSet::with_capacity(muted_ids.len());
         for id in muted_ids {
             let Ok(raw) = id.parse::<i64>() else {
                 continue;
@@ -297,6 +298,12 @@ impl NotificationSettingStore {
             if entry.mute_until_ms == 0 {
                 entry.mute_until_ms = i64::from(MUTE_INFINITY);
             }
+            seeded.insert(channel_id);
+        }
+        if !seeded.is_empty() {
+            crate::channel::ChannelList::global(cx).update(cx, |channels, cx| {
+                channels.set_channels_muted_any_clan(&seeded, true, cx);
+            });
         }
     }
 
@@ -316,6 +323,10 @@ impl NotificationSettingStore {
                 match fetched {
                     Ok(setting) => {
                         store.settings.insert(channel_id, setting);
+                        let muted = setting.is_time_muted(now_ms());
+                        crate::channel::ChannelList::global(cx).update(cx, |channels, cx| {
+                            channels.set_channel_muted_any_clan(channel_id, muted, cx);
+                        });
                         cx.emit(NotificationSettingEvent::Changed(channel_id));
                         cx.notify();
                     }

--- a/crates/mezon-ui/src/app/capture.rs
+++ b/crates/mezon-ui/src/app/capture.rs
@@ -518,7 +518,39 @@ pub fn topic_type(cx: &mut App, text: &str) -> anyhow::Result<Value> {
     cx.update_window(main_handle, |_, window, cx| {
         composer.update(cx, |composer, cx| composer.probe_set_text(text, window, cx));
     })?;
-    Ok(json!({ "ok": true, "text": text }))
+    topic_composer_snapshot(cx)
+}
+
+/// Accept one entry of the topic composer's suggestion popup — the `@`/`#`/`:` flow.
+///
+/// Typing `@name` alone only produces literal text: a real mention needs the picked
+/// entry, which is what writes the id into the message's `mentions` field. Detection on
+/// the receiving side reads that field, never the text, so a topic mention can only be
+/// exercised end-to-end through here.
+pub fn topic_pick(cx: &mut App, index: usize) -> anyhow::Result<Value> {
+    let (composer, _) = topic_panel(cx)?;
+    let main_handle = handle(cx).ok_or_else(|| anyhow::anyhow!("main window not found"))?;
+    let accepted = cx.update_window(main_handle, |_, window, cx| {
+        composer.update(cx, |composer, cx| composer.probe_accept(index, window, cx))
+    })?;
+    if !accepted {
+        anyhow::bail!("no suggestion at index {index}; call topic_type first");
+    }
+    topic_composer_snapshot(cx)
+}
+
+fn topic_composer_snapshot(cx: &mut App) -> anyhow::Result<Value> {
+    let (composer, _) = topic_panel(cx)?;
+    let composer = composer.read(cx);
+    let (popup_open, selected, suggestions) = composer.probe_suggestions();
+    Ok(json!({
+        "ok": true,
+        "text": composer.probe_text(cx).to_string(),
+        "attachments": composer.probe_attachments(),
+        "popup_open": popup_open,
+        "selected": selected,
+        "suggestions": suggestions,
+    }))
 }
 
 pub fn topic_submit(cx: &mut App) -> anyhow::Result<Value> {


### PR DESCRIPTION
Private channels and threads stopped turning unread: their rows never went bold on a live message, and opening them showed the backlog. Public channels kept working, so it read as "some channels are broken".

The gateway resolves a `channel_join` for a *public* channel to the clan-wide stream, not a per-channel one — the same stream `clan_join` tracks. Its `clan_join` handler answers an already-tracked clan from the tracker and skips the fan-out entirely, so every private channel and thread in that clan stays unsubscribed for the rest of the gateway session, with no way to repair it. Desktop lost that race every time: `select_channel` sent its `ChannelJoin` immediately while the clan join waited on a round trip. React survives on ordering it gets for free — its clan route loader dispatches `joinClan` before the channel loader dispatches `joinChannel`.

`MessagesStore::spawn_join` now awaits `ChannelList::ensure_clan_joined` before `join_chat`, which also keeps the softer constraint the gateway has: it builds the per-channel subscriptions from the cached `ListChannelDescs` for that user, so the join must follow the listing or it fans out over a cold cache. Order is now `ListChannelDescs -> clan_join -> channel_join`, with `ListChannelBadgeCount` after the join as before. `ensure_clan_joined` starts the listing itself, so a deep link or a restored route cannot skip the join.

Also in this area:

- A reconnect could leave a clan un-refetched and un-re-seeded. `resync` cleared `badge_seeded` but not the in-flight guards, so `fetch_clan` and `seed_badges` returned early behind a request the dead socket had abandoned — and when that request failed it cleared the guard belonging to its replacement. A `socket_generation`, bumped only by `resync`, fences those tasks so the guards can be dropped and everything re-issued.
- The rail never re-synced after a reconnect: `badges_loaded` only reset on logout, and `carry_live_badges` overwrote server counts with local ones regardless. `reload_badges` refetches once per reconnect and the carry now yields to an authoritative `ListClanBadgeCount`.
- `clan_join{clan_id: 0}` moved from the connect loop into `DirectMessageStore`, after the DM listing lands, for the same reason as the clan case. The DM fetch gained the same generation fence and a bounded retry, since the join hangs off it.

Verified against a local backend with two accounts: private channel, thread, DM, mention, reply, topic and topic-mention all deliver; a reconnect and a full restart both refill unread, badge and DM counts.