### PR TITLE
fix(chat): match stream embed controls and animation

### DIFF
--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -8471,7 +8471,7 @@ fn parse_embed_input(value: Option<&serde_json::Value>) -> Option<EmbedInput> {
             if options.is_empty() {
                 return None;
             }
-            Some(EmbedInput::Radio(EmbedRadio {
+            let mut radio = EmbedRadio {
                 id: id.into(),
                 options: options
                     .into_iter()
@@ -8485,7 +8485,11 @@ fn parse_embed_input(value: Option<&serde_json::Value>) -> Option<EmbedInput> {
                     })
                     .collect(),
                 max_options: wrapper.max_options.filter(|max| *max > 0),
-            }))
+            };
+            if radio.max_options.is_none() && radio.allows_multiple() {
+                radio.max_options = Some(i32::try_from(radio.options.len()).unwrap_or(i32::MAX));
+            }
+            Some(EmbedInput::Radio(radio))
         }
         Some(EMBED_COMPONENT_TYPE_ANIMATION) => {
             let component: ApiAnimationComponent =
@@ -9975,10 +9979,10 @@ mod tests {
                 options: vec![radio_option("a", "a"), radio_option("b", "b")],
                 max_options: Some(1),
             };
-            let unbounded_multi = EmbedRadio {
-                id: "unbounded-picks".into(),
+            let bounded_multi = EmbedRadio {
+                id: "implicit-picks".into(),
                 options: vec![radio_option("a", "a"), radio_option("b", "b")],
-                max_options: None,
+                max_options: Some(2),
             };
 
             store.update(cx, |store, cx| {
@@ -10002,12 +10006,12 @@ mod tests {
                     "picking the same option again clears it"
                 );
 
-                pick(store, &unbounded_multi, "a", cx);
-                pick(store, &unbounded_multi, "b", cx);
+                pick(store, &bounded_multi, "a", cx);
+                pick(store, &bounded_multi, "b", cx);
                 assert_eq!(
-                    store.message_select_selection(message_id, "unbounded-picks"),
+                    store.message_select_selection(message_id, "implicit-picks"),
                     ["a", "b"],
-                    "a missing max_options leaves a multi-choice radio unbounded"
+                    "an inferred multi-choice radio accepts each available option"
                 );
             });
         });
@@ -10354,7 +10358,7 @@ mod tests {
             panic!("expected a radio");
         };
         assert!(radio.allows_multiple());
-        assert_eq!(radio.max_options, None);
+        assert_eq!(radio.max_options, Some(2));
     }
 
     #[test]

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -8484,7 +8484,7 @@ fn parse_embed_input(value: Option<&serde_json::Value>) -> Option<EmbedInput> {
                         disabled: option.disabled,
                     })
                     .collect(),
-                max_options: Some(wrapper.max_options.filter(|max| *max > 0).unwrap_or(1)),
+                max_options: wrapper.max_options.filter(|max| *max > 0),
             }))
         }
         Some(EMBED_COMPONENT_TYPE_ANIMATION) => {
@@ -9975,6 +9975,11 @@ mod tests {
                 options: vec![radio_option("a", "a"), radio_option("b", "b")],
                 max_options: Some(1),
             };
+            let unbounded_multi = EmbedRadio {
+                id: "unbounded-picks".into(),
+                options: vec![radio_option("a", "a"), radio_option("b", "b")],
+                max_options: None,
+            };
 
             store.update(cx, |store, cx| {
                 pick(store, &single, "y", cx);
@@ -9995,6 +10000,14 @@ mod tests {
                         .message_select_selection(message_id, "picks")
                         .is_empty(),
                     "picking the same option again clears it"
+                );
+
+                pick(store, &unbounded_multi, "a", cx);
+                pick(store, &unbounded_multi, "b", cx);
+                assert_eq!(
+                    store.message_select_selection(message_id, "unbounded-picks"),
+                    ["a", "b"],
+                    "a missing max_options leaves a multi-choice radio unbounded"
                 );
             });
         });
@@ -10341,11 +10354,7 @@ mod tests {
             panic!("expected a radio");
         };
         assert!(radio.allows_multiple());
