### PR TITLE
fix: remove edit channel if not in channel or have permistion, keep d…

### DIFF
--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -599,6 +599,8 @@ pub struct ChannelList {
     deleted_channel_parents: HashMap<ChannelId, ChannelId>,
     channel_detail_pending: HashSet<ChannelId>,
     channel_detail_failed: HashSet<ChannelId>,
+    channel_details_for_settings: HashSet<ChannelId>,
+    detached_channel_details: HashMap<(ClanId, ChannelId), Channel>,
     _previous_channels_persist: Task<()>,
     _clan_sub: Subscription,
     _conn_watch: Task<()>,
@@ -773,6 +775,8 @@ impl ChannelList {
         self.deleted_channel_parents.clear();
         self.channel_detail_pending.clear();
         self.channel_detail_failed.clear();
+        self.channel_details_for_settings.clear();
+        self.detached_channel_details.clear();
         self.active_clan_id = None;
         if self.active_channel_id.take().is_some() {
             cx.emit(ChannelEvent::ActiveChannelChanged(None));
@@ -873,6 +877,8 @@ impl ChannelList {
             deleted_channel_parents: HashMap::new(),
             channel_detail_pending: HashSet::new(),
             channel_detail_failed: HashSet::new(),
+            channel_details_for_settings: HashSet::new(),
+            detached_channel_details: HashMap::new(),
             _previous_channels_persist: Task::ready(()),
             _clan_sub: clan_sub,
             _conn_watch: conn_watch,
@@ -933,6 +939,8 @@ impl ChannelList {
         self.loading.remove(&clan_id);
         self.pending_clan_refresh.remove(&clan_id);
         self.show_empty_categories.remove(&clan_id);
+        self.detached_channel_details
+            .retain(|(detail_clan_id, _), _| *detail_clan_id != clan_id);
         self.remembered_channels.remove(&clan_id);
         if self.previous_channels.remove(&clan_id).is_some() {
             self.persist_previous_channels(cx);
@@ -1767,6 +1775,7 @@ impl ChannelList {
                 match desc {
                     Some(desc) => this.apply_channel_detail(clan_id, desc, cx),
                     None => {
+                        this.channel_details_for_settings.remove(&channel_id);
                         this.channel_detail_failed.insert(channel_id);
                         cx.notify();
                     }
@@ -1777,6 +1786,24 @@ impl ChannelList {
         true
     }
 
+    /// Loads a complete channel description for the settings UI without forcing a hidden
+    /// thread into the sidebar's clan structure.
+    pub fn ensure_channel_for_settings(
+        &mut self,
+        clan_id: ClanId,
+        channel_id: ChannelId,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.channel(clan_id, channel_id).is_some() {
+            return true;
+        }
+        if self.is_locally_archived(channel_id) || self.is_locally_deleted(channel_id) {
+            return false;
+        }
+        self.channel_details_for_settings.insert(channel_id);
+        self.ensure_channel_in_clan(clan_id, channel_id, cx)
+    }
+
     fn apply_channel_detail(
         &mut self,
         clan_id: ClanId,
@@ -1785,15 +1812,23 @@ impl ChannelList {
     ) {
         let channel_id = ChannelId(desc.channel_id);
         if self.is_locally_archived(channel_id) || self.is_locally_deleted(channel_id) {
+            self.channel_details_for_settings.remove(&channel_id);
             return;
         }
         let badge = desc.badge_count.max(0) as u32;
         let mut channel = channel_from_desc(desc, badge, Vec::new(), false);
+        channel.clan_id = clan_id;
         if !channel.visible_in_sidebar() {
+            if self.channel_details_for_settings.remove(&channel_id) {
+                self.detached_channel_details
+                    .insert((clan_id, channel_id), channel);
+                cx.notify();
+                return;
+            }
             self.channel_detail_failed.insert(channel_id);
             return;
         }
-        channel.clan_id = clan_id;
+        self.channel_details_for_settings.remove(&channel_id);
         let Some(categories) = self.cache.get_mut(&clan_id) else {
             return;
         };
@@ -3052,17 +3087,30 @@ impl ChannelList {
                 .map_err(|e| UpdateChannelOverviewError::Other(e.to_string()))?;
 
             this.update(cx, |this, cx| {
-                if let Some(categories) = this.cache.get_mut(&clan_id)
+                let changed_in_structure = if let Some(categories) = this.cache.get_mut(&clan_id)
                     && update_channel(
                         categories,
                         channel_id,
-                        Some(validated),
-                        Some(topic),
+                        Some(validated.clone()),
+                        Some(topic.clone()),
                         Some(age_restricted),
                         channel.private,
-                    )
-                {
+                    ) {
                     this.invalidate_channel_index(clan_id);
+                    true
+                } else {
+                    false
+                };
+                let changed_detached = this
+                    .detached_channel_details
+                    .get_mut(&(clan_id, channel_id))
+                    .is_some_and(|detail| {
+                        detail.name = validated;
+                        detail.topic = topic;
+                        detail.age_restricted = age_restricted;
+                        true
+                    });
+                if changed_in_structure || changed_detached {
                     cx.notify();
                 }
             })
@@ -3820,8 +3868,10 @@ impl ChannelList {
     }
 
     pub fn channel(&self, clan_id: ClanId, channel_id: ChannelId) -> Option<&Channel> {
-        let (cat_idx, ch_idx) = self.channel_location(clan_id, channel_id)?;
-        self.cache.get(&clan_id)?.get(cat_idx)?.channels.get(ch_idx)
+        if let Some((cat_idx, ch_idx)) = self.channel_location(clan_id, channel_id) {
+            return self.cache.get(&clan_id)?.get(cat_idx)?.channels.get(ch_idx);
+        }
+        self.detached_channel_details.get(&(clan_id, channel_id))
     }
 
     pub fn find_channel_in_active_clan(&self, channel_id: ChannelId) -> Option<&Channel> {
@@ -4440,12 +4490,16 @@ impl ChannelList {
     }
 
     fn channel_mut(&mut self, clan_id: ClanId, channel_id: ChannelId) -> Option<&mut Channel> {
-        let (cat_idx, ch_idx) = self.channel_location(clan_id, channel_id)?;
-        self.cache
-            .get_mut(&clan_id)?
-            .get_mut(cat_idx)?
-            .channels
-            .get_mut(ch_idx)
+        if let Some((cat_idx, ch_idx)) = self.channel_location(clan_id, channel_id) {
+            return self
+                .cache
+                .get_mut(&clan_id)?
+                .get_mut(cat_idx)?
+                .channels
+                .get_mut(ch_idx);
+        }
+        self.detached_channel_details
+            .get_mut(&(clan_id, channel_id))
     }
 
     pub fn clan_id_for_channel(&self, channel_id: ChannelId) -> Option<ClanId> {
@@ -10673,6 +10727,56 @@ mod tests {
                 );
                 assert!(!channels.channel_in_clan(ClanId(1), ChannelId(9)));
                 assert!(channels.channel_detail_failed.contains(&ChannelId(9)));
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn settings_can_load_hidden_thread_without_adding_it_to_sidebar(cx: &mut gpui::TestAppContext) {
+        use mezon_client::transport::ApiChannelDesc;
+
+        cx.update(|cx| {
+            let channels = init_channel_list_with_threads(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(ClanId(1), structure_with_two_channels(), None, cx);
+                channels.channel_details_for_settings.insert(ChannelId(9));
+                channels.apply_channel_detail(
+                    ClanId(1),
+                    ApiChannelDesc {
+                        channel_id: 9,
+                        channel_label: "hidden thread".into(),
+                        channel_type: CHANNEL_TYPE_THREAD,
+                        clan_id: 1,
+                        category_name: String::new(),
+                        category_id: 0,
+                        channel_private: 0,
+                        count_mess_unread: 0,
+                        member_count: 0,
+                        parent_id: 1,
+                        is_mute: false,
+                        last_seen_message_id: 0,
+                        last_seen_timestamp: 0,
+                        last_sent_message_id: 0,
+                        last_sent_timestamp: 0,
+                        badge_count: 0,
+                        active: CHANNEL_ACTIVE_ARCHIVED,
+                        creator_id: 0,
+                        clan_name: String::new(),
+                        channel_avatar: String::new(),
+                        topic: "thread topic".into(),
+                        age_restricted: 0,
+                        e2ee: 0,
+                        app_id: 0,
+                    },
+                    cx,
+                );
+
+                assert!(!channels.channel_in_clan(ClanId(1), ChannelId(9)));
+                let thread = channels
+                    .channel(ClanId(1), ChannelId(9))
+                    .expect("settings detail");
+                assert_eq!(thread.name, "hidden thread");
+                assert_eq!(thread.topic, "thread topic");
             });
         });
     }

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -249,6 +249,15 @@ pub fn manage_allowed_by_server(
     is_creator || has_owner || has_administrator || has_manage_clan || has_manage_channel
 }
 
+pub fn channel_access_allowed(
+    private: bool,
+    is_creator: bool,
+    current_user_id: Option<UserId>,
+    user_ids: &[UserId],
+) -> bool {
+    !private || is_creator || current_user_id.is_some_and(|user_id| user_ids.contains(&user_id))
+}
+
 pub fn can_archive_channel(clan_id: ClanId, channel_id: ChannelId, cx: &App) -> bool {
     ChannelList::global(cx)
         .read(cx)
@@ -294,9 +303,16 @@ fn archive_permission_for(
     let creator_id = channel
         .map(|channel| channel.creator_id)
         .unwrap_or_else(|| fallback.as_ref().unwrap().creator_id);
-    let is_creator = BadgeService::try_global(cx)
-        .and_then(|badges| badges.read(cx).current_user_id(cx))
-        .is_some_and(|me| me == creator_id);
+    let current_user_id =
+        BadgeService::try_global(cx).and_then(|badges| badges.read(cx).current_user_id(cx));
+    let is_creator = current_user_id == Some(creator_id);
+    let can_access = fallback
+        .as_ref()
+        .map(|row| channel_access_allowed(row.private, is_creator, current_user_id, &row.user_ids))
+        .unwrap_or(channel.is_some());
+    if !can_access {
+        return false;
+    }
     let Some(permissions) = PermissionStore::try_global(cx) else {
         return is_creator;
     };
@@ -320,23 +336,25 @@ fn delete_permission_for(
     if ClanList::global(cx).read(cx).welcome_channel_id(clan_id) == Some(channel_id) {
         return false;
     }
-    let creator_id = channel_list
-        .channel(clan_id, channel_id)
+    let channel = channel_list.channel(clan_id, channel_id);
+    let fallback = ChannelSettingsStore::try_global(cx)
+        .and_then(|store| store.read(cx).row_by_id(clan_id, channel_id).cloned());
+    let creator_id = channel
         .map(|channel| channel.creator_id)
-        .or_else(|| {
-            ChannelSettingsStore::try_global(cx).and_then(|store| {
-                store
-                    .read(cx)
-                    .row_by_id(clan_id, channel_id)
-                    .map(|row| row.creator_id)
-            })
-        });
+        .or_else(|| fallback.as_ref().map(|row| row.creator_id));
     let Some(creator_id) = creator_id else {
         return false;
     };
-    let is_creator = BadgeService::try_global(cx)
-        .and_then(|badges| badges.read(cx).current_user_id(cx))
-        .is_some_and(|me| me == creator_id);
+    let current_user_id =
+        BadgeService::try_global(cx).and_then(|badges| badges.read(cx).current_user_id(cx));
+    let is_creator = current_user_id == Some(creator_id);
+    let can_access = fallback
+        .as_ref()
+        .map(|row| channel_access_allowed(row.private, is_creator, current_user_id, &row.user_ids))
+        .unwrap_or(channel.is_some());
+    if !can_access {
+        return false;
+    }
     let Some(permissions) = PermissionStore::try_global(cx) else {
         return is_creator;
     };
@@ -356,22 +374,22 @@ fn manage_permission_for(
     channel_id: ChannelId,
     cx: &App,
 ) -> bool {
-    let creator_id = channel_list
-        .channel(clan_id, channel_id)
+    let channel = channel_list.channel(clan_id, channel_id);
+    let fallback = ChannelSettingsStore::try_global(cx)
+        .and_then(|store| store.read(cx).row_by_id(clan_id, channel_id).cloned());
+    let creator_id = channel
         .map(|channel| channel.creator_id)
-        .or_else(|| {
-            ChannelSettingsStore::try_global(cx).and_then(|store| {
-                store
-                    .read(cx)
-                    .row_by_id(clan_id, channel_id)
-                    .map(|row| row.creator_id)
-            })
-        });
-    let is_creator = creator_id.is_some_and(|creator_id| {
-        BadgeService::try_global(cx)
-            .and_then(|badges| badges.read(cx).current_user_id(cx))
-            .is_some_and(|me| me == creator_id)
-    });
+        .or_else(|| fallback.as_ref().map(|row| row.creator_id));
+    let current_user_id =
+        BadgeService::try_global(cx).and_then(|badges| badges.read(cx).current_user_id(cx));
+    let is_creator = creator_id.is_some_and(|creator_id| current_user_id == Some(creator_id));
+    let can_access = fallback
+        .as_ref()
+        .map(|row| channel_access_allowed(row.private, is_creator, current_user_id, &row.user_ids))
+        .unwrap_or(channel.is_some());
+    if !can_access {
+        return false;
+    }
     let Some(permissions) = PermissionStore::try_global(cx) else {
         return is_creator;
     };
@@ -10316,6 +10334,25 @@ mod tests {
         assert!(manage_allowed_by_server(false, false, false, true, false));
         assert!(manage_allowed_by_server(false, true, false, false, false));
         assert!(!manage_allowed_by_server(false, false, false, false, false));
+    }
+
+    #[test]
+    fn private_channel_access_accepts_creator_or_member_only() {
+        let members = [UserId(2)];
+        assert!(channel_access_allowed(true, true, Some(UserId(1)), &[]));
+        assert!(channel_access_allowed(
+            true,
+            false,
+            Some(UserId(2)),
+            &members
+        ));
+        assert!(!channel_access_allowed(
+            true,
+            false,
+            Some(UserId(1)),
+            &members
+        ));
+        assert!(channel_access_allowed(false, false, None, &[]));
     }
 
     #[test]

--- a/crates/mezon-store/src/channel_settings.rs
+++ b/crates/mezon-store/src/channel_settings.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use gpui::{App, AppContext, Context, Entity, EventEmitter, Global};
 use mezon_client::{AppApi, RealtimeEvent};
-use mezon_proto::api;
+use mezon_proto::{api, realtime};
 
 use crate::message::MessageCode;
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
-use crate::{ChannelId, ClanId, UserId};
+use crate::{BadgeService, ChannelId, ClanId, ClanMembersStore, UserId};
 
 const API_PAGE_SIZE: i32 = 100;
 
@@ -258,8 +258,49 @@ impl ChannelSettingsStore {
                     this.handle_realtime_event(event, cx)
                 });
             }
+            dispatch.on(RealtimeKind::RoleEvent, &entity, |this, event, cx| {
+                this.handle_role_event(event, cx)
+            });
             dispatch.on_lagged(&entity, |this, cx| this.reload_loaded(cx));
         });
+    }
+
+    fn handle_role_event(&mut self, event: &RealtimeEvent, cx: &mut Context<Self>) {
+        let RealtimeEvent::Unhandled(realtime::envelope::Message::RoleEvent(role_event)) = event
+        else {
+            return;
+        };
+        let Some(role) = role_event.role.as_ref() else {
+            return;
+        };
+        let clan_id = ClanId(role.clan_id);
+        let Some(current_user_id) =
+            BadgeService::try_global(cx).and_then(|badges| badges.read(cx).current_user_id(cx))
+        else {
+            return;
+        };
+        let holds_role = ClanMembersStore::try_global(cx)
+            .and_then(|members| {
+                members
+                    .read(cx)
+                    .self_role_ids(clan_id)
+                    .map(|role_ids| role_ids.contains(&role.id))
+            })
+            .unwrap_or(false);
+        if !role_event_affects_user(role_event, current_user_id, holds_role) {
+            return;
+        }
+
+        let keys = self
+            .rows
+            .keys()
+            .copied()
+            .chain(self.loading.iter().copied())
+            .filter(|(row_clan_id, _)| *row_clan_id == clan_id)
+            .collect::<HashSet<_>>();
+        for key in keys {
+            self.reload(key, cx);
+        }
     }
 
     fn handle_message(&mut self, event: &RealtimeEvent, cx: &mut Context<Self>) {
@@ -645,6 +686,21 @@ fn clear_pending_restore(
     pending_by_key.retain(|_, pending| !pending.is_empty());
 }
 
+fn role_event_affects_user(
+    role_event: &realtime::RoleEvent,
+    current_user_id: UserId,
+    holds_role: bool,
+) -> bool {
+    if role_event.user_add_ids.contains(&current_user_id.get())
+        || role_event.user_remove_ids.contains(&current_user_id.get())
+    {
+        return true;
+    }
+    holds_role
+        && (!role_event.active_permission_ids.is_empty()
+            || !role_event.remove_permission_ids.is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -766,5 +822,33 @@ mod tests {
         assert!(!pending[&clan_one_key].contains_key(&ChannelId(4)));
         assert!(pending[&clan_one_key].contains_key(&ChannelId(6)));
         assert!(pending[&clan_two_key].contains_key(&ChannelId(4)));
+    }
+
+    #[test]
+    fn role_events_refresh_settings_only_when_they_affect_current_user() {
+        let current_user_id = UserId(7);
+        let added = realtime::RoleEvent {
+            user_add_ids: vec![current_user_id.get()],
+            ..Default::default()
+        };
+        let removed = realtime::RoleEvent {
+            user_remove_ids: vec![current_user_id.get()],
+            ..Default::default()
+        };
+        let permission_changed = realtime::RoleEvent {
+            active_permission_ids: vec![10],
+            ..Default::default()
+        };
+        let unrelated = realtime::RoleEvent::default();
+
+        assert!(role_event_affects_user(&added, current_user_id, false));
+        assert!(role_event_affects_user(&removed, current_user_id, false));
+        assert!(role_event_affects_user(
+            &permission_changed,
+            current_user_id,
+            true
+        ));
+        assert!(!role_event_affects_user(&unrelated, current_user_id, true));
+        assert!(!role_event_affects_user(&unrelated, current_user_id, false));
     }
 }

--- a/crates/mezon-ui/src/chat/clan_channels_page.rs
+++ b/crates/mezon-ui/src/chat/clan_channels_page.rs
@@ -128,6 +128,10 @@ impl ClanChannelsPage {
         if self.clan_id == clan_id {
             return;
         }
+        if !self.clan_id.is_zero() {
+            ChannelSettingsStore::global(cx)
+                .update(cx, |store, cx| store.reset_clan(self.clan_id, cx));
+        }
         self.clan_id = clan_id;
         self.reset_search(cx);
         self.expanded.clear();
@@ -157,11 +161,6 @@ impl ClanChannelsPage {
     }
 
     pub fn deactivate(&mut self, cx: &mut Context<Self>) {
-        if self.clan_id.get() != 0 {
-            ChannelSettingsStore::global(cx)
-                .update(cx, |store, cx| store.reset_clan(self.clan_id, cx));
-            self.clan_id = ClanId(0);
-        }
         self.reset_search(cx);
     }
 
@@ -926,6 +925,7 @@ fn build_channel_list_menu(
     let current_user_id =
         BadgeService::try_global(cx).and_then(|badges| badges.read(cx).current_user_id(cx));
     let is_creator = current_user_id == Some(state.row.creator_id);
+    let can_access = can_access_channel(state.row.private, current_user_id, &state.row.user_ids);
     let permissions = PermissionStore::try_global(cx);
     let has_permission = |permission| {
         permissions
@@ -946,13 +946,14 @@ fn build_channel_list_menu(
             has_manage_clan,
             has_manage_channel,
         );
-    let can_edit = manage_allowed_by_server(
-        is_creator,
-        has_owner,
-        has_admin,
-        has_manage_clan,
-        has_manage_channel,
-    );
+    let can_edit = can_access
+        && manage_allowed_by_server(
+            is_creator,
+            has_owner,
+            has_admin,
+            has_manage_clan,
+            has_manage_channel,
+        );
     let can_delete = !is_welcome
         && delete_allowed_by_server(
             is_creator,
@@ -1041,6 +1042,10 @@ fn build_channel_list_menu(
         });
     }
     menu
+}
+
+fn can_access_channel(private: bool, current_user_id: Option<UserId>, user_ids: &[UserId]) -> bool {
+    !private || current_user_id.is_some_and(|user_id| user_ids.contains(&user_id))
 }
 
 fn tr(locale: &str, key: &'static str) -> String {
@@ -1206,5 +1211,18 @@ mod tests {
     fn search_normalization_removes_diacritics() {
         assert_eq!(normalize_diacritics("Hiền"), "hien");
         assert_eq!(normalize_diacritics("Đà Nẵng"), "da nang");
+    }
+
+    #[test]
+    fn public_channels_are_accessible_without_membership() {
+        assert!(can_access_channel(false, Some(UserId(1)), &[]));
+    }
+
+    #[test]
+    fn private_channels_require_current_user_membership() {
+        let members = [UserId(2), UserId(3)];
+        assert!(can_access_channel(true, Some(UserId(2)), &members));
+        assert!(!can_access_channel(true, Some(UserId(1)), &members));
+        assert!(!can_access_channel(true, None, &members));
     }
 }

--- a/crates/mezon-ui/src/chat/clan_channels_page.rs
+++ b/crates/mezon-ui/src/chat/clan_channels_page.rs
@@ -55,6 +55,7 @@ pub struct ClanChannelsPage {
     visible_row_keys: Vec<VisibleRowKey>,
     list_state: ListState,
     open_menu: Option<ChannelListMenuState>,
+    pending_edit_channel: Option<ChannelId>,
 }
 
 #[derive(Clone)]
@@ -92,6 +93,27 @@ impl ClanChannelsPage {
             cx.notify();
         })
         .detach();
+        cx.observe(&ChannelList::global(cx), |this, _, cx| {
+            let Some(channel_id) = this.pending_edit_channel else {
+                return;
+            };
+            let channel_list = ChannelList::global(cx);
+            let channel_list = channel_list.read(cx);
+            if channel_list.channel(this.clan_id, channel_id).is_some() {
+                this.pending_edit_channel = None;
+                crate::router::navigate(
+                    cx,
+                    crate::router::Route::ChannelSettings {
+                        clan_id: this.clan_id,
+                        channel_id,
+                        tab: crate::chat::channel_settings::ChannelSettingsTab::Overview,
+                    },
+                );
+            } else if !channel_list.is_resolving_channel_detail(channel_id) {
+                this.pending_edit_channel = None;
+            }
+        })
+        .detach();
         cx.observe(&ClanMembersStore::global(cx), |this, _, cx| {
             if this.sort_field == Some(SortField::Creator) {
                 this.rows_dirty = true;
@@ -121,6 +143,7 @@ impl ClanChannelsPage {
                 .smooth_line_scroll()
                 .suppress_hover_while_scrolling(),
             open_menu: None,
+            pending_edit_channel: None,
         }
     }
 
@@ -138,6 +161,7 @@ impl ClanChannelsPage {
         self.visible_row_keys.clear();
         self.rows_dirty = true;
         self.page_size_picker_open = false;
+        self.pending_edit_channel = None;
         self.open_menu = None;
         ChannelSettingsStore::global(cx).update(cx, |store, cx| {
             store.ensure_loaded(clan_id, ChannelId(0), cx)
@@ -163,7 +187,31 @@ impl ClanChannelsPage {
     pub fn deactivate(&mut self, cx: &mut Context<Self>) {
         self.expanded.clear();
         self.visible_row_keys.clear();
+        self.pending_edit_channel = None;
         self.reset_search(cx);
+    }
+
+    fn open_channel_settings(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
+        let channel_list = ChannelList::global(cx);
+        if channel_list
+            .read(cx)
+            .channel(self.clan_id, channel_id)
+            .is_some()
+        {
+            crate::router::navigate(
+                cx,
+                crate::router::Route::ChannelSettings {
+                    clan_id: self.clan_id,
+                    channel_id,
+                    tab: crate::chat::channel_settings::ChannelSettingsTab::Overview,
+                },
+            );
+            return;
+        }
+        self.pending_edit_channel = Some(channel_id);
+        channel_list.update(cx, |channels, cx| {
+            channels.ensure_channel_for_settings(self.clan_id, channel_id, cx);
+        });
     }
 
     fn ensure_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -927,12 +975,17 @@ fn build_channel_list_menu(
     let current_user_id =
         BadgeService::try_global(cx).and_then(|badges| badges.read(cx).current_user_id(cx));
     let is_creator = current_user_id == Some(state.row.creator_id);
-    let can_access = channel_access_allowed(
-        state.row.private,
-        is_creator,
-        current_user_id,
-        &state.row.user_ids,
-    );
+    let parent = if is_thread && !state.row.parent_id.is_zero() {
+        ChannelSettingsStore::try_global(cx).and_then(|store| {
+            store
+                .read(cx)
+                .row_by_id(clan_id, state.row.parent_id)
+                .cloned()
+        })
+    } else {
+        None
+    };
+    let can_access = channel_list_menu_access_allowed(&state.row, parent.as_ref(), current_user_id);
     let permissions = PermissionStore::try_global(cx);
     let has_permission = |permission| {
         permissions
@@ -1015,15 +1068,12 @@ fn build_channel_list_menu(
                 "channelMenu.menu.organizationMenu.edit"
             },
         );
+        let edit_page = page.clone();
         menu = menu.item(label, move |_window, cx| {
-            crate::router::navigate(
-                cx,
-                crate::router::Route::ChannelSettings {
-                    clan_id,
-                    channel_id,
-                    tab: crate::chat::channel_settings::ChannelSettingsTab::Overview,
-                },
-            );
+            let _ = edit_page.update(cx, |this, cx| {
+                this.open_menu = None;
+                this.open_channel_settings(channel_id, cx);
+            });
         });
     }
     if can_delete {
@@ -1059,6 +1109,24 @@ fn build_channel_list_menu(
         });
     }
     menu
+}
+
+fn channel_list_row_access_allowed(row: &ChannelSetting, current_user_id: Option<UserId>) -> bool {
+    channel_access_allowed(
+        row.private,
+        current_user_id == Some(row.creator_id),
+        current_user_id,
+        &row.user_ids,
+    )
+}
+
+fn channel_list_menu_access_allowed(
+    row: &ChannelSetting,
+    parent: Option<&ChannelSetting>,
+    current_user_id: Option<UserId>,
+) -> bool {
+    channel_list_row_access_allowed(row, current_user_id)
+        && parent.is_none_or(|parent| channel_list_row_access_allowed(parent, current_user_id))
 }
 
 fn has_channel_menu_actions(can_archive: bool, can_edit: bool, can_delete: bool) -> bool {
@@ -1256,6 +1324,54 @@ mod tests {
     #[test]
     fn private_channel_creator_is_accessible_before_membership_syncs() {
         assert!(channel_access_allowed(true, true, Some(UserId(1)), &[]));
+    }
+
+    #[test]
+    fn public_thread_is_inaccessible_when_private_parent_is_inaccessible() {
+        let current_user_id = Some(UserId(1));
+        let thread = ChannelSetting {
+            id: ChannelId(11),
+            parent_id: ChannelId(10),
+            private: false,
+            ..Default::default()
+        };
+        let parent = ChannelSetting {
+            id: ChannelId(10),
+            creator_id: UserId(2),
+            private: true,
+            user_ids: vec![UserId(2)],
+            ..Default::default()
+        };
+
+        assert!(!channel_list_menu_access_allowed(
+            &thread,
+            Some(&parent),
+            current_user_id,
+        ));
+    }
+
+    #[test]
+    fn thread_requires_both_parent_and_own_access() {
+        let current_user_id = Some(UserId(1));
+        let parent = ChannelSetting {
+            id: ChannelId(10),
+            private: false,
+            ..Default::default()
+        };
+        let private_thread = ChannelSetting {
+            id: ChannelId(11),
+            parent_id: parent.id,
+            creator_id: UserId(2),
+            private: true,
+            user_ids: vec![UserId(2)],
+            ..Default::default()
+        };
+
+        assert!(!channel_list_menu_access_allowed(
+            &private_thread,
+            Some(&parent),
+            current_user_id,
+        ));
     }
 
     #[test]

--- a/crates/mezon-ui/src/chat/clan_channels_page.rs
+++ b/crates/mezon-ui/src/chat/clan_channels_page.rs
@@ -11,8 +11,8 @@ use mezon_store::{
     BadgeService, ChannelId, ChannelList, ChannelSetting, ChannelSettingsStore, ChannelType,
     ClanId, ClanList, ClanMembersStore, PERMISSION_ADMINISTRATOR, PERMISSION_CLAN_OWNER,
     PERMISSION_MANAGE_CHANNEL, PERMISSION_MANAGE_CLAN, PermissionStore, Settings, UserId,
-    archive_allowed_by_server, archive_menu_hidden, delete_allowed_by_server,
-    manage_allowed_by_server,
+    archive_allowed_by_server, archive_menu_hidden, channel_access_allowed,
+    delete_allowed_by_server, manage_allowed_by_server,
 };
 use ui::Tooltip;
 
@@ -161,6 +161,8 @@ impl ClanChannelsPage {
     }
 
     pub fn deactivate(&mut self, cx: &mut Context<Self>) {
+        self.expanded.clear();
+        self.visible_row_keys.clear();
         self.reset_search(cx);
     }
 
@@ -925,7 +927,12 @@ fn build_channel_list_menu(
     let current_user_id =
         BadgeService::try_global(cx).and_then(|badges| badges.read(cx).current_user_id(cx));
     let is_creator = current_user_id == Some(state.row.creator_id);
-    let can_access = can_access_channel(state.row.private, current_user_id, &state.row.user_ids);
+    let can_access = channel_access_allowed(
+        state.row.private,
+        is_creator,
+        current_user_id,
+        &state.row.user_ids,
+    );
     let permissions = PermissionStore::try_global(cx);
     let has_permission = |permission| {
         permissions
@@ -936,7 +943,8 @@ fn build_channel_list_menu(
     let has_admin = has_permission(PERMISSION_ADMINISTRATOR);
     let has_manage_clan = has_permission(PERMISSION_MANAGE_CLAN);
     let has_manage_channel = has_permission(PERMISSION_MANAGE_CHANNEL);
-    let can_archive = state.row.active != 0
+    let can_archive = can_access
+        && state.row.active != 0
         && !archive_menu_hidden(channel_type, is_welcome)
         && archive_allowed_by_server(
             is_thread,
@@ -954,7 +962,8 @@ fn build_channel_list_menu(
             has_manage_clan,
             has_manage_channel,
         );
-    let can_delete = !is_welcome
+    let can_delete = can_access
+        && !is_welcome
         && delete_allowed_by_server(
             is_creator,
             has_owner,
@@ -969,6 +978,14 @@ fn build_channel_list_menu(
             cx.notify();
         });
     });
+    if !has_channel_menu_actions(can_archive, can_edit, can_delete) {
+        return menu
+            .item(
+                tr(&locale, "common.permissionNotification.permissionDenied"),
+                |_window, _cx| {},
+            )
+            .disabled(true);
+    }
     if can_archive {
         let locale = locale.clone();
         menu = menu.item(
@@ -1044,8 +1061,8 @@ fn build_channel_list_menu(
     menu
 }
 
-fn can_access_channel(private: bool, current_user_id: Option<UserId>, user_ids: &[UserId]) -> bool {
-    !private || current_user_id.is_some_and(|user_id| user_ids.contains(&user_id))
+fn has_channel_menu_actions(can_archive: bool, can_edit: bool, can_delete: bool) -> bool {
+    can_archive || can_edit || can_delete
 }
 
 fn tr(locale: &str, key: &'static str) -> String {
@@ -1215,14 +1232,37 @@ mod tests {
 
     #[test]
     fn public_channels_are_accessible_without_membership() {
-        assert!(can_access_channel(false, Some(UserId(1)), &[]));
+        assert!(channel_access_allowed(false, false, Some(UserId(1)), &[]));
     }
 
     #[test]
     fn private_channels_require_current_user_membership() {
         let members = [UserId(2), UserId(3)];
-        assert!(can_access_channel(true, Some(UserId(2)), &members));
-        assert!(!can_access_channel(true, Some(UserId(1)), &members));
-        assert!(!can_access_channel(true, None, &members));
+        assert!(channel_access_allowed(
+            true,
+            false,
+            Some(UserId(2)),
+            &members
+        ));
+        assert!(!channel_access_allowed(
+            true,
+            false,
+            Some(UserId(1)),
+            &members
+        ));
+        assert!(!channel_access_allowed(true, false, None, &members));
+    }
+
+    #[test]
+    fn private_channel_creator_is_accessible_before_membership_syncs() {
+        assert!(channel_access_allowed(true, true, Some(UserId(1)), &[]));
+    }
+
+    #[test]
+    fn detects_when_channel_context_menu_has_no_actions() {
+        assert!(!has_channel_menu_actions(false, false, false));
+        assert!(has_channel_menu_actions(true, false, false));
+        assert!(has_channel_menu_actions(false, true, false));
+        assert!(has_channel_menu_actions(false, false, true));
     }
 }


### PR DESCRIPTION
> `Description:`

**env development:** window
- fix not show edit channel if not in channel or permistion
- fix keep cache data, not recall api get list channel data.
<img width="1181" height="267" alt="image" src="https://github.com/user-attachments/assets/eec9e50e-c7c9-4f85-9118-c56ae970a969" />
<img width="1182" height="416" alt="image" src="https://github.com/user-attachments/assets/960b9445-8789-4de4-bee3-1011d25df63c" />
