### PR TITLE
fix(chat): restrict blocked-user direct messages

### DIFF
--- a/crates/mezon-store/src/friend.rs
+++ b/crates/mezon-store/src/friend.rs
@@ -268,6 +268,10 @@ impl FriendStore {
             .any(|f| f.state == FriendState::Blocked && f.source_id == me && f.username == username)
     }
 
+    pub fn is_user_blocked_by_me(&self, user_id: UserId, cx: &App) -> bool {
+        is_blocked_by(&self.friends, user_id, self.current_user_id(cx))
+    }
+
     /// Count of incoming friend requests awaiting the current user's response
     /// (React `quantityPendingRequest` = friends with state `MY_PENDING`).
     pub fn pending_incoming_count(&self) -> usize {

--- a/crates/mezon-ui/src/chat/area.rs
+++ b/crates/mezon-ui/src/chat/area.rs
@@ -7,8 +7,9 @@ use gpui::{
     Subscription, Task, Window, div, prelude::*, px, rgb, rgba,
 };
 use mezon_store::{
-    ChannelId, ChannelPermissionsStore, ClanId, InVoiceInfo, MessagesEvent, MessagesStore,
-    PERMISSION_SEND_MESSAGE, Settings,
+    ChannelId, ChannelPermissionsStore, ClanId, DirectEvent, DirectKind, DirectMessageStore,
+    FriendEvent, FriendStore, InVoiceInfo, MessagesEvent, MessagesStore, PERMISSION_SEND_MESSAGE,
+    Settings,
 };
 use ui::PopoverMenuHandle;
 
@@ -46,12 +47,15 @@ pub struct ChatArea {
     send_permission_key: Option<(ClanId, ChannelId)>,
     send_permission_live: Option<bool>,
     can_send_message: Option<bool>,
-    no_permission_label: Option<(SharedString, SharedString)>,
+    dm_blocked: bool,
+    no_permission_label: Option<(SharedString, bool, SharedString)>,
     _submit_sub: Option<Subscription>,
     _reply_sub: Option<Subscription>,
     _edit_closed_sub: Option<Subscription>,
     _send_permission_sub: Subscription,
     _send_permission_channel_sub: Subscription,
+    _send_permission_direct_sub: Subscription,
+    _send_permission_friend_sub: Subscription,
     _send_permission_debounce: Option<Task<()>>,
     drop_title_cache: Option<(SharedString, SharedString, SharedString)>,
     drop_body_cache: Option<(SharedString, SharedString)>,
@@ -84,6 +88,24 @@ impl ChatArea {
                 }
             },
         );