-        assert_eq!(
-            radio.max_options,
-            Some(1),
-            "React defaults a missing max_options to 1"
-        );
+        assert_eq!(radio.max_options, None);
     }
 
     #[test]

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -1274,6 +1274,7 @@ pub struct ChannelMessages {
     icon_image_cache: Entity<LruImageCache>,
     ogp_image_cache: Entity<LruImageCache>,
     social_image_cache: Entity<LruImageCache>,
+    sprite_image_cache: Entity<LruImageCache>,
     active_videos: Rc<HashMap<(MessageId, usize), Entity<VideoPlayerView>>>,
     active_audios: Rc<indexmap::IndexMap<(MessageId, usize), Entity<AudioPlayerView>>>,
     gif_videos: Rc<HashMap<(MessageId, usize), Entity<GifVideoView>>>,
@@ -1856,6 +1857,7 @@ impl ChannelMessages {
         });
         let ogp_image_cache = crate::image_cache::ogp_timeline_cache("message-ogp", cx);
         let social_image_cache = crate::image_cache::social_thumb_cache("message-social", cx);
+        let sprite_image_cache = crate::image_cache::shared_sprite_sheet_cache(cx);
         let last_cold_inputs = Self::cold_inputs(cx);
         let (welcome, onboarding) = Self::compute_indicator_contexts(cx);
         let cached_unread_boundary = unread_boundary(&MessagesStore::global(cx), None, cx);
