### PR TITLE
feat(onboarding): surface the clan onboarding progress steps

### DIFF
--- a/crates/mezon-store/src/clan_load.rs
+++ b/crates/mezon-store/src/clan_load.rs
@@ -6,6 +6,7 @@ use crate::clan_members::ClanMembersStore;
 use crate::emoji::EmojiStore;
 use crate::ids::ClanId;
 use crate::notification_setting::NotificationSettingStore;
+use crate::onboarding::OnboardingStore;
 use crate::permissions::PermissionStore;
 use crate::roles::RolesStore;
 use crate::sticker::StickerStore;
@@ -136,6 +137,21 @@ impl ClanLoadScheduler {
             cx.update(|cx| {
                 NotificationSettingStore::global(cx)
                     .update(cx, |store, cx| store.prefetch_clan(clan_id, cx));
+            });
+
+            // Onboarding chrome (the sidebar progress card, the composer mission banner) needs
+            // both the guide items and this member's step, and only clans that turned onboarding
+            // on have either — so the pair is fetched here rather than on the guide page, which
+            // most members never open.
+            cx.update(|cx| {
+                let enabled = ClanList::global(cx)
+                    .read(cx)
+                    .clan(clan_id)
+                    .is_some_and(|clan| clan.is_onboarding);
+                if enabled {
+                    OnboardingStore::global(cx)
+                        .update(cx, |store, cx| store.ensure_loaded(clan_id, cx));
+                }
             });
 
             this.update(cx, |this, _| {

--- a/crates/mezon-store/src/onboarding.rs
+++ b/crates/mezon-store/src/onboarding.rs
@@ -289,6 +289,9 @@ impl OnboardingStore {
     }
 
     pub fn can_start_mission(&self, clan_id: ClanId, index: usize) -> bool {
+        if self.is_previewing(clan_id) {
+            return self.mission_progress(clan_id) == index;
+        }
         self.is_finished(clan_id) || self.mission_done(clan_id) == index
     }
 
@@ -297,17 +300,25 @@ impl OnboardingStore {
             return;
         }
         cx.notify();
-        let total = self
-            .clans
-            .get(&clan_id)
-            .map_or(0, |onboarding| onboarding.missions.len());
-        if total > 0 && self.mission_done.get(&clan_id).copied().unwrap_or(0) >= total {
+        if self.should_persist_completion(clan_id) {
             self.finish_onboarding(clan_id, cx);
         }
     }
 
+    /// Whether ticking the last mission should tell the server the run is over. Previewing walks
+    /// the same missions to show the owner what a new member sees, so it must not record anything.
+    fn should_persist_completion(&self, clan_id: ClanId) -> bool {
+        if self.is_previewing(clan_id) {
+            return false;
+        }
+        let total = self.mission_total(clan_id);
+        total > 0 && self.mission_done.get(&clan_id).copied().unwrap_or(0) >= total
+    }
+
     fn advance_mission(&mut self, clan_id: ClanId) -> bool {
-        if self.is_finished(clan_id) {
+        // Previewing restarts the run from zero for an owner who long since finished, so the
+        // server's "done" flag must not freeze the missions they are walking through.
+        if self.is_finished(clan_id) && !self.is_previewing(clan_id) {
             return false;
         }
         let total = self
@@ -336,12 +347,22 @@ impl OnboardingStore {
                     if this.reset_generation != reset_generation {
                         return;
                     }
-                    this.steps.remove(&clan_id);
+                    this.revert_finish(clan_id);
                     cx.notify();
                 });
             }
         })
         .detach();
+    }
+
+    /// Undo an optimistic finish the server refused. The tick that completed the run goes back
+    /// too, so the member is left on the mission they were on instead of on a finished count the
+    /// server never recorded.
+    fn revert_finish(&mut self, clan_id: ClanId) {
+        self.steps.remove(&clan_id);
+        if let Some(done) = self.mission_done.get_mut(&clan_id) {
+            *done = done.saturating_sub(1);
+        }
     }
 
     pub fn set_items(
@@ -619,6 +640,70 @@ mod tests {
         assert_eq!(store.mission_progress(CLAN), 0);
         assert_eq!(store.current_mission(CLAN).map(|item| item.id), Some(1));
         assert!(!store.show_progress(ClanId(8), true));
+    }
+
+    #[test]
+    fn preview_walks_the_missions_an_owner_already_finished() {
+        let mut store = test_store();
+        store.clans.insert(
+            CLAN,
+            ClanOnboarding::from_items(vec![
+                item(1, GUIDE_TYPE_TASK, 0),
+                item(2, GUIDE_TYPE_TASK, 0),
+            ]),
+        );
+        store.steps.insert(CLAN, DONE_ONBOARDING_STATUS);
+        store.preview = Some(CLAN);
+
+        assert!(store.can_start_mission(CLAN, 0));
+        assert!(
+            !store.can_start_mission(CLAN, 1),
+            "previewing follows the run in order, like a new member"
+        );
+        assert!(store.advance_mission(CLAN));
+        assert_eq!(store.mission_progress(CLAN), 1);
+        assert_eq!(store.current_mission(CLAN).map(|item| item.id), Some(2));
+        assert!(store.advance_mission(CLAN));
+        assert_eq!(store.mission_progress(CLAN), 2);
+        assert!(store.current_mission(CLAN).is_none());
+    }
+
+    #[test]
+    fn previewing_never_records_the_run_as_finished() {
+        let mut store = test_store();
+        store.clans.insert(
+            CLAN,
+            ClanOnboarding::from_items(vec![item(1, GUIDE_TYPE_TASK, 0)]),
+        );
+        store.mission_done.insert(CLAN, 1);
+        assert!(store.should_persist_completion(CLAN));
+
+        store.preview = Some(CLAN);
+        assert!(!store.should_persist_completion(CLAN));
+    }
+
+    #[test]
+    fn a_step_the_server_refused_takes_the_last_tick_back_with_it() {
+        let mut store = test_store();
+        store.clans.insert(
+            CLAN,
+            ClanOnboarding::from_items(vec![
+                item(1, GUIDE_TYPE_TASK, 0),
+                item(2, GUIDE_TYPE_TASK, 0),
+            ]),
+        );
+        store.mission_done.insert(CLAN, 2);
+        store.steps.insert(CLAN, DONE_ONBOARDING_STATUS);
+
+        store.revert_finish(CLAN);
+
+        assert!(!store.is_finished(CLAN));
+        assert_eq!(
+            store.mission_progress(CLAN),
+            1,
+            "the member is left on the mission they were on, not on a finished count"
+        );
+        assert_eq!(store.current_mission(CLAN).map(|item| item.id), Some(2));
     }
 
     #[test]

--- a/crates/mezon-store/src/onboarding.rs
+++ b/crates/mezon-store/src/onboarding.rs
@@ -65,6 +65,7 @@ pub struct OnboardingStore {
     steps_failed_at: HashMap<ClanId, Instant>,
     mission_done: HashMap<ClanId, usize>,
     answers: HashMap<ClanId, HashSet<(i64, usize)>>,
+    preview: Option<ClanId>,
     reset_generation: u64,
     api: Arc<AppApi>,
     _connection_watch: Task<()>,
@@ -93,6 +94,7 @@ impl OnboardingStore {
             steps_failed_at: HashMap::new(),
             mission_done: HashMap::new(),
             answers: HashMap::new(),
+            preview: None,
             reset_generation: 0,
             api,
             _connection_watch: connection_watch,
@@ -155,6 +157,7 @@ impl OnboardingStore {
         self.steps_failed_at.clear();
         self.mission_done.clear();
         self.answers.clear();
+        self.preview = None;
         self.reset_generation = self.reset_generation.wrapping_add(1);
         cx.notify();
     }
@@ -187,6 +190,67 @@ impl OnboardingStore {
 
     pub fn is_finished(&self, clan_id: ClanId) -> bool {
         self.steps.get(&clan_id).copied() == Some(DONE_ONBOARDING_STATUS)
+    }
+
+    pub fn mission_total(&self, clan_id: ClanId) -> usize {
+        self.clans
+            .get(&clan_id)
+            .map_or(0, |onboarding| onboarding.missions.len())
+    }
+
+    /// Missions ticked off, ignoring the server's "onboarding finished" flag. This is what the
+    /// progress chrome counts, so an owner in preview mode sees the run start from zero the way
+    /// a new member would.
+    pub fn mission_progress(&self, clan_id: ClanId) -> usize {
+        self.mission_done.get(&clan_id).copied().unwrap_or(0)
+    }
+
+    /// The mission the member is expected to do next, or `None` once every one is ticked.
+    pub fn current_mission(&self, clan_id: ClanId) -> Option<&OnboardingItem> {
+        self.clans
+            .get(&clan_id)?
+            .missions
+            .get(self.mission_progress(clan_id))
+    }
+
+    /// Whether `ListOnboardingStep` has answered for this clan. The progress chrome stays hidden
+    /// until it has, so a member who already finished never sees it flash on the way in.
+    pub fn steps_loaded(&self, clan_id: ClanId) -> bool {
+        self.steps.contains_key(&clan_id)
+    }
+
+    pub fn preview_clan(&self) -> Option<ClanId> {
+        self.preview
+    }
+
+    pub fn is_previewing(&self, clan_id: ClanId) -> bool {
+        self.preview == Some(clan_id)
+    }
+
+    /// Look at the clan the way a brand new member would: the progress chrome shows even for the
+    /// owner, who has long since finished onboarding.
+    pub fn open_preview(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
+        self.preview = Some(clan_id);
+        cx.notify();
+    }
+
+    pub fn close_preview(&mut self, cx: &mut Context<Self>) {
+        if self.preview.take().is_some() {
+            cx.notify();
+        }
+    }
+
+    /// The gate the onboarding progress chrome shares — the sidebar card and the composer
+    /// mission banner. `clan_enabled` is the clan's `is_onboarding` flag, which lives on
+    /// `ClanList`.
+    pub fn show_progress(&self, clan_id: ClanId, clan_enabled: bool) -> bool {
+        if self.is_previewing(clan_id) {
+            return true;
+        }
+        clan_enabled
+            && self.steps_loaded(clan_id)
+            && self.mission_total(clan_id) > 0
+            && !self.is_finished(clan_id)
     }
 
     pub fn answer_selected(&self, clan_id: ClanId, question_id: i64, index: usize) -> bool {
@@ -438,6 +502,7 @@ mod tests {
             steps_failed_at: HashMap::new(),
             mission_done: HashMap::new(),
             answers: HashMap::new(),
+            preview: None,
             reset_generation: 0,
             api: Arc::new(AppApi::new(
                 Arc::new(mezon_client::TransportClient::new(String::new())),
@@ -513,6 +578,59 @@ mod tests {
             ClanOnboarding::from_items(vec![item(1, GUIDE_TYPE_RULE, 0)]),
         );
         assert!(!store.load_failed(CLAN));
+    }
+
+    #[test]
+    fn progress_chrome_waits_for_the_step_fetch_and_hides_once_finished() {
+        let mut store = test_store();
+        store.clans.insert(
+            CLAN,
+            ClanOnboarding::from_items(vec![item(1, GUIDE_TYPE_TASK, 0)]),
+        );
+        // Items are in, but `ListOnboardingStep` has not answered yet.
+        assert!(!store.show_progress(CLAN, true));
+        store.steps.insert(CLAN, 0);
+        assert!(store.show_progress(CLAN, true));
+        // A clan that never switched onboarding on shows nothing either way.
+        assert!(!store.show_progress(CLAN, false));
+        store.steps.insert(CLAN, DONE_ONBOARDING_STATUS);
+        assert!(!store.show_progress(CLAN, false));
+        assert!(!store.show_progress(CLAN, true));
+    }
+
+    #[test]
+    fn preview_forces_the_chrome_on_and_restarts_the_count() {
+        let mut store = test_store();
+        store.clans.insert(
+            CLAN,
+            ClanOnboarding::from_items(vec![
+                item(1, GUIDE_TYPE_TASK, 0),
+                item(2, GUIDE_TYPE_TASK, 0),
+            ]),
+        );
+        store.steps.insert(CLAN, DONE_ONBOARDING_STATUS);
+        assert!(!store.show_progress(CLAN, true));
+        assert_eq!(store.mission_done(CLAN), 2);
+
+        store.preview = Some(CLAN);
+        assert!(store.show_progress(CLAN, true));
+        // The finished flag ticks every mission on the guide, but the owner previewing the clan
+        // still starts the run from the first one.
+        assert_eq!(store.mission_progress(CLAN), 0);
+        assert_eq!(store.current_mission(CLAN).map(|item| item.id), Some(1));
+        assert!(!store.show_progress(ClanId(8), true));
+    }
+
+    #[test]
+    fn no_current_mission_once_every_one_is_done() {
+        let mut store = test_store();
+        store.clans.insert(
+            CLAN,
+            ClanOnboarding::from_items(vec![item(1, GUIDE_TYPE_TASK, 0)]),
+        );
+        assert_eq!(store.current_mission(CLAN).map(|item| item.id), Some(1));
+        store.mission_done.insert(CLAN, 1);
+        assert!(store.current_mission(CLAN).is_none());
     }
 
     #[test]

--- a/crates/mezon-ui/src/app/root.rs
+++ b/crates/mezon-ui/src/app/root.rs
@@ -18,7 +18,9 @@ use gpui::{
     Animation, AnimationExt as _, AnyView, App, ClickEvent, Context, Entity, FontWeight,
     MouseButton, NavigationDirection, StyleRefinement, Task, Window, div, img, prelude::*, px,
 };
-use mezon_store::{AuthState, ChannelList, ClanId, ClanList, ConnectionStore, Settings};
+use mezon_store::{
+    AuthState, ChannelList, ClanId, ClanList, ConnectionStore, OnboardingStore, Settings,
+};
 use std::time::{Duration, Instant};
 
 pub struct RootView {
@@ -156,6 +158,9 @@ impl RootView {
             }
         })
         .detach();
+
+        cx.observe(&OnboardingStore::global(cx), |_, _, cx| cx.notify())
+            .detach();
 
         cx.observe(&auth_state, |this, auth_state, cx| {
             if matches!(*auth_state.read(cx), AuthState::Connecting(_)) {
@@ -478,6 +483,13 @@ impl Render for RootView {
             }
         };
 
+        // React gates the strip on `previewMode.clanId === currentClanId`, so switching clans
+        // parks the preview rather than following the owner around.
+        let preview_bar = OnboardingStore::try_global(cx)
+            .and_then(|store| store.read(cx).preview_clan())
+            .filter(|clan_id| ClanList::global(cx).read(cx).active_clan_id == Some(*clan_id))
+            .map(|clan_id| render_onboarding_preview_bar(clan_id, theme, locale));
+
         div()
             .relative()
             .flex()
@@ -503,6 +515,7 @@ impl Render for RootView {
             .when(window_controls::HAS_CUSTOM_TITLE_BAR, |this| {
                 this.child(render_title_bar(self.title_bar.clone()))
             })
+            .children(preview_bar)
             .child(content)
             .when(window_controls::is_edge_resizable(), |this| {
                 this.child(window_controls::render_resize_edges(window))
@@ -510,6 +523,77 @@ impl Render for RootView {
             .child(self.shell.clone())
             .child(self.call_overlay.clone())
     }
+}
+
+/// The strip React drops across the top while an owner is previewing their clan the way a new
+/// member sees it. Closing it hands them back to the onboarding settings they opened it from.
+fn render_onboarding_preview_bar(clan_id: ClanId, theme: &Theme, locale: &str) -> gpui::AnyElement {
+    // The bar spans the whole window, so on macOS the close button has to start clear of the
+    // native traffic lights it would otherwise sit on top of.
+    let close_left = if cfg!(target_os = "macos") {
+        px(88.)
+    } else {
+        px(24.)
+    };
+    div()
+        .relative()
+        .flex()
+        .flex_row()
+        .flex_none()
+        .items_center()
+        .justify_center()
+        .w_full()
+        .h(px(48.))
+        .px_4()
+        .bg(theme.bg_secondary)
+        .border_b_1()
+        .border_color(theme.border)
+        .child(
+            div()
+                .id("onboarding-close-preview")
+                .absolute()
+                .left(close_left)
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_1()
+                .px_2()
+                .py(px(4.))
+                .rounded(px(4.))
+                .border_1()
+                .border_color(theme.border)
+                .cursor_pointer()
+                .text_color(theme.text_primary)
+                .hover(|style| style.bg(theme.bg_hover))
+                .child(
+                    Icon::new(IconName::ArrowLeft)
+                        .size(px(14.))
+                        .text_color(theme.text_primary),
+                )
+                .child(
+                    div()
+                        .text_size(px(12.))
+                        .font_weight(FontWeight::MEDIUM)
+                        .child(mezon_i18n::t(locale, "common.closePreviewMode")),
+                )
+                .on_click(move |_, _, cx| {
+                    OnboardingStore::global(cx).update(cx, |store, cx| store.close_preview(cx));
+                    crate::router::navigate(
+                        cx,
+                        Route::ClanSettings {
+                            clan_id,
+                            page: ClanSettingsPage::Onboarding,
+                        },
+                    );
+                }),
+        )
+        .child(
+            div()
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(theme.text_primary)
+                .child(mezon_i18n::t(locale, "common.previewModeDescription")),
+        )
+        .into_any_element()
 }
 
 fn render_title_bar(title_bar: Entity<TitleBar>) -> AnyView {

--- a/crates/mezon-ui/src/chat/area.rs
+++ b/crates/mezon-ui/src/chat/area.rs
@@ -7,9 +7,9 @@ use gpui::{
     Subscription, Task, Window, div, prelude::*, px, rgb, rgba,
 };
 use mezon_store::{
-    ChannelId, ChannelPermissionsStore, ClanId, DirectEvent, DirectKind, DirectMessageStore,
-    FriendEvent, FriendStore, InVoiceInfo, MessagesEvent, MessagesStore, PERMISSION_SEND_MESSAGE,
-    Settings,
+    ChannelId, ChannelList, ChannelPermissionsStore, ClanId, ClanList, DirectEvent, DirectKind,
+    DirectMessageStore, FriendEvent, FriendStore, InVoiceInfo, MessagesEvent, MessagesStore,
+    OnboardingStore, PERMISSION_SEND_MESSAGE, Settings,
 };
 use ui::PopoverMenuHandle;
 
@@ -63,6 +63,101 @@ pub struct ChatArea {
 }
 
 const SEND_PERMISSION_DEBOUNCE: Duration = Duration::from_millis(500);
+
+/// The strip React parks directly on top of the composer while a member still has onboarding
+/// missions left: the next mission, and clicking it does the mission.
+fn onboarding_mission_banner(locale: &str, cx: &mut App) -> Option<gpui::AnyElement> {
+    let clan_id = ClanList::global(cx).read(cx).active_clan_id?;
+    let store = OnboardingStore::global(cx);
+    let store = store.read(cx);
+    // This runs on every chat render, so the clan with no missions — every clan, for most
+    // people — bails on one hash lookup, before the scan `ClanList::clan` costs.
+    if store.mission_total(clan_id) == 0 {
+        return None;
+    }
+    let clan_enabled = ClanList::global(cx)
+        .read(cx)
+        .clan(clan_id)
+        .is_some_and(|clan| clan.is_onboarding);
+    if !store.show_progress(clan_id, clan_enabled) {
+        return None;
+    }
+    let index = store.mission_progress(clan_id);
+    let mission = store.current_mission(clan_id)?;
+    let title: SharedString = mission.title.clone().into();
+    let task_type = mission.task_type;
+    let channel_id = ChannelId(mission.channel_id);
+    let channel_name = ChannelList::global(cx)
+        .read(cx)
+        .channel(clan_id, channel_id)
+        .map(|channel| SharedString::from(format!("#{}", channel.name)));
+    let theme = cx.theme();
+    Some(
+        div()
+            .flex_none()
+            .w_full()
+            .px_3()
+            .child(
+                div()
+                    .id("onboarding-mission-banner")
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap_3()
+                    .w_full()
+                    .h(px(56.))
+                    .px_4()
+                    .rounded_t(px(6.))
+                    .cursor_pointer()
+                    .bg(theme.tokens.bg_tertiary)
+                    .hover(|style| style.bg(theme.tokens.bg_item_hover))
+                    .child(
+                        Icon::new(IconName::Hashtag)
+                            .size(px(20.))
+                            .text_color(theme.tokens.text_theme_primary),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .flex_1()
+                            .min_w_0()
+                            .overflow_hidden()
+                            .child(
+                                div()
+                                    .w_full()
+                                    .truncate()
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(theme.tokens.text_secondary)
+                                    .child(title),
+                            )
+                            .child(
+                                div()
+                                    .flex()
+                                    .flex_row()
+                                    .gap_1()
+                                    .text_size(px(10.))
+                                    .text_color(theme.tokens.text_theme_primary)
+                                    .child(crate::chat::clan_guide_page::mission_summary(
+                                        locale, task_type,
+                                    ))
+                                    .children(channel_name.map(|name| {
+                                        div()
+                                            .font_weight(FontWeight::SEMIBOLD)
+                                            .text_color(theme.tokens.text_secondary)
+                                            .child(name)
+                                    })),
+                            ),
+                    )
+                    .on_click(move |_, _, cx| {
+                        crate::chat::clan_guide_page::start_mission(
+                            clan_id, channel_id, task_type, index, cx,
+                        );
+                    }),
+            )
+            .into_any_element(),
+    )
+}
 
 fn leave_removed_conversation(channel_id: ChannelId, cx: &mut App) {
     let viewing = route_targets_conversation(&Router::global(cx).read(cx).route(), channel_id);
@@ -746,6 +841,12 @@ impl ChatArea {
             div().into_any_element()
         };
 
+        let onboarding_mission = if !is_dm && !media_channel_view && !send_denied {
+            onboarding_mission_banner(locale, cx)
+        } else {
+            None
+        };
+
         let timeline_popover_open = self.timeline.read(cx).profile_popover_open();
         let member_popover_open = self
             .member_panel
@@ -800,7 +901,8 @@ impl ChatArea {
                 ))
                 .when(send_denied, |col| col.child(no_permission_notice))
                 .when(!send_denied, |col| {
-                    col.when_some(input_bar.clone(), |col, input_bar| col.child(input_bar))
+                    col.children(onboarding_mission)
+                        .when_some(input_bar.clone(), |col, input_bar| col.child(input_bar))
                         .when_some(app_channel_bar.as_ref(), |col, target| {
                             col.child(render_channel_app_bar(locale, target.clone(), cx.theme()))
                         })

--- a/crates/mezon-ui/src/chat/clan_guide_page.rs
+++ b/crates/mezon-ui/src/chat/clan_guide_page.rs
@@ -673,7 +673,7 @@ fn guide_card(
         })
 }
 
-fn mission_summary(locale: &str, task_type: i32) -> &'static str {
+pub(crate) fn mission_summary(locale: &str, task_type: i32) -> &'static str {
     let key = match task_type {
         MISSION_VISIT => "guide.missionTitles.visit",
         MISSION_DO_SOMETHING => "guide.missionTitles.doSomething",
@@ -682,7 +682,7 @@ fn mission_summary(locale: &str, task_type: i32) -> &'static str {
     mezon_i18n::t(locale, key)
 }
 
-fn start_mission(
+pub(crate) fn start_mission(
     clan_id: ClanId,
     channel_id: ChannelId,
     task_type: i32,

--- a/crates/mezon-ui/src/chat/layout.rs
+++ b/crates/mezon-ui/src/chat/layout.rs
@@ -430,6 +430,10 @@ impl ChatLayout {
         .detach();
         cx.observe(&MessageSearchStore::global(cx), |_, _, cx| cx.notify())
             .detach();
+        cx.observe(&mezon_store::OnboardingStore::global(cx), |_, _, cx| {
+            cx.notify()
+        })
+        .detach();
         cx.subscribe(&TopicsStore::global(cx), |this, _, event, cx| match event {
             TopicsEvent::Opened => {
                 ThreadsStore::global(cx).update(cx, |threads, cx| threads.cancel_create(cx));

--- a/crates/mezon-ui/src/clan/settings/onboarding_setting_page.rs
+++ b/crates/mezon-ui/src/clan/settings/onboarding_setting_page.rs
@@ -854,6 +854,7 @@ impl OnboardingSettingPage {
     fn render_main(&self, theme: &Theme, locale: &str, cx: &mut Context<Self>) -> gpui::AnyElement {
         let setup = cx.entity().downgrade();
         let guide = cx.entity().downgrade();
+        let preview_clan = self.clan_id;
         v_flex()
             .gap_5()
             .child(
@@ -875,8 +876,22 @@ impl OnboardingSettingPage {
                             )))
                             .child(
                                 div()
+                                    .id("onboarding-open-preview")
+                                    .cursor_pointer()
                                     .text_color(rgb(0x5865f2))
-                                    .child(mezon_i18n::t(locale, "common.preview")),
+                                    .hover(|style| style.text_color(rgb(0x818cf8)))
+                                    .child(mezon_i18n::t(locale, "onBoardingClan.buttons.preview"))
+                                    .on_click(move |_, _, cx| {
+                                        OnboardingStore::global(cx).update(cx, |store, cx| {
+                                            store.open_preview(preview_clan, cx)
+                                        });
+                                        crate::router::navigate(
+                                            cx,
+                                            crate::router::Route::ClanGuide {
+                                                clan_id: preview_clan,
+                                            },
+                                        );
+                                    }),
                             ),
                     ),
             )
@@ -1231,12 +1246,9 @@ impl OnboardingSettingPage {
                     .justify_between()
                     .child(
                         div().text_size(px(12.)).child(
-                            format!(
-                                "{} {}",
-                                mezon_i18n::t(locale, "onBoardingClan.questionsPage.title"),
-                                index + 1
-                            )
-                            .to_uppercase(),
+                            mezon_i18n::t(locale, "onBoardingClan.questionsPage.questionNumber")
+                                .replace("{{number}}", &(index + 1).to_string())
+                                .to_uppercase(),
                         ),
                     )
                     .child(
@@ -1304,12 +1316,12 @@ impl OnboardingSettingPage {
             if let Some(input) = &question.title_input {
                 card = card.child(Input::new(input).w_full());
             }
-            card = card.child(div().text_color(theme.text_secondary).child(format!(
-                "{} - {} / {}",
-                mezon_i18n::t(locale, "onBoardingClan.questionsPage.addAnswer"),
-                question.answers.len(),
-                MAX_ANSWERS
-            )));
+            card = card.child(
+                div().text_color(theme.text_secondary).child(
+                    mezon_i18n::t(locale, "onBoardingClan.questionsPage.availableAnswers")
+                        .replace("{{count}}", &question.answers.len().to_string()),
+                ),
+            );
             let mut answers = h_flex().gap_2().flex_wrap();
             for (answer_index, answer) in question.answers.iter().enumerate() {
                 let edit = cx.entity().downgrade();

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
@@ -9,8 +9,8 @@ use gpui::{
 };
 use mezon_store::{
     BadgeService, ChannelId, ChannelList, ChannelType, ClanId, ClanList, ClanMembersStore,
-    EventsStore, FAVOR_CATE_ID, PERMISSION_ADMINISTRATOR, PERMISSION_MANAGE_CLAN, PermissionStore,
-    Settings, StreamMember, StreamStore, VoiceMember,
+    EventsStore, FAVOR_CATE_ID, OnboardingStore, PERMISSION_ADMINISTRATOR, PERMISSION_MANAGE_CLAN,
+    PermissionStore, Settings, StreamMember, StreamStore, VoiceMember,
 };
 
 use crate::channel_app::launch_channel_app_from_store;
@@ -125,6 +125,7 @@ pub struct ChannelSidebar {
     _permissions_observe: Subscription,
     _channel_permissions_observe: Subscription,
     _notification_setting_observe: Subscription,
+    _onboarding_observe: Subscription,
 }
 
 struct ActiveChannelSidebar(gpui::WeakEntity<ChannelSidebar>);
@@ -318,6 +319,7 @@ impl ChannelSidebar {
             }
         });
         let permissions_observe = cx.observe(&PermissionStore::global(cx), |_, _, cx| cx.notify());
+        let onboarding_observe = cx.observe(&OnboardingStore::global(cx), |_, _, cx| cx.notify());
         let channel_permissions_observe = cx.subscribe(
             &mezon_store::ChannelPermissionsStore::global(cx),
             |this, _, event: &mezon_store::ChannelPermissionsEvent, cx| {
@@ -377,6 +379,7 @@ impl ChannelSidebar {
             _permissions_observe: permissions_observe,
             _channel_permissions_observe: channel_permissions_observe,
             _notification_setting_observe: notification_setting_observe,
+            _onboarding_observe: onboarding_observe,
         };
         cx.set_global(ActiveChannelSidebar(cx.entity().downgrade()));
         this.rebuild_items(cx);
@@ -389,6 +392,25 @@ impl ChannelSidebar {
         self.last_clan_inputs = clan_inputs_fingerprint(self.clan_list.read(cx));
         if let Some(clan_id) = self.clan_list.read(cx).active_clan_id {
             EventsStore::global(cx).update(cx, |store, cx| store.ensure_loaded(clan_id, cx));
+            // `ClanLoadScheduler` already fetches this when the clan is entered; this covers the
+            // other way in — an owner who just switched onboarding on and expects the progress
+            // card without leaving and re-entering the clan. `rebuild_items` is hot (every
+            // `ChannelList` notify lands here), so the two hash lookups gate the clan-list scan:
+            // once both halves are in, this costs nothing.
+            let onboarding = OnboardingStore::global(cx);
+            let unloaded = {
+                let store = onboarding.read(cx);
+                !store.has_onboarding(clan_id) || !store.steps_loaded(clan_id)
+            };
+            if unloaded
+                && self
+                    .clan_list
+                    .read(cx)
+                    .clan(clan_id)
+                    .is_some_and(|clan| clan.is_onboarding)
+            {
+                onboarding.update(cx, |store, cx| store.ensure_loaded(clan_id, cx));
+            }
         }
         let clans = self.clan_list.read(cx);
         let channels = self.channel_list.read(cx);
@@ -1422,6 +1444,97 @@ fn sidebar_skeleton_layer(theme: &Theme, cx: &App) -> gpui::Div {
         .child(render_skeleton(cx))
 }
 
+/// The "Get Started" progress card React shows above the Clan Guide row while a member still
+/// has missions left — `missionDone of missionSum` plus a bar that fills as they tick off.
+fn onboarding_get_started(
+    clan_id: ClanId,
+    theme: &crate::theme::Theme,
+    locale: &str,
+    cx: &App,
+) -> AnyElement {
+    let store = OnboardingStore::global(cx);
+    let store = store.read(cx);
+    let done = store.mission_progress(clan_id);
+    let total = store.mission_total(clan_id);
+    // A bar that reads as empty still has to read as a bar, so an untouched clan keeps a sliver.
+    let fill = if total == 0 {
+        0.03
+    } else {
+        (done as f32 / total as f32).clamp(0.03, 1.)
+    };
+    div()
+        .id("clan-onboarding-get-started")
+        .flex()
+        .flex_col()
+        .w_full()
+        .px_2()
+        .pt_1()
+        .pb_2()
+        .gap_2()
+        .border_b_1()
+        .border_color(theme.border)
+        .cursor_pointer()
+        .child(
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .justify_between()
+                .w_full()
+                .child(
+                    div()
+                        .text_sm()
+                        .font_weight(gpui::FontWeight::BOLD)
+                        .text_color(theme.text_primary)
+                        .child(mezon_i18n::t(locale, "channelList.onboarding.getStarted")),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap_px()
+                        .text_size(px(12.))
+                        .text_color(theme.text_primary)
+                        .child(
+                            div()
+                                .font_weight(gpui::FontWeight::BOLD)
+                                .child(done.to_string()),
+                        )
+                        .child(div().child(mezon_i18n::t(locale, "channelList.onboarding.of")))
+                        .child(
+                            div()
+                                .font_weight(gpui::FontWeight::BOLD)
+                                .child(total.to_string()),
+                        )
+                        .child(
+                            Icon::new(IconName::ArrowRight)
+                                .size(px(12.))
+                                .text_color(theme.text_secondary),
+                        ),
+                ),
+        )
+        .child(
+            div()
+                .w_full()
+                .h(px(4.))
+                .rounded(px(8.))
+                .overflow_hidden()
+                .bg(theme.bg_hover)
+                .child(
+                    div()
+                        .w(relative(fill))
+                        .h_full()
+                        .rounded(px(8.))
+                        .bg(gpui::rgb(0x16a34a)),
+                ),
+        )
+        .on_click(move |_, _, cx| {
+            crate::router::navigate(cx, crate::router::Route::ClanGuide { clan_id });
+        })
+        .into_any_element()
+}
+
 fn nav_row(
     icon: IconName,
     label: impl Into<SharedString>,
@@ -1669,12 +1782,20 @@ fn render_banner_and_events(
             crate::router::navigate(cx, crate::router::Route::ClanChannels { clan_id });
         }
     });
+    let onboarding_card = members_clan_id
+        .filter(|clan_id| {
+            OnboardingStore::global(cx)
+                .read(cx)
+                .show_progress(*clan_id, clan_has_onboarding)
+        })
+        .map(|clan_id| onboarding_get_started(clan_id, theme, locale, cx));
     let nav_col = div()
         .flex()
         .flex_col()
         .w_full()
         .p_2()
         .gap_1()
+        .children(onboarding_card)
         .when(clan_has_onboarding, |element| element.child(guide_row))
         .child(events_row)
         .child(members_row)


### PR DESCRIPTION
The chrome that sits around an onboarding-enabled clan was never ported: the i18n keys came across but nothing in the client rendered them, so a member had no way to see or advance the steps the clan set up.

- sidebar: a "Get Started · N of M" card with a progress bar, above the Clan Guide row (channelList.onboarding.getStarted/.of)
- chat: the current-mission strip on top of the composer; clicking it does the mission and advances to the next one
- preview mode: the settings "Preview" link now opens the clan the way a new member sees it, with the top strip and a close button that hands the owner back to the onboarding settings (common.closePreviewMode / common.previewModeDescription)
- fetch the guide items and this member's step when a clan is entered, in ClanLoadScheduler's deferred tier

Every surface is gated on the clan's is_onboarding flag plus a loaded step, so a clan without onboarding renders and fetches exactly what it did before, and the two hot paths (the chat render and rebuild_items) bail on a hash lookup before touching the clan list.

Mission progress deliberately matches the web client, including its quirks: a send-message mission only navigates, and the per-mission counter lives in memory while only the finished state is persisted.

Two strings on the questions page now use the keys they were ported with, questionNumber and availableAnswers, instead of ad-hoc formatting.