### PR TITLE
fix(composer): grow the input in the frame the text changes

### DIFF
--- a/crates/mezon-ui/src/chat/mention_input/text_field.rs
+++ b/crates/mezon-ui/src/chat/mention_input/text_field.rs
@@ -192,6 +192,7 @@ pub(crate) struct MentionInputState {
     line_height: Pixels,
     scroll_offset: Point<Pixels>,
     measured_rows: usize,
+    measured_for: Option<(SharedString, Pixels)>,
     content_height: Pixels,
     pending_caret_reveal: bool,
     is_selecting: bool,
@@ -240,6 +241,7 @@ impl MentionInputState {
             line_height: px(20.),
             scroll_offset: Point::default(),
             measured_rows: 1,
+            measured_for: None,
             content_height: px(0.),
             pending_caret_reveal: true,
             is_selecting: false,
@@ -1412,6 +1414,70 @@ impl IntoElement for MentionTextElement {
     }
 }
 
+impl MentionTextElement {
+    fn measure_rows_for_layout(&mut self, window: &mut Window, cx: &mut App) {
+        let input = self.input.read(cx);
+        if input.is_masked() || input.content.is_empty() {
+            return;
+        }
+        let Some(width) = input.last_bounds.map(|bounds| bounds.size.width) else {
+            return;
+        };
+        if width <= Pixels::ZERO {
+            return;
+        }
+        let display_text = input.display_text();
+        if input.measured_for.as_ref() == Some(&(display_text.clone(), width)) {
+            return;
+        }
+        let marked_range = input.marked_range.clone();
+        let brand_color: Hsla = cx.theme().brand.into();
+        let emoji_color: Hsla = rgb(EMOJI_SPAN_COLOR).into();
+        let resolved_spans: Vec<ResolvedSpan> = input
+            .mention_spans
+            .iter()
+            .map(|span| {
+                let (color, bold) = match span.kind {
+                    MentionSpanKind::Mention | MentionSpanKind::Hashtag => (brand_color, false),
+                    MentionSpanKind::Emoji => (emoji_color, true),
+                };
+                ResolvedSpan {
+                    range: span.range.clone(),
+                    color,
+                    bold,
+                }
+            })
+            .collect();
+        let style = window.text_style();
+        let font_size = style.font_size.to_pixels(window.rem_size());
+        let line_height = window.line_height();
+        let base = TextRun {
+            len: display_text.len(),
+            font: style.font(),
+            color: style.color,
+            background_color: None,
+            underline: None,
+            strikethrough: None,
+        };
+        let runs = build_text_runs(display_text.len(), &base, marked_range, &resolved_spans);
+        let wrapped = window
+            .text_system()
+            .shape_text(display_text.clone(), font_size, &runs, Some(width), None)
+            .unwrap_or_default();
+        let total_h = wrapped
+            .iter()
+            .fold(Pixels::ZERO, |acc, line| {
+                acc + wrapped_line_height(line, line_height)
+            })
+            .max(line_height);
+        let rows = (total_h / line_height).round().max(1.) as usize;
+        self.input.update(cx, |input, _| {
+            input.measured_rows = rows;
+            input.measured_for = Some((display_text, width));
+        });
+    }
+}
+
 impl Element for MentionTextElement {
     type RequestLayoutState = ();
     type PrepaintState = PrepaintState;
@@ -1431,6 +1497,7 @@ impl Element for MentionTextElement {
         window: &mut Window,
         cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
+        self.measure_rows_for_layout(window, cx);
         let line_count = self.input.read(cx).visible_line_count();
         let visible = line_count.clamp(1, MAX_VISIBLE_LINES);
         let mut style = Style::default();

--- a/crates/mezon-ui/src/chat/mention_input/text_field.rs
+++ b/crates/mezon-ui/src/chat/mention_input/text_field.rs
@@ -1427,7 +1427,11 @@ impl MentionTextElement {
             return;
         }
         let display_text = input.display_text();
-        if input.measured_for.as_ref() == Some(&(display_text.clone(), width)) {
+        if input
+            .measured_for
+            .as_ref()
+            .is_some_and(|(text, measured_width)| *measured_width == width && *text == display_text)
+        {
             return;
         }
         let marked_range = input.marked_range.clone();

--- a/crates/mezon-ui/src/chat/mention_input/text_field.rs
+++ b/crates/mezon-ui/src/chat/mention_input/text_field.rs
@@ -1415,24 +1415,26 @@ impl IntoElement for MentionTextElement {
 }
 
 impl MentionTextElement {
-    fn measure_rows_for_layout(&mut self, window: &mut Window, cx: &mut App) {
-        let input = self.input.read(cx);
+    fn measured_rows(
+        state: &Entity<MentionInputState>,
+        width: Pixels,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> usize {
+        let input = state.read(cx);
         if input.is_masked() || input.content.is_empty() {
-            return;
+            return 1;
         }
-        let Some(width) = input.last_bounds.map(|bounds| bounds.size.width) else {
-            return;
-        };
         if width <= Pixels::ZERO {
-            return;
+            return input.visible_line_count();
         }
         let display_text = input.display_text();
         if input
             .measured_for
             .as_ref()
-            .is_some_and(|(text, measured_width)| *measured_width == width && *text == display_text)
+            .is_some_and(|(text, measured)| *measured == width && *text == display_text)
         {
-            return;
+            return input.visible_line_count();
         }
         let marked_range = input.marked_range.clone();
         let brand_color: Hsla = cx.theme().brand.into();
@@ -1475,10 +1477,11 @@ impl MentionTextElement {
             })
             .max(line_height);
         let rows = (total_h / line_height).round().max(1.) as usize;
-        self.input.update(cx, |input, _| {
+        state.update(cx, |input, _| {
             input.measured_rows = rows;
             input.measured_for = Some((display_text, width));
         });
+        state.read(cx).visible_line_count()
     }
 }
 
@@ -1499,15 +1502,30 @@ impl Element for MentionTextElement {
         _id: Option<&GlobalElementId>,
         _inspector_id: Option<&InspectorElementId>,
         window: &mut Window,
-        cx: &mut App,
+        _cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
-        self.measure_rows_for_layout(window, cx);
-        let line_count = self.input.read(cx).visible_line_count();
-        let visible = line_count.clamp(1, MAX_VISIBLE_LINES);
         let mut style = Style::default();
         style.size.width = gpui::relative(1.).into();
-        style.size.height = (window.line_height() * visible as f32).into();
-        (window.request_layout(style, [], cx), ())
+        let state = self.input.clone();
+        let layout_id = window.request_measured_layout(
+            style,
+            move |known_dimensions, available_space, window, cx| {
+                let width = known_dimensions.width.or(match available_space.width {
+                    gpui::AvailableSpace::Definite(width) => Some(width),
+                    _ => None,
+                });
+                let line_count = match width {
+                    Some(width) => Self::measured_rows(&state, width, window, cx),
+                    None => state.read(cx).visible_line_count(),
+                };
+                let visible = line_count.clamp(1, MAX_VISIBLE_LINES);
+                let height = known_dimensions
+                    .height
+                    .unwrap_or(window.line_height() * visible as f32);
+                gpui::size(width.unwrap_or(Pixels::ZERO), height)
+            },
+        );
+        (layout_id, ())
     }
 
     fn prepaint(

--- a/crates/mezon-ui/src/chat/mention_input/text_field.rs
+++ b/crates/mezon-ui/src/chat/mention_input/text_field.rs
@@ -36,6 +36,7 @@ use crate::util::text_edit::{
 };
 
 const MASK: char = '\u{2022}';
+const MEASURE_CACHE_ENTRIES: usize = 4;
 const MAX_VISIBLE_LINES: usize = 10;
 
 struct DocLine {
@@ -192,7 +193,7 @@ pub(crate) struct MentionInputState {
     line_height: Pixels,
     scroll_offset: Point<Pixels>,
     measured_rows: usize,
-    measured_for: Option<(SharedString, Pixels)>,
+    measure_cache: Vec<(SharedString, Pixels, usize)>,
     content_height: Pixels,
     pending_caret_reveal: bool,
     is_selecting: bool,
@@ -241,7 +242,7 @@ impl MentionInputState {
             line_height: px(20.),
             scroll_offset: Point::default(),
             measured_rows: 1,
-            measured_for: None,
+            measure_cache: Vec::new(),
             content_height: px(0.),
             pending_caret_reveal: true,
             is_selecting: false,
@@ -1429,13 +1430,14 @@ impl MentionTextElement {
             return input.visible_line_count();
         }
         let display_text = input.display_text();
-        if input
-            .measured_for
-            .as_ref()
-            .is_some_and(|(text, measured)| *measured == width && *text == display_text)
+        if let Some((_, _, rows)) = input
+            .measure_cache
+            .iter()
+            .find(|(text, cached_width, _)| *cached_width == width && *text == display_text)
         {
-            return input.visible_line_count();
+            return (*rows).max(input.line_count);
         }
+        let hard_lines = input.line_count;
         let marked_range = input.marked_range.clone();
         let brand_color: Hsla = cx.theme().brand.into();
         let emoji_color: Hsla = rgb(EMOJI_SPAN_COLOR).into();
@@ -1478,10 +1480,10 @@ impl MentionTextElement {
             .max(line_height);
         let rows = (total_h / line_height).round().max(1.) as usize;
         state.update(cx, |input, _| {
-            input.measured_rows = rows;
-            input.measured_for = Some((display_text, width));
+            input.measure_cache.insert(0, (display_text, width, rows));
+            input.measure_cache.truncate(MEASURE_CACHE_ENTRIES);
         });
-        state.read(cx).visible_line_count()
+        rows.max(hard_lines)
     }
 }
 

--- a/crates/mezon-ui/src/components/primitives/textarea.rs
+++ b/crates/mezon-ui/src/components/primitives/textarea.rs
@@ -108,6 +108,7 @@ pub struct TextArea {
     line_height: Pixels,
     scroll_offset: Point<Pixels>,
     measured_rows: usize,
+    measured_for: Option<(SharedString, Pixels)>,
     content_height: Pixels,
     pending_caret_reveal: bool,
     is_selecting: bool,
@@ -160,6 +161,7 @@ impl TextArea {
             line_height: px(20.),
             scroll_offset: Point::default(),
             measured_rows: 1,
+            measured_for: None,
             content_height: px(0.),
             pending_caret_reveal: true,
             is_selecting: false,
@@ -1190,6 +1192,48 @@ impl IntoElement for TextAreaElement {
     }
 }
 
+impl TextAreaElement {
+    fn measure_rows_for_layout(&mut self, window: &mut Window, cx: &mut App) {
+        let input = self.input.read(cx);
+        if input.single_line || input.content.is_empty() {
+            return;
+        }
+        let Some(width) = input.last_bounds.map(|bounds| bounds.size.width) else {
+            return;
+        };
+        if width <= Pixels::ZERO {
+            return;
+        }
+        let display_text = input.content.clone();
+        if input
+            .measured_for
+            .as_ref()
+            .is_some_and(|(text, measured_width)| *measured_width == width && *text == display_text)
+        {
+            return;
+        }
+        let style = window.text_style();
+        let font_size = style.font_size.to_pixels(window.rem_size());
+        let run = TextRun {
+            len: display_text.len(),
+            font: style.font(),
+            color: style.color,
+            background_color: None,
+            underline: None,
+            strikethrough: None,
+        };
+        let wrapped = window
+            .text_system()
+            .shape_text(display_text.clone(), font_size, &[run], Some(width), None)
+            .unwrap_or_default();
+        let rows = wrapped.len().max(1);
+        self.input.update(cx, |input, _| {
+            input.measured_rows = rows;
+            input.measured_for = Some((display_text, width));
+        });
+    }
+}
+
 impl Element for TextAreaElement {
     type RequestLayoutState = ();
     type PrepaintState = PrepaintState;
@@ -1209,6 +1253,7 @@ impl Element for TextAreaElement {
         window: &mut Window,
         cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
+        self.measure_rows_for_layout(window, cx);
         let input = self.input.read(cx);
         let visible = input.visible_line_count().clamp(1, input.max_visible_lines);
         let mut style = Style::default();

--- a/crates/mezon-ui/src/components/primitives/textarea.rs
+++ b/crates/mezon-ui/src/components/primitives/textarea.rs
@@ -108,7 +108,6 @@ pub struct TextArea {
     line_height: Pixels,
     scroll_offset: Point<Pixels>,
     measured_rows: usize,
-    measured_for: Option<(SharedString, Pixels)>,
     content_height: Pixels,
     pending_caret_reveal: bool,
     is_selecting: bool,
@@ -161,7 +160,6 @@ impl TextArea {
             line_height: px(20.),
             scroll_offset: Point::default(),
             measured_rows: 1,
-            measured_for: None,
             content_height: px(0.),
             pending_caret_reveal: true,
             is_selecting: false,
@@ -1192,51 +1190,6 @@ impl IntoElement for TextAreaElement {
     }
 }
 
-impl TextAreaElement {
-    fn measured_rows(
-        state: &Entity<TextArea>,
-        width: Pixels,
-        window: &mut Window,
-        cx: &mut App,
-    ) -> usize {
-        let input = state.read(cx);
-        if input.single_line || input.content.is_empty() {
-            return 1;
-        }
-        if width <= Pixels::ZERO {
-            return input.visible_line_count();
-        }
-        let display_text = input.content.clone();
-        if input
-            .measured_for
-            .as_ref()
-            .is_some_and(|(text, measured)| *measured == width && *text == display_text)
-        {
-            return input.visible_line_count();
-        }
-        let style = window.text_style();
-        let font_size = style.font_size.to_pixels(window.rem_size());
-        let run = TextRun {
-            len: display_text.len(),
-            font: style.font(),
-            color: style.color,
-            background_color: None,
-            underline: None,
-            strikethrough: None,
-        };
-        let wrapped = window
-            .text_system()
-            .shape_text(display_text.clone(), font_size, &[run], Some(width), None)
-            .unwrap_or_default();
-        let rows = wrapped.len().max(1);
-        state.update(cx, |input, _| {
-            input.measured_rows = rows;
-            input.measured_for = Some((display_text, width));
-        });
-        state.read(cx).visible_line_count()
-    }
-}
-
 impl Element for TextAreaElement {
     type RequestLayoutState = ();
     type PrepaintState = PrepaintState;
@@ -1256,29 +1209,12 @@ impl Element for TextAreaElement {
         window: &mut Window,
         cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
-        let max_visible_lines = self.input.read(cx).max_visible_lines;
+        let input = self.input.read(cx);
+        let visible = input.visible_line_count().clamp(1, input.max_visible_lines);
         let mut style = Style::default();
         style.size.width = gpui::relative(1.).into();
-        let state = self.input.clone();
-        let layout_id = window.request_measured_layout(
-            style,
-            move |known_dimensions, available_space, window, cx| {
-                let width = known_dimensions.width.or(match available_space.width {
-                    gpui::AvailableSpace::Definite(width) => Some(width),
-                    _ => None,
-                });
-                let line_count = match width {
-                    Some(width) => Self::measured_rows(&state, width, window, cx),
-                    None => state.read(cx).visible_line_count(),
-                };
-                let visible = line_count.clamp(1, max_visible_lines);
-                let height = known_dimensions
-                    .height
-                    .unwrap_or(window.line_height() * visible as f32);
-                gpui::size(width.unwrap_or(Pixels::ZERO), height)
-            },
-        );
-        (layout_id, ())
+        style.size.height = (window.line_height() * visible as f32).into();
+        (window.request_layout(style, [], cx), ())
     }
 
     fn prepaint(

--- a/crates/mezon-ui/src/components/primitives/textarea.rs
+++ b/crates/mezon-ui/src/components/primitives/textarea.rs
@@ -1193,24 +1193,26 @@ impl IntoElement for TextAreaElement {
 }
 
 impl TextAreaElement {
-    fn measure_rows_for_layout(&mut self, window: &mut Window, cx: &mut App) {
-        let input = self.input.read(cx);
+    fn measured_rows(
+        state: &Entity<TextArea>,
+        width: Pixels,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> usize {
+        let input = state.read(cx);
         if input.single_line || input.content.is_empty() {
-            return;
+            return 1;
         }
-        let Some(width) = input.last_bounds.map(|bounds| bounds.size.width) else {
-            return;
-        };
         if width <= Pixels::ZERO {
-            return;
+            return input.visible_line_count();
         }
         let display_text = input.content.clone();
         if input
             .measured_for
             .as_ref()
-            .is_some_and(|(text, measured_width)| *measured_width == width && *text == display_text)
+            .is_some_and(|(text, measured)| *measured == width && *text == display_text)
         {
-            return;
+            return input.visible_line_count();
         }
         let style = window.text_style();
         let font_size = style.font_size.to_pixels(window.rem_size());
@@ -1227,10 +1229,11 @@ impl TextAreaElement {
             .shape_text(display_text.clone(), font_size, &[run], Some(width), None)
             .unwrap_or_default();
         let rows = wrapped.len().max(1);
-        self.input.update(cx, |input, _| {
+        state.update(cx, |input, _| {
             input.measured_rows = rows;
             input.measured_for = Some((display_text, width));
         });
+        state.read(cx).visible_line_count()
     }
 }
 
@@ -1253,13 +1256,29 @@ impl Element for TextAreaElement {
         window: &mut Window,
         cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
-        self.measure_rows_for_layout(window, cx);
-        let input = self.input.read(cx);
-        let visible = input.visible_line_count().clamp(1, input.max_visible_lines);
+        let max_visible_lines = self.input.read(cx).max_visible_lines;
         let mut style = Style::default();
         style.size.width = gpui::relative(1.).into();
-        style.size.height = (window.line_height() * visible as f32).into();
-        (window.request_layout(style, [], cx), ())
+        let state = self.input.clone();
+        let layout_id = window.request_measured_layout(
+            style,
+            move |known_dimensions, available_space, window, cx| {
+                let width = known_dimensions.width.or(match available_space.width {
+                    gpui::AvailableSpace::Definite(width) => Some(width),
+                    _ => None,
+                });
+                let line_count = match width {
+                    Some(width) => Self::measured_rows(&state, width, window, cx),
+                    None => state.read(cx).visible_line_count(),
+                };
+                let visible = line_count.clamp(1, max_visible_lines);
+                let height = known_dimensions
+                    .height
+                    .unwrap_or(window.line_height() * visible as f32);
+                gpui::size(width.unwrap_or(Pixels::ZERO), height)
+            },
+        );
+        (layout_id, ())
     }
 
     fn prepaint(


### PR DESCRIPTION
The wrapped row count was only discovered while painting, so the taller box could not be laid out until the frame after that. In a busy channel frames are half a second apart when nothing else is moving, so typing past the wrap or pasting left the box at its old height until the caret blink happened to draw the next one — the lag the issue describes.

The row count is now measured during layout, against the width the last paint established, and only when the text or that width actually changed. Paint stays authoritative for the first frame and for resizes, and agrees with the layout measurement the rest of the time, so it no longer has to notify to correct the height.