### PR TITLE
fix(browser): open a plain tab instead of app mode under the app sandbox

### DIFF
--- a/crates/mezon-native/src/browser.rs
+++ b/crates/mezon-native/src/browser.rs
@@ -92,6 +92,10 @@ fn chromium_desktop_stem(xdg_settings_output: &str) -> Option<&str> {
 /// reachable shape.
 pub fn open_url_app_window(url: &str) -> anyhow::Result<()> {
     crate::ensure_http_url(url)?;
+    if app_sandbox_strips_launch_arguments() {
+        tracing::info!("app sandbox drops browser switches, opening a browser tab instead");
+        return crate::open_url(url);
+    }
     match default_chromium_browser() {
         Some(browser) => launch_app_window(&browser, url).or_else(|error| {
             tracing::warn!("app-window launch failed, falling back to a browser tab: {error:#}");
@@ -99,6 +103,10 @@ pub fn open_url_app_window(url: &str) -> anyhow::Result<()> {
         }),
         None => crate::open_url(url),
     }
+}
+
+fn app_sandbox_strips_launch_arguments() -> bool {
+    cfg!(target_os = "macos") && std::env::var_os("APP_SANDBOX_CONTAINER_ID").is_some()
 }
 
 fn silenced(command: &mut std::process::Command) -> &mut std::process::Command {


### PR DESCRIPTION
> Rewritten. The first version of this PR blamed `--app=` for the profile picker and pinned `--profile-directory`; that diagnosis was wrong and has been dropped. What follows is measured.

## The bug

On the App Store build, opening a **channel app**, a **YouTube/TikTok link card** or the **built-in voice app** starts Chrome on the profile picker and the page never opens. The url is gone; picking a profile does not bring it back.

Only reproduces when the browser is **not already running**. A warm browser is merely activated and nothing opens at all, so it reads as intermittent.

## Why

App mode asks LaunchServices to launch the browser with `--app=<url>`, and a sandboxed process is not allowed to pass arguments to another application, so LaunchServices strips them.

Measured on a cold browser, same call, two callers:

| caller | Chrome's actual command line |
|---|---|
| unsandboxed shell | `…/Google Chrome --profile-directory=Profile 4 --app=https://example.com/?cold=B` |
| **sandboxed app** | `…/Google Chrome` — empty, parent `launchd` |

With neither the switch nor a positional url, Chromium's `GetStartupProfileMode` falls through to `ProfilePicker::GetStartupMode()`, and the url — which only ever existed as an argument — is gone.

Nothing reported it because `/usr/bin/open` **exits 0 either way**: the launch really did succeed, only the arguments were dropped. `launch_app_window` returned `Ok`, so the browser-tab fallback never ran and no warning was logged.

## The fix

Under the sandbox, skip app mode and open a plain tab. A url handed to LaunchServices travels as a *document*, not as argv, which the sandbox does allow, and Chromium then treats it as a command-line tab.

The sandbox test is `APP_SANDBOX_CONTAINER_ID`, the same signal `mezon-store`'s `running_in_app_sandbox()` already uses for the update channel and the wallet keychain namespace, so the two agree by construction.

Verified end-to-end on the installed sandboxed build with a cold browser — the page opens in the last-used profile:

```
19:25:42  Untitled - Google Chrome - Huy (ncc.asia)                    + Who's using Chrome?
19:25:43  Reimplement ctrl K search… - Google Chrome - Huy (ncc.asia)  + Who's using Chrome?
```

The toolbar-less window stays for builds that are not sandboxed, where the switches do survive.

## Known trade-offs

- **The signed `data=` launch token becomes visible in the address bar** on the App Store build. It was always in the url; app mode hid the omnibox. Unavoidable without app mode, and the alternative today is that the page does not open at all.
- **The profile picker itself is not removed.** It is Chrome's own cold-start behaviour on a machine with several profiles — the same window appears when this user clicks *any* link with the browser closed, and from an unsandboxed shell too. This PR makes the page open alongside it instead of being lost.
- **`open_url` cannot observe the opener's exit status** (`open_url_reaped`'s `pre_exec` fork makes the direct child exit 0 by construction), so a failed open on the sandbox path is still silent. Pre-existing on every link the app opens; not addressed here.
- **The document open resolves per-url handler claims**, so an installed web-app bundle claiming that url would receive it instead of the browser. The old path pinned the browser with `open -n -a`. Pre-existing for every other link; worth a follow-up if channel-app urls warrant pinning.

## Verification

- `cargo clippy -p mezon-native --all-targets --all-features --locked -- -D warnings` clean; `cargo nextest -p mezon-native` 34 passed; `scripts/fmt.sh check` clean.
- Chrome 152.0.7977.66, 10 profiles, macOS 15.4, installed build `app.mezon.ai` with `com.apple.security.app-sandbox=true`.
- Cold-browser matrix measured by reading Chrome's real command line and window list: unsandboxed `--app=` → app window, no picker; unsandboxed `open <url>` → tab + picker; sandboxed `--app=` → picker only, url lost; sandboxed `open <url>` → tab + picker.
- `APP_SANDBOX_CONTAINER_ID` confirmed set inside a sandboxed process with an ad-hoc signed test bundle. Note for anyone re-checking: `ps eww` shows the *pre-sandbox* exec environment, not what the process sees.

Not covered: Linux and Windows take the unchanged path and were not exercised on a real desktop.
