### PR TITLE
fix(paste): stop a lazy clipboard from freezing the window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6211,6 +6211,7 @@ dependencies = [
  "gpui",
  "mezon-store",
  "mezon-theme",
+ "objc",
  "tracing",
  "unicode-segmentation",
 ]

--- a/crates/mezon-app/src/main.rs
+++ b/crates/mezon-app/src/main.rs
@@ -647,6 +647,7 @@ fn run_app(lock: SingleInstance, initial_url: Option<String>) {
         }
 
         init_ui(cx);
+        mezon_ui::clipboard::enable_off_main_thread_reads();
 
         AppConfig::init_global(app_config_handle, cx);
 

--- a/crates/mezon-canvas/src/editor.rs
+++ b/crates/mezon-canvas/src/editor.rs
@@ -1564,28 +1564,27 @@ impl CanvasEditorState {
         if self.read_only {
             return;
         }
-        let Some(item) = cx.read_from_clipboard() else {
-            return;
-        };
-        let images: Vec<Image> = item
-            .entries()
-            .iter()
-            .filter_map(|entry| match entry {
-                ClipboardEntry::Image(image) => Some(image.clone()),
-                _ => None,
-            })
-            .collect();
-        if !images.is_empty() {
-            self.paste_images(images, window, cx);
-            return;
-        }
-        if let Some(text) = item.text() {
-            self.replace_text_in_range(
-                self.selected_range.clone(),
-                &text.replace("\r\n", "\n"),
-                cx,
-            );
-        }
+        mezon_widgets::clipboard::read_then(self, window, cx, |this, item, window, cx| {
+            let images: Vec<Image> = item
+                .entries()
+                .iter()
+                .filter_map(|entry| match entry {
+                    ClipboardEntry::Image(image) => Some(image.clone()),
+                    _ => None,
+                })
+                .collect();
+            if !images.is_empty() {
+                this.paste_images(images, window, cx);
+                return;
+            }
+            if let Some(text) = item.text() {
+                this.replace_text_in_range(
+                    this.selected_range.clone(),
+                    &text.replace("\r\n", "\n"),
+                    cx,
+                );
+            }
+        });
     }
 
     fn paste_images(&mut self, images: Vec<Image>, _window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/mezon-ui/src/chat/mention_input/text_field.rs
+++ b/crates/mezon-ui/src/chat/mention_input/text_field.rs
@@ -780,10 +780,13 @@ impl MentionInputState {
         window.show_character_palette();
     }
 
-    fn paste(&mut self, _: &Paste, _window: &mut Window, cx: &mut Context<Self>) {
-        let Some(item) = cx.read_from_clipboard() else {
-            return;
-        };
+    fn paste(&mut self, _: &Paste, window: &mut Window, cx: &mut Context<Self>) {
+        mezon_widgets::clipboard::read_then(self, window, cx, |this, item, _window, cx| {
+            this.apply_paste(item, cx)
+        });
+    }
+
+    fn apply_paste(&mut self, item: ClipboardItem, cx: &mut Context<Self>) {
         let images: Vec<Image> = item
             .entries()
             .iter()

--- a/crates/mezon-ui/src/components/primitives/textarea.rs
+++ b/crates/mezon-ui/src/components/primitives/textarea.rs
@@ -718,16 +718,18 @@ impl TextArea {
     }
 
     fn paste(&mut self, _: &Paste, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) else {
-            return;
-        };
-        let normalized = normalize_pasted(&text);
-        let sanitized = if self.single_line {
-            normalized.replace('\n', " ")
-        } else {
-            normalized
-        };
-        self.replace_text_in_range(None, &sanitized, window, cx);
+        mezon_widgets::clipboard::read_then(self, window, cx, |this, item, window, cx| {
+            let Some(text) = item.text() else {
+                return;
+            };
+            let normalized = normalize_pasted(&text);
+            let sanitized = if this.single_line {
+                normalized.replace('\n', " ")
+            } else {
+                normalized
+            };
+            this.replace_text_in_range(None, &sanitized, window, cx);
+        });
     }
 
     fn on_key_down(&mut self, _: &KeyDownEvent, _: &mut Window, _: &mut Context<Self>) {

--- a/crates/mezon-ui/src/lib.rs
+++ b/crates/mezon-ui/src/lib.rs
@@ -21,6 +21,8 @@ pub mod tour;
 pub mod util;
 pub mod window_layout;
 
+pub use mezon_widgets::clipboard;
+
 pub use app::root::RootView;
 pub use app::shell::Shell;
 pub use app::threads_toast::ThreadCreateToastBridge;

--- a/crates/mezon-widgets/Cargo.toml
+++ b/crates/mezon-widgets/Cargo.toml
@@ -13,3 +13,6 @@ mezon-theme.workspace = true
 mezon-store.workspace = true
 unicode-segmentation.workspace = true
 tracing.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc.workspace = true

--- a/crates/mezon-widgets/src/clipboard.rs
+++ b/crates/mezon-widgets/src/clipboard.rs
@@ -1,0 +1,113 @@
+#[cfg(target_os = "macos")]
+use gpui::AppContext as _;
+use gpui::{ClipboardItem, Context, Window};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static OFF_MAIN_THREAD_READS: AtomicBool = AtomicBool::new(false);
+
+pub fn enable_off_main_thread_reads() {
+    OFF_MAIN_THREAD_READS.store(true, Ordering::Relaxed);
+}
+
+pub fn read_then<T: 'static>(
+    this: &mut T,
+    window: &mut Window,
+    cx: &mut Context<T>,
+    apply: impl FnOnce(&mut T, ClipboardItem, &mut Window, &mut Context<T>) + 'static,
+) {
+    #[cfg(target_os = "macos")]
+    if OFF_MAIN_THREAD_READS.load(Ordering::Relaxed) && mac::advertises_plain_text_only() {
+        let text = cx.background_spawn(async { mac::plain_text() });
+        cx.spawn_in(window, async move |entity, cx| {
+            let Some(text) = text.await else {
+                return;
+            };
+            entity
+                .update_in(cx, |this, window, cx| {
+                    apply(this, ClipboardItem::new_string(text), window, cx)
+                })
+                .ok();
+        })
+        .detach();
+        return;
+    }
+
+    let Some(item) = cx.read_from_clipboard() else {
+        return;
+    };
+    apply(this, item, window, cx);
+}
+
+#[cfg(target_os = "macos")]
+mod mac {
+    use objc::runtime::Object;
+    use objc::{class, msg_send, sel, sel_impl};
+    use std::ffi::{CStr, CString};
+    use std::ptr;
+
+    const PLAIN_TEXT: &str = "public.utf8-plain-text";
+    const FILENAMES: &str = "NSFilenamesPboardType";
+    const ZED_TEXT_HASH: &str = "zed-text-hash";
+
+    pub(super) fn advertises_plain_text_only() -> bool {
+        unsafe {
+            let pasteboard: *mut Object = msg_send![class!(NSPasteboard), generalPasteboard];
+            if pasteboard.is_null() {
+                return false;
+            }
+            let types: *mut Object = msg_send![pasteboard, types];
+            if types.is_null() {
+                return false;
+            }
+            contains(types, PLAIN_TEXT)
+                && !contains(types, FILENAMES)
+                && !contains(types, ZED_TEXT_HASH)
+        }
+    }
+
+    pub(super) fn plain_text() -> Option<String> {
+        unsafe {
+            let pool: *mut Object = msg_send![class!(NSAutoreleasePool), new];
+            let pasteboard: *mut Object = msg_send![class!(NSPasteboard), generalPasteboard];
+            let text = if pasteboard.is_null() {
+                None
+            } else {
+                let kind = ns_string(PLAIN_TEXT);
+                let value: *mut Object = msg_send![pasteboard, stringForType: kind];
+                ns_string_to_rust(value)
+            };
+            let _: () = msg_send![pool, release];
+            text
+        }
+    }
+
+    unsafe fn contains(types: *mut Object, kind: &str) -> bool {
+        unsafe {
+            let needle = ns_string(kind);
+            if needle.is_null() {
+                return false;
+            }
+            msg_send![types, containsObject: needle]
+        }
+    }
+
+    unsafe fn ns_string(value: &str) -> *mut Object {
+        let Ok(raw) = CString::new(value) else {
+            return ptr::null_mut();
+        };
+        unsafe { msg_send![class!(NSString), stringWithUTF8String: raw.as_ptr()] }
+    }
+
+    unsafe fn ns_string_to_rust(value: *mut Object) -> Option<String> {
+        if value.is_null() {
+            return None;
+        }
+        unsafe {
+            let utf8: *const std::os::raw::c_char = msg_send![value, UTF8String];
+            if utf8.is_null() {
+                return None;
+            }
+            Some(CStr::from_ptr(utf8).to_string_lossy().into_owned())
+        }
+    }
+}

--- a/crates/mezon-widgets/src/input.rs
+++ b/crates/mezon-widgets/src/input.rs
@@ -740,14 +740,16 @@ impl InputState {
     }
 
     fn paste(&mut self, _: &Paste, window: &mut Window, cx: &mut Context<Self>) {
-        if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
-            let sanitized = if self.multi_line {
-                text
-            } else {
-                text.replace('\n', " ")
-            };
-            self.replace_text_in_range(None, &sanitized, window, cx);
-        }
+        crate::clipboard::read_then(self, window, cx, |this, item, window, cx| {
+            if let Some(text) = item.text() {
+                let sanitized = if this.multi_line {
+                    text
+                } else {
+                    text.replace('\n', " ")
+                };
+                this.replace_text_in_range(None, &sanitized, window, cx);
+            }
+        });
     }
 
     fn on_key_down(&mut self, _: &KeyDownEvent, _: &mut Window, _: &mut Context<Self>) {

--- a/crates/mezon-widgets/src/lib.rs
+++ b/crates/mezon-widgets/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod blink_manager;
 mod button;
+pub mod clipboard;
 mod icon;
 pub mod input;
 mod sizing;


### PR DESCRIPTION
Pasting read the system clipboard synchronously inside the key handler. A pasteboard whose owner hands over its data lazily — content copied on an iPhone through Universal Clipboard, Office, a promise provider — answers on its own schedule, and the whole window sat still until it did: no frames, no input. Measured against a provider with a known delay, the main thread stalled 1508ms and 413ms, matching the provider exactly.

The read now happens on a background thread whenever the pasteboard carries plain text and nothing else we treat specially, which is the shape a copied link has. The text lands a moment later instead of holding the window. Anything else — files, an image with no text — keeps the synchronous read it had, since those already go through a temp file and their precedence is what the platform read defines.

Only the binary opts in. A test drives a clipboard double through gpui, and that is what a test must read.