### PR TITLE
feat(dm): add and remove members of a group DM

### DIFF
--- a/assets/i18n/blr.json
+++ b/assets/i18n/blr.json
@@ -2509,6 +2509,7 @@
   "directMessage.remove.button": "Пацвердзіць",
   "directMessage.remove.content": "Размова ў гэтым канале больш недаступная!",
   "directMessage.remove.title": "Размова недаступная",
+  "directMessage.removeFromGroup.description": "Вы ўпэўнены, што хочаце выдаліць {{username}} з гэтай групы?",
   "directMessage.selectConversation": "Абярыце размову для пачатку зносін",
   "directMessage.yourMessages": "Вашы паведамленні",
   "discover.about": "Пра",

--- a/assets/i18n/blr.json
+++ b/assets/i18n/blr.json
@@ -2488,6 +2488,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Стварыць паведамленне або групавы чат",
   "directMessage.createMessageGroup.createGroupChat": "Стварыць групавы чат",
   "directMessage.createMessageGroup.creating": "Стварэнне...",
+  "directMessage.createMessageGroup.groupFull": "У гэтай групе ўжо максімальная колькасць удзельнікаў — {{count}}.",
   "directMessage.createMessageGroup.noFriendsFound": "Сябры, якіх яшчэ няма ў гэтай размове, не знойдзены.",
   "directMessage.createMessageGroup.searchPlaceholder": "Увядзіце імёны сяброў",
   "directMessage.createMessageGroup.selectFriends": "Абярыце сяброў",

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -2489,6 +2489,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Direktnachricht oder Gruppenchat erstellen",
   "directMessage.createMessageGroup.createGroupChat": "Gruppenchat erstellen",
   "directMessage.createMessageGroup.creating": "Wird erstellt...",
+  "directMessage.createMessageGroup.groupFull": "Diese Gruppe hat bereits die maximale Anzahl von {{count}} Mitgliedern.",
   "directMessage.createMessageGroup.noFriendsFound": "Keine Freunde gefunden, die nicht bereits Teil dieses Chats sind.",
   "directMessage.createMessageGroup.searchPlaceholder": "Benutzernamen deiner Freunde eingeben",
   "directMessage.createMessageGroup.selectFriends": "Freunde auswählen",

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -2510,6 +2510,7 @@
   "directMessage.remove.button": "Bestätigen",
   "directMessage.remove.content": "Der Chat in diesem Kanal ist nicht mehr verfügbar!",
   "directMessage.remove.title": "Chat nicht verfügbar",
+  "directMessage.removeFromGroup.description": "Möchtest du {{username}} wirklich aus dieser Gruppe entfernen?",
   "directMessage.selectConversation": "Wähle einen Chat aus, um Nachrichten zu schreiben",
   "directMessage.yourMessages": "Deine Nachrichten",
   "discover.about": "Über",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -2510,6 +2510,7 @@
   "directMessage.remove.button": "Confirm",
   "directMessage.remove.content": "This conversation is no longer available!",
   "directMessage.remove.title": "Chat Unavailable",
+  "directMessage.removeFromGroup.description": "Are you sure you want to remove {{username}} from this group?",
   "directMessage.selectConversation": "Select a conversation to start messaging",
   "directMessage.yourMessages": "Your messages",
   "discover.about": "About",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -2489,6 +2489,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Create DM or Group Chat",
   "directMessage.createMessageGroup.createGroupChat": "Create Group Chat",
   "directMessage.createMessageGroup.creating": "Creating...",
+  "directMessage.createMessageGroup.groupFull": "This group already has the maximum of {{count}} members.",
   "directMessage.createMessageGroup.noFriendsFound": "No friends found that are not already in this DM.",
   "directMessage.createMessageGroup.searchPlaceholder": "Type the username of a friend",
   "directMessage.createMessageGroup.selectFriends": "Select Friends",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -2513,6 +2513,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Crear mensaje directo o chat grupal",
   "directMessage.createMessageGroup.createGroupChat": "Crear chat grupal",
   "directMessage.createMessageGroup.creating": "Creando...",
+  "directMessage.createMessageGroup.groupFull": "Este grupo ya tiene el máximo de {{count}} miembros.",
   "directMessage.createMessageGroup.noFriendsFound": "No se encontraron amigos que no estén ya en este DM.",
   "directMessage.createMessageGroup.searchPlaceholder": "Escribe el nombre de usuario de un amigo",
   "directMessage.createMessageGroup.selectFriends": "Seleccionar amigos",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -2534,6 +2534,7 @@
   "directMessage.remove.button": "Confirmar",
   "directMessage.remove.content": "¡Esta conversación ya no está disponible!",
   "directMessage.remove.title": "Chat no disponible",
+  "directMessage.removeFromGroup.description": "¿Seguro que quieres eliminar a {{username}} de este grupo?",
   "directMessage.selectConversation": "Selecciona una conversación para empezar a chatear",
   "directMessage.yourMessages": "Tus mensajes",
   "discover.about": "Acerca de",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -2488,6 +2488,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Créer un message ou un chat de groupe",
   "directMessage.createMessageGroup.createGroupChat": "Créer un chat de groupe",
   "directMessage.createMessageGroup.creating": "Création en cours...",
+  "directMessage.createMessageGroup.groupFull": "Ce groupe a déjà atteint le maximum de {{count}} membres.",
   "directMessage.createMessageGroup.noFriendsFound": "Aucun ami trouvé qui n'est pas déjà dans cette conversation.",
   "directMessage.createMessageGroup.searchPlaceholder": "Entrez le nom d'utilisateur de vos amis",
   "directMessage.createMessageGroup.selectFriends": "Sélectionnez des amis",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -2509,6 +2509,7 @@
   "directMessage.remove.button": "Confirmer",
   "directMessage.remove.content": "La conversation dans ce canal n'est plus disponible !",
   "directMessage.remove.title": "Conversation non disponible",
+  "directMessage.removeFromGroup.description": "Voulez-vous vraiment retirer {{username}} de ce groupe ?",
   "directMessage.selectConversation": "Sélectionnez une conversation pour commencer à discuter",
   "directMessage.yourMessages": "Vos messages",
   "discover.about": "À propos",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -2510,6 +2510,7 @@
   "directMessage.remove.button": "Conferma",
   "directMessage.remove.content": "La conversazione in questo canale non è più disponibile!",
   "directMessage.remove.title": "Conversazione non disponibile",
+  "directMessage.removeFromGroup.description": "Vuoi davvero rimuovere {{username}} da questo gruppo?",
   "directMessage.selectConversation": "Seleziona una conversazione per iniziare a scrivere",
   "directMessage.yourMessages": "I tuoi messaggi",
   "discover.about": "Informazioni",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -2489,6 +2489,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Crea un messaggio o un gruppo chat",
   "directMessage.createMessageGroup.createGroupChat": "Crea gruppo chat",
   "directMessage.createMessageGroup.creating": "Creazione in corso...",
+  "directMessage.createMessageGroup.groupFull": "Questo gruppo ha già il massimo di {{count}} membri.",
   "directMessage.createMessageGroup.noFriendsFound": "Nessun amico trovato che non sia già presente in questa conversazione.",
   "directMessage.createMessageGroup.searchPlaceholder": "Cerca un amico per nome utente",
   "directMessage.createMessageGroup.selectFriends": "Seleziona amici",

--- a/assets/i18n/jpn.json
+++ b/assets/i18n/jpn.json
@@ -2510,6 +2510,7 @@
   "directMessage.remove.button": "確認",
   "directMessage.remove.content": "このチャンネルの会話は利用できません!",
   "directMessage.remove.title": "会話が利用できません",
+  "directMessage.removeFromGroup.description": "{{username}} をこのグループから削除してもよろしいですか？",
   "directMessage.selectConversation": "チャットを開始するには会話を選択",
   "directMessage.yourMessages": "あなたのメッセージ",
   "discover.about": "概要",

--- a/assets/i18n/jpn.json
+++ b/assets/i18n/jpn.json
@@ -2489,6 +2489,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "メッセージまたはグループチャットを作成",
   "directMessage.createMessageGroup.createGroupChat": "グループチャットを作成",
   "directMessage.createMessageGroup.creating": "作成中...",
+  "directMessage.createMessageGroup.groupFull": "このグループはすでに最大{{count}}人のメンバーに達しています。",
   "directMessage.createMessageGroup.noFriendsFound": "この会話に含まれていない友達が見つかりません。",
   "directMessage.createMessageGroup.searchPlaceholder": "友達の名前を入力",
   "directMessage.createMessageGroup.selectFriends": "友達を選択",

--- a/assets/i18n/kr.json
+++ b/assets/i18n/kr.json
@@ -2489,6 +2489,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "메시지 또는 그룹 채팅 만들기",
   "directMessage.createMessageGroup.createGroupChat": "그룹 채팅 만들기",
   "directMessage.createMessageGroup.creating": "만드는 중...",
+  "directMessage.createMessageGroup.groupFull": "이 그룹은 이미 최대 {{count}}명의 멤버로 가득 찼습니다.",
   "directMessage.createMessageGroup.noFriendsFound": "이 대화에 없는 친구를 찾지 못했습니다.",
   "directMessage.createMessageGroup.searchPlaceholder": "친구의 사용자 이름 입력",
   "directMessage.createMessageGroup.selectFriends": "친구 선택",

--- a/assets/i18n/kr.json
+++ b/assets/i18n/kr.json
@@ -2510,6 +2510,7 @@
   "directMessage.remove.button": "확인",
   "directMessage.remove.content": "이 채널의 대화가 사용 가능하지 않습니다!",
   "directMessage.remove.title": "대화 사용 가능",
+  "directMessage.removeFromGroup.description": "{{username}} 님을 이 그룹에서 삭제하시겠습니까?",
   "directMessage.selectConversation": "메시지를 시작하려면 대화를 선택하세요",
   "directMessage.yourMessages": "내 메시지",
   "discover.about": "소개",

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -2488,6 +2488,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Bericht of groepschat aanmaken",
   "directMessage.createMessageGroup.createGroupChat": "Groepschat aanmaken",
   "directMessage.createMessageGroup.creating": "Aan het maken...",
+  "directMessage.createMessageGroup.groupFull": "Deze groep heeft al het maximum van {{count}} leden.",
   "directMessage.createMessageGroup.noFriendsFound": "Geen vrienden gevonden die nog niet in dit gesprek zijn.",
   "directMessage.createMessageGroup.searchPlaceholder": "Voer vriend gebruikersnaam in",
   "directMessage.createMessageGroup.selectFriends": "Vrienden selecteren",

--- a/assets/i18n/nl.json
+++ b/assets/i18n/nl.json
@@ -2509,6 +2509,7 @@
   "directMessage.remove.button": "Bevestigen",
   "directMessage.remove.content": "Dit gesprek in het kanaal is niet meer beschikbaar!",
   "directMessage.remove.title": "Gesprek niet beschikbaar",
+  "directMessage.removeFromGroup.description": "Weet je zeker dat je {{username}} uit deze groep wilt verwijderen?",
   "directMessage.selectConversation": "Kies een gesprek om te beginnen met chatten",
   "directMessage.yourMessages": "Jouw berichten",
   "discover.about": "Over",

--- a/assets/i18n/pl.json
+++ b/assets/i18n/pl.json
@@ -2509,6 +2509,7 @@
   "directMessage.remove.button": "Potwierdź",
   "directMessage.remove.content": "Konwersacja w tym kanale nie jest już dostępna!",
   "directMessage.remove.title": "Konwersacja niedostępna",
+  "directMessage.removeFromGroup.description": "Czy na pewno chcesz usunąć {{username}} z tej grupy?",
   "directMessage.selectConversation": "Wybierz konwersację, aby rozpocząć rozmowę",
   "directMessage.yourMessages": "Twoje wiadomości",
   "discover.about": "O nas",

--- a/assets/i18n/pl.json
+++ b/assets/i18n/pl.json
@@ -2488,6 +2488,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Utwórz wiadomość lub czat grupowy",
   "directMessage.createMessageGroup.createGroupChat": "Utwórz czat grupowy",
   "directMessage.createMessageGroup.creating": "Tworzenie...",
