### PR TITLE
fix(embed): prevent multiline field overlap

### DIFF
--- a/crates/mezon-ui/src/chat/message/embed_fields.rs
+++ b/crates/mezon-ui/src/chat/message/embed_fields.rs
@@ -130,6 +130,8 @@ fn render_field(
     };
     if multi_column {
         column = column.flex_1();
+    } else {
+        column = column.w_full();
     }
     column = column.child(text_block);
 


### PR DESCRIPTION
## Summary

- make single-column embed fields fill the available card width
- keep multi-column embed sizing unchanged
- prevent multiline field text from overlapping following fields

## Verification

- manually reproduced and verified the affected direct-message embed
- `cargo build -p mezon-app`
- `just fmt-check`
- `cargo nextest run -p mezon-ui --no-capture` — 467 passed

## Existing develop blockers

- `just lint` currently fails on `clippy::nonminimal_bool` in `crates/mezon-ui/src/chat/channel_settings/overview_tab.rs`
- `just test` currently fails because the Russian locale is missing `screenShare.systemWillAsk`
