### PR TITLE
fix(onboarding): make preview a view of the run, not the run itself

### DIFF
--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -4528,6 +4528,11 @@ impl MessagesStore {
         let is_public = self.is_public;
         let mode = self.mode;
         let has_attachments = !attachments.is_empty();
+        if let Some(onboarding) = crate::onboarding::OnboardingStore::try_global(cx) {
+            onboarding.update(cx, |store, cx| {
+                store.note_message_sent(clan_id, channel_id, cx);
+            });
+        }
         let reply = match reply_override {
             Some(draft) => Some(draft),
             None => self.take_reply_target(),

--- a/crates/mezon-store/src/onboarding.rs
+++ b/crates/mezon-store/src/onboarding.rs
@@ -2,11 +2,11 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use gpui::{App, AppContext, Context, Entity, Global, Task};
+use gpui::{App, AppContext, Context, Entity, Global, Subscription, Task};
 use mezon_client::{AppApi, ConnectionStatus};
 
-use crate::clan::OnboardingItem;
-use crate::ids::ClanId;
+use crate::clan::{ClanEvent, ClanList, OnboardingItem};
+use crate::ids::{ChannelId, ClanId};
 
 const CACHE_TTL: Duration = Duration::from_secs(20 * 60);
 const FETCH_RETRY_BACKOFF: Duration = Duration::from_secs(30);
@@ -22,6 +22,12 @@ pub const MISSION_VISIT: i32 = 2;
 pub const MISSION_DO_SOMETHING: i32 = 3;
 
 pub const DONE_ONBOARDING_STATUS: i32 = 3;
+
+#[derive(Debug, Default)]
+struct PreviewRun {
+    done: usize,
+    answers: HashSet<(i64, usize)>,
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct ClanOnboarding {
@@ -64,11 +70,13 @@ pub struct OnboardingStore {
     steps_fetched_at: HashMap<ClanId, Instant>,
     steps_failed_at: HashMap<ClanId, Instant>,
     mission_done: HashMap<ClanId, usize>,
+    step_before_finish: HashMap<ClanId, i32>,
     answers: HashMap<ClanId, HashSet<(i64, usize)>>,
-    preview: Option<ClanId>,
+    preview: Option<(ClanId, PreviewRun)>,
     reset_generation: u64,
     api: Arc<AppApi>,
     _connection_watch: Task<()>,
+    _clan_watch: Option<Subscription>,
 }
 
 struct GlobalOnboardingStore(Entity<OnboardingStore>);
@@ -83,6 +91,17 @@ impl OnboardingStore {
 
     fn new(api: Arc<AppApi>, cx: &mut Context<Self>) -> Self {
         let connection_watch = Self::spawn_connection_watch(api.clone(), cx);
+        let clan_watch = ClanList::try_global(cx).map(|clans| {
+            cx.subscribe(&clans, |this, _, event: &ClanEvent, cx| {
+                if let ClanEvent::ActiveClanChanged(clan_id) = event
+                    && this
+                        .preview_clan()
+                        .is_some_and(|previewing| clan_id.is_none_or(|active| active != previewing))
+                {
+                    this.close_preview(cx);
+                }
+            })
+        });
         Self {
             clans: HashMap::new(),
             loading: HashSet::new(),
@@ -93,11 +112,13 @@ impl OnboardingStore {
             steps_fetched_at: HashMap::new(),
             steps_failed_at: HashMap::new(),
             mission_done: HashMap::new(),
+            step_before_finish: HashMap::new(),
             answers: HashMap::new(),
             preview: None,
             reset_generation: 0,
             api,
             _connection_watch: connection_watch,
+            _clan_watch: clan_watch,
         }
     }
 
@@ -156,6 +177,7 @@ impl OnboardingStore {
         self.steps_fetched_at.clear();
         self.steps_failed_at.clear();
         self.mission_done.clear();
+        self.step_before_finish.clear();
         self.answers.clear();
         self.preview = None;
         self.reset_generation = self.reset_generation.wrapping_add(1);
@@ -178,14 +200,10 @@ impl OnboardingStore {
         self.clans.contains_key(&clan_id)
     }
 
-    pub fn mission_done(&self, clan_id: ClanId) -> usize {
-        if self.is_finished(clan_id) {
-            return self
-                .clans
-                .get(&clan_id)
-                .map_or(0, |onboarding| onboarding.missions.len());
-        }
-        self.mission_done.get(&clan_id).copied().unwrap_or(0)
+    pub fn load_attempted(&self, clan_id: ClanId) -> bool {
+        self.loading.contains(&clan_id)
+            || self.fetched_at.contains_key(&clan_id)
+            || self.failed_at.contains_key(&clan_id)
     }
 
     pub fn is_finished(&self, clan_id: ClanId) -> bool {
@@ -198,11 +216,28 @@ impl OnboardingStore {
             .map_or(0, |onboarding| onboarding.missions.len())
     }
 
-    /// Missions ticked off, ignoring the server's "onboarding finished" flag. This is what the
-    /// progress chrome counts, so an owner in preview mode sees the run start from zero the way
-    /// a new member would.
     pub fn mission_progress(&self, clan_id: ClanId) -> usize {
+        if let Some(run) = self.preview_run(clan_id) {
+            return run.done;
+        }
+        if self.is_finished(clan_id) {
+            return self.mission_total(clan_id);
+        }
         self.mission_done.get(&clan_id).copied().unwrap_or(0)
+    }
+
+    fn preview_run(&self, clan_id: ClanId) -> Option<&PreviewRun> {
+        self.preview
+            .as_ref()
+            .filter(|(previewing, _)| *previewing == clan_id)
+            .map(|(_, run)| run)
+    }
+
+    fn preview_run_mut(&mut self, clan_id: ClanId) -> Option<&mut PreviewRun> {
+        self.preview
+            .as_mut()
+            .filter(|(previewing, _)| *previewing == clan_id)
+            .map(|(_, run)| run)
     }
 
     /// The mission the member is expected to do next, or `None` once every one is ticked.
@@ -216,21 +251,21 @@ impl OnboardingStore {
     /// Whether `ListOnboardingStep` has answered for this clan. The progress chrome stays hidden
     /// until it has, so a member who already finished never sees it flash on the way in.
     pub fn steps_loaded(&self, clan_id: ClanId) -> bool {
-        self.steps.contains_key(&clan_id)
+        self.steps_fetched_at.contains_key(&clan_id)
     }
 
     pub fn preview_clan(&self) -> Option<ClanId> {
-        self.preview
+        self.preview.as_ref().map(|(clan_id, _)| *clan_id)
     }
 
     pub fn is_previewing(&self, clan_id: ClanId) -> bool {
-        self.preview == Some(clan_id)
+        self.preview_clan() == Some(clan_id)
     }
 
     /// Look at the clan the way a brand new member would: the progress chrome shows even for the
     /// owner, who has long since finished onboarding.
     pub fn open_preview(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
-        self.preview = Some(clan_id);
+        self.preview = Some((clan_id, PreviewRun::default()));
         cx.notify();
     }
 
@@ -244,23 +279,29 @@ impl OnboardingStore {
     /// mission banner. `clan_enabled` is the clan's `is_onboarding` flag, which lives on
     /// `ClanList`.
     pub fn show_progress(&self, clan_id: ClanId, clan_enabled: bool) -> bool {
+        if !clan_enabled || self.mission_total(clan_id) == 0 {
+            return false;
+        }
         if self.is_previewing(clan_id) {
             return true;
         }
-        clan_enabled
-            && self.steps_loaded(clan_id)
-            && self.mission_total(clan_id) > 0
-            && !self.is_finished(clan_id)
+        self.steps_loaded(clan_id) && !self.is_finished(clan_id)
     }
 
     pub fn answer_selected(&self, clan_id: ClanId, question_id: i64, index: usize) -> bool {
-        self.answers
-            .get(&clan_id)
+        self.selected_answers(clan_id)
             .is_some_and(|answers| answers.contains(&(question_id, index)))
     }
 
     pub fn answered_count(&self, clan_id: ClanId) -> usize {
-        self.answers.get(&clan_id).map_or(0, HashSet::len)
+        self.selected_answers(clan_id).map_or(0, HashSet::len)
+    }
+
+    fn selected_answers(&self, clan_id: ClanId) -> Option<&HashSet<(i64, usize)>> {
+        match self.preview_run(clan_id) {
+            Some(run) => Some(&run.answers),
+            None => self.answers.get(&clan_id),
+        }
     }
 
     pub fn answered_percent(&self, clan_id: ClanId) -> f32 {
@@ -281,7 +322,10 @@ impl OnboardingStore {
         index: usize,
         cx: &mut Context<Self>,
     ) {
-        let answers = self.answers.entry(clan_id).or_default();
+        let answers = match self.preview_run_mut(clan_id) {
+            Some(run) => &mut run.answers,
+            None => self.answers.entry(clan_id).or_default(),
+        };
         if !answers.insert((question_id, index)) {
             answers.remove(&(question_id, index));
         }
@@ -289,10 +333,27 @@ impl OnboardingStore {
     }
 
     pub fn can_start_mission(&self, clan_id: ClanId, index: usize) -> bool {
-        if self.is_previewing(clan_id) {
-            return self.mission_progress(clan_id) == index;
+        if !self.is_previewing(clan_id) && self.is_finished(clan_id) {
+            return true;
         }
-        self.is_finished(clan_id) || self.mission_done(clan_id) == index
+        self.mission_progress(clan_id) == index
+    }
+
+    pub fn note_message_sent(
+        &mut self,
+        clan_id: ClanId,
+        channel_id: ChannelId,
+        cx: &mut Context<Self>,
+    ) {
+        if self.mission_is_satisfied_by_send(clan_id, channel_id) {
+            self.complete_mission(clan_id, cx);
+        }
+    }
+
+    fn mission_is_satisfied_by_send(&self, clan_id: ClanId, channel_id: ChannelId) -> bool {
+        self.current_mission(clan_id).is_some_and(|mission| {
+            mission.task_type == MISSION_SEND_MESSAGE && mission.channel_id == channel_id.get()
+        })
     }
 
     pub fn complete_mission(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
@@ -316,15 +377,17 @@ impl OnboardingStore {
     }
 
     fn advance_mission(&mut self, clan_id: ClanId) -> bool {
-        // Previewing restarts the run from zero for an owner who long since finished, so the
-        // server's "done" flag must not freeze the missions they are walking through.
-        if self.is_finished(clan_id) && !self.is_previewing(clan_id) {
+        let total = self.mission_total(clan_id);
+        if let Some(run) = self.preview_run_mut(clan_id) {
+            if run.done >= total {
+                return false;
+            }
+            run.done += 1;
+            return true;
+        }
+        if self.is_finished(clan_id) {
             return false;
         }
-        let total = self
-            .clans
-            .get(&clan_id)
-            .map_or(0, |onboarding| onboarding.missions.len());
         let done = self.mission_done.entry(clan_id).or_insert(0);
         if *done >= total {
             return false;
@@ -334,7 +397,9 @@ impl OnboardingStore {
     }
 
     fn finish_onboarding(&mut self, clan_id: ClanId, cx: &mut Context<Self>) {
-        self.steps.insert(clan_id, DONE_ONBOARDING_STATUS);
+        let step_before = self.steps.insert(clan_id, DONE_ONBOARDING_STATUS);
+        self.step_before_finish
+            .insert(clan_id, step_before.unwrap_or(0));
         let api = self.api.clone();
         let reset_generation = self.reset_generation;
         cx.spawn(async move |this, cx| {
@@ -359,7 +424,8 @@ impl OnboardingStore {
     /// too, so the member is left on the mission they were on instead of on a finished count the
     /// server never recorded.
     fn revert_finish(&mut self, clan_id: ClanId) {
-        self.steps.remove(&clan_id);
+        let step_before = self.step_before_finish.remove(&clan_id).unwrap_or(0);
+        self.steps.insert(clan_id, step_before);
         if let Some(done) = self.mission_done.get_mut(&clan_id) {
             *done = done.saturating_sub(1);
         }
@@ -522,6 +588,7 @@ mod tests {
             steps_fetched_at: HashMap::new(),
             steps_failed_at: HashMap::new(),
             mission_done: HashMap::new(),
+            step_before_finish: HashMap::new(),
             answers: HashMap::new(),
             preview: None,
             reset_generation: 0,
@@ -530,6 +597,7 @@ mod tests {
                 String::new(),
             )),
             _connection_watch: Task::ready(()),
+            _clan_watch: None,
         }
     }
 
@@ -565,11 +633,11 @@ mod tests {
         assert!(store.can_start_mission(CLAN, 0));
         assert!(!store.can_start_mission(CLAN, 1));
         assert!(store.advance_mission(CLAN));
-        assert_eq!(store.mission_done(CLAN), 1);
+        assert_eq!(store.mission_progress(CLAN), 1);
         assert!(store.can_start_mission(CLAN, 1));
         assert!(store.advance_mission(CLAN));
         assert!(!store.advance_mission(CLAN));
-        assert_eq!(store.mission_done(CLAN), 2);
+        assert_eq!(store.mission_progress(CLAN), 2);
     }
 
     #[test]
@@ -583,7 +651,7 @@ mod tests {
             ]),
         );
         store.steps.insert(CLAN, DONE_ONBOARDING_STATUS);
-        assert_eq!(store.mission_done(CLAN), 2);
+        assert_eq!(store.mission_progress(CLAN), 2);
         assert!(store.can_start_mission(CLAN, 1));
         assert!(!store.advance_mission(CLAN));
     }
@@ -610,13 +678,32 @@ mod tests {
         );
         // Items are in, but `ListOnboardingStep` has not answered yet.
         assert!(!store.show_progress(CLAN, true));
-        store.steps.insert(CLAN, 0);
+
+        store.steps_fetched_at.insert(CLAN, Instant::now());
         assert!(store.show_progress(CLAN, true));
+
         // A clan that never switched onboarding on shows nothing either way.
         assert!(!store.show_progress(CLAN, false));
         store.steps.insert(CLAN, DONE_ONBOARDING_STATUS);
         assert!(!store.show_progress(CLAN, false));
         assert!(!store.show_progress(CLAN, true));
+    }
+
+    #[test]
+    fn a_clan_with_no_missions_shows_no_progress_even_while_previewing() {
+        let mut store = test_store();
+        store.clans.insert(
+            CLAN,
+            ClanOnboarding::from_items(vec![item(1, GUIDE_TYPE_RULE, 0)]),
+        );
+        store.steps_fetched_at.insert(CLAN, Instant::now());
+        store.preview = Some((CLAN, PreviewRun::default()));
+
+        assert!(
+            !store.show_progress(CLAN, true),
+            "a guide with no missions has no run to show"
+        );
+        assert!(!store.show_progress(CLAN, false));
     }
 
     #[test]
@@ -631,9 +718,9 @@ mod tests {
         );
         store.steps.insert(CLAN, DONE_ONBOARDING_STATUS);
         assert!(!store.show_progress(CLAN, true));
-        assert_eq!(store.mission_done(CLAN), 2);
+        assert_eq!(store.mission_progress(CLAN), 2);
 
-        store.preview = Some(CLAN);
+        store.preview = Some((CLAN, PreviewRun::default()));
         assert!(store.show_progress(CLAN, true));
         // The finished flag ticks every mission on the guide, but the owner previewing the clan
         // still starts the run from the first one.
@@ -653,7 +740,7 @@ mod tests {
             ]),
         );
         store.steps.insert(CLAN, DONE_ONBOARDING_STATUS);
-        store.preview = Some(CLAN);
+        store.preview = Some((CLAN, PreviewRun::default()));
 
         assert!(store.can_start_mission(CLAN, 0));
         assert!(
@@ -678,7 +765,7 @@ mod tests {
         store.mission_done.insert(CLAN, 1);
         assert!(store.should_persist_completion(CLAN));
 
-        store.preview = Some(CLAN);
+        store.preview = Some((CLAN, PreviewRun::default()));
         assert!(!store.should_persist_completion(CLAN));
     }
 
@@ -716,6 +803,147 @@ mod tests {
         assert_eq!(store.current_mission(CLAN).map(|item| item.id), Some(1));
         store.mission_done.insert(CLAN, 1);
         assert!(store.current_mission(CLAN).is_none());
+    }
+
+    #[test]
+    fn previewing_leaves_the_members_own_run_untouched() {
+        let mut store = test_store();
+        store.clans.insert(
+            CLAN,
+            ClanOnboarding::from_items(vec![
+                item(1, GUIDE_TYPE_TASK, 0),
+                item(2, GUIDE_TYPE_TASK, 0),
+            ]),
+        );
+        store.steps.insert(CLAN, 0);
+        store.mission_done.insert(CLAN, 1);
+
+        store.preview = Some((CLAN, PreviewRun::default()));
+        assert_eq!(
+            store.mission_progress(CLAN),
+            0,
+            "preview starts its own run"
+        );
+        assert!(store.advance_mission(CLAN));
+        assert!(store.advance_mission(CLAN));
+        assert_eq!(store.mission_progress(CLAN), 2);
+        assert!(!store.should_persist_completion(CLAN));
+
+        store.preview = None;
+        assert_eq!(
+            store.mission_progress(CLAN),
+            1,
+            "the member is still on the mission they were really on"
+        );
+        assert!(
+            store.advance_mission(CLAN),
+            "their own run must still be completable"
+        );
+        assert!(store.should_persist_completion(CLAN));
+    }
+
+    #[test]
+    fn every_preview_starts_over() {
+        let mut store = test_store();
+        store.clans.insert(
+            CLAN,
+            ClanOnboarding::from_items(vec![
+                item(1, GUIDE_TYPE_TASK, 0),
+                item(2, GUIDE_TYPE_TASK, 0),
+            ]),
+        );
+        store.preview = Some((CLAN, PreviewRun::default()));
+        assert!(store.advance_mission(CLAN));
+        assert_eq!(store.mission_progress(CLAN), 1);
+
+        store.preview = Some((CLAN, PreviewRun::default()));
+        assert_eq!(store.mission_progress(CLAN), 0);
+        assert_eq!(store.current_mission(CLAN).map(|item| item.id), Some(1));
+    }
+
+    #[test]
+    fn preview_answers_do_not_leak_into_the_real_ones() {
+        let mut store = test_store();
+        store.clans.insert(
+            CLAN,
+            ClanOnboarding::from_items(vec![item(1, GUIDE_TYPE_QUESTION, 4)]),
+        );
+        store.answers.entry(CLAN).or_default().insert((1, 0));
+
+        store.preview = Some((CLAN, PreviewRun::default()));
+        assert!(
+            !store.answer_selected(CLAN, 1, 0),
+            "preview starts unanswered"
+        );
+        store
+            .preview_run_mut(CLAN)
+            .expect("previewing")
+            .answers
+            .insert((1, 3));
+        assert_eq!(store.answered_count(CLAN), 1);
+
+        store.preview = None;
+        assert!(store.answer_selected(CLAN, 1, 0));
+        assert!(!store.answer_selected(CLAN, 1, 3));
+        assert_eq!(store.answered_count(CLAN), 1);
+    }
+
+    #[test]
+    fn a_refused_step_keeps_the_chrome_on_screen() {
+        let mut store = test_store();
+        store.clans.insert(
+            CLAN,
+            ClanOnboarding::from_items(vec![
+                item(1, GUIDE_TYPE_TASK, 0),
+                item(2, GUIDE_TYPE_TASK, 0),
+            ]),
+        );
+        store.steps_fetched_at.insert(CLAN, Instant::now());
+        store.steps.insert(CLAN, 0);
+        store.mission_done.insert(CLAN, 2);
+
+        store.step_before_finish.insert(CLAN, 0);
+        store.steps.insert(CLAN, DONE_ONBOARDING_STATUS);
+        store.revert_finish(CLAN);
+
+        assert!(!store.is_finished(CLAN));
+        assert!(
+            store.show_progress(CLAN, true),
+            "a refused step must not take the card and the banner with it"
+        );
+        assert_eq!(store.mission_progress(CLAN), 1);
+        assert_eq!(store.current_mission(CLAN).map(|item| item.id), Some(2));
+    }
+
+    #[test]
+    fn a_send_message_mission_is_ticked_by_the_send_that_satisfies_it() {
+        let mut store = test_store();
+        let mut mission = item(1, GUIDE_TYPE_TASK, 0);
+        mission.task_type = MISSION_SEND_MESSAGE;
+        mission.channel_id = 42;
+        let mut second = item(2, GUIDE_TYPE_TASK, 0);
+        second.task_type = MISSION_VISIT;
+        store
+            .clans
+            .insert(CLAN, ClanOnboarding::from_items(vec![mission, second]));
+
+        assert_eq!(store.current_mission(CLAN).map(|item| item.id), Some(1));
+        assert!(
+            !store.mission_is_satisfied_by_send(CLAN, ChannelId(7)),
+            "a send elsewhere is not this mission"
+        );
+        assert!(store.mission_is_satisfied_by_send(CLAN, ChannelId(42)));
+    }
+
+    #[test]
+    fn a_load_that_was_attempted_stops_the_sidebar_asking_again() {
+        let mut store = test_store();
+        assert!(!store.load_attempted(CLAN));
+        store.failed_at.insert(CLAN, Instant::now());
+        assert!(store.load_attempted(CLAN));
+        store.failed_at.remove(&CLAN);
+        store.fetched_at.insert(CLAN, Instant::now());
+        assert!(store.load_attempted(CLAN));
     }
 
     #[test]

--- a/crates/mezon-ui/src/app/root.rs
+++ b/crates/mezon-ui/src/app/root.rs
@@ -438,6 +438,7 @@ impl Render for RootView {
         let base_font_family = ::theme::theme_settings(cx).ui_font(cx).family.clone();
         let theme = cx.theme();
 
+        let mut preview_bar = None;
         let content: gpui::AnyElement = match self.auth_state.read(cx) {
             AuthState::NotAuthenticated | AuthState::OtpRequested { .. } => {
                 cached_fill(self.login_view.clone())
@@ -460,6 +461,17 @@ impl Render for RootView {
             }
             AuthState::Authenticated(_) => {
                 let route = Router::global(cx).read(cx).route();
+                if matches!(
+                    route,
+                    Route::Chat | Route::Channel { .. } | Route::ClanGuide { .. }
+                ) {
+                    preview_bar = OnboardingStore::try_global(cx)
+                        .and_then(|store| store.read(cx).preview_clan())
+                        .filter(|clan_id| {
+                            ClanList::global(cx).read(cx).active_clan_id == Some(*clan_id)
+                        })
+                        .map(|clan_id| render_onboarding_preview_bar(clan_id, theme, locale));
+                }
                 match route {
                     Route::SettingsAccount
                     | Route::SettingsProfile
@@ -482,13 +494,6 @@ impl Render for RootView {
                 }
             }
         };
-
-        // React gates the strip on `previewMode.clanId === currentClanId`, so switching clans
-        // parks the preview rather than following the owner around.
-        let preview_bar = OnboardingStore::try_global(cx)
-            .and_then(|store| store.read(cx).preview_clan())
-            .filter(|clan_id| ClanList::global(cx).read(cx).active_clan_id == Some(*clan_id))
-            .map(|clan_id| render_onboarding_preview_bar(clan_id, theme, locale));
 
         div()
             .relative()
@@ -528,31 +533,29 @@ impl Render for RootView {
 /// The strip React drops across the top while an owner is previewing their clan the way a new
 /// member sees it. Closing it hands them back to the onboarding settings they opened it from.
 fn render_onboarding_preview_bar(clan_id: ClanId, theme: &Theme, locale: &str) -> gpui::AnyElement {
-    // The bar spans the whole window, so on macOS the close button has to start clear of the
-    // native traffic lights it would otherwise sit on top of.
-    let close_left = if cfg!(target_os = "macos") {
-        px(88.)
+    let leading_inset = if cfg!(target_os = "macos") {
+        px(80.)
     } else {
-        px(24.)
+        px(16.)
     };
     div()
-        .relative()
+        .occlude()
         .flex()
         .flex_row()
         .flex_none()
         .items_center()
-        .justify_center()
+        .gap_4()
         .w_full()
         .h(px(48.))
-        .px_4()
+        .pl(leading_inset)
+        .pr_4()
         .bg(theme.bg_secondary)
         .border_b_1()
         .border_color(theme.border)
         .child(
             div()
                 .id("onboarding-close-preview")
-                .absolute()
-                .left(close_left)
+                .flex_none()
                 .flex()
                 .flex_row()
                 .items_center()
@@ -589,6 +592,10 @@ fn render_onboarding_preview_bar(clan_id: ClanId, theme: &Theme, locale: &str) -
         )
         .child(
             div()
+                .flex_1()
+                .min_w_0()
+                .truncate()
+                .text_center()
                 .font_weight(FontWeight::SEMIBOLD)
                 .text_color(theme.text_primary)
                 .child(mezon_i18n::t(locale, "common.previewModeDescription")),

--- a/crates/mezon-ui/src/app/root.rs
+++ b/crates/mezon-ui/src/app/root.rs
@@ -148,6 +148,7 @@ impl RootView {
             this.sync_clan_settings_page(cx);
             this.sync_channel_settings_tab(cx);
             this.schedule_tour_autostart(cx);
+            end_preview_off_its_own_screens(cx);
             cx.notify();
         })
         .detach();
@@ -461,10 +462,7 @@ impl Render for RootView {
             }
             AuthState::Authenticated(_) => {
                 let route = Router::global(cx).read(cx).route();
-                if matches!(
-                    route,
-                    Route::Chat | Route::Channel { .. } | Route::ClanGuide { .. }
-                ) {
+                if previewable_route(&route) {
                     preview_bar = OnboardingStore::try_global(cx)
                         .and_then(|store| store.read(cx).preview_clan())
                         .filter(|clan_id| {
@@ -532,6 +530,26 @@ impl Render for RootView {
 
 /// The strip React drops across the top while an owner is previewing their clan the way a new
 /// member sees it. Closing it hands them back to the onboarding settings they opened it from.
+fn previewable_route(route: &Route) -> bool {
+    matches!(
+        route,
+        Route::Chat | Route::Channel { .. } | Route::ClanGuide { .. }
+    )
+}
+
+fn end_preview_off_its_own_screens(cx: &mut App) {
+    let Some(store) = OnboardingStore::try_global(cx) else {
+        return;
+    };
+    if store.read(cx).preview_clan().is_none() {
+        return;
+    }
+    let route = Router::global(cx).read(cx).route();
+    if !previewable_route(&route) {
+        store.update(cx, |store, cx| store.close_preview(cx));
+    }
+}
+
 fn render_onboarding_preview_bar(clan_id: ClanId, theme: &Theme, locale: &str) -> gpui::AnyElement {
     let leading_inset = if cfg!(target_os = "macos") {
         px(80.)

--- a/crates/mezon-ui/src/chat/clan_guide_page.rs
+++ b/crates/mezon-ui/src/chat/clan_guide_page.rs
@@ -467,7 +467,7 @@ impl ClanGuidePage {
                 .into_any_element();
         }
         let clan_id = self.clan_id;
-        let done = store.mission_done(clan_id);
+        let done = store.mission_progress(clan_id);
         let channels = ChannelList::global(cx);
         let channels = channels.read(cx);
         for (index, mission) in missions.iter().enumerate() {

--- a/crates/mezon-ui/src/clan/settings/onboarding_setting_page.rs
+++ b/crates/mezon-ui/src/clan/settings/onboarding_setting_page.rs
@@ -855,6 +855,7 @@ impl OnboardingSettingPage {
         let setup = cx.entity().downgrade();
         let guide = cx.entity().downgrade();
         let preview_clan = self.clan_id;
+        let preview_blocked = self.dirty;
         v_flex()
             .gap_5()
             .child(
@@ -877,21 +878,27 @@ impl OnboardingSettingPage {
                             .child(
                                 div()
                                     .id("onboarding-open-preview")
-                                    .cursor_pointer()
-                                    .text_color(rgb(0x5865f2))
-                                    .hover(|style| style.text_color(rgb(0x818cf8)))
-                                    .child(mezon_i18n::t(locale, "onBoardingClan.buttons.preview"))
-                                    .on_click(move |_, _, cx| {
-                                        OnboardingStore::global(cx).update(cx, |store, cx| {
-                                            store.open_preview(preview_clan, cx)
-                                        });
-                                        crate::router::navigate(
-                                            cx,
-                                            crate::router::Route::ClanGuide {
-                                                clan_id: preview_clan,
-                                            },
-                                        );
-                                    }),
+                                    .when(!preview_blocked, |link| {
+                                        link.cursor_pointer()
+                                            .text_color(rgb(0x5865f2))
+                                            .hover(|style| style.text_color(rgb(0x818cf8)))
+                                            .on_click(move |_, _, cx| {
+                                                OnboardingStore::global(cx).update(
+                                                    cx,
+                                                    |store, cx| {
+                                                        store.open_preview(preview_clan, cx)
+                                                    },
+                                                );
+                                                crate::router::navigate(
+                                                    cx,
+                                                    crate::router::Route::ClanGuide {
+                                                        clan_id: preview_clan,
+                                                    },
+                                                );
+                                            })
+                                    })
+                                    .when(preview_blocked, |link| link.text_color(theme.text_muted))
+                                    .child(mezon_i18n::t(locale, "onBoardingClan.buttons.preview")),
                             ),
                     ),
             )

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
@@ -390,25 +390,22 @@ impl ChannelSidebar {
         let locale = self.settings.read(cx).language.clone();
         self.last_locale = locale.clone();
         self.last_clan_inputs = clan_inputs_fingerprint(self.clan_list.read(cx));
-        if let Some(clan_id) = self.clan_list.read(cx).active_clan_id {
+        let active_clan = {
+            let clans = self.clan_list.read(cx);
+            clans
+                .active_clan()
+                .map(|clan| (clan.id, clan.is_onboarding))
+        };
+        if let Some((clan_id, _)) = active_clan {
             EventsStore::global(cx).update(cx, |store, cx| store.ensure_loaded(clan_id, cx));
-            // `ClanLoadScheduler` already fetches this when the clan is entered; this covers the
-            // other way in — an owner who just switched onboarding on and expects the progress
-            // card without leaving and re-entering the clan. `rebuild_items` is hot (every
-            // `ChannelList` notify lands here), so the two hash lookups gate the clan-list scan:
-            // once both halves are in, this costs nothing.
+        }
+        if let Some((clan_id, true)) = active_clan {
             let onboarding = OnboardingStore::global(cx);
             let unloaded = {
                 let store = onboarding.read(cx);
                 !store.load_attempted(clan_id) || !store.steps_loaded(clan_id)
             };
-            if unloaded
-                && self
-                    .clan_list
-                    .read(cx)
-                    .clan(clan_id)
-                    .is_some_and(|clan| clan.is_onboarding)
-            {
+            if unloaded {
                 onboarding.update(cx, |store, cx| store.ensure_loaded(clan_id, cx));
             }
         }

--- a/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
+++ b/crates/mezon-ui/src/sidebar/channel_sidebar/mod.rs
@@ -400,7 +400,7 @@ impl ChannelSidebar {
             let onboarding = OnboardingStore::global(cx);
             let unloaded = {
                 let store = onboarding.read(cx);
-                !store.has_onboarding(clan_id) || !store.steps_loaded(clan_id)
+                !store.load_attempted(clan_id) || !store.steps_loaded(clan_id)
             };
             if unloaded
                 && self
@@ -1620,6 +1620,7 @@ fn clan_inputs_fingerprint(clans: &ClanList) -> (Option<ClanId>, u64) {
     let mut hash = FNV_OFFSET;
     if let Some(clan) = clans.active_clan() {
         hash = fold(hash, clan.name.as_bytes());
+        hash = fold(hash, &[u8::from(clan.is_onboarding)]);
     }
     if let Some(banner) = clans.active_clan_banner() {
         hash = fold(hash, banner.as_bytes());


### PR DESCRIPTION
The review of #453 found preview had been built as a mode flag inside the domain store: it reinterpreted four methods while sharing the member's real counters, had no teardown, snapshotted nothing on entry, and its only exit was a button macOS could not click. Those compound — an owner could enter a mode they could not leave, in which their own onboarding could never be reported to the server.

Preview now carries its own run. `PreviewRun` holds the walk's progress and its answers, so previewing neither reads nor moves `mission_done`, every preview starts at the first mission, and answers ticked while looking around do not become the owner's real ones. Entering is the only thing that starts one; leaving the clan by any route ends it, via `ClanEvent`.

The exit control is reachable again: the strip now occludes the invisible window-drag band that was eating its clicks, and the button sits in flow beside the description instead of under text that painted over it. The strip is drawn only over the previewed clan's own screens, not over settings, an invite, or the reconnect splash.

Three more from the same review:

- Clicking Preview with unsaved edits navigated away, dropping the settings page and every edit on it, then showed the server's un-edited copy. The link now waits for a save.
- `steps_loaded` asked the data map rather than whether the fetch answered, so an empty `ListOnboardingStep` — what the server sends a member who has not started — hid the whole chrome for the cache TTL. Same shape in `revert_finish`, which dropped the entry the gate reads.
- A send-message mission had no completion path at all, pinning the composer banner in every channel forever. The send path reports it.

Plus: the guide page reads the same progress the card and banner do; the sidebar's fingerprint tracks `is_onboarding`, so switching it on shows the card instead of waiting for an unrelated notify; and its hot-path gate asks whether a load was attempted rather than whether data arrived, so it converges instead of scanning the clan list on every rebuild.