### PR TITLE
fix(thread): invite members from public parents

### DIFF
--- a/crates/mezon-active-windows/src/catalog.rs
+++ b/crates/mezon-active-windows/src/catalog.rs
@@ -149,10 +149,10 @@ pub fn match_linux_process(
         return Some(matched);
     }
     let comm_normalized = comm.replace('_', " ");
-    if comm_normalized != comm {
-        if let Some(matched) = match_process_name(&comm_normalized) {
-            return Some(matched);
-        }
+    if comm_normalized != comm
+        && let Some(matched) = match_process_name(&comm_normalized)
+    {
+        return Some(matched);
     }
     for (comm_alias, catalog_alias) in LINUX_COMM_ALIASES {
         if comm.eq_ignore_ascii_case(comm_alias) {
@@ -200,6 +200,7 @@ pub fn pick_highest_priority_match(
     best.map(|(name, kind, _)| (name, kind))
 }
 
+#[cfg(any(target_os = "linux", test))]
 pub(crate) fn running_process_kind_priority(kind: ActivityKind) -> u8 {
     match kind {
         ActivityKind::Coding => 3,

--- a/crates/mezon-active-windows/src/platform/macos.rs
+++ b/crates/mezon-active-windows/src/platform/macos.rs
@@ -2,7 +2,8 @@ use crate::info::ActiveWindowInfo;
 use core_foundation::array::CFArrayGetValueAtIndex;
 use core_foundation::base::TCFType;
 use core_foundation::dictionary::CFDictionary;
-use core_foundation::number::CFNumber;
+use core_foundation::number::{CFNumber, CFNumberRef};
+use core_foundation::string::CFStringRef;
 use std::ffi::c_void;
 use std::os::raw::c_void as RawCVoid;
 
@@ -80,7 +81,7 @@ fn dictionary_string(dict: &CFDictionary, key: &str) -> String {
         return String::new();
     };
     let cf_str = unsafe {
-        core_foundation::string::CFString::wrap_under_get_rule(*value_ref as *const c_void)
+        core_foundation::string::CFString::wrap_under_get_rule(*value_ref as CFStringRef)
     };
     cf_str.to_string()
 }
@@ -88,7 +89,7 @@ fn dictionary_string(dict: &CFDictionary, key: &str) -> String {
 fn dictionary_i64(dict: &CFDictionary, key: &str) -> Option<i64> {
     let key = core_foundation::string::CFString::new(key);
     let value_ref = dict.find(key.as_concrete_TypeRef() as *const RawCVoid)?;
-    let number = unsafe { CFNumber::wrap_under_get_rule(*value_ref as *const c_void) };
+    let number = unsafe { CFNumber::wrap_under_get_rule(*value_ref as CFNumberRef) };
     number.to_i64()
 }
 

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -6270,6 +6270,7 @@ pub(crate) fn plan_thread_membership(
     self_id: Option<UserId>,
     thread_members: &[UserId],
     parent_members: &[UserId],
+    parent_is_public: bool,
     mentioned: &[UserId],
 ) -> Vec<UserId> {
     let mut plan = Vec::new();
@@ -6281,7 +6282,7 @@ pub(crate) fn plan_thread_membership(
     for user_id in mentioned {
         if Some(*user_id) == self_id
             || thread_members.contains(user_id)
-            || !parent_members.contains(user_id)
+            || (!parent_is_public && !parent_members.contains(user_id))
             || plan.contains(user_id)
         {
             continue;
@@ -6329,6 +6330,7 @@ struct ThreadSendContext {
     parent_id: ChannelId,
     channel_type: Option<i32>,
     parent_channel_type: Option<i32>,
+    parent_is_public: bool,
     self_id: Option<UserId>,
     /// `None` when the store holds no roster for the channel. Distinguishing that
     /// from an empty roster matters: an unloaded thread would otherwise read as
@@ -6352,12 +6354,16 @@ fn thread_send_context(
     let parent_channel_type = channels
         .channel(clan_id, parent_id)
         .map(|channel| channel.channel_type.as_raw() as i32);
+    let parent_is_public = channels
+        .channel(clan_id, parent_id)
+        .is_some_and(|channel| !channel.private);
     let members = ChannelMembersStore::try_global(cx)?;
     let members = members.read(cx);
     Some(ThreadSendContext {
         parent_id,
         channel_type,
         parent_channel_type,
+        parent_is_public,
         self_id: viewer_user_id(cx),
         thread_members: members
             .has_channel(channel_id)
@@ -6447,25 +6453,27 @@ async fn resolve_thread_membership_plan(
     let mut candidates = ctx.mentioned;
     candidates.extend_from_slice(extra_candidates);
     // Parent membership only gates the candidates; a self-join never consults it.
-    let parent_members = if needs_parent_lookup(&thread_members, &candidates) {
-        resolve_channel_members(
-            api,
-            this,
-            clan_id,
-            ctx.parent_id,
-            ctx.parent_channel_type,
-            ctx.parent_members,
-            cx,
-        )
-        .await
-        .unwrap_or_default()
-    } else {
-        Vec::new()
-    };
+    let parent_members =
+        if !ctx.parent_is_public && needs_parent_lookup(&thread_members, &candidates) {
+            resolve_channel_members(
+                api,
+                this,
+                clan_id,
+                ctx.parent_id,
+                ctx.parent_channel_type,
+                ctx.parent_members,
+                cx,
+            )
+            .await
+            .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
     plan_thread_membership(
         if join_self { ctx.self_id } else { None },
         &thread_members,
         &parent_members,
+        ctx.parent_is_public,
         &candidates,
     )
 }
@@ -8963,8 +8971,13 @@ mod tests {
 
     #[test]
     fn thread_send_joins_sender_when_not_a_member() {
-        let plan =
-            plan_thread_membership(Some(UserId(1)), &[UserId(2)], &[UserId(1), UserId(2)], &[]);
+        let plan = plan_thread_membership(
+            Some(UserId(1)),
+            &[UserId(2)],
+            &[UserId(1), UserId(2)],
+            false,
+            &[],
+        );
 
         assert_eq!(plan, vec![UserId(1)]);
     }
@@ -8975,6 +8988,7 @@ mod tests {
             Some(UserId(1)),
             &[UserId(1), UserId(2)],
             &[UserId(1), UserId(2)],
+            false,
             &[],
         );
 
@@ -8987,6 +9001,7 @@ mod tests {
             Some(UserId(1)),
             &[UserId(1)],
             &[UserId(1), UserId(2), UserId(3)],
+            false,
             &[UserId(2), UserId(3)],
         );
 
@@ -8999,6 +9014,7 @@ mod tests {
             Some(UserId(1)),
             &[UserId(1)],
             &[UserId(1), UserId(2)],
+            false,
             &[UserId(2), UserId(9)],
         );
 
@@ -9011,6 +9027,7 @@ mod tests {
             Some(UserId(1)),
             &[UserId(1), UserId(2)],
             &[UserId(1), UserId(2)],
+            false,
             &[UserId(2)],
         );
 
@@ -9023,6 +9040,7 @@ mod tests {
             Some(UserId(1)),
             &[],
             &[UserId(1), UserId(2)],
+            false,
             &[UserId(1), UserId(2), UserId(2)],
         );
 
@@ -9031,7 +9049,7 @@ mod tests {
 
     #[test]
     fn thread_send_without_a_known_viewer_only_adds_mentions() {
-        let plan = plan_thread_membership(None, &[], &[UserId(2)], &[UserId(2)]);
+        let plan = plan_thread_membership(None, &[], &[UserId(2)], false, &[UserId(2)]);
 
         assert_eq!(plan, vec![UserId(2)]);
     }
@@ -9047,16 +9065,28 @@ mod tests {
     }
 
     #[test]
+    fn public_parent_does_not_require_an_explicit_channel_roster() {
+        let plan = plan_thread_membership(Some(UserId(1)), &[UserId(1)], &[], true, &[UserId(2)]);
+
+        assert_eq!(plan, vec![UserId(2)]);
+    }
+
+    #[test]
     fn thread_reaction_joins_a_parent_member() {
-        let plan =
-            plan_thread_membership(None, &[UserId(2)], &[UserId(1), UserId(2)], &[UserId(1)]);
+        let plan = plan_thread_membership(
+            None,
+            &[UserId(2)],
+            &[UserId(1), UserId(2)],
+            false,
+            &[UserId(1)],
+        );
 
         assert_eq!(plan, vec![UserId(1)]);
     }
 
     #[test]
     fn thread_reaction_does_not_join_a_non_parent_member() {
-        let plan = plan_thread_membership(None, &[UserId(2)], &[UserId(2)], &[UserId(1)]);
+        let plan = plan_thread_membership(None, &[UserId(2)], &[UserId(2)], false, &[UserId(1)]);
 
         assert!(plan.is_empty());
     }

--- a/crates/mezon-store/src/threads.rs
+++ b/crates/mezon-store/src/threads.rs
@@ -1012,10 +1012,12 @@ impl ThreadsStore {
         let category_id = self.category_id.clone();
         let channel_private = self.create_private;
         let clan_id_i64 = clan_id_parsed.get();
-        let parent_channel_type = ChannelList::global(cx)
+        let parent_channel = ChannelList::global(cx)
             .read(cx)
             .channel(clan_id_parsed, parent_channel_id)
-            .map(|channel| channel.channel_type.as_raw() as i32);
+            .map(|channel| (channel.channel_type.as_raw() as i32, channel.private));
+        let parent_channel_type = parent_channel.map(|(channel_type, _)| channel_type);
+        let parent_is_public = parent_channel.is_some_and(|(_, private)| !private);
         let cached_parent_members = ChannelMembersStore::try_global(cx).and_then(|members| {
             let members = members.read(cx);
             members
@@ -1113,7 +1115,7 @@ impl ThreadsStore {
 
             let parent_members = match cached_parent_members {
                 Some(ids) => ids,
-                None => match parent_channel_type {
+                None if !parent_is_public => match parent_channel_type {
                     Some(channel_type) => {
                         match api
                             .list_channel_users(clan_id_i64, parent_channel_id.get(), channel_type)
@@ -1145,8 +1147,10 @@ impl ThreadsStore {
                     }
                     None => Vec::new(),
                 },
+                None => Vec::new(),
             };
-            let invite_ids = plan_thread_membership(None, &[], &parent_members, &mentioned);
+            let invite_ids =
+                plan_thread_membership(None, &[], &parent_members, parent_is_public, &mentioned);
 
             let mut invite_failed = false;
             if !invite_ids.is_empty() {


### PR DESCRIPTION
## Summary

- Treat clan membership as sufficient when inviting mentioned users from a public parent channel, whose explicit channel roster can be empty.
- Preserve the explicit parent-membership gate for private parent channels.
- Apply the same rule to both message/reaction-driven invitations and initial private-thread creation.
- Restore the macOS active-window build against core-foundation 0.10 so the required final app link can run.

## Verification

- Live web-to-Rust flow: web created a private thread and invited the Rust user; Rust received realtime state and loaded messages.
- Live Rust-to-web flow under a public parent: mentioning a valid clan member increased thread membership from 2 to 3; web received the message and member update in realtime.
- Full nextest sweep: 2,126 tests executed; 2,124 passed. The two failures are existing base issues outside this diff: ru lacks screenShare.systemWillAsk, and webhook_target_channels_excludes_locally_archived_user_channels does not initialize GlobalThreadsStore.
- Rerun excluding those two known base failures: 2,124/2,124 passed.
- just lint passed.
- cargo build -p mezon-app passed.