+  "directMessage.createMessageGroup.groupFull": "Ta grupa ma już maksymalną liczbę {{count}} członków.",
   "directMessage.createMessageGroup.noFriendsFound": "Nie znaleziono przyjaciół, których nie ma jeszcze w tej konwersacji.",
   "directMessage.createMessageGroup.searchPlaceholder": "Wpisz nazwę użytkownika swojego przyjaciela",
   "directMessage.createMessageGroup.selectFriends": "Wybierz przyjaciół",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -2489,6 +2489,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Criar mensagem ou chat em grupo",
   "directMessage.createMessageGroup.createGroupChat": "Criar chat em grupo",
   "directMessage.createMessageGroup.creating": "Criando...",
+  "directMessage.createMessageGroup.groupFull": "Este grupo já atingiu o máximo de {{count}} membros.",
   "directMessage.createMessageGroup.noFriendsFound": "Nenhum amigo encontrado que ainda não esteja nesta conversa.",
   "directMessage.createMessageGroup.searchPlaceholder": "Digite o nome de usuário dos amigos",
   "directMessage.createMessageGroup.selectFriends": "Selecionar amigos",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -2510,6 +2510,7 @@
   "directMessage.remove.button": "Confirmar",
   "directMessage.remove.content": "A conversa neste canal não está mais disponível!",
   "directMessage.remove.title": "Conversa indisponível",
+  "directMessage.removeFromGroup.description": "Tem certeza de que deseja remover {{username}} deste grupo?",
   "directMessage.selectConversation": "Selecione uma conversa para começar a conversar",
   "directMessage.yourMessages": "Suas mensagens",
   "discover.about": "Sobre",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -2727,6 +2727,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Написать или создать групповой чат",
   "directMessage.createMessageGroup.createGroupChat": "Создать групповой чат",
   "directMessage.createMessageGroup.creating": "Создание...",
+  "directMessage.createMessageGroup.groupFull": "В этой группе уже максимальное количество участников — {{count}}.",
   "directMessage.createMessageGroup.noFriendsFound": "Не найдено друзей, которые ещё не находятся в этом личном сообщении.",
   "directMessage.createMessageGroup.searchPlaceholder": "Введите имя пользователя друга",
   "directMessage.createMessageGroup.selectFriends": "Выбрать друзей",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -2748,6 +2748,7 @@
   "directMessage.remove.button": "Подтвердить",
   "directMessage.remove.content": "Этот разговор больше недоступен!",
   "directMessage.remove.title": "Чат недоступен",
+  "directMessage.removeFromGroup.description": "Вы уверены, что хотите удалить {{username}} из этой группы?",
   "directMessage.selectConversation": "Выберите разговор, чтобы начать переписку",
   "directMessage.yourMessages": "Ваши сообщения",
   "discover.about": "О",

--- a/assets/i18n/swe.json
+++ b/assets/i18n/swe.json
@@ -2510,6 +2510,7 @@
   "directMessage.remove.button": "Bekräfta",
   "directMessage.remove.content": "Samtal i denna kanal är inte längre tillgänglig!",
   "directMessage.remove.title": "Samtal inte tillgänglig",
+  "directMessage.removeFromGroup.description": "Är du säker på att du vill ta bort {{username}} från den här gruppen?",
   "directMessage.selectConversation": "Välj ett samtal för att börja chatta",
   "directMessage.yourMessages": "Dina meddelanden",
   "discover.about": "Om",

--- a/assets/i18n/swe.json
+++ b/assets/i18n/swe.json
@@ -2489,6 +2489,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Skapa meddelande eller gruppchatt",
   "directMessage.createMessageGroup.createGroupChat": "Skapa gruppchatt",
   "directMessage.createMessageGroup.creating": "Skapar...",
+  "directMessage.createMessageGroup.groupFull": "Den här gruppen har redan max {{count}} medlemmar.",
   "directMessage.createMessageGroup.noFriendsFound": "Inga vänner hittade som inte redan finns i detta samtal.",
   "directMessage.createMessageGroup.searchPlaceholder": "Ange dina vänars användarnamn",
   "directMessage.createMessageGroup.selectFriends": "Välj vänner",

--- a/assets/i18n/tt.json
+++ b/assets/i18n/tt.json
@@ -2518,6 +2518,7 @@
   "directMessage.remove.button": "Раслау",
   "directMessage.remove.content": "Бу сөйләшү инде доступлы түгел!",
   "directMessage.remove.title": "Чат доступлы түгел",
+  "directMessage.removeFromGroup.description": "Сез {{username}} бу төркемнән чыгарырга телисезме?",
   "directMessage.selectConversation": "Хат алышу башлау өчен сөйләшүне сайлагыз",
   "directMessage.yourMessages": "Сезнең хәбәрләрегез",
   "discover.about": "Турында",

--- a/assets/i18n/tt.json
+++ b/assets/i18n/tt.json
@@ -2497,6 +2497,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Язу яки төркемле чат булдыру",
   "directMessage.createMessageGroup.createGroupChat": "Төркемле чат булдыру",
   "directMessage.createMessageGroup.creating": "Булдыру...",
+  "directMessage.createMessageGroup.groupFull": "Бу төркемдә инде максималь {{count}} катнашучы бар.",
   "directMessage.createMessageGroup.noFriendsFound": "Әле бу шәхси хәбәрдә булмаган дуслар табылмады.",
   "directMessage.createMessageGroup.searchPlaceholder": "Дустыгызның кулланучы исемен керетегез",
   "directMessage.createMessageGroup.selectFriends": "Дусларны сайлау",

--- a/assets/i18n/ukr.json
+++ b/assets/i18n/ukr.json
@@ -2488,6 +2488,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Створити повідомлення або груповий чат",
   "directMessage.createMessageGroup.createGroupChat": "Створити груповий чат",
   "directMessage.createMessageGroup.creating": "Створення...",
+  "directMessage.createMessageGroup.groupFull": "У цій групі вже максимальна кількість учасників — {{count}}.",
   "directMessage.createMessageGroup.noFriendsFound": "Друзів, яких ще немає в цій розмові, не знайдено.",
   "directMessage.createMessageGroup.searchPlaceholder": "Введіть імена друзів",
   "directMessage.createMessageGroup.selectFriends": "Оберіть друзів",

--- a/assets/i18n/ukr.json
+++ b/assets/i18n/ukr.json
@@ -2509,6 +2509,7 @@
   "directMessage.remove.button": "Підтвердити",
   "directMessage.remove.content": "Розмова в цьому каналі більше недоступна!",
   "directMessage.remove.title": "Розмова недоступна",
+  "directMessage.removeFromGroup.description": "Ви впевнені, що хочете видалити {{username}} з цієї групи?",
   "directMessage.selectConversation": "Оберіть розмову для початку спілкування",
   "directMessage.yourMessages": "Ваші повідомлення",
   "discover.about": "Про",

--- a/assets/i18n/vi.json
+++ b/assets/i18n/vi.json
@@ -2509,6 +2509,7 @@
   "directMessage.remove.button": "Xác nhận",
   "directMessage.remove.content": "Cuộc trò chuyện ở kênh này không còn khả dụng!",
   "directMessage.remove.title": "Trò chuyện không khả dụng",
+  "directMessage.removeFromGroup.description": "Bạn có chắc muốn xóa {{username}} khỏi nhóm này?",
   "directMessage.selectConversation": "Chọn một cuộc trò chuyện để bắt đầu nhắn tin",
   "directMessage.yourMessages": "Tin nhắn của bạn",
   "discover.about": "Giới thiệu",

--- a/assets/i18n/vi.json
+++ b/assets/i18n/vi.json
@@ -2488,6 +2488,7 @@
   "directMessage.createMessageGroup.createDMOrGroupChat": "Tạo tin nhắn hoặc nhóm chat",
   "directMessage.createMessageGroup.createGroupChat": "Tạo nhóm chat",
   "directMessage.createMessageGroup.creating": "Đang tạo...",