@@ -1937,6 +1939,7 @@ impl ChannelMessages {
             icon_image_cache,
             ogp_image_cache,
             social_image_cache,
+            sprite_image_cache,
             active_videos: Rc::new(HashMap::new()),
             active_audios: Rc::new(indexmap::IndexMap::new()),
             gif_videos: Rc::new(HashMap::new()),
@@ -4622,6 +4625,7 @@ impl ChannelMessages {
         let small_avatar_image_cache = self.small_avatar_image_cache.clone();
         let ogp_image_cache = self.ogp_image_cache.clone();
         let social_image_cache = self.social_image_cache.clone();
+        let sprite_image_cache = self.sprite_image_cache.clone();
         let icon_image_cache = self.icon_image_cache.clone();
         let reply_highlight_id = TopicsStore::global(cx)
             .read(cx)
@@ -4687,6 +4691,7 @@ impl ChannelMessages {
                         icon_cache: icon_image_cache.clone(),
                         ogp_cache: ogp_image_cache.clone(),
                         social_cache: social_image_cache.clone(),
+                        sprite_cache: sprite_image_cache.clone(),
                         unread_boundary_id: None,
                         highlight_id: None,
                         reply_highlight_id,
@@ -4893,6 +4898,7 @@ impl Render for ChannelMessages {
         let small_avatar_image_cache = self.small_avatar_image_cache.clone();
         let ogp_image_cache = self.ogp_image_cache.clone();
         let social_image_cache = self.social_image_cache.clone();
+        let sprite_image_cache = self.sprite_image_cache.clone();
         let icon_image_cache = self.icon_image_cache.clone();
         let unread_boundary_id = self.cached_unread_boundary;
         let highlight_id = self.highlight_id;
@@ -4966,6 +4972,7 @@ impl Render for ChannelMessages {
                         icon_cache: icon_image_cache.clone(),
                         ogp_cache: ogp_image_cache.clone(),
                         social_cache: social_image_cache.clone(),
+                        sprite_cache: sprite_image_cache.clone(),
                         unread_boundary_id,
                         highlight_id,
                         reply_highlight_id,

--- a/crates/mezon-ui/src/chat/message/context.rs
+++ b/crates/mezon-ui/src/chat/message/context.rs
@@ -72,6 +72,7 @@ pub struct RowCtx<'a> {
     pub icon_cache: Entity<LruImageCache>,
     pub ogp_cache: Entity<LruImageCache>,
     pub social_cache: Entity<LruImageCache>,
+    pub sprite_cache: Entity<LruImageCache>,
     pub unread_boundary_id: Option<MessageId>,
     pub highlight_id: Option<MessageId>,
     pub reply_highlight_id: Option<MessageId>,

--- a/crates/mezon-ui/src/chat/message/embed_fields.rs
+++ b/crates/mezon-ui/src/chat/message/embed_fields.rs
@@ -267,7 +267,7 @@ fn render_embed_radio(
                 .to_vec()
         })
         .unwrap_or_default();
-    let mut column = div().flex().flex_col().w(px(INPUT_WIDTH));
+    let mut column = div().flex().flex_col().w_full().max_w(px(INPUT_WIDTH));
     for (index, option) in radio.options.iter().enumerate() {
         column = column.child(render_embed_radio_option(
             message_id,
@@ -316,11 +316,6 @@ fn render_embed_radio_option(
         .style
         .map_or(theme.tokens.text_theme_primary, button_bg);
     let mut button = div()
-        .id(SharedString::from(format!(
-            "embed-radio-{}-{embed_index}-{}-{index}",
-            message_id.get(),
-            radio.id
-        )))
         .flex()
         .flex_shrink_0()
         .items_center()
@@ -342,12 +337,25 @@ fn render_embed_radio_option(
                 .into_any_element(),
         );
     }
+    let mut row = div()
+        .id(SharedString::from(format!(
+            "embed-radio-{}-{embed_index}-{}-{index}",
+            message_id.get(),
+            radio.id
+        )))
+        .flex()
+        .flex_row()
+        .justify_between()
+        .items_center()
+        .gap_4()
+        .child(labels)
+        .child(button);
     if !option.disabled {
         let radio_id = radio.id.clone();
         let multiple = radio.allows_multiple();
         let max_options = radio.max_options;
         let value = option.value.clone();
-        button = button.cursor_pointer().on_click(move |_, _, cx| {
+        row = row.cursor_pointer().on_click(move |_, _, cx| {
             let radio_id = radio_id.clone();
             let value = value.clone();
             MessagesStore::global(cx).update(cx, |store, cx| {
@@ -356,15 +364,7 @@ fn render_embed_radio_option(
         });
     }
 
-    div()
-        .flex()
-        .flex_row()
-        .justify_between()
-        .items_center()
-        .gap_4()
-        .child(labels)
-        .child(button)
-        .into_any_element()
+    row.into_any_element()
 }
 
 fn render_embed_grid(grid: &EmbedGrid) -> AnyElement {
@@ -397,14 +397,14 @@ fn render_embed_animation(
     animation: &EmbedAnimation,
     ctx: &RowCtx,
 ) -> AnyElement {
-    let mut row = div().flex().gap_2().rounded_md();
+    let mut row = div().flex().min_w_0().w_full().gap_2().rounded_md();
     if animation.vertical {
         row = row.flex_col();
     }
     let Some(atlas) = ctx.sprite_atlases.get(&animation.url_position) else {
         let side = px(animation_box_size(animation, ctx));
         for _ in &animation.pool {
-            row = row.child(div().flex_shrink_0().w(side).h(side));
+            row = row.child(div().w(side).h(side));
         }
         return row.into_any_element();
     };
@@ -449,15 +449,16 @@ fn render_animation_box(
     let sheet_width = atlas.sheet_width * ratio;
     let sheet_height = atlas.sheet_height * ratio;
 
-    let sheet = img(animation.url_image.clone())
+    let sheet = div()
+        .image_cache(ctx.sprite_cache.clone())
         .absolute()
         .w(px(sheet_width))
-        .h(px(sheet_height));
+        .h(px(sheet_height))
+        .child(img(animation.url_image.clone()).size_full());
 
     let last = *rects.last()?;
     let clipped = div()
         .relative()
-        .flex_shrink_0()
         .w(px(width))
         .h(px(height))
         .overflow_hidden();

--- a/crates/mezon-ui/src/image_cache.rs
+++ b/crates/mezon-ui/src/image_cache.rs
@@ -169,6 +169,9 @@ impl Global for SharedRoleIconCache {}
 struct SharedRoleIconPreviewCache(Entity<LruImageCache>);
 impl Global for SharedRoleIconPreviewCache {}
 
+struct SharedSpriteSheetCache(Entity<LruImageCache>);
+impl Global for SharedSpriteSheetCache {}
+
 const OGP_TIMELINE_CACHE_CAPACITY: usize = 12;
 const OGP_TIMELINE_CACHE_BYTES: u64 = 6 * 1024 * 1024;
 const OGP_AUX_CACHE_CAPACITY: usize = 4;
@@ -210,6 +213,23 @@ pub fn social_thumb_cache(label: &'static str, cx: &mut App) -> Entity<LruImageC
             cx,
         )
     })
+}
+
+pub fn shared_sprite_sheet_cache(cx: &mut App) -> Entity<LruImageCache> {
+    if let Some(existing) = cx.try_global::<SharedSpriteSheetCache>() {
+        return existing.0.clone();
+    }
+    let cache = cx.new(|cx| {
+        LruImageCache::sprite_sheet(
+            "message-sprites-shared",
+            SPRITE_SHEET_CACHE_CAPACITY,
+            SPRITE_SHEET_CACHE_BYTES,
+            SPRITE_SHEET_ENTRY_MAX_BYTES,
+            cx,
+        )
+    });
+    cx.set_global(SharedSpriteSheetCache(cache.clone()));
+    cache
 }
 
 /// Shared decode cache for role icons. They render at 12-20px everywhere, so
@@ -482,6 +502,9 @@ pub(crate) async fn read_body_limited(
 
 pub const MESSAGE_IMAGE_CACHE_CAPACITY: usize = 48;
 pub const MESSAGE_IMAGE_CACHE_BYTES: u64 = 32 * 1024 * 1024;
+const SPRITE_SHEET_CACHE_CAPACITY: usize = 4;
+const SPRITE_SHEET_CACHE_BYTES: u64 = 16 * 1024 * 1024;
+const SPRITE_SHEET_ENTRY_MAX_BYTES: u64 = 8 * 1024 * 1024;
 pub const AVATAR_IMAGE_CACHE_CAPACITY: usize = 256;
 pub const AVATAR_IMAGE_CACHE_BYTES: u64 = 8 * 1024 * 1024;
 
@@ -532,6 +555,7 @@ const FRAME_BUMP_REARM: Duration = Duration::from_millis(100);
 const STATS_LOG_INTERVAL: u64 = 600;
 const MESSAGE_ANIMATION_MAX_PX: u32 = 400;
 const MESSAGE_STATIC_MAX_PX: u32 = 1024;
+const SPRITE_SHEET_MAX_PX: u32 = 8192;
 const SHARED_ANIMATION_MAX_PX: u32 = 400;
 const SHARED_STATIC_MAX_PX: u32 = 2048;
 /// Longest side (px) that an animated GIF/WebP is downscaled to for the image
@@ -656,6 +680,7 @@ enum LoaderKind {
     /// cards, capped at [`GALLERY_PREVIEW_DECODE_MAX_PX`].
     GalleryPreview,
     Message,
+    SpriteSheet,
     /// The image-viewer loader: still images keep near-full resolution
     /// ([`VIEWER_STATIC_MAX_PX`]); animated GIF/WebP keep every frame so they
     /// animate, but downscaled to [`VIEWER_ANIMATION_MAX_PX`] and bounded by an
@@ -887,6 +912,23 @@ impl LruImageCache {
         Self::with_loader(
             label,
             LoaderKind::Message,
+            max_items,
+            max_bytes,
+            max_entry_bytes,
+            cx,
+        )
+    }
+
+    pub fn sprite_sheet(
+        label: &'static str,
+        max_items: usize,
+        max_bytes: u64,
+        max_entry_bytes: u64,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self::with_loader(
+            label,
+            LoaderKind::SpriteSheet,
             max_items,
             max_bytes,
             max_entry_bytes,
@@ -1275,6 +1317,9 @@ impl LruImageCache {
             }
             LoaderKind::Message => {
                 AssetLogger::<MessageImageLoader>::load(resource.clone(), cx).boxed()
+            }
+            LoaderKind::SpriteSheet => {
+                AssetLogger::<SpriteSheetImageLoader>::load(resource.clone(), cx).boxed()
             }
             LoaderKind::Viewer => {
                 AssetLogger::<ViewerImageLoader>::load(resource.clone(), cx).boxed()
@@ -1845,6 +1890,26 @@ fn canvas_dimensions(
     Ok(reader.into_dimensions()?)
 }
 
+fn validate_sprite_sheet_decode(bytes: &[u8]) -> Result<(), ImageCacheError> {
+    let format = image::guess_format(bytes)?;
+    let (width, height) = canvas_dimensions(bytes, format)?;
+    let decoded_bytes = u64::from(width)
+        .saturating_mul(u64::from(height))
+        .saturating_mul(4);
+    if width > SPRITE_SHEET_MAX_PX
+        || height > SPRITE_SHEET_MAX_PX
+        || decoded_bytes > SPRITE_SHEET_ENTRY_MAX_BYTES
+    {
+        return Err(ImageCacheError::Asset(
+            format!(
+                "sprite sheet too large to preserve: {width}x{height}, {decoded_bytes} decoded bytes"
+            )
+            .into(),
+        ));
+    }
+    Ok(())
+}
+
 fn reject_oversized_canvas(
     bytes: &[u8],
     format: image::ImageFormat,
@@ -1882,7 +1947,9 @@ fn animated_webp_decoder(
 ) -> Result<image::codecs::webp::WebPDecoder<std::io::Cursor<&[u8]>>, ImageCacheError> {
     let mut decoder = image::codecs::webp::WebPDecoder::new(std::io::Cursor::new(bytes))?;
     image::ImageDecoder::set_limits(&mut decoder, decoder_limits())?;
-    decoder.set_background_color(image::Rgba([0, 0, 0, 0]))?;
+    if decoder.has_animation() {
+        decoder.set_background_color(image::Rgba([0, 0, 0, 0]))?;
+    }
     Ok(decoder)
 }
 
@@ -2287,6 +2354,26 @@ fn load_bounded(
     wide_lane: bool,
     cx: &mut App,
 ) -> impl Future<Output = Result<Arc<RenderImage>, ImageCacheError>> + Send + 'static {
+    load_bounded_inner(
+        source,
+        animation_max_px,
+        static_max_px,
+        animation_byte_budget,
+        false,
+        wide_lane,
+        cx,
+    )
+}
+
+fn load_bounded_inner(
+    source: Resource,
+    animation_max_px: u32,
+    static_max_px: u32,
+    animation_byte_budget: u64,
+    preserve_native: bool,
+    wide_lane: bool,
+    cx: &mut App,
+) -> impl Future<Output = Result<Arc<RenderImage>, ImageCacheError>> + Send + 'static {
     let client = cx.http_client();
     let svg_renderer = cx.svg_renderer();
     let asset_source = cx.asset_source().clone();
@@ -2328,17 +2415,24 @@ fn load_bounded(
             },
         };
 
-        if image::guess_format(&bytes).is_ok() {
-            decode_message_image(
-                &bytes,
-                animation_max_px,
-                static_max_px,
-                animation_byte_budget,
-            )
-        } else {
-            svg_renderer
+        match image::guess_format(&bytes) {
+            Ok(_) => {
+                if preserve_native {
+                    validate_sprite_sheet_decode(&bytes)?;
+                }
+                decode_message_image(
+                    &bytes,
+                    animation_max_px,
+                    static_max_px,
+                    animation_byte_budget,
+                )
+            }
+            Err(_) if preserve_native => Err(ImageCacheError::Asset(
+                "sprite sheet must use a supported raster format".into(),
+            )),
+            Err(_) => svg_renderer
                 .render_single_frame(&bytes, 1.0)
-                .map_err(Into::into)
+                .map_err(Into::into),
         }
     }
 }
@@ -2363,6 +2457,28 @@ impl Asset for SharedImageLoader {
             SHARED_ANIMATION_MAX_PX,
             SHARED_STATIC_MAX_PX,
             SHARED_ENTRY_MAX_BYTES,
+            false,
+            cx,
+        )
+    }
+}
+
+pub enum SpriteSheetImageLoader {}
+
+impl Asset for SpriteSheetImageLoader {
+    type Source = Resource;
+    type Output = Result<Arc<RenderImage>, ImageCacheError>;
+
+    fn load(
+        source: Self::Source,
+        cx: &mut App,
+    ) -> impl Future<Output = Self::Output> + Send + 'static {
+        load_bounded_inner(
+            source,
+            SPRITE_SHEET_MAX_PX,
+            SPRITE_SHEET_MAX_PX,
+            SPRITE_SHEET_ENTRY_MAX_BYTES,
+            true,
             false,
             cx,
         )
@@ -2807,6 +2923,82 @@ mod tests {
         let size = image.size(0);
         assert_eq!(size.width, size.height);
         assert_eq!(image.delay(0), image::Delay::from_numer_denom_ms(50, 1));
+    }
+
+    #[test]
+    fn avatar_cache_decodes_static_webp() {
+        use image::ImageEncoder as _;
+
+        let pixels = image::RgbaImage::from_pixel(8, 4, image::Rgba([10, 20, 30, 255]));
+        let mut bytes = Vec::new();
+        image::codecs::webp::WebPEncoder::new_lossless(&mut bytes)
+            .write_image(
+                pixels.as_raw(),
+                pixels.width(),
+                pixels.height(),
+                image::ExtendedColorType::Rgba8,
+            )
+            .expect("static WebP encodes");
+
+        let image = decode_avatar_image(
+            &bytes,
+            AVATAR_DECODE_MAX_PX,
+            AnimationCaps {
+                max_px: AVATAR_DECODE_MAX_PX,
+                max_frames: usize::MAX,
+                max_bytes: AVATAR_ENTRY_MAX_BYTES,
+            },
+        )
+        .expect("static WebP decodes");
+
+        assert_eq!(image.frame_count(), 1);
+        assert_eq!(image.size(0).width, image.size(0).height);
+    }
+
+    #[test]
+    fn sprite_sheet_cache_preserves_native_resolution() {
+        use image::ImageEncoder as _;
+
+        let pixels = image::RgbaImage::from_pixel(8000, 80, image::Rgba([255, 0, 0, 255]));
+        let mut bytes = Vec::new();
+        image::codecs::png::PngEncoder::new(&mut bytes)
+            .write_image(
+                pixels.as_raw(),
+                pixels.width(),
+                pixels.height(),
+                image::ExtendedColorType::Rgba8,
+            )
+            .expect("sprite sheet encodes");
+
+        validate_sprite_sheet_decode(&bytes).expect("sprite sheet fits the cache budget");
+        let image = decode_message_image(
+            &bytes,
+            SPRITE_SHEET_MAX_PX,
+            SPRITE_SHEET_MAX_PX,
+            SPRITE_SHEET_ENTRY_MAX_BYTES,
+        )
+        .expect("sprite sheet decodes");
+        let size = image.size(0);
+
+        assert_eq!((size.width.0 as u32, size.height.0 as u32), (8000, 80));
+    }
+
+    #[test]
+    fn sprite_sheet_cache_rejects_oversized_decoded_canvas() {
+        use image::ImageEncoder as _;
+
+        let pixels = image::RgbaImage::from_pixel(2048, 1025, image::Rgba([0, 0, 0, 0]));
+        let mut bytes = Vec::new();
+        image::codecs::png::PngEncoder::new(&mut bytes)
+            .write_image(
+                pixels.as_raw(),
+                pixels.width(),
+                pixels.height(),
+                image::ExtendedColorType::Rgba8,
+            )
+            .expect("sprite sheet encodes");
+
+        assert!(validate_sprite_sheet_decode(&bytes).is_err());
     }
 
     /// A 64x64 animated WebP of a 16x16 sprite (opaque core, transparent margin,

--- a/crates/mezon-ui/src/image_cache.rs
+++ b/crates/mezon-ui/src/image_cache.rs
@@ -1890,24 +1890,20 @@ fn canvas_dimensions(
     Ok(reader.into_dimensions()?)
 }
 
-fn validate_sprite_sheet_decode(bytes: &[u8]) -> Result<(), ImageCacheError> {
+fn sprite_sheet_decode_limits(bytes: &[u8]) -> Result<(u32, u32), ImageCacheError> {
     let format = image::guess_format(bytes)?;
     let (width, height) = canvas_dimensions(bytes, format)?;
     let decoded_bytes = u64::from(width)
         .saturating_mul(u64::from(height))
         .saturating_mul(4);
-    if width > SPRITE_SHEET_MAX_PX
-        || height > SPRITE_SHEET_MAX_PX
-        || decoded_bytes > SPRITE_SHEET_ENTRY_MAX_BYTES
+    if width <= SPRITE_SHEET_MAX_PX
+        && height <= SPRITE_SHEET_MAX_PX
+        && decoded_bytes <= SPRITE_SHEET_ENTRY_MAX_BYTES
     {
-        return Err(ImageCacheError::Asset(
-            format!(
-                "sprite sheet too large to preserve: {width}x{height}, {decoded_bytes} decoded bytes"
-            )
-            .into(),
-        ));
+        Ok((SPRITE_SHEET_MAX_PX, SPRITE_SHEET_MAX_PX))
+    } else {
+        Ok((MESSAGE_ANIMATION_MAX_PX, MESSAGE_STATIC_MAX_PX))
     }
-    Ok(())
 }
 
 fn reject_oversized_canvas(
@@ -2417,9 +2413,11 @@ fn load_bounded_inner(
 
         match image::guess_format(&bytes) {
             Ok(_) => {
-                if preserve_native {
-                    validate_sprite_sheet_decode(&bytes)?;
-                }
+                let (animation_max_px, static_max_px) = if preserve_native {
+                    sprite_sheet_decode_limits(&bytes)?
+                } else {
+                    (animation_max_px, static_max_px)
+                };
                 decode_message_image(
                     &bytes,
                     animation_max_px,
@@ -2970,11 +2968,16 @@ mod tests {
             )
             .expect("sprite sheet encodes");
 
-        validate_sprite_sheet_decode(&bytes).expect("sprite sheet fits the cache budget");
+        let (animation_max_px, static_max_px) =
+            sprite_sheet_decode_limits(&bytes).expect("sprite sheet dimensions parse");
+        assert_eq!(
+            (animation_max_px, static_max_px),
+            (SPRITE_SHEET_MAX_PX, SPRITE_SHEET_MAX_PX)
+        );
         let image = decode_message_image(
             &bytes,
-            SPRITE_SHEET_MAX_PX,
-            SPRITE_SHEET_MAX_PX,
+            animation_max_px,
+            static_max_px,
             SPRITE_SHEET_ENTRY_MAX_BYTES,
         )
         .expect("sprite sheet decodes");
@@ -2984,10 +2987,10 @@ mod tests {
     }
 
     #[test]
-    fn sprite_sheet_cache_rejects_oversized_decoded_canvas() {
+    fn sprite_sheet_cache_downscales_a_larger_valid_canvas() {
         use image::ImageEncoder as _;
 
-        let pixels = image::RgbaImage::from_pixel(2048, 1025, image::Rgba([0, 0, 0, 0]));
+        let pixels = image::RgbaImage::from_pixel(1812, 1510, image::Rgba([0, 0, 0, 0]));
         let mut bytes = Vec::new();
         image::codecs::png::PngEncoder::new(&mut bytes)
             .write_image(
@@ -2998,7 +3001,23 @@ mod tests {
             )
             .expect("sprite sheet encodes");
 
-        assert!(validate_sprite_sheet_decode(&bytes).is_err());
+        let (animation_max_px, static_max_px) =
+            sprite_sheet_decode_limits(&bytes).expect("sprite sheet dimensions parse");
+        assert_eq!(
+            (animation_max_px, static_max_px),
+            (MESSAGE_ANIMATION_MAX_PX, MESSAGE_STATIC_MAX_PX)
+        );
+        let image = decode_message_image(
+            &bytes,
+            animation_max_px,
+            static_max_px,
+            SPRITE_SHEET_ENTRY_MAX_BYTES,
+        )
+        .expect("larger sprite sheet falls back to bounded decoding");
+        let size = image.size(0);
+
+        assert!(size.width.0 <= MESSAGE_STATIC_MAX_PX as i32);
+        assert!(size.height.0 <= MESSAGE_STATIC_MAX_PX as i32);
     }
 
     /// A 64x64 animated WebP of a 16x16 sprite (opaque core, transparent margin,


### PR DESCRIPTION
## Summary

- make radio option rows responsive and clickable in narrow stream chat, while honoring payloads that allow multiple selections
- render music visualizer sprite sheets at native resolution through a small bounded shared cache so the animation matches web
- preserve static WebP thumbnail decoding and add regression coverage for sprite limits and radio selection

## Verification

- cargo fmt -p mezon-ui -p mezon-store -- --check
- just test -p mezon-store radio -p mezon-ui sprite_sheet_cache (4 passed)
- cargo clippy -p mezon-ui -p mezon-store --all-targets --locked -- -D warnings -A clippy::nonminimal_bool
- cargo build -p mezon-app --locked
- git diff --cached --check

Full just test was also run; it stops on an existing develop failure because the Russian locale is missing screenShare.systemWillAsk. just lint likewise reaches an existing unrelated clippy::nonminimal_bool error in crates/mezon-ui/src/chat/channel_settings/overview_tab.rs.