+        let send_permission_direct_sub = cx.subscribe(
+            &DirectMessageStore::global(cx),
+            |this: &mut crate::ChatLayout, _, event: &DirectEvent, cx| {
+                let DirectEvent::Changed { channel_id } = event;
+                let active_channel = MessagesStore::global(cx).read(cx).active_channel_id();
+                if channel_id.is_none() || *channel_id == active_channel {
+                    this.chat_area.sync_send_permission(cx);
+                }
+            },
+        );
+        let send_permission_friend_sub = cx.subscribe(
+            &FriendStore::global(cx),
+            |this: &mut crate::ChatLayout, _, event: &FriendEvent, cx| {
+                if matches!(event, FriendEvent::Changed) {
+                    this.chat_area.sync_send_permission(cx);
+                }
+            },
+        );
         Self {
             timeline,
             mention_input: None,
@@ -100,12 +122,15 @@ impl ChatArea {
             send_permission_key: None,
             send_permission_live: None,
             can_send_message: None,
+            dm_blocked: false,
             no_permission_label: None,
             _submit_sub: None,
             _reply_sub: None,
             _edit_closed_sub: None,
             _send_permission_sub: send_permission_sub,
             _send_permission_channel_sub: send_permission_channel_sub,
+            _send_permission_direct_sub: send_permission_direct_sub,
+            _send_permission_friend_sub: send_permission_friend_sub,
             _send_permission_debounce: None,
             drop_title_cache: None,
             drop_body_cache: None,
@@ -113,17 +138,32 @@ impl ChatArea {
     }
 
     pub fn sync_send_permission(&mut self, cx: &mut Context<crate::ChatLayout>) {
-        let key = {
+        let (key, dm_peer) = {
             let messages = MessagesStore::global(cx).read(cx);
             if messages.is_dm() {
-                None
+                let peer = messages.active_channel_id().and_then(|channel_id| {
+                    let direct_store = DirectMessageStore::try_global(cx)?;
+                    let direct_store = direct_store.read(cx);
+                    let direct = direct_store.find(channel_id)?;
+                    (direct.kind == DirectKind::Dm).then_some(direct.peer_user_id)?
+                });
+                (None, peer)
             } else {
-                messages
-                    .active_clan_id()
-                    .filter(|clan_id| !clan_id.is_zero())
-                    .zip(messages.active_channel_id())
+                (
+                    messages
+                        .active_clan_id()
+                        .filter(|clan_id| !clan_id.is_zero())
+                        .zip(messages.active_channel_id()),
+                    None,
+                )
             }
         };
+        let dm_blocked = dm_peer.is_some_and(|peer| {
+            FriendStore::try_global(cx)
+                .is_some_and(|store| store.read(cx).is_user_blocked_by_me(peer, cx))
+        });
+        let mut notify = self.dm_blocked != dm_blocked;
+        self.dm_blocked = dm_blocked;
         let live = key.and_then(|(clan_id, channel_id)| {
             ChannelPermissionsStore::try_global(cx).and_then(|store| {
                 store
@@ -132,6 +172,9 @@ impl ChatArea {
             })
         });
         if key == self.send_permission_key && live == self.send_permission_live {
+            if notify {
+                cx.notify();
+            }
             return;
         }
         let switched = key != self.send_permission_key;
@@ -141,9 +184,15 @@ impl ChatArea {
             self._send_permission_debounce = None;
             if self.can_send_message != live {
                 self.can_send_message = live;
+                notify = true;
+            }
+            if notify {
                 cx.notify();
             }
             return;
+        }
+        if notify {
+            cx.notify();
         }
         self._send_permission_debounce = Some(cx.spawn(async move |this, cx| {
             cx.background_executor()
@@ -157,6 +206,10 @@ impl ChatArea {
                 }
             });
         }));
+    }
+
+    pub(crate) fn send_denied(&self) -> bool {
+        self.dm_blocked || self.can_send_message == Some(false)
     }
 
     pub fn bind_channel_members(&mut self, cx: &mut Context<crate::ChatLayout>) {
@@ -281,7 +334,7 @@ impl ChatArea {
                 window,
                 |this: &mut crate::ChatLayout, _, event: &ChannelMessagesEvent, window, cx| {
                     let ChannelMessagesEvent::EditClosed = event;
-                    if this.chat_area.can_send_message == Some(false) {
+                    if this.chat_area.send_denied() {
                         return;
                     }
                     if let Some(input) = this.chat_area.mention_input.clone() {
@@ -628,15 +681,27 @@ impl ChatArea {
             )
         };
 
-        let send_denied = !media_channel_view && self.can_send_message == Some(false);
+        let send_denied = !media_channel_view && self.send_denied();
         let no_permission_notice = if send_denied {
             let label = match &self.no_permission_label {
-                Some((cached_locale, label)) if cached_locale.as_ref() == locale => label.clone(),
+                Some((cached_locale, cached_dm_blocked, label))
+                    if cached_locale.as_ref() == locale
+                        && *cached_dm_blocked == self.dm_blocked =>
+                {
+                    label.clone()
+                }
                 _ => {
-                    let label: SharedString =
-                        mezon_i18n::t(locale, "common.noPermissionToSendMessage").into();
-                    self.no_permission_label =
-                        Some((SharedString::from(locale.to_string()), label.clone()));
+                    let key = if self.dm_blocked {
+                        "message.blockedUserMessage"
+                    } else {
+                        "common.noPermissionToSendMessage"
+                    };
+                    let label: SharedString = mezon_i18n::t(locale, key).into();
+                    self.no_permission_label = Some((
+                        SharedString::from(locale.to_string()),
+                        self.dm_blocked,
+                        label.clone(),
+                    ));
                     label
                 }
             };
@@ -680,12 +745,12 @@ impl ChatArea {
                 let input_visible = !send_denied;
                 col.on_drop(
                     move |paths: &ExternalPaths, window: &mut Window, cx: &mut App| {
-                        if let Some(drop_input) = drop_input.clone() {
+                        if let Some(drop_input) = drop_input.clone()
+                            && input_visible
+                        {
                             let dropped: Vec<PathBuf> = paths.paths().to_vec();
                             drop_input.update(cx, |input, cx| {
-                                if input_visible {
-                                    input.focus_input(window, cx);
-                                }
+                                input.focus_input(window, cx);
                                 input.add_dropped_paths(dropped, window, cx)
                             });
                         }

--- a/crates/mezon-ui/src/chat/call_actions.rs
+++ b/crates/mezon-ui/src/chat/call_actions.rs
@@ -1,6 +1,7 @@
 use gpui::{App, SharedString};
 use mezon_store::{
-    CallPeer, CallPhase, CallStore, ChannelId, DirectKind, DirectMessageStore, Settings, UserId,
+    CallPeer, CallPhase, CallStore, ChannelId, DirectKind, DirectMessageStore, FriendStore,
+    Settings, UserId,
 };
 
 use crate::app::shell::Shell;
@@ -44,6 +45,9 @@ pub(crate) fn call_current_dm(video: bool, cx: &mut App) {
         info_toast("common.comingSoon", cx);
         return;
     };
+    if is_blocked_by_me(UserId(peer.user_id), cx) {
+        return;
+    }
     CallStore::global(cx).update(cx, |store, cx| store.start_call(peer, video, cx));
 }
 
@@ -53,6 +57,9 @@ pub(crate) fn call_user(
     error_message: SharedString,
     cx: &mut App,
 ) {
+    if is_blocked_by_me(target.user, cx) {
+        return;
+    }
     if warn_already_in_call(cx) {
         return;
     }
@@ -99,6 +106,11 @@ fn start_call_in(target: &CallTarget, channel: ChannelId, video: bool, cx: &mut 
         avatar: (!target.avatar.is_empty()).then(|| target.avatar.to_string()),
     };
     CallStore::global(cx).update(cx, |store, cx| store.start_call(peer, video, cx));
+}
+
+fn is_blocked_by_me(user_id: UserId, cx: &App) -> bool {
+    FriendStore::try_global(cx)
+        .is_some_and(|store| store.read(cx).is_user_blocked_by_me(user_id, cx))
 }
 
 fn warn_already_in_call(cx: &mut App) -> bool {

--- a/crates/mezon-ui/src/chat/channel_header.rs
+++ b/crates/mezon-ui/src/chat/channel_header.rs
@@ -6,8 +6,8 @@ use gpui::{
     Window, div, point, prelude::*, px,
 };
 use mezon_store::{
-    ChannelId, DirectKind, DirectMessageStore, DmAvatarPresence, InVoiceInfo, PinnedMessagesStore,
-    Settings, StreamStore, ThreadsStore,
+    ChannelId, DirectKind, DirectMessageStore, DmAvatarPresence, FriendEvent, FriendStore,
+    InVoiceInfo, PinnedMessagesStore, Settings, StreamStore, ThreadsStore,
 };
 use ui::{Clickable, PopoverMenu, PopoverMenuHandle, Toggleable, Tooltip};
 
@@ -41,6 +41,7 @@ fn canvas_popover_y_offset() -> Pixels {
 pub struct DmHeaderInfo {
     pub channel_id: ChannelId,
     pub is_group: bool,
+    pub blocked_by_me: bool,
     /// Peer presence for a 1:1 DM; always `None` for a group.
     pub presence: DmAvatarPresence,
     pub label: SharedString,
@@ -261,13 +262,19 @@ impl ChannelHeader {
             ("hdr-files", IconName::FileIcon),
         ];
         let dm_one_to_one = self.dm_header.as_ref().is_some_and(|info| !info.is_group);
+        let dm_one_to_one_blocked = self
+            .dm_header
+            .as_ref()
+            .is_some_and(|info| !info.is_group && info.blocked_by_me);
         let actions: Vec<(&str, IconName)> = if self.dm {
             let mut items: Vec<(&str, IconName)> = Vec::with_capacity(4);
-            if dm_one_to_one {
+            if dm_one_to_one && !dm_one_to_one_blocked {
                 items.push(("hdr-call", IconName::IconPhoneDM));
                 items.push(("hdr-video-call", IconName::IconMeetDM));
             }
-            items.push(("hdr-members", IconName::MemberList));
+            if !dm_one_to_one_blocked {
+                items.push(("hdr-members", IconName::MemberList));
+            }
             items.push(("hdr-pin", IconName::PinRight));
             items
         } else {
@@ -951,6 +958,7 @@ pub struct ChatHeader {
     _notification_observe: Subscription,
     _pinned_observe: Subscription,
     _direct_observe: Subscription,
+    _friend_subscribe: Subscription,
     _group_members_observe: Subscription,
     _presence_subscribe: Subscription,
 }
@@ -973,6 +981,14 @@ impl ChatHeader {
         let _direct_observe = cx.observe(&DirectMessageStore::global(cx), |this, _, cx| {
             this.refresh_dm_header(cx)
         });
+        let _friend_subscribe = cx.subscribe(
+            &FriendStore::global(cx),
+            |this, _, event: &FriendEvent, cx| {
+                if matches!(event, FriendEvent::Changed) {
+                    this.refresh_dm_header(cx);
+                }
+            },
+        );
         let _group_members_observe = cx.observe(
             &mezon_store::GroupMembersStore::global(cx),
             |this, _, cx| this.refresh_dm_header(cx),
@@ -1014,6 +1030,7 @@ impl ChatHeader {
             _notification_observe,
             _pinned_observe,
             _direct_observe,
+            _friend_subscribe,
             _group_members_observe,
             _presence_subscribe,
         }
@@ -1033,6 +1050,11 @@ impl ChatHeader {
         let store = DirectMessageStore::try_global(cx)?;
         let dm = store.read(cx).find(direct_id)?;
         let is_group = dm.kind == DirectKind::Group;
+        let blocked_by_me = dm.peer_user_id.is_some_and(|peer| {
+            !is_group
+                && FriendStore::try_global(cx)
+                    .is_some_and(|store| store.read(cx).is_user_blocked_by_me(peer, cx))
+        });
         let presence = dm_peer_presence(dm, cx);
         let avatar_src = if dm.avatar.is_empty() {
             String::new()
@@ -1057,6 +1079,7 @@ impl ChatHeader {
         Some(DmHeaderInfo {
             channel_id: dm.id,
             is_group,
+            blocked_by_me,
             presence,
             label: SharedString::from(dm.label.clone()),
             avatar_src: SharedString::from(avatar_src),

--- a/crates/mezon-ui/src/chat/layout.rs
+++ b/crates/mezon-ui/src/chat/layout.rs
@@ -2005,6 +2005,9 @@ impl Render for ChatLayout {
 
 impl ChatLayout {
     pub(crate) fn send_current_message(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.chat_area.send_denied() {
+            return;
+        }
         let Some(mention_input) = self.chat_area.mention_input.clone() else {
             return;
         };
@@ -2342,6 +2345,9 @@ impl ChatLayout {
     }
 
     pub(crate) fn send_sticker(&mut self, url: String, filename: String, cx: &mut Context<Self>) {
+        if self.chat_area.send_denied() {
+            return;
+        }
         crate::chat::ChatSending::send_sticker(url, filename, &self.auth_state, cx);
     }
 
@@ -2352,10 +2358,16 @@ impl ChatLayout {
         height: u32,
         cx: &mut Context<Self>,
     ) {
+        if self.chat_area.send_denied() {
+            return;
+        }
         crate::chat::ChatSending::send_gif(url, width, height, &self.auth_state, cx);
     }
 
     pub(crate) fn send_sound(&mut self, url: String, filename: String, cx: &mut Context<Self>) {
+        if self.chat_area.send_denied() {
+            return;
+        }
         crate::chat::ChatSending::send_sound(url, filename, &self.auth_state, cx);
     }
 


### PR DESCRIPTION
## Summary

- replace the composer with the localized blocked-conversation notice in blocked 1:1 DMs
- hide voice call, video call, and member actions for blocked peers
- reject message, attachment, and call actions even if a stale UI action still fires
- react immediately to DM navigation and block/unblock relationship changes

## Validation

- `cargo check -p mezon-store -p mezon-ui --all-targets --all-features --locked`
- `cargo nextest run -p mezon-store friend::tests` — 10 passed
- the same change passed the full lint gate and 2,153-test suite before rebasing onto the latest `develop`

## Existing develop gate failures

- `just lint` currently fails in unchanged `crates/mezon-ui/src/chat/channel_settings/overview_tab.rs` on `clippy::nonminimal_bool`
- `just test` currently fails in unchanged i18n data because `ru` is missing `screenShare.systemWillAsk`; the targeted store/UI run also exposes an unchanged channel test missing `GlobalThreadsStore`