+  "directMessage.createMessageGroup.groupFull": "Nhóm đã đủ tối đa {{count}} thành viên.",
   "directMessage.createMessageGroup.noFriendsFound": "Không tìm thấy bạn bè nào chưa có trong cuộc trò chuyện này.",
   "directMessage.createMessageGroup.searchPlaceholder": "Nhập tên người dùng của bạn bè",
   "directMessage.createMessageGroup.selectFriends": "Chọn bạn bè",

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -44,9 +44,14 @@ pub struct ApiStatusError {
 
 impl ApiStatusError {
     pub const OUT_OF_RANGE: u32 = 11;
+    pub const INVALID_ARGUMENT: u32 = 3;
 
     pub fn is_out_of_range(self) -> bool {
         self.code == Self::OUT_OF_RANGE
+    }
+
+    pub fn is_invalid_argument(self) -> bool {
+        self.code == Self::INVALID_ARGUMENT
     }
 
     pub fn is_create_channel_limit_exceeded(self) -> bool {
@@ -7163,7 +7168,7 @@ impl MezonTransport {
         .encode_to_vec();
         let (code, _) = self.send_api_request(cid, "AddChannelUsers", body).await?;
         if code != 0 {
-            return Err(anyhow::anyhow!("API error: code={}", code));
+            return Err(api_status_error(code));
         }
         Ok(())
     }

--- a/crates/mezon-client/src/transport.rs
+++ b/crates/mezon-client/src/transport.rs
@@ -7188,7 +7188,7 @@ impl MezonTransport {
             .send_api_request(cid, "RemoveChannelUsers", body)
             .await?;
         if code != 0 {
-            return Err(anyhow::anyhow!("API error: code={}", code));
+            return Err(api_status_error(code));
         }
         Ok(())
     }

--- a/crates/mezon-mcp/src/catalog.rs
+++ b/crates/mezon-mcp/src/catalog.rs
@@ -365,14 +365,14 @@ Parameters: none.",
         name: "member_menu_pick",
         description: "\
 Run one row of the open member context menu (Profile, Message, Add Friend, Unblock, Remove Friend,
-Ban, Unban, Kick, Remove from thread).
+Ban, Unban, Kick, Remove from thread, Remove from group).
 
 Call member_menu_open first and pick the index from its item list. Rows of kind \"submenu\" or
 \"danger_submenu\" (Ban) additionally need value — one of the option values returned for that row
 (seconds; 0 means until the ban is lifted).
 
-Destructive: Kick, Ban and Remove-from-thread hit the server immediately; Remove Friend and Kick
-open a confirmation modal instead.
+Destructive: Kick, Ban, Remove-from-thread and Remove-from-group hit the server immediately;
+Remove Friend and Kick open a confirmation modal instead.
 
 Parameters:
 - index (required): item index from member_menu_open/member_menu_state.

--- a/crates/mezon-store/src/direct.rs
+++ b/crates/mezon-store/src/direct.rs
@@ -334,7 +334,11 @@ impl DirectMessageStore {
     fn register_realtime(cx: &mut Context<Self>) {
         let entity = cx.entity();
         RealtimeDispatch::global(cx).update(cx, |dispatch, _| {
-            for kind in [RealtimeKind::UserChannelAdded, RealtimeKind::ChannelUpdated] {
+            for kind in [
+                RealtimeKind::UserChannelAdded,
+                RealtimeKind::UserChannelRemoved,
+                RealtimeKind::ChannelUpdated,
+            ] {
                 dispatch.on(kind, &entity, |this, event, cx| {
                     this.handle_event(event, cx)
                 });
@@ -908,6 +912,20 @@ impl DirectMessageStore {
                 cx.emit(DirectEvent::Changed { channel_id: None });
                 cx.notify();
             }
+            RealtimeEvent::UserChannelRemoved(e) => {
+                let channel_id = ChannelId(e.channel_id);
+                if self.channels.find(channel_id).is_none() {
+                    return;
+                }
+                let me = crate::badge::BadgeService::try_global(cx)
+                    .and_then(|badge| badge.read(cx).current_user_id(cx));
+                let Some(me) = me else {
+                    return;
+                };
+                if e.user_ids.iter().any(|id| UserId(*id) == me) {
+                    self.forget_conversation(channel_id, cx);
+                }
+            }
             _ => {}
         }
     }
@@ -1377,7 +1395,10 @@ fn enrich_direct_from_event_users(
 }
 
 fn apply_member_count(channel: &mut DirectChannel, member_count: u32) -> bool {
-    if member_count == 0 || channel.member_count == member_count {
+    if channel.kind != DirectKind::Group
+        || member_count == 0
+        || channel.member_count == member_count
+    {
         return false;
     }
     channel.member_count = member_count;
@@ -1418,7 +1439,10 @@ fn direct_from_message(
         avatar: m.avatar.clone(),
         peer_user_id,
         peer_username,
-        creator_id: (m.sender_id != 0).then_some(UserId(m.sender_id)),
+        creator_id: match kind {
+            DirectKind::Dm => (m.sender_id != 0).then_some(UserId(m.sender_id)),
+            DirectKind::Group => None,
+        },
         online: true,
         member_count: 0,
         unread_count: u32::from(increment_unread),
@@ -1632,6 +1656,26 @@ mod tests {
         assert!(!apply_member_count(&mut channel, 5));
         assert!(!apply_member_count(&mut channel, 0));
         assert_eq!(channel.member_count, 5);
+    }
+
+    #[test]
+    fn member_count_leaves_a_one_to_one_dm_alone() {
+        let mut channel = group_channel_with_members(2);
+        channel.kind = DirectKind::Dm;
+        assert!(!apply_member_count(&mut channel, 1));
+        assert_eq!(channel.member_count, 2);
+    }
+
+    #[test]
+    fn a_group_row_from_a_message_claims_no_creator() {
+        let mut m = incoming_dm_message();
+        m.mode = STREAM_MODE_GROUP;
+        let group = direct_from_message(&m, false, true);
+        assert_eq!(group.kind, DirectKind::Group);
+        assert_eq!(group.creator_id, None);
+
+        let dm = direct_from_message(&incoming_dm_message(), false, true);
+        assert_eq!(dm.creator_id, Some(UserId(dm.peer_user_id.unwrap().0)));
     }
 
     fn group_channel_with_members(member_count: u32) -> DirectChannel {

--- a/crates/mezon-store/src/direct.rs
+++ b/crates/mezon-store/src/direct.rs
@@ -885,12 +885,24 @@ impl DirectMessageStore {
                 let self_id = crate::badge::BadgeService::try_global(cx)
                     .and_then(|badge| badge.read(cx).current_user_id(cx));
                 enrich_direct_from_event_users(&mut channel, &e.users, self_id);
+                let member_count = channel.member_count;
                 let inserted = self.channels.push_new(channel);
                 tracing::info!(
                     "user_channel_added: direct channel {} inserted={inserted}",
                     desc.channel_id
                 );
                 if !inserted {
+                    let channel_id = ChannelId(desc.channel_id);
+                    let recounted = self
+                        .channels
+                        .find_mut(channel_id)
+                        .is_some_and(|existing| apply_member_count(existing, member_count));
+                    if recounted {
+                        cx.emit(DirectEvent::Changed {
+                            channel_id: Some(channel_id),
+                        });
+                        cx.notify();
+                    }
                     return;
                 }
                 cx.emit(DirectEvent::Changed { channel_id: None });
@@ -1364,6 +1376,14 @@ fn enrich_direct_from_event_users(
     }
 }
 
+fn apply_member_count(channel: &mut DirectChannel, member_count: u32) -> bool {
+    if member_count == 0 || channel.member_count == member_count {
+        return false;
+    }
+    channel.member_count = member_count;
+    true
+}
+
 fn direct_from_message(
     m: &mezon_proto::api::ChannelMessage,
     from_me: bool,
@@ -1595,6 +1615,40 @@ mod tests {
         assert_eq!(channel.label, "potinoc605");
         assert_eq!(channel.peer_user_id, Some(UserId(2)));
         assert_eq!(channel.peer_username, "potinoc605");
+    }
+
+    #[test]
+    fn member_count_follows_the_roster_size_in_the_event() {
+        let mut channel = group_channel_with_members(5);
+        assert!(apply_member_count(&mut channel, 7));
+        assert_eq!(channel.member_count, 7);
+        assert!(apply_member_count(&mut channel, 6));
+        assert_eq!(channel.member_count, 6);
+    }
+
+    #[test]
+    fn member_count_ignores_a_repeat_or_missing_count() {
+        let mut channel = group_channel_with_members(5);
+        assert!(!apply_member_count(&mut channel, 5));
+        assert!(!apply_member_count(&mut channel, 0));
+        assert_eq!(channel.member_count, 5);
+    }
+
+    fn group_channel_with_members(member_count: u32) -> DirectChannel {
+        DirectChannel {
+            id: ChannelId(9),
+            label: "group".into(),
+            kind: DirectKind::Group,
+            avatar: String::new(),
+            peer_user_id: None,
+            peer_username: String::new(),
+            creator_id: None,
+            online: false,
+            member_count,
+            unread_count: 0,
+            last_sent_timestamp: 0,
+            last_seen_timestamp: 0,
+        }
     }
 
     #[test]

--- a/crates/mezon-store/src/direct.rs
+++ b/crates/mezon-store/src/direct.rs
@@ -81,6 +81,10 @@ pub enum DirectEvent {
     /// message, read-state change) so consumers can skip irrelevant channels;
     /// `None` means a bulk change (fetch page, reset) — treat as "anything".
     Changed { channel_id: Option<ChannelId> },
+    /// The signed-in user is no longer part of `channel_id` — removed, or left
+    /// on their own. The conversation is already gone from the store, so a view
+    /// sitting on it has to leave.
+    Removed { channel_id: ChannelId },
 }
 
 const DM_PAGE_SIZE: i32 = 500;
@@ -1045,6 +1049,7 @@ impl DirectMessageStore {
         if self.current.map(|(id, _)| id) == Some(channel_id) {
             self.current = None;
         }
+        cx.emit(DirectEvent::Removed { channel_id });
         cx.emit(DirectEvent::Changed { channel_id: None });
         cx.notify();
     }
@@ -2744,7 +2749,9 @@ mod tests {
             let store = dm_store(cx);
             let collected = seen.clone();
             let sub = cx.subscribe(&store, move |_, event: &DirectEvent, _| {
-                let DirectEvent::Changed { channel_id } = event;
+                let DirectEvent::Changed { channel_id } = event else {
+                    return;
+                };
                 collected.lock().expect("lock").push(*channel_id);
             });
             store.update(cx, |store, cx| {

--- a/crates/mezon-store/src/group_members.rs
+++ b/crates/mezon-store/src/group_members.rs
@@ -232,6 +232,21 @@ impl GroupMembersStore {
         })
     }
 
+    pub fn remove_member(
+        &mut self,
+        channel_id: ChannelId,
+        user_id: UserId,
+        cx: &mut Context<Self>,
+    ) -> Task<anyhow::Result<()>> {
+        let api = self.api.clone();
+        cx.spawn(async move |this, cx| {
+            api.remove_channel_users(channel_id.get(), vec![user_id.get().to_string()])
+                .await?;
+            this.update(cx, |this, _| this.cache.mark_stale(&channel_id))?;
+            Ok(())
+        })
+    }
+
     fn fetch(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
         if !self.loading.insert(channel_id) {
             return;

--- a/crates/mezon-store/src/group_members.rs
+++ b/crates/mezon-store/src/group_members.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use gpui::{App, AppContext, Context, Entity, EventEmitter, Global, Task};
-use mezon_client::{AppApi, ConnectionStatus, RealtimeEvent};
+use mezon_client::{AppApi, ConnectionStatus, RealtimeEvent, api_status_from_error};
 use mezon_proto::{api, realtime};
 
 use crate::KeyedCache;
@@ -13,6 +13,8 @@ use crate::realtime::{RealtimeDispatch, RealtimeKind};
 const MAX_CACHED_GROUPS: usize = 64;
 
 const GROUP_MEMBER_FETCH_LIMIT: i32 = 500;
+
+pub const MAX_GROUP_MEMBERS: usize = 20;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct GroupMember {
@@ -36,6 +38,13 @@ impl GroupMember {
     pub fn avatar(&self) -> &str {
         &self.user.avatar_url
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AddGroupMembersError {
+    GroupFull,
+    Api(u32),
+    Other(String),
 }
 
 #[derive(Debug, Clone)]
@@ -201,6 +210,28 @@ impl GroupMembersStore {
         self.fetch(channel_id, cx);
     }
 
+    pub fn add_members(
+        &mut self,
+        channel_id: ChannelId,
+        user_ids: Vec<UserId>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<(), AddGroupMembersError>> {
+        if user_ids.is_empty() {
+            return Task::ready(Ok(()));
+        }
+        let api = self.api.clone();
+        cx.spawn(async move |this, cx| {
+            let ids: Vec<String> = user_ids.iter().map(|id| id.get().to_string()).collect();
+            if let Err(err) = api.add_channel_users(channel_id.get(), ids).await {
+                tracing::warn!("add_channel_users failed for group {channel_id}: {err}");
+                return Err(map_add_members_error(err));
+            }
+            this.update(cx, |this, _| this.cache.mark_stale(&channel_id))
+                .map_err(|err| AddGroupMembersError::Other(err.to_string()))?;
+            Ok(())
+        })
+    }
+
     fn fetch(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
         if !self.loading.insert(channel_id) {
             return;
@@ -249,6 +280,14 @@ impl GroupMembersStore {
             cx.emit(GroupMembersEvent::Changed { channel_id });
             cx.notify();
         }
+    }
+}
+
+fn map_add_members_error(err: anyhow::Error) -> AddGroupMembersError {
+    match api_status_from_error(&err) {
+        Some(status) if status.is_invalid_argument() => AddGroupMembersError::GroupFull,
+        Some(status) => AddGroupMembersError::Api(status.code),
+        None => AddGroupMembersError::Other(err.to_string()),
     }
 }
 
@@ -364,6 +403,27 @@ mod tests {
         assert_eq!(members[0].name(), "only-one");
         assert_eq!(members[1].name(), "");
         assert!(!members[0].online);
+    }
+
+    #[test]
+    fn add_error_maps_invalid_argument_to_a_full_group() {
+        let err = mezon_client::ApiStatusError { code: 3 }.into();
+        assert_eq!(map_add_members_error(err), AddGroupMembersError::GroupFull);
+    }
+
+    #[test]
+    fn add_error_keeps_other_api_codes() {
+        let err = mezon_client::ApiStatusError { code: 13 }.into();
+        assert_eq!(map_add_members_error(err), AddGroupMembersError::Api(13));
+    }
+
+    #[test]
+    fn add_error_falls_back_to_the_message() {
+        let err = anyhow::anyhow!("socket closed");
+        assert_eq!(
+            map_add_members_error(err),
+            AddGroupMembersError::Other("socket closed".to_string())
+        );
     }
 
     #[test]

--- a/crates/mezon-store/src/group_members.rs
+++ b/crates/mezon-store/src/group_members.rs
@@ -106,6 +106,7 @@ impl GroupBucket {
 pub struct GroupMembersStore {
     cache: KeyedCache<ChannelId, GroupBucket>,
     loading: HashSet<ChannelId>,
+    mutations: HashMap<ChannelId, u64>,
     api: Arc<AppApi>,
     _conn_watch: Task<()>,
 }
@@ -134,6 +135,7 @@ impl GroupMembersStore {
     pub fn reset(&mut self, cx: &mut Context<Self>) {
         self.cache.clear();
         self.loading.clear();
+        self.mutations.clear();
         cx.notify();
     }
 
@@ -143,6 +145,7 @@ impl GroupMembersStore {
         Self {
             cache: KeyedCache::new(Some(MAX_CACHED_GROUPS)),
             loading: HashSet::new(),
+            mutations: HashMap::new(),
             api,
             _conn_watch: conn_watch,
         }
@@ -188,6 +191,10 @@ impl GroupMembersStore {
         self.cache.mark_all_stale();
     }
 
+    pub fn is_loaded(&self, channel_id: ChannelId) -> bool {
+        self.cache.contains(&channel_id)
+    }
+
     pub fn members(&self, channel_id: ChannelId) -> &[GroupMember] {
         self.cache
             .get(&channel_id)
@@ -226,8 +233,7 @@ impl GroupMembersStore {
                 tracing::warn!("add_channel_users failed for group {channel_id}: {err}");
                 return Err(map_add_members_error(err));
             }
-            this.update(cx, |this, _| this.cache.mark_stale(&channel_id))
-                .map_err(|err| AddGroupMembersError::Other(err.to_string()))?;
+            let _ = this.update(cx, |this, cx| this.note_mutation(channel_id, cx));
             Ok(())
         })
     }
@@ -242,7 +248,7 @@ impl GroupMembersStore {
         cx.spawn(async move |this, cx| {
             api.remove_channel_users(channel_id.get(), vec![user_id.get().to_string()])
                 .await?;
-            this.update(cx, |this, _| this.cache.mark_stale(&channel_id))?;
+            let _ = this.update(cx, |this, cx| this.note_mutation(channel_id, cx));
             Ok(())
         })
     }
@@ -252,6 +258,7 @@ impl GroupMembersStore {
             return;
         }
         let api = self.api.clone();
+        let started_at = self.mutation_count(channel_id);
         cx.spawn(async move |this, cx| {
             let result = api
                 .list_channel_users_uc(channel_id.get(), GROUP_MEMBER_FETCH_LIMIT)
@@ -260,6 +267,10 @@ impl GroupMembersStore {
                 this.loading.remove(&channel_id);
                 match result {
                     Ok(resp) => {
+                        if this.mutation_count(channel_id) != started_at {
+                            this.fetch(channel_id, cx);
+                            return;
+                        }
                         let members = group_members_from_proto(&resp);
                         this.cache
                             .insert(channel_id, GroupBucket::from_members(members), None);
@@ -273,6 +284,17 @@ impl GroupMembersStore {
             });
         })
         .detach();
+    }
+
+    fn mutation_count(&self, channel_id: ChannelId) -> u64 {
+        self.mutations.get(&channel_id).copied().unwrap_or(0)
+    }
+
+    fn note_mutation(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
+        let next = self.mutation_count(channel_id).wrapping_add(1);
+        self.mutations.insert(channel_id, next);
+        self.cache.mark_stale(&channel_id);
+        self.fetch(channel_id, cx);
     }
 
     fn handle_event(&mut self, event: &RealtimeEvent, cx: &mut Context<Self>) {

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -156,7 +156,9 @@ pub use gifts::{
     flower_price, format_flower_amount, is_uncertain_transfer_error,
     parse_flower_interactive_params, serialize_flower_interactive_params,
 };
-pub use group_members::{GroupMember, GroupMembersEvent, GroupMembersStore};
+pub use group_members::{
+    AddGroupMembersError, GroupMember, GroupMembersEvent, GroupMembersStore, MAX_GROUP_MEMBERS,
+};
 pub use ids::{ChannelId, ClanId, MessageId, ParseIdError, RoleId, UserId};
 pub use inbox::{GLOBAL_INBOX_BUCKET_CLAN_ID, InboxEvent, InboxStore};
 pub use invite::{InviteDetails, InviteEvent, InviteState, InviteStore};

--- a/crates/mezon-ui/src/app/shell/confirm_remove_group_member_modal.rs
+++ b/crates/mezon-ui/src/app/shell/confirm_remove_group_member_modal.rs
@@ -1,0 +1,109 @@
+use gpui::{Context, FocusHandle, SharedString, Window, div, prelude::*, px};
+use mezon_store::{ChannelId, GroupMembersStore, UserId};
+
+use super::Shell;
+use crate::components::primitives::{Button, ButtonVariants, h_flex, v_flex};
+use crate::theme::ActiveTheme;
+
+pub(super) struct ConfirmRemoveGroupMemberModal {
+    pub(super) focus_handle: FocusHandle,
+    pub(super) channel_id: ChannelId,
+    pub(super) user_id: UserId,
+    pub(super) title: SharedString,
+    pub(super) description: SharedString,
+    pub(super) cancel_label: SharedString,
+    pub(super) confirm_label: SharedString,
+    pub(super) success_message: SharedString,
+    pub(super) failed_message: SharedString,
+    pub(super) removing: bool,
+}
+
+impl Render for ConfirmRemoveGroupMemberModal {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let removing = self.removing;
+
+        v_flex()
+            .track_focus(&self.focus_handle)
+            .key_context("menu")
+            .on_action(cx.listener(|_, _: &::menu::Cancel, _window, cx| {
+                Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+            }))
+            .w(px(440.))
+            .gap_4()
+            .p(px(20.))
+            .rounded_lg()
+            .border_1()
+            .border_color(theme.border)
+            .bg(theme.bg_floating)
+            .shadow_lg()
+            .child(
+                div()
+                    .text_lg()
+                    .font_weight(gpui::FontWeight::SEMIBOLD)
+                    .text_color(theme.text_primary)
+                    .child(self.title.clone()),
+            )
+            .child(
+                div()
+                    .text_sm()
+                    .text_color(theme.text_secondary)
+                    .child(self.description.clone()),
+            )
+            .child(
+                h_flex()
+                    .justify_end()
+                    .gap_2()
+                    .child(
+                        Button::new("confirm-remove-group-member-cancel")
+                            .label(self.cancel_label.clone())
+                            .ghost()
+                            .on_click(|_, _window, cx| {
+                                Shell::global(cx).update(cx, |shell, cx| shell.close_modal(cx));
+                            }),
+                    )
+                    .child(
+                        Button::new("confirm-remove-group-member-confirm")
+                            .label(self.confirm_label.clone())
+                            .danger()
+                            .disabled(removing)
+                            .on_click(cx.listener(|this, _, _window, cx| {
+                                if this.removing {
+                                    return;
+                                }
+                                this.removing = true;
+                                cx.notify();
+                                let channel_id = this.channel_id;
+                                let user_id = this.user_id;
+                                let success = this.success_message.clone();
+                                let failed = this.failed_message.clone();
+                                let task = GroupMembersStore::global(cx).update(cx, |store, cx| {
+                                    store.remove_member(channel_id, user_id, cx)
+                                });
+                                cx.spawn(async move |this, cx| {
+                                    let result = task.await;
+                                    let _ = this.update(cx, |this, cx| {
+                                        this.removing = false;
+                                        cx.notify();
+                                    });
+                                    cx.update(|cx| {
+                                        Shell::global(cx).update(cx, |shell, cx| {
+                                            shell.close_modal(cx);
+                                            match result {
+                                                Ok(()) => shell.success(success, cx),
+                                                Err(error) => {
+                                                    tracing::error!(
+                                                        "remove member {user_id} from group {channel_id} failed: {error}"
+                                                    );
+                                                    shell.error(failed, cx);
+                                                }
+                                            }
+                                        });
+                                    });
+                                })
+                                .detach();
+                            })),
+                    ),
+            )
+    }
+}

--- a/crates/mezon-ui/src/app/shell/mod.rs
+++ b/crates/mezon-ui/src/app/shell/mod.rs
@@ -33,6 +33,7 @@ mod confirm_leave_clan_modal;
 mod confirm_leave_dm_group_modal;
 mod confirm_leave_thread_modal;
 mod confirm_remove_friend_modal;
+mod confirm_remove_group_member_modal;
 mod disable_clan_community_modal;
 mod transfer_owner_modal;
 mod upload_limit_modal;
@@ -57,6 +58,7 @@ use confirm_leave_dm_group_modal::ConfirmLeaveDmGroupModal;
 use confirm_leave_thread_modal::ConfirmLeaveThreadModal;
 pub use confirm_remove_friend_modal::FriendRemovalKind;
 use confirm_remove_friend_modal::{ConfirmRemoveFriendModal, interpolate_username};
+use confirm_remove_group_member_modal::ConfirmRemoveGroupMemberModal;
 use disable_clan_community_modal::DisableClanCommunityModal;
 use transfer_owner_modal::{TransferOwnerModal, TransferOwnerParty};
 use upload_limit_modal::UploadLimitModal;
@@ -1340,6 +1342,36 @@ impl Shell {
             confirm_label: mezon_i18n::t(locale, "leaveGroup.leaveGroup").into(),
             failed_message: mezon_i18n::t(locale, "common.somethingWentWrong").into(),
             leaving: false,
+        });
+        let focus_handle = view.read(cx).focus_handle.clone();
+        window.focus(&focus_handle, cx);
+        self.show_modal(view.into(), cx);
+    }
+
+    pub fn confirm_remove_group_member(
+        &mut self,
+        channel_id: mezon_store::ChannelId,
+        user_id: mezon_store::UserId,
+        display_name: &str,
+        locale: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let description = mezon_i18n::t(locale, "directMessage.removeFromGroup.description")
+            .replace("{{username}}", display_name);
+        let view = cx.new(|cx| ConfirmRemoveGroupMemberModal {
+            focus_handle: cx.focus_handle(),
+            channel_id,
+            user_id,
+            title: mezon_i18n::t(locale, "directMessage.contextMenu.removeFromGroup").into(),
+            description: description.into(),
+            cancel_label: mezon_i18n::t(locale, "common.cancel").into(),
+            confirm_label: mezon_i18n::t(locale, "common.confirm").into(),
+            success_message: mezon_i18n::t(locale, "userProfile.userInfoDM.menu.removeSuccess")
+                .into(),
+            failed_message: mezon_i18n::t(locale, "userProfile.userInfoDM.menu.removeFailed")
+                .into(),
+            removing: false,
         });
         let focus_handle = view.read(cx).focus_handle.clone();
         window.focus(&focus_handle, cx);

--- a/crates/mezon-ui/src/chat/add_members_to_group_modal.rs
+++ b/crates/mezon-ui/src/chat/add_members_to_group_modal.rs
@@ -1,40 +1,64 @@
+use std::collections::HashSet;
+
 use crate::app::shell::Shell;
 use crate::components::compositions::{
     FRIEND_PICK_ROW_HEIGHT, FriendPickRow, render_friend_pick_row,
 };
-use crate::components::primitives::{Input, InputEvent, InputState};
-use crate::router::{Route, navigate};
+use crate::components::primitives::{Input, InputEvent, InputState, Sizable, Size, Spinner};
 use crate::theme::ActiveTheme;
 use gpui::{
     App, ClickEvent, Context, Entity, FocusHandle, Focusable, FontWeight, SharedString,
     Subscription, UniformListScrollHandle, Window, div, prelude::*, px, uniform_list,
 };
 use mezon_store::{
-    DirectMessageStore, FriendEvent, FriendState, FriendStore, MAX_GROUP_MEMBERS, UserId,
+    AddGroupMembersError, ChannelId, DirectMessageStore, FriendEvent, FriendState, FriendStore,
+    GroupMembersEvent, GroupMembersStore, MAX_GROUP_MEMBERS, UserId,
 };
 
-pub struct CreateMessageGroupModal {
+pub struct AddMembersToGroupModal {
     focus_handle: FocusHandle,
+    channel_id: ChannelId,
     locale: String,
+    title: SharedString,
+    add_label: SharedString,
     search_input: Entity<InputState>,
     all_rows: Vec<FriendPickRow>,
     visible: Vec<usize>,
     selected: Vec<UserId>,
-    creating: bool,
+    member_count: usize,
+    adding: bool,
     scroll: UniformListScrollHandle,
     _input_sub: Subscription,
     _friend_sub: Subscription,
+    _group_sub: Subscription,
 }
 
-impl Focusable for CreateMessageGroupModal {
+impl Focusable for AddMembersToGroupModal {
     fn focus_handle(&self, _cx: &App) -> FocusHandle {
         self.focus_handle.clone()
     }
 }
 
-impl CreateMessageGroupModal {
-    pub fn new(locale: String, window: &mut Window, cx: &mut Context<Self>) -> Self {
+impl AddMembersToGroupModal {
+    pub fn open(channel_id: ChannelId, locale: String, window: &mut Window, cx: &mut App) {
+        let modal = cx.new(|cx| Self::new(channel_id, locale, window, cx));
+        Shell::global(cx).update(cx, |shell, cx| shell.show_modal(modal.clone().into(), cx));
+        window.defer(cx, move |window, cx| {
+            modal.update(cx, |this, cx| {
+                this.search_input
+                    .update(cx, |input, cx| input.focus(window, cx));
+            });
+        });
+    }
+
+    pub fn new(
+        channel_id: ChannelId,
+        locale: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
         FriendStore::global(cx).update(cx, |store, cx| store.ensure_loaded(cx));
+        GroupMembersStore::global(cx).update(cx, |store, cx| store.ensure_loaded(channel_id, cx));
 
         let placeholder = mezon_i18n::t(
             &locale,
@@ -65,34 +89,88 @@ impl CreateMessageGroupModal {
                 }
             },
         );
+        let group_sub = cx.subscribe(
+            &GroupMembersStore::global(cx),
+            |this: &mut Self, _store, event: &GroupMembersEvent, cx| {
+                let GroupMembersEvent::Changed { channel_id } = event;
+                if *channel_id == this.channel_id {
+                    this.rebuild_rows(cx);
+                    cx.notify();
+                }
+            },
+        );
         search_input.update(cx, |input, cx| input.focus(window, cx));
+
+        let title = mezon_i18n::t(&locale, "common.addMembers")
+            .to_string()
+            .into();
+        let add_label = mezon_i18n::t(&locale, "directMessage.createMessageGroup.addToGroupChat")
+            .to_string()
+            .into();
 
         let mut modal = Self {
             focus_handle: cx.focus_handle(),
+            channel_id,
             locale,
+            title,
+            add_label,
             search_input,
             all_rows: Vec::new(),
             visible: Vec::new(),
             selected: Vec::new(),
-            creating: false,
+            member_count: 0,
+            adding: false,
             scroll: UniformListScrollHandle::new(),
             _input_sub: input_sub,
             _friend_sub: friend_sub,
+            _group_sub: group_sub,
         };
         modal.rebuild_rows(cx);
         modal
     }
 
     fn rebuild_rows(&mut self, cx: &mut Context<Self>) {
+        let current = self.current_member_ids(cx);
         let friends = FriendStore::global(cx);
         let friends = friends.read(cx);
         self.all_rows = friends
             .friends()
             .iter()
             .filter(|friend| friend.state != FriendState::Blocked)
+            .filter(|friend| !current.contains(&friend.id))
             .map(|friend| FriendPickRow::from_friend(friend, cx))
             .collect();
+        let eligible: HashSet<UserId> = self.all_rows.iter().map(|row| row.user_id).collect();
+        self.selected.retain(|id| eligible.contains(id));
+        let capacity = self.capacity();
+        self.selected.truncate(capacity);
         self.refilter(cx);
+    }
+
+    fn current_member_ids(&mut self, cx: &App) -> HashSet<UserId> {
+        let members: Vec<UserId> = GroupMembersStore::try_global(cx)
+            .map(|store| {
+                store
+                    .read(cx)
+                    .members(self.channel_id)
+                    .iter()
+                    .map(|member| member.id())
+                    .collect()
+            })
+            .unwrap_or_default();
+        self.member_count = if members.is_empty() {
+            DirectMessageStore::try_global(cx)
+                .and_then(|store| {
+                    store
+                        .read(cx)
+                        .find(self.channel_id)
+                        .map(|dm| dm.member_count as usize)
+                })
+                .unwrap_or(0)
+        } else {
+            members.len()
+        };
+        members.into_iter().collect()
     }
 
     fn refilter(&mut self, cx: &mut Context<Self>) {
@@ -106,12 +184,12 @@ impl CreateMessageGroupModal {
             .collect();
     }
 
-    fn number_can_add(&self) -> usize {
-        (MAX_GROUP_MEMBERS - 1).min(self.all_rows.len())
+    fn capacity(&self) -> usize {
+        addable_slots(self.member_count, self.all_rows.len())
     }
 
     fn remaining_can_add(&self) -> usize {
-        self.number_can_add().saturating_sub(self.selected.len())
+        self.capacity().saturating_sub(self.selected.len())
     }
 
     fn is_selected(&self, user_id: UserId) -> bool {
@@ -119,10 +197,13 @@ impl CreateMessageGroupModal {
     }
 
     fn toggle(&mut self, user_id: UserId, cx: &mut Context<Self>) {
+        if self.adding {
+            return;
+        }
         if let Some(pos) = self.selected.iter().position(|id| *id == user_id) {
             self.selected.remove(pos);
         } else {
-            if self.selected.len() >= MAX_GROUP_MEMBERS - 1 {
+            if self.selected.len() >= self.capacity() {
                 return;
             }
             self.selected.push(user_id);
@@ -130,83 +211,43 @@ impl CreateMessageGroupModal {
         cx.notify();
     }
 
-    fn create_label(&self) -> SharedString {
-        let key = if self.creating {
-            "directMessage.createMessageGroup.creating"
-        } else if self.selected.is_empty() {
-            "directMessage.createMessageGroup.createDMOrGroupChat"
-        } else if self.selected.len() == 1 {
-            "directMessage.createMessageGroup.createDM"
-        } else {
-            "directMessage.createMessageGroup.createGroupChat"
-        };
-        SharedString::from(mezon_i18n::t(&self.locale, key))
-    }
-
-    fn handle_create(&mut self, cx: &mut Context<Self>) {
-        if self.creating || self.selected.is_empty() {
+    fn handle_add(&mut self, cx: &mut Context<Self>) {
+        if self.adding || self.selected.is_empty() {
             return;
         }
-        let Some(store) = DirectMessageStore::try_global(cx) else {
+        let Some(store) = GroupMembersStore::try_global(cx) else {
             return;
         };
-
-        let friend_store = FriendStore::global(cx);
-        let friends = friend_store.read(cx);
-        let mut members: Vec<(UserId, String, String, String)> = Vec::new();
-        for id in &self.selected {
-            if let Some(friend) = friends.friend(*id) {
-                members.push((
-                    *id,
-                    friend.label().to_string(),
-                    friend.avatar_url.clone(),
-                    friend.username.clone(),
-                ));
-            }
-        }
-        if members.is_empty() {
-            return;
-        }
-
+        let channel_id = self.channel_id;
         let modal_id = cx.entity_id();
-        self.creating = true;
+        let user_ids = self.selected.clone();
+        let failed: SharedString = mezon_i18n::t(&self.locale, "common.somethingWentWrong").into();
+        let group_full: SharedString =
+            mezon_i18n::t(&self.locale, "directMessage.createMessageGroup.groupFull")
+                .replace("{{count}}", &MAX_GROUP_MEMBERS.to_string())
+                .into();
+
+        self.adding = true;
         cx.notify();
 
-        let task = if members.len() == 1 {
-            let (id, label, avatar, username) = members.remove(0);
-            store.update(cx, |store, cx| {
-                store.create_dm_with_user(id, label, avatar, username, cx)
-            })
-        } else {
-            let group_label = members
-                .iter()
-                .map(|member| member.1.clone())
-                .collect::<Vec<_>>()
-                .join(", ");
-            let ids: Vec<UserId> = members.into_iter().map(|member| member.0).collect();
-            store.update(cx, |store, cx| {
-                store.create_group_with_users(ids, group_label, cx)
-            })
-        };
-
+        let task = store.update(cx, |store, cx| store.add_members(channel_id, user_ids, cx));
         cx.spawn(async move |this, cx| match task.await {
-            Ok((channel_id, channel_type)) => {
+            Ok(()) => {
                 cx.update(|cx| {
-                    navigate(
-                        cx,
-                        Route::DirectMessage {
-                            direct_id: channel_id,
-                            message_type: channel_type.to_string(),
-                        },
-                    );
                     Shell::global(cx).update(cx, |shell, cx| shell.close_modal_view(modal_id, cx));
                 });
             }
             Err(err) => {
-                tracing::warn!("create dm/group failed: {err}");
+                let message = match err {
+                    AddGroupMembersError::GroupFull => group_full,
+                    _ => failed,
+                };
                 let _ = this.update(cx, |this, cx| {
-                    this.creating = false;
+                    this.adding = false;
                     cx.notify();
+                });
+                cx.update(|cx| {
+                    Shell::global(cx).update(cx, |shell, cx| shell.error(message.clone(), cx));
                 });
             }
         })
@@ -218,23 +259,23 @@ impl CreateMessageGroupModal {
     }
 }
 
-impl Render for CreateMessageGroupModal {
+fn addable_slots(member_count: usize, candidate_count: usize) -> usize {
+    MAX_GROUP_MEMBERS
+        .saturating_sub(member_count)
+        .min(candidate_count)
+}
+
+impl Render for AddMembersToGroupModal {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme().clone();
         let entity = cx.entity();
 
-        let title = mezon_i18n::t(
-            &self.locale,
-            "directMessage.createMessageGroup.selectFriends",
-        )
-        .to_string();
         let subtitle = mezon_i18n::t(
             &self.locale,
             "directMessage.createMessageGroup.canAddMoreFriends",
         )
         .replace("{{count}}", &self.remaining_can_add().to_string());
-        let create_label = self.create_label();
-        let enabled = !self.creating && !self.selected.is_empty();
+        let enabled = !self.adding && !self.selected.is_empty();
 
         const LIST_HEIGHT: f32 = 190.;
 
@@ -257,7 +298,7 @@ impl Render for CreateMessageGroupModal {
         } else {
             let list_entity = entity.clone();
             uniform_list(
-                "create-group-friends",
+                "add-group-members-friends",
                 row_count,
                 move |range, _window, cx| {
                     let theme = cx.theme().clone();
@@ -290,13 +331,14 @@ impl Render for CreateMessageGroupModal {
         };
 
         let button_entity = entity.clone();
-        let create_button = div()
-            .id("create-dm-group-submit")
+        let add_button = div()
+            .id("add-group-members-submit")
             .h(px(38.))
             .w_full()
             .flex()
             .items_center()
             .justify_center()
+            .gap_2()
             .rounded(px(6.))
             .text_size(px(14.))
             .font_weight(FontWeight::MEDIUM)
@@ -305,12 +347,15 @@ impl Render for CreateMessageGroupModal {
             .when(enabled, |el| {
                 el.cursor_pointer().hover(|s| s.opacity(0.9)).on_click(
                     move |_: &ClickEvent, _window, cx| {
-                        button_entity.update(cx, |this, cx| this.handle_create(cx));
+                        button_entity.update(cx, |this, cx| this.handle_add(cx));
                     },
                 )
             })
             .when(!enabled, |el| el.opacity(0.6))
-            .child(create_label);
+            .when(self.adding, |el| {
+                el.child(Spinner::new().with_size(Size::XSmall).color(gpui::white()))
+            })
+            .child(self.add_label.clone());
 
         div()
             .track_focus(&self.focus_handle)
@@ -335,7 +380,7 @@ impl Render for CreateMessageGroupModal {
                             .text_size(px(20.))
                             .font_weight(FontWeight::SEMIBOLD)
                             .text_color(theme.tokens.text_theme_primary)
-                            .child(title),
+                            .child(self.title.clone()),
                     )
                     .child(
                         div()
@@ -349,7 +394,28 @@ impl Render for CreateMessageGroupModal {
                     )),
             )
             .child(list_body)
-            .child(div().p(px(20.)).child(create_button))
+            .child(div().p(px(20.)).child(add_button))
             .into_any_element()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slots_are_bounded_by_the_server_cap() {
+        assert_eq!(addable_slots(3, 50), MAX_GROUP_MEMBERS - 3);
+    }
+
+    #[test]
+    fn slots_are_bounded_by_the_candidates_on_offer() {
+        assert_eq!(addable_slots(3, 2), 2);
+    }
+
+    #[test]
+    fn a_full_group_offers_no_slots() {
+        assert_eq!(addable_slots(MAX_GROUP_MEMBERS, 10), 0);
+        assert_eq!(addable_slots(MAX_GROUP_MEMBERS + 5, 10), 0);
     }
 }

--- a/crates/mezon-ui/src/chat/add_members_to_group_modal.rs
+++ b/crates/mezon-ui/src/chat/add_members_to_group_modal.rs
@@ -11,8 +11,8 @@ use gpui::{
     Subscription, UniformListScrollHandle, Window, div, prelude::*, px, uniform_list,
 };
 use mezon_store::{
-    AddGroupMembersError, ChannelId, DirectMessageStore, FriendEvent, FriendState, FriendStore,
-    GroupMembersEvent, GroupMembersStore, MAX_GROUP_MEMBERS, UserId,
+    AddGroupMembersError, ChannelId, FriendEvent, FriendState, FriendStore, GroupMembersEvent,
+    GroupMembersStore, MAX_GROUP_MEMBERS, UserId,
 };
 
 pub struct AddMembersToGroupModal {
@@ -25,7 +25,7 @@ pub struct AddMembersToGroupModal {
     all_rows: Vec<FriendPickRow>,
     visible: Vec<usize>,
     selected: Vec<UserId>,
-    member_count: usize,
+    roster_size: Option<usize>,
     adding: bool,
     scroll: UniformListScrollHandle,
     _input_sub: Subscription,
@@ -116,7 +116,7 @@ impl AddMembersToGroupModal {
             all_rows: Vec::new(),
             visible: Vec::new(),
             selected: Vec::new(),
-            member_count: 0,
+            roster_size: None,
             adding: false,
             scroll: UniformListScrollHandle::new(),
             _input_sub: input_sub,
@@ -128,8 +128,8 @@ impl AddMembersToGroupModal {
     }
 
     fn rebuild_rows(&mut self, cx: &mut Context<Self>) {
-        let (current, member_count) = self.current_members(cx);
-        self.member_count = member_count;
+        let (current, roster_size) = self.current_members(cx);
+        self.roster_size = roster_size;
         let friends = FriendStore::global(cx);
         let friends = friends.read(cx);
         self.all_rows = friends
@@ -146,30 +146,21 @@ impl AddMembersToGroupModal {
         self.refilter(cx);
     }
 
-    fn current_members(&self, cx: &App) -> (HashSet<UserId>, usize) {
-        let members: Vec<UserId> = GroupMembersStore::try_global(cx)
-            .map(|store| {
-                store
-                    .read(cx)
-                    .members(self.channel_id)
-                    .iter()
-                    .map(|member| member.id())
-                    .collect()
-            })
-            .unwrap_or_default();
-        let member_count = if members.is_empty() {
-            DirectMessageStore::try_global(cx)
-                .and_then(|store| {
-                    store
-                        .read(cx)
-                        .find(self.channel_id)
-                        .map(|dm| dm.member_count as usize)
-                })
-                .unwrap_or(0)
-        } else {
-            members.len()
+    fn current_members(&self, cx: &App) -> (HashSet<UserId>, Option<usize>) {
+        let Some(store) = GroupMembersStore::try_global(cx) else {
+            return (HashSet::new(), None);
         };
-        (members.into_iter().collect(), member_count)
+        let store = store.read(cx);
+        if !store.is_loaded(self.channel_id) {
+            return (HashSet::new(), None);
+        }
+        let members: HashSet<UserId> = store
+            .members(self.channel_id)
+            .iter()
+            .map(|member| member.id())
+            .collect();
+        let size = members.len();
+        (members, Some(size))
     }
 
     fn refilter(&mut self, cx: &mut Context<Self>) {
@@ -178,13 +169,16 @@ impl AddMembersToGroupModal {
             .all_rows
             .iter()
             .enumerate()
-            .filter(|(_, row)| row.matches_query(&query))
+            .filter(|(_, row)| row.matches_lowercase_query(&query))
             .map(|(ix, _)| ix)
             .collect();
     }
 
     fn capacity(&self) -> usize {
-        addable_slots(self.member_count, self.all_rows.len())
+        match self.roster_size {
+            Some(size) => addable_slots(size, self.all_rows.len()),
+            None => 0,
+        }
     }
 
     fn remaining_can_add(&self) -> usize {
@@ -219,6 +213,7 @@ impl AddMembersToGroupModal {
         };
         let channel_id = self.channel_id;
         let modal_id = cx.entity_id();
+        let locale = self.locale.clone();
         let user_ids = self.selected.clone();
         let failed: SharedString = mezon_i18n::t(&self.locale, "common.somethingWentWrong").into();
         let group_full: SharedString =
@@ -232,6 +227,10 @@ impl AddMembersToGroupModal {
         let task = store.update(cx, |store, cx| store.add_members(channel_id, user_ids, cx));
         cx.spawn(async move |this, cx| match task.await {
             Ok(()) => {
+                let _ = this.update(cx, |this, cx| {
+                    this.adding = false;
+                    cx.notify();
+                });
                 cx.update(|cx| {
                     Shell::global(cx).update(cx, |shell, cx| shell.close_modal_view(modal_id, cx));
                 });
@@ -239,7 +238,10 @@ impl AddMembersToGroupModal {
             Err(err) => {
                 let message = match err {
                     AddGroupMembersError::GroupFull => group_full,
-                    _ => failed,
+                    AddGroupMembersError::Api(code) => {
+                        SharedString::from(mezon_i18n::api_error(&locale, code))
+                    }
+                    AddGroupMembersError::Other(_) => failed,
                 };
                 let _ = this.update(cx, |this, cx| {
                     this.adding = false;
@@ -279,7 +281,12 @@ impl Render for AddMembersToGroupModal {
         const LIST_HEIGHT: f32 = 190.;
 
         let row_count = self.visible.len();
-        let list_body = if row_count == 0 {
+        let list_body = if self.roster_size.is_none() || row_count == 0 {
+            let key = if self.roster_size.is_none() {
+                "root.loading"
+            } else {
+                "directMessage.createMessageGroup.noFriendsFound"
+            };
             div()
                 .h(px(LIST_HEIGHT))
                 .flex()
@@ -289,10 +296,7 @@ impl Render for AddMembersToGroupModal {
                 .text_center()
                 .text_size(px(14.))
                 .text_color(theme.text_secondary)
-                .child(mezon_i18n::t(
-                    &self.locale,
-                    "directMessage.createMessageGroup.noFriendsFound",
-                ))
+                .child(mezon_i18n::t(&self.locale, key))
                 .into_any_element()
         } else {
             let list_entity = entity.clone();

--- a/crates/mezon-ui/src/chat/add_members_to_group_modal.rs
+++ b/crates/mezon-ui/src/chat/add_members_to_group_modal.rs
@@ -51,7 +51,7 @@ impl AddMembersToGroupModal {
         });
     }
 
-    pub fn new(
+    fn new(
         channel_id: ChannelId,
         locale: String,
         window: &mut Window,
@@ -99,8 +99,6 @@ impl AddMembersToGroupModal {
                 }
             },
         );
-        search_input.update(cx, |input, cx| input.focus(window, cx));
-
         let title = mezon_i18n::t(&locale, "common.addMembers")
             .to_string()
             .into();
@@ -130,7 +128,8 @@ impl AddMembersToGroupModal {
     }
 
     fn rebuild_rows(&mut self, cx: &mut Context<Self>) {
-        let current = self.current_member_ids(cx);
+        let (current, member_count) = self.current_members(cx);
+        self.member_count = member_count;
         let friends = FriendStore::global(cx);
         let friends = friends.read(cx);
         self.all_rows = friends
@@ -147,7 +146,7 @@ impl AddMembersToGroupModal {
         self.refilter(cx);
     }
 
-    fn current_member_ids(&mut self, cx: &App) -> HashSet<UserId> {
+    fn current_members(&self, cx: &App) -> (HashSet<UserId>, usize) {
         let members: Vec<UserId> = GroupMembersStore::try_global(cx)
             .map(|store| {
                 store
@@ -158,7 +157,7 @@ impl AddMembersToGroupModal {
                     .collect()
             })
             .unwrap_or_default();
-        self.member_count = if members.is_empty() {
+        let member_count = if members.is_empty() {
             DirectMessageStore::try_global(cx)
                 .and_then(|store| {
                     store
@@ -170,7 +169,7 @@ impl AddMembersToGroupModal {
         } else {
             members.len()
         };
-        members.into_iter().collect()
+        (members.into_iter().collect(), member_count)
     }
 
     fn refilter(&mut self, cx: &mut Context<Self>) {

--- a/crates/mezon-ui/src/chat/area.rs
+++ b/crates/mezon-ui/src/chat/area.rs
@@ -29,6 +29,7 @@ use crate::chat::pinned_popover::PinnedPopoverPanel;
 use crate::components::compositions::channel_row::ChannelIcon;
 use crate::components::primitives::{Icon, IconName, InputState};
 use crate::image_cache::LruImageCache;
+use crate::router::{Route, Router, navigate};
 use crate::theme::ActiveTheme;
 
 pub struct ChatArea {
@@ -63,6 +64,16 @@ pub struct ChatArea {
 
 const SEND_PERMISSION_DEBOUNCE: Duration = Duration::from_millis(500);
 
+fn leave_removed_conversation(channel_id: ChannelId, cx: &mut App) {
+    if route_targets_conversation(&Router::global(cx).read(cx).route(), channel_id) {
+        navigate(cx, Route::Friends);
+    }
+}
+
+fn route_targets_conversation(route: &Route, channel_id: ChannelId) -> bool {
+    matches!(route, Route::DirectMessage { direct_id, .. } if *direct_id == channel_id)
+}
+
 impl ChatArea {
     pub fn new(settings: Entity<Settings>, cx: &mut Context<crate::ChatLayout>) -> Self {
         let timeline = cx.new({
@@ -91,9 +102,15 @@ impl ChatArea {
         let send_permission_direct_sub = cx.subscribe(
             &DirectMessageStore::global(cx),
             |this: &mut crate::ChatLayout, _, event: &DirectEvent, cx| {
-                let DirectEvent::Changed { channel_id } = event;
+                let channel_id = match event {
+                    DirectEvent::Changed { channel_id } => *channel_id,
+                    DirectEvent::Removed { channel_id } => {
+                        leave_removed_conversation(*channel_id, cx);
+                        Some(*channel_id)
+                    }
+                };
                 let active_channel = MessagesStore::global(cx).read(cx).active_channel_id();
-                if channel_id.is_none() || *channel_id == active_channel {
+                if channel_id.is_none() || channel_id == active_channel {
                     this.chat_area.sync_send_permission(cx);
                 }
             },
@@ -855,5 +872,32 @@ impl ChatArea {
             .when(!hide_header, |this| this.child(header))
             .child(body)
             .into_any_element()
+    }
+}
+
+#[cfg(test)]
+mod removed_conversation_tests {
+    use super::{ChannelId, Route, route_targets_conversation};
+
+    fn direct(id: i64) -> Route {
+        Route::DirectMessage {
+            direct_id: ChannelId(id),
+            message_type: "2".to_string(),
+        }
+    }
+
+    #[test]
+    fn the_open_conversation_has_to_be_left() {
+        assert!(route_targets_conversation(&direct(7), ChannelId(7)));
+    }
+
+    #[test]
+    fn another_conversation_stays_put() {
+        assert!(!route_targets_conversation(&direct(7), ChannelId(8)));
+    }
+
+    #[test]
+    fn a_route_outside_direct_messages_stays_put() {
+        assert!(!route_targets_conversation(&Route::Friends, ChannelId(7)));
     }
 }

--- a/crates/mezon-ui/src/chat/channel_header.rs
+++ b/crates/mezon-ui/src/chat/channel_header.rs
@@ -13,6 +13,7 @@ use ui::{Clickable, PopoverMenu, PopoverMenuHandle, Toggleable, Tooltip};
 
 use crate::app::shell::Shell;
 use crate::app::window_controls;
+use crate::chat::add_members_to_group_modal::AddMembersToGroupModal;
 use crate::chat::call_actions::call_current_dm;
 use crate::chat::edit_group_modal::EditGroupModal;
 use crate::chat::files_popover::{FilesPopoverPanel, files_popover_on_open};
@@ -49,6 +50,7 @@ pub struct DmHeaderInfo {
     pub avatar_raw: SharedString,
     pub members_text: Option<SharedString>,
     pub edit_tooltip: SharedString,
+    pub add_members_tooltip: SharedString,
     pub locale: SharedString,
 }
 
@@ -320,7 +322,11 @@ impl ChannelHeader {
         } else {
             None
         };
-        let buttons = Self::build_action_buttons(
+        let add_members_button = dm_header
+            .as_ref()
+            .filter(|info| info.is_group)
+            .map(|info| Self::render_add_members_button(info, icon_color, bg_hover));
+        let mut buttons = Self::build_action_buttons(
             actions,
             theme,
             icon_color,
@@ -345,6 +351,9 @@ impl ChannelHeader {
             notification_trigger,
             cx,
         );
+        if let Some(button) = add_members_button {
+            buttons.insert(0, button);
+        }
 
         div()
             .flex()
@@ -552,6 +561,37 @@ impl ChannelHeader {
             on_toggle_timeline: None,
         };
         header.render_inbox_button(theme, cx)
+    }
+
+    fn render_add_members_button(
+        info: &DmHeaderInfo,
+        icon_color: gpui::Rgba,
+        bg_hover: gpui::Rgba,
+    ) -> AnyElement {
+        let tooltip = info.add_members_tooltip.clone();
+        let channel_id = info.channel_id;
+        let locale = info.locale.clone();
+        div()
+            .id("hdr-add-members")
+            .flex()
+            .items_center()
+            .justify_center()
+            .w(px(32.))
+            .h(px(32.))
+            .rounded_md()
+            .cursor_pointer()
+            .hover(move |s| s.bg(bg_hover))
+            .tooltip(Tooltip::text(tooltip))
+            .occlude()
+            .child(
+                Icon::new(IconName::IconAddFriendDM)
+                    .size(px(20.))
+                    .text_color(icon_color),
+            )
+            .on_click(move |_, window, cx| {
+                AddMembersToGroupModal::open(channel_id, locale.to_string(), window, cx);
+            })
+            .into_any_element()
     }
 
     fn build_action_buttons(
@@ -1091,6 +1131,9 @@ impl ChatHeader {
             members_text,
             edit_tooltip: SharedString::from(
                 mezon_i18n::t(locale, "channelTopbar.tooltips.clickToEdit").to_string(),
+            ),
+            add_members_tooltip: SharedString::from(
+                mezon_i18n::t(locale, "channelTopbar.tooltips.addFriendsToDM").to_string(),
             ),
             locale: SharedString::from(locale.to_string()),
         })

--- a/crates/mezon-ui/src/chat/member_list.rs
+++ b/crates/mezon-ui/src/chat/member_list.rs
@@ -718,6 +718,7 @@ fn member_menu_json(panel: &Entity<MemberListPanel>, cx: &App) -> serde_json::Va
             "show_ban": permissions.show_ban,
             "show_kick": permissions.show_kick,
             "show_remove_from_thread": permissions.show_remove_from_thread,
+            "show_remove_from_group": permissions.show_remove_from_group,
             "clan_id": permissions.clan_id.map(|id| id.to_string()),
             "channel_id": permissions.channel_id.map(|id| id.to_string()),
         },
@@ -1726,9 +1727,19 @@ fn build_member_menu(args: MemberMenuArgs) -> ContextMenu {
             .danger_item(t("directMessage.contextMenu.removeFromGroup"), {
                 let panel = panel.clone();
                 let locale = locale.clone();
-                move |_window: &mut Window, cx: &mut App| {
-                    remove_member_from_group(channel_id, user_id, &locale, cx);
+                let display_name = display_name.clone();
+                move |window: &mut Window, cx: &mut App| {
                     close_member_menu(&panel, cx);
+                    Shell::global(cx).update(cx, |shell, cx| {
+                        shell.confirm_remove_group_member(
+                            channel_id,
+                            user_id,
+                            display_name.as_ref(),
+                            &locale,
+                            window,
+                            cx,
+                        );
+                    });
                 }
             });
     }
@@ -1743,30 +1754,6 @@ fn can_remove_from_group(
     creator_id: Option<UserId>,
 ) -> bool {
     !is_self && me.is_some() && kind == DirectKind::Group && creator_id == me
-}
-
-fn remove_member_from_group(channel_id: ChannelId, user_id: UserId, locale: &str, cx: &mut App) {
-    let success: SharedString =
-        mezon_i18n::t(locale, "userProfile.userInfoDM.menu.removeSuccess").into();
-    let failure: SharedString =
-        mezon_i18n::t(locale, "userProfile.userInfoDM.menu.removeFailed").into();
-    let task = GroupMembersStore::global(cx)
-        .update(cx, |store, cx| store.remove_member(channel_id, user_id, cx));
-    cx.spawn(async move |cx| {
-        let result = task.await;
-        cx.update(|cx| {
-            Shell::global(cx).update(cx, |shell, cx| match result {
-                Ok(()) => shell.success(success, cx),
-                Err(error) => {
-                    tracing::error!(
-                        "remove member {user_id} from group {channel_id} failed: {error}"
-                    );
-                    shell.error(failure, cx);
-                }
-            });
-        });
-    })
-    .detach();
 }
 
 fn remove_member_from_thread(channel_id: ChannelId, user_id: UserId, locale: &str, cx: &mut App) {
@@ -1824,6 +1811,11 @@ mod permission_tests {
     #[test]
     fn the_owner_does_not_get_the_item_on_themselves() {
         assert!(!can_remove_from_group(true, ME, DirectKind::Group, ME));
+    }
+
+    #[test]
+    fn a_group_with_no_known_creator_offers_nothing() {
+        assert!(!can_remove_from_group(false, ME, DirectKind::Group, None));
     }
 
     #[test]

--- a/crates/mezon-ui/src/chat/member_list.rs
+++ b/crates/mezon-ui/src/chat/member_list.rs
@@ -1375,7 +1375,7 @@ impl MemberMenuPermissions {
                 is_blocked,
                 blocked_by_me,
                 show_remove_from_group,
-                channel_id: show_remove_from_group.then_some(group_channel).flatten(),
+                channel_id: group_channel.filter(|_| show_remove_from_group),
                 ..Default::default()
             };
         };
@@ -1746,17 +1746,25 @@ fn can_remove_from_group(
 }
 
 fn remove_member_from_group(channel_id: ChannelId, user_id: UserId, locale: &str, cx: &mut App) {
+    let success: SharedString =
+        mezon_i18n::t(locale, "userProfile.userInfoDM.menu.removeSuccess").into();
     let failure: SharedString =
         mezon_i18n::t(locale, "userProfile.userInfoDM.menu.removeFailed").into();
     let task = GroupMembersStore::global(cx)
         .update(cx, |store, cx| store.remove_member(channel_id, user_id, cx));
     cx.spawn(async move |cx| {
-        if let Err(error) = task.await {
-            tracing::error!("remove member {user_id} from group {channel_id} failed: {error}");
-            cx.update(|cx| {
-                Shell::global(cx).update(cx, |shell, cx| shell.error(failure, cx));
+        let result = task.await;
+        cx.update(|cx| {
+            Shell::global(cx).update(cx, |shell, cx| match result {
+                Ok(()) => shell.success(success, cx),
+                Err(error) => {
+                    tracing::error!(
+                        "remove member {user_id} from group {channel_id} failed: {error}"
+                    );
+                    shell.error(failure, cx);
+                }
             });
-        }
+        });
     })
     .detach();
 }

--- a/crates/mezon-ui/src/chat/member_list.rs
+++ b/crates/mezon-ui/src/chat/member_list.rs
@@ -298,7 +298,9 @@ impl MemberListPanel {
                 );
                 subs.push(
                     cx.subscribe(&DirectMessageStore::global(cx), |this, _, event, cx| {
-                        let DirectEvent::Changed { channel_id } = event;
+                        let DirectEvent::Changed { channel_id } = event else {
+                            return;
+                        };
                         let relevant = match channel_id {
                             Some(id) => shows_group(*id, cx),
                             None => true,

--- a/crates/mezon-ui/src/chat/member_list.rs
+++ b/crates/mezon-ui/src/chat/member_list.rs
@@ -1332,6 +1332,7 @@ struct MemberMenuPermissions {
     show_ban: bool,
     show_kick: bool,
     show_remove_from_thread: bool,
+    show_remove_from_group: bool,
     is_friend: bool,
     is_blocked: bool,
     blocked_by_me: bool,
@@ -1357,11 +1358,24 @@ impl MemberMenuPermissions {
             })
             .unwrap_or((false, false, false));
         let Some(ProfileContext::Clan(clan_id)) = context else {
+            let group_channel = match context {
+                Some(ProfileContext::Direct(channel_id)) => Some(channel_id),
+                _ => None,
+            };
+            let show_remove_from_group = group_channel.is_some_and(|channel_id| {
+                DirectMessageStore::try_global(cx).is_some_and(|store| {
+                    store.read(cx).find(channel_id).is_some_and(|dm| {
+                        can_remove_from_group(is_self, me, dm.kind, dm.creator_id)
+                    })
+                })
+            });
             return Self {
                 is_self,
                 is_friend,
                 is_blocked,
                 blocked_by_me,
+                show_remove_from_group,
+                channel_id: show_remove_from_group.then_some(group_channel).flatten(),
                 ..Default::default()
             };
         };
@@ -1398,6 +1412,7 @@ impl MemberMenuPermissions {
             show_ban: has_administrator && !is_self,
             show_kick: !is_self && elevated,
             show_remove_from_thread: !is_self && is_thread && (is_channel_creator || elevated),
+            show_remove_from_group: false,
             is_friend,
             is_blocked,
             blocked_by_me,
@@ -1703,7 +1718,47 @@ fn build_member_menu(args: MemberMenuArgs) -> ContextMenu {
         }
     }
 
+    if permissions.show_remove_from_group
+        && let Some(channel_id) = permissions.channel_id
+    {
+        menu = menu
+            .separator()
+            .danger_item(t("directMessage.contextMenu.removeFromGroup"), {
+                let panel = panel.clone();
+                let locale = locale.clone();
+                move |_window: &mut Window, cx: &mut App| {
+                    remove_member_from_group(channel_id, user_id, &locale, cx);
+                    close_member_menu(&panel, cx);
+                }
+            });
+    }
+
     menu
+}
+
+fn can_remove_from_group(
+    is_self: bool,
+    me: Option<UserId>,
+    kind: DirectKind,
+    creator_id: Option<UserId>,
+) -> bool {
+    !is_self && me.is_some() && kind == DirectKind::Group && creator_id == me
+}
+
+fn remove_member_from_group(channel_id: ChannelId, user_id: UserId, locale: &str, cx: &mut App) {
+    let failure: SharedString =
+        mezon_i18n::t(locale, "userProfile.userInfoDM.menu.removeFailed").into();
+    let task = GroupMembersStore::global(cx)
+        .update(cx, |store, cx| store.remove_member(channel_id, user_id, cx));
+    cx.spawn(async move |cx| {
+        if let Err(error) = task.await {
+            tracing::error!("remove member {user_id} from group {channel_id} failed: {error}");
+            cx.update(|cx| {
+                Shell::global(cx).update(cx, |shell, cx| shell.error(failure, cx));
+            });
+        }
+    })
+    .detach();
 }
 
 fn remove_member_from_thread(channel_id: ChannelId, user_id: UserId, locale: &str, cx: &mut App) {
@@ -1734,6 +1789,44 @@ fn remove_member_from_thread(channel_id: ChannelId, user_id: UserId, locale: &st
         });
     })
     .detach();
+}
+
+#[cfg(test)]
+mod permission_tests {
+    use super::can_remove_from_group;
+    use mezon_store::{DirectKind, UserId};
+
+    const ME: Option<UserId> = Some(UserId(1));
+
+    #[test]
+    fn the_group_owner_can_remove_another_member() {
+        assert!(can_remove_from_group(false, ME, DirectKind::Group, ME));
+    }
+
+    #[test]
+    fn a_plain_member_cannot_remove_anyone() {
+        assert!(!can_remove_from_group(
+            false,
+            ME,
+            DirectKind::Group,
+            Some(UserId(2))
+        ));
+    }
+
+    #[test]
+    fn the_owner_does_not_get_the_item_on_themselves() {
+        assert!(!can_remove_from_group(true, ME, DirectKind::Group, ME));
+    }
+
+    #[test]
+    fn a_one_to_one_dm_never_offers_it() {
+        assert!(!can_remove_from_group(false, ME, DirectKind::Dm, ME));
+    }
+
+    #[test]
+    fn a_signed_out_reader_never_matches_a_missing_creator() {
+        assert!(!can_remove_from_group(false, None, DirectKind::Group, None));
+    }
 }
 
 #[cfg(test)]

--- a/crates/mezon-ui/src/chat/mention_input/mod.rs
+++ b/crates/mezon-ui/src/chat/mention_input/mod.rs
@@ -1684,7 +1684,9 @@ impl MentionInput {
             cx.subscribe(
                 &DirectMessageStore::global(cx),
                 |this, _, event: &DirectEvent, cx| {
-                    let DirectEvent::Changed { channel_id } = event;
+                    let DirectEvent::Changed { channel_id } = event else {
+                        return;
+                    };
                     if channel_id.is_none() || *channel_id == mention_direct_id(cx) {
                         this.invalidate_pool(Sigil::At, cx);
                     }

--- a/crates/mezon-ui/src/chat/mod.rs
+++ b/crates/mezon-ui/src/chat/mod.rs
@@ -1,3 +1,4 @@
+pub mod add_members_to_group_modal;
 pub mod age_restricted;
 pub mod area;
 pub use mezon_canvas::{CanvasPopoverPanel, CanvasView, canvas_popover_on_open};

--- a/crates/mezon-ui/src/components/compositions/friend_pick_row.rs
+++ b/crates/mezon-ui/src/components/compositions/friend_pick_row.rs
@@ -37,7 +37,7 @@ impl FriendPickRow {
         }
     }
 
-    pub fn matches_query(&self, query: &str) -> bool {
+    pub fn matches_lowercase_query(&self, query: &str) -> bool {
         if query.is_empty() {
             return true;
         }
@@ -155,14 +155,14 @@ mod tests {
 
     #[test]
     fn empty_query_matches_everything() {
-        assert!(row("Alice", "alice").matches_query(""));
+        assert!(row("Alice", "alice").matches_lowercase_query(""));
     }
 
     #[test]
     fn matches_display_name_and_username_case_insensitively() {
         let row = row("Alice Nguyen", "alice99");
-        assert!(row.matches_query("nguyen"));
-        assert!(row.matches_query("alice9"));
-        assert!(!row.matches_query("bob"));
+        assert!(row.matches_lowercase_query("nguyen"));
+        assert!(row.matches_lowercase_query("alice9"));
+        assert!(!row.matches_lowercase_query("bob"));
     }
 }

--- a/crates/mezon-ui/src/components/compositions/friend_pick_row.rs
+++ b/crates/mezon-ui/src/components/compositions/friend_pick_row.rs
@@ -1,0 +1,168 @@
+use gpui::{AnyElement, App, ClickEvent, FontWeight, SharedString, div, prelude::*, px, svg};
+use mezon_store::{Friend, UserId};
+
+use crate::theme::Theme;
+use crate::util::imgproxy;
+
+pub const FRIEND_PICK_ROW_HEIGHT: f32 = 40.;
+
+#[derive(Clone)]
+pub struct FriendPickRow {
+    pub user_id: UserId,
+    pub key: SharedString,
+    pub name: SharedString,
+    pub username: SharedString,
+    pub avatar_src: SharedString,
+    pub avatar_raw: SharedString,
+    name_lc: String,
+    username_lc: String,
+}
+
+impl FriendPickRow {
+    pub fn from_friend(friend: &Friend, cx: &App) -> Self {
+        let avatar_src = if friend.avatar_url.is_empty() {
+            String::new()
+        } else {
+            imgproxy::avatar_url(cx, &friend.avatar_url)
+        };
+        Self {
+            user_id: friend.id,
+            key: format!("friend-{}", friend.id).into(),
+            name: SharedString::from(friend.label().to_string()),
+            username: SharedString::from(friend.username.clone()),
+            avatar_src: SharedString::from(avatar_src),
+            avatar_raw: SharedString::from(friend.avatar_url.clone()),
+            name_lc: friend.label().to_lowercase(),
+            username_lc: friend.username.to_lowercase(),
+        }
+    }
+
+    pub fn matches_query(&self, query: &str) -> bool {
+        if query.is_empty() {
+            return true;
+        }
+        self.name_lc.contains(query) || self.username_lc.contains(query)
+    }
+}
+
+pub fn render_friend_pick_row(
+    theme: &Theme,
+    row: &FriendPickRow,
+    selected: bool,
+    on_toggle: impl Fn(UserId, &mut App) + 'static,
+) -> AnyElement {
+    let mut avatar = crate::components::primitives::Avatar::new()
+        .name(row.name.clone())
+        .size_px(px(32.));
+    if !row.avatar_src.is_empty() {
+        avatar = avatar.src(row.avatar_src.clone());
+        if !row.avatar_raw.is_empty() && row.avatar_raw != row.avatar_src {
+            avatar = avatar.fallback_src(row.avatar_raw.clone());
+        }
+    } else if !row.avatar_raw.is_empty() {
+        avatar = avatar.src(row.avatar_raw.clone());
+    }
+
+    let user_id = row.user_id;
+    let checkbox_border = if selected {
+        theme.brand
+    } else {
+        theme.interactive_normal
+    };
+
+    div()
+        .pl(px(12.))
+        .pr(px(8.))
+        .child(
+            div()
+                .id(SharedString::from(format!("pick-row-{}", row.key)))
+                .h(px(FRIEND_PICK_ROW_HEIGHT))
+                .w_full()
+                .px(px(8.))
+                .flex()
+                .items_center()
+                .justify_between()
+                .gap_2()
+                .rounded_lg()
+                .cursor_pointer()
+                .hover(|s| s.bg(theme.tokens.bg_active_member_channel))
+                .on_click(move |_: &ClickEvent, _window, cx| on_toggle(user_id, cx))
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap_2()
+                        .min_w_0()
+                        .flex_1()
+                        .child(avatar)
+                        .child(
+                            div()
+                                .truncate()
+                                .text_size(px(14.))
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(theme.tokens.text_theme_primary)
+                                .child(row.name.clone()),
+                        )
+                        .child(
+                            div()
+                                .flex_none()
+                                .text_size(px(14.))
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(theme.text_secondary)
+                                .child(row.username.clone()),
+                        ),
+                )
+                .child(
+                    div()
+                        .flex_none()
+                        .size(px(16.))
+                        .rounded(px(6.))
+                        .border_1()
+                        .border_color(checkbox_border)
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .when(selected, |el| {
+                            el.child(
+                                svg()
+                                    .path("icons/check.svg")
+                                    .size(px(12.))
+                                    .flex_none()
+                                    .text_color(theme.brand),
+                            )
+                        }),
+                ),
+        )
+        .into_any_element()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(name: &str, username: &str) -> FriendPickRow {
+        FriendPickRow {
+            user_id: UserId(1),
+            key: "friend-1".into(),
+            name: name.to_string().into(),
+            username: username.to_string().into(),
+            avatar_src: SharedString::default(),
+            avatar_raw: SharedString::default(),
+            name_lc: name.to_lowercase(),
+            username_lc: username.to_lowercase(),
+        }
+    }
+
+    #[test]
+    fn empty_query_matches_everything() {
+        assert!(row("Alice", "alice").matches_query(""));
+    }
+
+    #[test]
+    fn matches_display_name_and_username_case_insensitively() {
+        let row = row("Alice Nguyen", "alice99");
+        assert!(row.matches_query("nguyen"));
+        assert!(row.matches_query("alice9"));
+        assert!(!row.matches_query("bob"));
+    }
+}

--- a/crates/mezon-ui/src/components/compositions/mod.rs
+++ b/crates/mezon-ui/src/components/compositions/mod.rs
@@ -4,11 +4,13 @@ pub mod custom_status_bubble;
 pub mod dm_row;
 pub mod footer_profile_popup;
 pub mod form_field;
+pub mod friend_pick_row;
 pub mod otp_input;
 pub mod user_info_bar;
 
 pub use custom_status_bubble::CustomStatusBubble;
 pub use dm_row::{DM_ROW_HEIGHT, DmRow};
 pub use form_field::FormField;
+pub use friend_pick_row::{FRIEND_PICK_ROW_HEIGHT, FriendPickRow, render_friend_pick_row};
 pub use otp_input::OtpInput;
 pub use user_info_bar::UserInfoBar;

--- a/crates/mezon-ui/src/sidebar/create_message_group_modal.rs
+++ b/crates/mezon-ui/src/sidebar/create_message_group_modal.rs
@@ -101,7 +101,7 @@ impl CreateMessageGroupModal {
             .all_rows
             .iter()
             .enumerate()
-            .filter(|(_, row)| row.matches_query(&query))
+            .filter(|(_, row)| row.matches_lowercase_query(&query))
             .map(|(ix, _)| ix)
             .collect();
     }

--- a/crates/mezon-ui/src/sidebar/direct_sidebar.rs
+++ b/crates/mezon-ui/src/sidebar/direct_sidebar.rs
@@ -16,6 +16,7 @@ use super::create_message_group_modal::CreateMessageGroupModal;
 use ui::{ScrollAxes, Scrollbars, WithScrollbar};
 
 use crate::app::shell::{FriendRemovalKind, Shell};
+use crate::chat::add_members_to_group_modal::AddMembersToGroupModal;
 use crate::chat::edit_group_modal::EditGroupModal;
 use crate::chat::user_profile_modal::UserProfileModal;
 use crate::command_palette::CommandPaletteModal;
@@ -511,10 +512,18 @@ fn build_dm_menu(
     }
 
     if is_group && let Some(target) = target.as_ref() {
+        let add_locale = locale.to_string();
+        menu = menu.separator().item(
+            t("common.addMembers"),
+            move |window: &mut Window, cx: &mut App| {
+                AddMembersToGroupModal::open(channel_id, add_locale.clone(), window, cx);
+            },
+        );
+
         let group_label = target.label.clone();
         let group_avatar = target.avatar.clone();
         let group_locale = locale.to_string();
-        menu = menu.separator().item(
+        menu = menu.item(
             t("directMessage.contextMenu.editGroup"),
             move |window: &mut Window, cx: &mut App| {
                 let modal = cx.new(|cx| {


### PR DESCRIPTION
## What this adds

A group DM could be created but never changed: `GroupMembersStore` was read-only, and no surface
reached `AddChannelUsers` / `RemoveChannelUsers` for a group. This PR closes both directions.

**Add members** — `GroupMembersStore::add_members` drives `AddChannelUsers`, from two entry points:
the add-friends button on a group DM header and an "Add Members" item in the DM context menu. The
picker offers only friends that are not already in the group, caps selection at the server's
`MAX_USER_IN_GROUP` (20), and shows how many seats are left.

**Remove a member** — `GroupMembersStore::remove_member` drives `RemoveChannelUsers` from a
"Remove From Group" row in the member list, gated the way the server gates it: only the group
creator, never on yourself, never in a 1:1 DM.

## Why it is shaped this way

- **The roster is not refetched after a mutation.** For a group, `sendToStreamForAddUserGroup`
  puts the *full* post-add membership in `UserChannelAdded` and dispatches it to the channel
  stream, so the store patches in place and only marks its cache stale as a safety net for a lost
  event. Removal rides `UserChannelRemoved` the same way.
- **`code=3` is a real state, not a generic failure.** `AddChannelUsers` returns
  `InvalidArgument` when the group is already at 20, so `AddChannelUsers` now fails with the
  typed `ApiStatusError` and the store maps it to `AddGroupMembersError::GroupFull`, which the UI
  turns into "this group already has the maximum of 20 members" instead of a generic toast.
- **Permission mirrors the backend.** A group DM has `clan_id == 0`, so the server lets *any*
  member add (only `CheckUserInChannelRedis`) but only the creator remove
  (`CheckChannelCreator`) — the UI gates exactly that way.
- **`DirectChannel::member_count`** now follows the count the add event reports instead of
  staying at whatever `ListChannelDescs` last returned.
- The friend picker row moved to `components/compositions` so the create-group modal shares it,
  with the filter keys folded once at build time instead of on every keystroke.

## Hardening after review

A max-effort review pass found four real holes, all fixed in this branch:

- **The cap could be bypassed.** `AddChannelUsers` only checks the *pre-add* count against
  `MAX_USER_IN_GROUP`, never `count + len(user_ids)`, so a stale or missing local member count
  opened all 20 slots and let a group grow past the limit. The picker now hands out no slots at
  all until the roster is loaded, and shows a loading row instead of listing every friend as a
  candidate.
- **The ownership gate trusted a field that lies.** `direct_from_message` set `creator_id` to the
  message *sender* for group rows, so "Remove From Group" appeared for whoever happened to seed
  the row and stayed hidden from the real owner. Fixed at the source: a group row synthesized
  from a message claims no creator.
- **Being removed left a ghost.** `DirectMessageStore` ignored `UserChannelRemoved`, so a removed
  member kept a sidebar row that opens on a permission error. It now drops the conversation, and
  `apply_member_count` is limited to groups, where the event actually carries a roster count.
- **A list response could resurrect a stale roster.** `fetch` stamps its result fresh
  unconditionally, so a response that started before an add could overwrite the realtime patch
  and stay authoritative for the rest of the 20-minute TTL. `GroupMembersStore` now counts
  mutations per channel and discards — then refetches — any response older than the last one.

Also: removal goes through a confirmation modal like every other destructive action in the shell,
a successful add no longer reports failure when the modal has closed, and `RemoveChannelUsers`
carries the same typed `ApiStatusError` as its add counterpart.

## Verified against prod

Driven on a throwaway group with a second account signed into the web client:

| Case | Result |
|---|---|
| Add from desktop → web | group appears live for the added user, no reload; member count + system message match |
| Add from web → desktop | roster and system message arrive live, no refetch, no restart |
| Remove from desktop → web | web member count drops live |
| Owner gate | item present in a group I created, absent in one I did not, absent on myself |
| Picker | members already in the group are filtered out; capacity counts down 17 → 16; multi-select adds in one call |

Removal was re-verified after the confirmation modal landed: the dialog names the member, the
roster stays put while it is open, and confirming drops the member and reports it.

`just lint` and `just test` are green (2225 tests, 13 new: capacity math, query matching, error
mapping, member-count patching and its DM gate, the owner gate, and the group-row creator rule).

## Not covered

- The group-at-20 toast has unit coverage for the mapping but was never driven end to end.
- The Tatar and Belarusian strings for the new `groupFull` key are best-effort and worth a native
  read.
