### PR TITLE
fix(network): bound the connect attempt and ignore callbacks from sk

### DIFF
--- a/crates/mezon-client/src/abridged_tcp_adapter.rs
+++ b/crates/mezon-client/src/abridged_tcp_adapter.rs
@@ -14,7 +14,10 @@ const WRITE_QUEUE_CAPACITY: usize = 256;
 const WRITE_ENQUEUE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const SOCKET_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 const SOCK_HOST_IP_ENV: &str = "MEZON_SOCK_HOST_IP";
-const TCP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+// Budget for one whole connect attempt: TCP, the TLS handshake and I/O-loop
+// startup share it. Only the TCP leg used to be bounded, so a stalled TLS
+// handshake or a wedged I/O loop hung the reconnect forever.
+const CONNECT_ATTEMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 #[cfg(debug_assertions)]
 fn sock_host_ip_override(host: &str) -> Option<String> {
@@ -33,14 +36,11 @@ fn sock_host_ip_override(_host: &str) -> Option<String> {
     None
 }
 
-async fn connect_tcp(host: &str, port: u16) -> Result<TcpStream> {
-    tokio::time::timeout(
-        TCP_CONNECT_TIMEOUT,
-        TcpStream::connect(format!("{host}:{port}")),
-    )
-    .await
-    .map_err(|_| anyhow::anyhow!("TCP connect timed out after 15s"))?
-    .map_err(|e| anyhow::anyhow!("TCP connect failed: {e}"))
+async fn connect_tcp(host: &str, port: u16, deadline: tokio::time::Instant) -> Result<TcpStream> {
+    tokio::time::timeout_at(deadline, TcpStream::connect(format!("{host}:{port}")))
+        .await
+        .map_err(|_| anyhow::anyhow!("TCP connect timed out after 10s"))?
+        .map_err(|e| anyhow::anyhow!("TCP connect failed: {e}"))
 }
 
 #[cfg(debug_assertions)]
@@ -761,16 +761,20 @@ impl TransportAdapter for AbridgedTcpAdapter {
         let config = build_client_config();
         let connector = tokio_rustls::TlsConnector::from(Arc::new(config));
 
+        let deadline = tokio::time::Instant::now() + CONNECT_ATTEMPT_TIMEOUT;
+
         tracing::debug!("TCP connecting...");
         let tcp = match sock_host_ip_override(host) {
-            Some(ip) => match connect_tcp(&ip, port).await {
+            Some(ip) => match connect_tcp(&ip, port, deadline).await {
                 Ok(tcp) => tcp,
                 Err(e) => {
                     tracing::warn!("pinned socket host failed ({e}); falling back to DNS");
-                    connect_tcp(host, port).await?
+                    // Fresh budget: the pinned attempt may already have spent it all.
+                    let dns_deadline = tokio::time::Instant::now() + CONNECT_ATTEMPT_TIMEOUT;
+                    connect_tcp(host, port, dns_deadline).await?
                 }
             },
-            None => connect_tcp(host, port).await?,
+            None => connect_tcp(host, port, deadline).await?,
         };
         let local = tcp
             .local_addr()
@@ -781,9 +785,9 @@ impl TransportAdapter for AbridgedTcpAdapter {
             .map_err(|e| anyhow::anyhow!("Invalid DNS name: {e}"))?;
 
         tracing::debug!("Starting TLS handshake...");
-        let tls = connector
-            .connect(domain, tcp)
+        let tls = tokio::time::timeout_at(deadline, connector.connect(domain, tcp))
             .await
+            .map_err(|_| anyhow::anyhow!("TLS handshake timed out after 10s"))?
             .map_err(|e| anyhow::anyhow!("TLS handshake failed: {e}"))?;
         tracing::debug!("TLS handshake complete");
 
@@ -810,8 +814,9 @@ impl TransportAdapter for AbridgedTcpAdapter {
         });
 
         tracing::debug!("Waiting for I/O loop to be ready...");
-        ready_rx
+        tokio::time::timeout_at(deadline, ready_rx)
             .await
+            .map_err(|_| anyhow::anyhow!("I/O loop startup timed out after 10s"))?
             .map_err(|_| anyhow::anyhow!("I/O loop panicked before starting"))?;
         tracing::info!("I/O loop confirmed READY");
         *self.io_task.lock().await = Some(task);

--- a/crates/mezon-store/src/connection.rs
+++ b/crates/mezon-store/src/connection.rs
@@ -5,6 +5,7 @@
 //! gpui-coupled lifecycle lives here as a store instead of in the app binary.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use gpui::{
     App, AppContext, AsyncApp, BackgroundExecutor, Context, Entity, Global, Subscription, Task,
@@ -67,6 +68,10 @@ pub struct ConnectionStore {
     connecting_attempt: u32,
     transport: Arc<TransportClient>,
     wake: Arc<tokio::sync::Notify>,
+    /// Bumped whenever the live connection is replaced. Callbacks captured by an
+    /// older attempt compare against it and stay quiet, so a socket that dies
+    /// while its successor is already up cannot mark the new one disconnected.
+    connection_generation: Arc<AtomicU64>,
     _manager: Task<()>,
     _auth_observe: Subscription,
     _heartbeat: Task<()>,
@@ -112,8 +117,12 @@ impl ConnectionStore {
     pub fn reconnect(&self, cx: &mut Context<Self>) {
         let transport = self.transport.clone();
         let wake = self.wake.clone();
+        let connection_generation = self.connection_generation.clone();
         cx.background_executor()
             .spawn(async move {
+                // Retire the live connection first: its close callback must not
+                // land on the attempt this reconnect is about to start.
+                connection_generation.fetch_add(1, Ordering::AcqRel);
                 if let Err(e) = transport.close().await {
                     tracing::warn!("Failed to close the transport before reconnect: {e}");
                 }
@@ -167,6 +176,8 @@ impl ConnectionStore {
         let heartbeat = Self::spawn_heartbeat(transport.clone(), api.clone(), wake.clone(), cx);
         let transport_handle = transport.clone();
         let wake_handle = wake.clone();
+        let connection_generation = Arc::new(AtomicU64::new(0));
+        let connection_generation_handle = connection_generation.clone();
 
         let probe_url = AppConfig::try_global(cx)
             .map(|cfg| favicon_probe_url(&cfg.redirect_uri))
@@ -208,6 +219,7 @@ impl ConnectionStore {
                 let Some(mut session) = session else {
                     api.set_http_fallback(None);
                     if connected_user_id.take().is_some() {
+                        connection_generation.fetch_add(1, Ordering::AcqRel);
                         if let Err(e) = transport.close().await {
                             tracing::warn!("Failed to close TCP transport after logout: {e}");
                         }
@@ -350,6 +362,7 @@ impl ConnectionStore {
                     tracing::warn!("Failed to close stale transport: {e}");
                 }
 
+                let generation = connection_generation.fetch_add(1, Ordering::AcqRel) + 1;
                 tracing::info!("Connecting shared abridged TCP transport to {endpoint_label}");
                 api.set_status(ConnectionStatus::Connecting);
                 let token = if use_jwt {
@@ -363,6 +376,8 @@ impl ConnectionStore {
                 let api_for_publish = api.clone();
                 let api_for_close = api.clone();
                 let wake_for_close = wake.clone();
+                let connection_generation_for_publish = connection_generation.clone();
+                let connection_generation_for_close = connection_generation.clone();
                 connect_ack_rx.borrow_and_update();
                 let connect_result = transport
                     .connect(
@@ -370,9 +385,17 @@ impl ConnectionStore {
                         explicit_port,
                         &token,
                         move |event| {
-                            api_for_publish.publish_event(event);
+                            if connection_generation_for_publish.load(Ordering::Acquire)
+                                == generation
+                            {
+                                api_for_publish.publish_event(event);
+                            }
                         },
                         move |was_clean| {
+                            if connection_generation_for_close.load(Ordering::Acquire) != generation
+                            {
+                                return;
+                            }
                             if was_clean {
                                 tracing::info!("TCP transport closed cleanly");
                             } else {
@@ -389,9 +412,18 @@ impl ConnectionStore {
                         tracing::info!("Shared abridged TCP transport connected");
                         let signaled = tokio::select! {
                             res = connect_ack_rx.changed() => res.is_ok(),
-                            _ = exec.timer(CONNECT_CONFIRM_GRACE) => true,
+                            _ = exec.timer(CONNECT_CONFIRM_GRACE) => false,
                         };
-                        let handshake_ok = signaled && transport.is_open().await;
+                        // Running out the grace period is not evidence the gateway
+                        // accepted us — it only means nothing arrived yet. Ask the
+                        // socket directly instead of assuming.
+                        let handshake_ok = if !transport.is_open().await {
+                            false
+                        } else if signaled {
+                            true
+                        } else {
+                            transport.ping_roundtrip().await.is_ok()
+                        };
                         if handshake_ok {
                             ConnectOutcome::Confirmed
                         } else {
@@ -491,6 +523,7 @@ impl ConnectionStore {
             connecting_attempt: 0,
             transport: transport_handle,
             wake: wake_handle,
+            connection_generation: connection_generation_handle,
             _manager: manager,
             _auth_observe: auth_observe,
             _heartbeat: heartbeat,


### PR DESCRIPTION
Three reconnect problems that stand on their own, extracted from the multi-DC failover work (#431) so they can land without waiting on the gateway.

- bound the whole connect attempt, not just its first leg. Only the TCP connect had a timeout; the TLS handshake and the wait for the I/O loop to report ready had none at all, so a stalled peer hung the reconnect indefinitely. One 10s deadline now covers TCP + TLS + startup. The pinned-IP path gets a fresh budget for its DNS fallback rather than inheriting a spent one
- stop treating the confirm grace period as success. Reaching the 1s timer only means nothing has arrived yet, but it was read as "gateway accepted us" and the connection was marked Confirmed. Ping the socket and use the answer
- ignore transport callbacks belonging to a connection we have already replaced. A socket that dies just after its successor is up would publish events onto the new connection and set status Disconnected under it. Each attempt carries a generation; the event and close callbacks compare against it before acting, and reconnect/logout retire the current one

No behaviour depends on the endpoint catalog or /v2/healthy/endpoint — those stay in #431.

Verified on the local stack: connect, kill the socket node, backoff, recover; 2251 tests, lint clean.
