### PR TITLE
feat(download): reveal completed downloads

### DIFF
--- a/crates/mezon-store/src/platform.rs
+++ b/crates/mezon-store/src/platform.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 pub enum DownloadEvent {
     Started,
     Progress { written: u64, total: Option<u64> },
-    Finished,
+    Finished { path: std::path::PathBuf },
     Failed,
 }
 
@@ -25,6 +25,7 @@ pub fn download_url_with_dialog(
             Ok(Ok(Some(path))) => path,
             _ => return,
         };
+        let finished_path = path.clone();
         cx.update(|cx| on_event(DownloadEvent::Started, cx));
         let (tx, rx) = flume::unbounded::<(u64, Option<u64>)>();
         let download = cx.background_executor().spawn(async move {
@@ -37,7 +38,9 @@ pub fn download_url_with_dialog(
             cx.update(|cx| on_event(DownloadEvent::Progress { written, total }, cx));
         }
         let event = match download.await {
-            Ok(()) => DownloadEvent::Finished,
+            Ok(()) => DownloadEvent::Finished {
+                path: finished_path,
+            },
             Err(error) => {
                 tracing::error!("attachment download failed: {error}");
                 DownloadEvent::Failed

--- a/crates/mezon-ui/src/util/download.rs
+++ b/crates/mezon-ui/src/util/download.rs
@@ -35,7 +35,8 @@ pub fn save_with_progress_toast(url: SharedString, filename: SharedString, cx: &
                         mezon_i18n::t(&locale, "download.downloading").replace("{{name}}", &name);
                     shell.progress_toast(key, message, progress, cx);
                 }
-                DownloadEvent::Finished => {
+                DownloadEvent::Finished { path } => {
+                    cx.reveal_path(&path);
                     let message =
                         mezon_i18n::t(&locale, "download.saved").replace("{{name}}", &name);
                     shell.finish_toast(key, ToastKind::Success, message, cx);


### PR DESCRIPTION
## Summary

- carry the saved path with the completed download event
- reveal the downloaded file in Finder, Explorer, or the Linux file manager after a successful save
- leave cancelled and failed downloads unchanged

## Performance and impact

- clones one PathBuf once per user-initiated download
- reveal_path dispatches through the GPUI platform background executor
- no render-path or download-transfer behavior changes

## Verification

- `cargo build -p mezon-app`
- `just fmt-check`
- `cargo clippy -p mezon-store -p mezon-ui --no-deps -- -D warnings -A clippy::nonminimal_bool`
- `cargo nextest run -p mezon-store -p mezon-ui --no-fail-fast` — 1588 passed, 1 unrelated baseline failure

## Existing develop blockers

- `just lint` fails on `clippy::nonminimal_bool` in `crates/mezon-ui/src/chat/channel_settings/overview_tab.rs`
- the targeted test run has one existing failure in `channel::tests::webhook_target_channels_excludes_locally_archived_user_channels` because `GlobalThreadsStore` is not initialized