### PR TITLE
fix(topic): stop dropping the reply whose id matches the topic origin

### DIFF
--- a/crates/mezon-store/src/message.rs
+++ b/crates/mezon-store/src/message.rs
@@ -718,6 +718,14 @@ pub struct TokenTransaction {
 #[derive(Debug, Clone)]
 pub struct Message {
     pub id: MessageId,
+    /// The bucket this row lives in: a topic's id for a topic reply, the
+    /// channel's id otherwise — mirroring mezon-react's
+    /// `channelMessages[topicId || channelId]` entity state. A message id is only
+    /// unique *inside* one bucket, because the server mints it from a per-channel
+    /// sequence with no channel component (`(seq << shift) | node | year`), so
+    /// this is the other half of a row's identity. `MessageList` stamps it when
+    /// the row enters a bucket; it is `ChannelId(0)` until then.
+    pub channel_id: ChannelId,
     pub sort_id: i64,
     pub row_anchor_id: MessageId,
     pub content: String,
@@ -1649,6 +1657,7 @@ impl Message {
         let rich_layout = build_rich_layout(&spans);
         Self {
             id,
+            channel_id: ChannelId(0),
             sort_id: id.get(),
             row_anchor_id: id,
             content,

--- a/crates/mezon-store/src/messages.rs
+++ b/crates/mezon-store/src/messages.rs
@@ -293,17 +293,36 @@ struct MessageList {
     items: Vec<Message>,
     index: HashMap<MessageId, usize>,
     temp_ids: Vec<MessageId>,
+    /// The bucket these rows belong to (see `Message::channel_id`). Every row that
+    /// enters the list is stamped with it, so a row carries the other half of its
+    /// identity wherever it is cloned to — the topic panel builds one list out of
+    /// two buckets and a bare `MessageId` cannot tell them apart.
+    channel_id: ChannelId,
 }
 
 impl MessageList {
-    fn from_messages(items: Vec<Message>) -> Self {
+    fn from_messages(channel_id: ChannelId, mut items: Vec<Message>) -> Self {
+        for msg in &mut items {
+            msg.channel_id = channel_id;
+        }
         let mut list = Self {
             items,
             index: HashMap::new(),
             temp_ids: Vec::new(),
+            channel_id,
         };
         list.reindex();
         list
+    }
+
+    fn stamp(&self, msg: &mut Message) {
+        msg.channel_id = self.channel_id;
+    }
+
+    fn stamp_all(&self, msgs: &mut [Message]) {
+        for msg in msgs {
+            msg.channel_id = self.channel_id;
+        }
     }
 
     fn reindex(&mut self) {
@@ -372,12 +391,14 @@ impl MessageList {
         })
     }
 
-    fn replace(&mut self, items: Vec<Message>) {
+    fn replace(&mut self, mut items: Vec<Message>) {
+        self.stamp_all(&mut items);
         self.items = items;
         self.reindex();
     }
 
-    fn push_sorted(&mut self, msg: Message) {
+    fn push_sorted(&mut self, mut msg: Message) {
+        self.stamp(&mut msg);
         self.items.push(msg);
         sort_messages(&mut self.items);
         trim_messages(&mut self.items);
@@ -385,7 +406,8 @@ impl MessageList {
         self.reindex();
     }
 
-    fn push_grouped(&mut self, msg: Message) {
+    fn push_grouped(&mut self, mut msg: Message) {
+        self.stamp(&mut msg);
         let in_order = self
             .items
             .last()
@@ -441,7 +463,8 @@ impl MessageList {
         self.items[idx].show_forwarded_label = show_forwarded_label;
     }
 
-    fn replace_at(&mut self, idx: usize, msg: Message) {
+    fn replace_at(&mut self, idx: usize, mut msg: Message) {
+        self.stamp(&mut msg);
         let old_id = self.items[idx].id;
         let new_id = msg.id;
         self.items[idx] = msg;
@@ -501,7 +524,8 @@ impl MessageList {
                  two rows are sharing one id"
             );
         }
-        let merged = merge_sparse_sender(&existing, incoming);
+        let mut merged = merge_sparse_sender(&existing, incoming);
+        self.stamp(&mut merged);
         if let Some(slot) = self.get_mut_by_id(id) {
             *slot = merged;
         }
@@ -509,7 +533,8 @@ impl MessageList {
         true
     }
 
-    fn replace_resort(&mut self, idx: usize, msg: Message) {
+    fn replace_resort(&mut self, idx: usize, mut msg: Message) {
+        self.stamp(&mut msg);
         self.items[idx] = msg;
         sort_messages(&mut self.items);
         trim_messages(&mut self.items);
@@ -518,6 +543,7 @@ impl MessageList {
     }
 
     fn prepend_older(&mut self, mut older: Vec<Message>) -> usize {
+        self.stamp_all(&mut older);
         older.append(&mut self.items);
         sort_messages(&mut older);
         let dropped_bottom = trim_messages_back(&mut older);
@@ -528,6 +554,7 @@ impl MessageList {
     }
 
     fn append_newer(&mut self, mut newer: Vec<Message>) -> usize {
+        self.stamp_all(&mut newer);
         self.items.append(&mut newer);
         sort_messages(&mut self.items);
         let dropped = trim_messages(&mut self.items);
@@ -6867,7 +6894,7 @@ impl MessagesStore {
         self.cache.insert(
             channel_id,
             ChannelMessages {
-                messages: MessageList::from_messages(messages),
+                messages: MessageList::from_messages(channel_id, messages),
                 has_more,
             },
             active.as_ref(),
@@ -11418,8 +11445,10 @@ mod tests {
     #[test]
     fn optimistic_create_time_increments_within_same_sender_burst() {
         let now = 1_700_000_000i64;
-        let mut list =
-            MessageList::from_messages(vec![Message::new(MessageId(1), "a", "42", "Me", now - 5)]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(MessageId(1), "a", "42", "Me", now - 5)],
+        );
         assert_eq!(optimistic_create_time_at(&list, "42", now), now + 1);
         list.push_grouped(Message::new(
             MessageId::next_optimistic(),
@@ -11434,13 +11463,10 @@ mod tests {
     #[test]
     fn optimistic_create_time_resets_after_combine_window() {
         let now = 1_700_000_000i64;
-        let list = MessageList::from_messages(vec![Message::new(
-            MessageId(1),
-            "a",
-            "42",
-            "Me",
-            now - 700,
-        )]);
+        let list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(MessageId(1), "a", "42", "Me", now - 700)],
+        );
         assert_eq!(optimistic_create_time_at(&list, "42", now), now);
     }
 
@@ -11463,10 +11489,13 @@ mod tests {
 
     #[test]
     fn push_message_grouped_appends_in_order() {
-        let mut list = MessageList::from_messages(vec![
-            Message::new(MessageId(1), "a", "u1", "U1", 100),
-            Message::new(MessageId(2), "b", "u1", "U1", 110),
-        ]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![
+                Message::new(MessageId(1), "a", "u1", "U1", 100),
+                Message::new(MessageId(2), "b", "u1", "U1", 110),
+            ],
+        );
         list.push_grouped(Message::new(MessageId(3), "c", "u1", "U1", 120));
         assert_eq!(list.len(), 3);
         assert_eq!(list.as_slice()[2].id, MessageId(3));
@@ -11476,10 +11505,13 @@ mod tests {
 
     #[test]
     fn push_message_grouped_resorts_when_out_of_order() {
-        let mut list = MessageList::from_messages(vec![
-            Message::new(MessageId(1), "a", "u1", "U1", 100),
-            Message::new(MessageId(3), "c", "u1", "U1", 120),
-        ]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![
+                Message::new(MessageId(1), "a", "u1", "U1", 100),
+                Message::new(MessageId(3), "c", "u1", "U1", 120),
+            ],
+        );
         list.push_grouped(Message::new(MessageId(2), "b", "u1", "U1", 110));
         let ids: Vec<MessageId> = list.as_slice().iter().map(|m| m.id).collect();
         assert_eq!(ids, [MessageId(1), MessageId(2), MessageId(3)]);
@@ -11488,8 +11520,10 @@ mod tests {
 
     #[test]
     fn push_message_grouped_breaks_group_for_different_sender() {
-        let mut list =
-            MessageList::from_messages(vec![Message::new(MessageId(1), "a", "u1", "U1", 100)]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(MessageId(1), "a", "u1", "U1", 100)],
+        );
         list.push_grouped(Message::new(MessageId(2), "b", "u2", "U2", 105));
         assert!(!list.as_slice()[1].combined_with_prev);
         assert_list_consistent(&list);
@@ -11497,8 +11531,10 @@ mod tests {
 
     #[test]
     fn push_message_grouped_sets_forwarded_label_on_first_realtime_forward() {
-        let mut list =
-            MessageList::from_messages(vec![Message::new(MessageId(1), "a", "u1", "U1", 100)]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(MessageId(1), "a", "u1", "U1", 100)],
+        );
         list.push_grouped(Message::new(MessageId(2), "fwd", "u1", "U1", 110).with_forwarded(true));
         assert!(list.as_slice()[1].is_forwarded);
         assert!(list.as_slice()[1].show_forwarded_label);
@@ -11507,8 +11543,10 @@ mod tests {
 
     #[test]
     fn push_message_grouped_hides_forwarded_label_for_same_sender_burst() {
-        let mut list =
-            MessageList::from_messages(vec![Message::new(MessageId(1), "a", "u1", "U1", 100)]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(MessageId(1), "a", "u1", "U1", 100)],
+        );
         list.push_grouped(
             Message::new(MessageId(2), "fwd-a", "u1", "U1", 110).with_forwarded(true),
         );
@@ -11528,7 +11566,7 @@ mod tests {
 
     #[test]
     fn optimistic_sort_id_lands_in_the_server_snowflake_space() {
-        let list = MessageList::from_messages(Vec::new());
+        let list = MessageList::from_messages(ChannelId(1), Vec::new());
         let sort_id = optimistic_sort_id_at(&list, SEND_NOW_MS, 7);
         assert_eq!(sort_id >> SNOWFLAKE_TIME_SHIFT, SEND_NOW_MS);
         assert_eq!(sort_id & SNOWFLAKE_SEQUENCE_MASK, 7);
@@ -11538,7 +11576,10 @@ mod tests {
     #[test]
     fn optimistic_sort_id_stays_above_a_tail_minted_ahead_of_the_local_clock() {
         let ahead = server_id_at(SEND_NOW_MS + 5_000);
-        let list = MessageList::from_messages(vec![Message::new(ahead, "a", "u1", "U1", 100)]);
+        let list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(ahead, "a", "u1", "U1", 100)],
+        );
         assert_eq!(
             optimistic_sort_id_at(&list, SEND_NOW_MS, 0),
             ahead.get() + 1
@@ -11547,13 +11588,16 @@ mod tests {
 
     #[test]
     fn failed_optimistic_row_keeps_its_slot_when_a_later_message_arrives() {
-        let mut list = MessageList::from_messages(vec![Message::new(
-            server_id_at(SEND_NOW_MS - 1_000),
-            "a",
-            "u1",
-            "U1",
-            100,
-        )]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(
+                server_id_at(SEND_NOW_MS - 1_000),
+                "a",
+                "u1",
+                "U1",
+                100,
+            )],
+        );
         let sort_id = optimistic_sort_id_at(&list, SEND_NOW_MS, 0);
         let mut failed =
             Message::new(MessageId::next_optimistic(), "b", "u2", "U2", 110).with_sort_id(sort_id);
@@ -11573,13 +11617,16 @@ mod tests {
 
     #[test]
     fn acking_a_temp_that_is_no_longer_the_tail_restores_id_order() {
-        let mut list = MessageList::from_messages(vec![Message::new(
-            server_id_at(SEND_NOW_MS - 1_000),
-            "old",
-            "u1",
-            "U1",
-            100,
-        )]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(
+                server_id_at(SEND_NOW_MS - 1_000),
+                "old",
+                "u1",
+                "U1",
+                100,
+            )],
+        );
         let temp_id = MessageId::next_optimistic();
         list.push_grouped(
             Message::new(temp_id, "mine", "me", "Me", 110).with_sort_id(optimistic_sort_id_at(
@@ -11612,13 +11659,16 @@ mod tests {
 
     #[test]
     fn acking_a_temp_at_the_tail_does_not_resort() {
-        let mut list = MessageList::from_messages(vec![Message::new(
-            server_id_at(SEND_NOW_MS - 1_000),
-            "old",
-            "u1",
-            "U1",
-            100,
-        )]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(
+                server_id_at(SEND_NOW_MS - 1_000),
+                "old",
+                "u1",
+                "U1",
+                100,
+            )],
+        );
         let temp_id = MessageId::next_optimistic();
         list.push_grouped(
             Message::new(temp_id, "mine", "me", "Me", 110).with_sort_id(optimistic_sort_id_at(
@@ -11653,9 +11703,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn a_row_is_stamped_with_the_bucket_it_is_put_into() {
+        // A message id is only unique inside one bucket, so the bucket is the
+        // other half of a row's identity and has to survive being cloned out.
+        let topic = ChannelId(77);
+        let mut list =
+            MessageList::from_messages(topic, vec![Message::new(MessageId(1), "a", "u", "U", 1)]);
+        assert_eq!(list.as_slice()[0].channel_id, topic);
+
+        list.push_grouped(Message::new(MessageId(2), "b", "u", "U", 2));
+        list.prepend_older(vec![Message::new(MessageId(0), "z", "u", "U", 0)]);
+        list.append_newer(vec![Message::new(MessageId(3), "c", "u", "U", 3)]);
+
+        assert!(
+            list.as_slice().iter().all(|m| m.channel_id == topic),
+            "every path that puts a row into the list must stamp it"
+        );
+    }
+
     fn channel_msgs(msgs: Vec<Message>) -> ChannelMessages {
         ChannelMessages {
-            messages: MessageList::from_messages(msgs),
+            messages: MessageList::from_messages(ChannelId(1), msgs),
             has_more: false,
         }
     }
@@ -11757,10 +11826,13 @@ mod tests {
     #[test]
     fn temp_match_reconciles_optimistic_row_in_place() {
         let temp1 = MessageId::next_optimistic();
-        let mut list = MessageList::from_messages(vec![
-            Message::new(MessageId(100), "earlier", "u1", "U", 100),
-            Message::new(temp1, "hello world", "u9", "Me", 200),
-        ]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![
+                Message::new(MessageId(100), "earlier", "u1", "U", 100),
+                Message::new(temp1, "hello world", "u9", "Me", 200),
+            ],
+        );
         assert_eq!(list.temp_match_position("u9", "hello world"), Some(1));
         assert_eq!(list.temp_match_position("u9", "other"), None);
         let idx = list.temp_match_position("u9", "hello world").unwrap();
@@ -11782,8 +11854,10 @@ mod tests {
             "optimistic text must be stripped like the server-stored text"
         );
         let temp = MessageId::next_optimistic();
-        let list =
-            MessageList::from_messages(vec![Message::new(temp, optimistic_text, "u9", "Me", 200)]);
+        let list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(temp, optimistic_text, "u9", "Me", 200)],
+        );
         assert_eq!(
             list.temp_match_position("u9", "bold"),
             Some(0),
@@ -11793,10 +11867,13 @@ mod tests {
 
     #[test]
     fn server_echo_merge_preserves_message_grouping() {
-        let mut list = MessageList::from_messages(vec![
-            Message::new(MessageId(100), "first", "u9", "Me", 200),
-            Message::new(MessageId(101), "second", "u9", "Me", 201),
-        ]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![
+                Message::new(MessageId(100), "first", "u9", "Me", 200),
+                Message::new(MessageId(101), "second", "u9", "Me", 201),
+            ],
+        );
         let echo = Message::new(MessageId(101), "second", "0", "", 201);
         assert!(list.merge_existing(MessageId(101), echo));
         assert!(
@@ -11808,10 +11885,13 @@ mod tests {
 
     #[test]
     fn append_update_remove_keep_index_and_order() {
-        let mut list = MessageList::from_messages(vec![
-            Message::new(MessageId(10), "a", "u1", "U", 100),
-            Message::new(MessageId(20), "b", "u1", "U", 110),
-        ]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![
+                Message::new(MessageId(10), "a", "u1", "U", 100),
+                Message::new(MessageId(20), "b", "u1", "U", 110),
+            ],
+        );
         list.push_grouped(Message::new(MessageId(30), "c", "u1", "U", 120));
         assert_eq!(list.position(MessageId(30)), Some(2));
         list.get_mut_by_id(MessageId(20)).unwrap().content = "edited".into();
@@ -11825,10 +11905,13 @@ mod tests {
 
     #[test]
     fn prepend_older_and_append_newer_preserve_order_and_index() {
-        let mut list = MessageList::from_messages(vec![
-            Message::new(MessageId(50), "e", "u1", "U", 150),
-            Message::new(MessageId(60), "f", "u1", "U", 160),
-        ]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![
+                Message::new(MessageId(50), "e", "u1", "U", 150),
+                Message::new(MessageId(60), "f", "u1", "U", 160),
+            ],
+        );
         let dropped = list.prepend_older(vec![
             Message::new(MessageId(30), "c", "u1", "U", 130),
             Message::new(MessageId(40), "d", "u1", "U", 140),
@@ -11858,8 +11941,10 @@ mod tests {
 
     #[test]
     fn window_replace_rebuilds_index() {
-        let mut list =
-            MessageList::from_messages(vec![Message::new(MessageId(1), "a", "u1", "U", 100)]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(MessageId(1), "a", "u1", "U", 100)],
+        );
         list.replace(vec![
             Message::new(MessageId(8), "h", "u1", "U", 180),
             Message::new(MessageId(9), "i", "u1", "U", 190),
@@ -11873,6 +11958,7 @@ mod tests {
     #[test]
     fn append_at_cap_evicts_front_and_reindexes() {
         let mut list = MessageList::from_messages(
+            ChannelId(1),
             (0..MAX_MESSAGES_PER_CHANNEL)
                 .map(|i| Message::new(MessageId(i as i64), "m", "u", "U", i as i64))
                 .collect(),
@@ -11902,7 +11988,7 @@ mod tests {
             (1..MAX_MESSAGES_PER_CHANNEL)
                 .map(|i| Message::new(MessageId(i as i64), "m", "u", "U", i as i64)),
         );
-        let mut list = MessageList::from_messages(items);
+        let mut list = MessageList::from_messages(ChannelId(1), items);
         assert_eq!(list.len(), MAX_MESSAGES_PER_CHANNEL);
         assert_eq!(list.temp_ids, vec![temp_old]);
 
@@ -11925,26 +12011,34 @@ mod tests {
 
     #[test]
     fn has_more_bottom_false_when_tail_in_buffer() {
-        let list = MessageList::from_messages(vec![
-            Message::new(MessageId(1), "a", "u1", "U", 100),
-            Message::new(MessageId(99), "z", "u1", "U", 200),
-        ]);
+        let list = MessageList::from_messages(
+            ChannelId(1),
+            vec![
+                Message::new(MessageId(1), "a", "u1", "U", 100),
+                Message::new(MessageId(99), "z", "u1", "U", 200),
+            ],
+        );
         assert!(!has_more_bottom_for(Some(MessageId(99)), &list));
     }
 
     #[test]
     fn has_more_bottom_true_when_tail_not_in_buffer() {
-        let list = MessageList::from_messages(vec![
-            Message::new(MessageId(1), "a", "u1", "U", 100),
-            Message::new(MessageId(50), "m", "u1", "U", 150),
-        ]);
+        let list = MessageList::from_messages(
+            ChannelId(1),
+            vec![
+                Message::new(MessageId(1), "a", "u1", "U", 100),
+                Message::new(MessageId(50), "m", "u1", "U", 150),
+            ],
+        );
         assert!(has_more_bottom_for(Some(MessageId(99)), &list));
     }
 
     #[test]
     fn has_more_bottom_false_without_tail_or_empty_buffer() {
-        let list =
-            MessageList::from_messages(vec![Message::new(MessageId(1), "a", "u1", "U", 100)]);
+        let list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(MessageId(1), "a", "u1", "U", 100)],
+        );
         assert!(!has_more_bottom_for(None, &list));
         assert!(!has_more_bottom_for(
             Some(MessageId(1)),
@@ -11954,10 +12048,13 @@ mod tests {
 
     #[test]
     fn an_empty_newer_page_pins_the_tail_to_the_loaded_newest() {
-        let list = MessageList::from_messages(vec![
-            Message::new(MessageId(1), "a", "u1", "U", 100),
-            Message::new(MessageId(50), "m", "u1", "U", 150),
-        ]);
+        let list = MessageList::from_messages(
+            ChannelId(1),
+            vec![
+                Message::new(MessageId(1), "a", "u1", "U", 100),
+                Message::new(MessageId(50), "m", "u1", "U", 150),
+            ],
+        );
         assert!(has_more_bottom_for(Some(MessageId(99)), &list));
 
         let reconciled = reconciled_tail_after_empty_page(
@@ -11997,10 +12094,13 @@ mod tests {
 
     #[test]
     fn tail_keyed_by_storage_bucket_avoids_parent_poison() {
-        let parent_buffer = MessageList::from_messages(vec![
-            Message::new(MessageId(100), "a", "u1", "U", 1),
-            Message::new(MessageId(200), "b", "u1", "U", 2),
-        ]);
+        let parent_buffer = MessageList::from_messages(
+            ChannelId(1),
+            vec![
+                Message::new(MessageId(100), "a", "u1", "U", 1),
+                Message::new(MessageId(200), "b", "u1", "U", 2),
+            ],
+        );
 
         let topic_msg = mezon_proto::api::ChannelMessage {
             channel_id: 10,
@@ -12259,7 +12359,7 @@ mod tests {
         let failed_id = failed.id;
         let pending_id = pending.id;
 
-        let list = MessageList::from_messages(vec![failed, pending]);
+        let list = MessageList::from_messages(ChannelId(1), vec![failed, pending]);
         let idx = list
             .temp_match_position("42", "hello")
             .expect("a non-failed temp should match");
@@ -12269,18 +12369,21 @@ mod tests {
 
     #[test]
     fn patch_reply_previews_after_delete_marks_reference() {
-        let mut list = MessageList::from_messages(vec![
-            Message::new(MessageId(1), "reply", "u1", "U", 100).with_references(vec![
-                MessageReference {
-                    message_ref_id: MessageId(42),
-                    sender_id: UserId(1),
-                    sender_name: "x".into(),
-                    content: "orig".into(),
-                    content_preview: "orig".into(),
-                    ..Default::default()
-                },
-            ]),
-        ]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![
+                Message::new(MessageId(1), "reply", "u1", "U", 100).with_references(vec![
+                    MessageReference {
+                        message_ref_id: MessageId(42),
+                        sender_id: UserId(1),
+                        sender_name: "x".into(),
+                        content: "orig".into(),
+                        content_preview: "orig".into(),
+                        ..Default::default()
+                    },
+                ]),
+            ],
+        );
         patch_reply_previews_after_delete(&mut list, MessageId(42));
         assert_eq!(
             list.as_slice()[0].references[0].content,
@@ -13050,8 +13153,10 @@ mod tests {
 
     #[test]
     fn has_more_bottom_ignores_an_optimistic_tail_id() {
-        let list =
-            MessageList::from_messages(vec![Message::new(MessageId(1), "a", "u1", "U", 100)]);
+        let list = MessageList::from_messages(
+            ChannelId(1),
+            vec![Message::new(MessageId(1), "a", "u1", "U", 100)],
+        );
         assert!(
             !has_more_bottom_for(Some(MessageId::next_optimistic()), &list),
             "an un-acked optimistic row is not evidence of unloaded server history"
@@ -13060,11 +13165,14 @@ mod tests {
 
     #[test]
     fn removing_a_reply_in_the_middle_keeps_the_index_and_order() {
-        let mut list = MessageList::from_messages(vec![
-            Message::new(MessageId(1), "first", "u1", "U1", 100),
-            Message::new(MessageId(2), "second", "u2", "U2", 200),
-            Message::new(MessageId(3), "third", "u3", "U3", 300),
-        ]);
+        let mut list = MessageList::from_messages(
+            ChannelId(1),
+            vec![
+                Message::new(MessageId(1), "first", "u1", "U1", 100),
+                Message::new(MessageId(2), "second", "u2", "U2", 200),
+                Message::new(MessageId(3), "third", "u3", "U3", 300),
+            ],
+        );
 
         assert_eq!(list.remove_id(MessageId(2)), Some(1));
         assert_list_consistent(&list);

--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -2078,17 +2078,7 @@ impl ChannelMessages {
             .active_topic_id()
             .map(|topic_id| store.messages_in_channel(ChannelId(topic_id)))
             .unwrap_or_default();
-        let mut messages = Vec::with_capacity(replies.len() + usize::from(origin.is_some()));
-        if let Some(mut origin) = origin {
-            origin.combined_with_prev = false;
-            messages.push(origin);
-        }
-        for msg in replies {
-            if origin_id != Some(msg.id) {
-                messages.push(msg.clone());
-            }
-        }
-        messages
+        merge_topic_rows(origin, replies)
     }
 
     fn refresh_topic_messages(&mut self, cx: &App) -> bool {
@@ -2300,15 +2290,14 @@ impl ChannelMessages {
         cx: &App,
     ) -> Vec<MessageId> {
         let messages = Self::collect_topic_messages(cx);
-        message_context_menu::resolve_forward_group_in(&messages, message_id, sender_id)
+        let start = topic_row_index(&messages, message_id, active_topic_bucket(cx)).unwrap_or(0);
+        message_context_menu::resolve_forward_group_in(&messages[start..], message_id, sender_id)
     }
 
     fn find_local_message(&self, message_id: MessageId, cx: &App) -> Option<Message> {
         if self.is_topic_box {
-            self.topic_messages
-                .iter()
-                .find(|m| m.id == message_id)
-                .cloned()
+            topic_row_index(&self.topic_messages, message_id, active_topic_bucket(cx))
+                .map(|idx| self.topic_messages[idx].clone())
         } else {
             MessagesStore::global(cx)
                 .read(cx)
@@ -2531,8 +2520,11 @@ impl ChannelMessages {
         self.context_menu_forward_all = match sender_and_poll {
             Some((sender_id, false)) => {
                 if self.is_topic_box {
+                    let start =
+                        topic_row_index(&self.topic_messages, message_id, active_topic_bucket(cx))
+                            .unwrap_or(0);
                     message_context_menu::resolve_forward_group_in(
-                        &self.topic_messages,
+                        &self.topic_messages[start..],
                         message_id,
                         sender_id.as_str(),
                     )
@@ -5497,6 +5489,159 @@ mod skeleton_tests {
 
         let many: Vec<MessageId> = (1..=150).rev().map(MessageId).collect();
         assert!(fab_unread_count(Some(MessageId(0)), many.iter().copied()) > 99);
+    }
+}
+
+/// The rows the topic panel shows: the origin message it hangs off, then that
+/// topic's replies.
+///
+/// The two come from different id spaces. The server mints a message id as
+/// `(sequence << shift) | node | year` with a **per-channel** sequence and no
+/// channel component, so the Nth message of the parent channel and the Nth reply
+/// of the topic carry byte-identical ids. The origin is a parent-channel row and
+/// the replies live in the topic's own bucket, so a collision is not a duplicate
+/// — dropping a reply that matches `origin.id` hid one real reply from every
+/// topic (the one whose sequence position equals the origin's) while the topic
+/// reply count kept counting it. There is nothing to de-duplicate either: the
+/// bucket never holds the origin, since replies are stored under
+/// `channel_id = topic_id` and the origin has `topic_id == 0`.
+///
+/// `Message::channel_id` carries which bucket a row came from, so the two are
+/// still told apart after they are merged into one list. Element ids are keyed on
+/// a single integer (`row_anchor_id`) and cannot hold the pair, so the origin's is
+/// moved out of the replies' (positive) id space rather than a row being thrown
+/// away. Mirrors mezon-react, which renders `firstMsgOfThisTopic` outside the
+/// id-keyed message list and never filters the replies (`ChannelMessages.tsx`).
+fn active_topic_bucket(cx: &App) -> Option<ChannelId> {
+    TopicsStore::global(cx)
+        .read(cx)
+        .active_topic_id()
+        .map(ChannelId)
+}
+
+/// Which row an id-keyed row action in the topic panel refers to.
+///
+/// The panel is one list over two buckets (see `merge_topic_rows`) and a message
+/// id is only unique inside one of them, so an id can match both the origin row
+/// and one reply. It resolves to the reply: the origin is context, every other row
+/// is the topic's, and an action that lands on the wrong one is far cheaper on a
+/// reply than on the message the whole topic hangs off — deleting that one takes
+/// the topic with it.
+fn topic_row_index(
+    messages: &[Message],
+    message_id: MessageId,
+    topic: Option<ChannelId>,
+) -> Option<usize> {
+    messages
+        .iter()
+        .position(|m| m.id == message_id && Some(m.channel_id) == topic)
+        .or_else(|| messages.iter().position(|m| m.id == message_id))
+}
+
+fn merge_topic_rows(origin: Option<Message>, replies: &[Message]) -> Vec<Message> {
+    let mut messages = Vec::with_capacity(replies.len() + usize::from(origin.is_some()));
+    if let Some(mut origin) = origin {
+        origin.combined_with_prev = false;
+        origin.row_anchor_id = MessageId(origin.id.get().wrapping_neg());
+        messages.push(origin);
+    }
+    messages.extend_from_slice(replies);
+    messages
+}
+
+#[cfg(test)]
+mod topic_row_tests {
+    use super::{merge_topic_rows, topic_row_index};
+    use mezon_store::{ChannelId, Message, MessageId};
+
+    fn reply(id: i64, text: &str) -> Message {
+        Message::new(MessageId(id), text, "1", "u", 0)
+    }
+
+    #[test]
+    fn a_reply_sharing_the_origins_id_is_still_shown() {
+        // Message ids are per-channel sequences: the topic's 4th reply carries the
+        // same id as the 4th message of the parent channel, which is the origin.
+        let origin = reply(104, "hhh");
+        let replies = [
+            reply(101, "test"),
+            reply(102, "hi"),
+            reply(103, "he"),
+            reply(104, "hi"),
+            reply(105, "ok"),
+        ];
+
+        let rows = merge_topic_rows(Some(origin), &replies);
+
+        let shown: Vec<&str> = rows.iter().map(|m| m.content.as_str()).collect();
+        assert_eq!(shown, ["hhh", "test", "hi", "he", "hi", "ok"]);
+    }
+
+    #[test]
+    fn the_origin_row_cannot_collide_with_a_reply_element_id() {
+        let rows = merge_topic_rows(Some(reply(104, "hhh")), &[reply(104, "hi")]);
+
+        assert_eq!(rows[0].row_anchor_id, MessageId(-104));
+        assert_eq!(rows[1].row_anchor_id, MessageId(104));
+        assert!(!rows[0].combined_with_prev);
+    }
+
+    #[test]
+    fn each_row_keeps_the_bucket_it_came_from() {
+        let mut origin = reply(104, "hhh");
+        origin.channel_id = ChannelId(10);
+        let mut in_topic = reply(104, "hi");
+        in_topic.channel_id = ChannelId(77);
+
+        let rows = merge_topic_rows(Some(origin), &[in_topic]);
+
+        // Same id, different bucket — which is what tells the two rows apart.
+        assert_eq!(rows[0].id, rows[1].id);
+        assert_eq!(rows[0].channel_id, ChannelId(10));
+        assert_eq!(rows[1].channel_id, ChannelId(77));
+    }
+
+    #[test]
+    fn a_row_action_on_a_colliding_id_resolves_to_the_reply() {
+        let mut origin = reply(104, "hhh");
+        origin.channel_id = ChannelId(10);
+        let mut collides = reply(104, "hi");
+        collides.channel_id = ChannelId(77);
+        let rows = merge_topic_rows(Some(origin), &[collides]);
+
+        // Row 0 is the origin, row 1 the reply that happens to share its id.
+        assert_eq!(
+            topic_row_index(&rows, MessageId(104), Some(ChannelId(77))),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn the_origin_is_still_reachable_when_nothing_collides() {
+        let mut origin = reply(104, "hhh");
+        origin.channel_id = ChannelId(10);
+        let mut other = reply(101, "test");
+        other.channel_id = ChannelId(77);
+        let rows = merge_topic_rows(Some(origin), &[other]);
+
+        assert_eq!(
+            topic_row_index(&rows, MessageId(104), Some(ChannelId(77))),
+            Some(0)
+        );
+        assert_eq!(
+            topic_row_index(&rows, MessageId(101), Some(ChannelId(77))),
+            Some(1)
+        );
+        assert_eq!(
+            topic_row_index(&rows, MessageId(999), Some(ChannelId(77))),
+            None
+        );
+    }
+
+    #[test]
+    fn without_an_origin_only_the_replies_are_shown() {
+        let rows = merge_topic_rows(None, &[reply(101, "test"), reply(102, "hi")]);
+        assert_eq!(rows.len(), 2);
     }
 }
 


### PR DESCRIPTION
## The bug

The topic panel renders one row fewer than the topic actually has. QA hit it on
Windows: the panel showed `hhh · test · hi · he · ok` where web showed
`hhh · test · hi · he · hi · ok`, while the parent message's badge still said
**5 replies**. Quitting and reopening the app did not heal it.

## Root cause

A message id is only unique **inside one channel**. `mezon-api` mints it as
`(sequence << shift) | node | year` (`snowflake.go:195`) from a **per-channel**
Redis sequence, with no channel component. Topic replies are stored under
`channel_id = topic_id`, so they get their own sequence — and the Nth message of
a channel and the Nth reply of a topic come out with byte-identical ids.

Measured on prod (`CLAN TEST 01 / zzz-repro-3`):

| | msg #1 | msg #5 |
|---|---|---|
| parent channel | `1840651252636061696` | `1840651252652838912` |
| topic A | `1840651252636061696` | `1840651252652838912` |
| topic B | `1840651252636061696` | — |

`collect_topic_messages` builds one list out of two buckets — the origin row
from the parent channel, the replies from the topic — and filtered the replies
with `if origin_id != Some(msg.id)`. So it ate the reply that happened to share
the origin's id.

**Rule: reply number N of every topic was invisible, where N is the origin
message's sequence position in its parent channel.** Deterministic, survives a
restart, and the reply count keeps counting the row that never renders.

Confirmed with a control on the live app:

| | bucket | rendered |
|---|---|---|
| topic with an id collision | 8 replies | **8** (should be 9) |
| topic without one | 1 reply | **2** = origin + 1 |

## Why web is fine

`mezon-react` keys its entity state **per bucket**
(`channelMessages[topicId || channelId]`, `messages.slice.ts:1888`),
`MessagesEntity` carries `channel_id` (`:96`), and the topic origin is rendered
*outside* the id-keyed list (`ChannelMessages.tsx:1271`) — so the replies are
never filtered.

## The fix

Follows that model:

- **`Message::channel_id`** records the bucket a row lives in (topic id for a
  reply, channel id otherwise). `MessageList` carries the bucket and stamps every
  path that puts a row into it — one choke point, so a future insert path cannot
  quietly skip it.
- **`merge_topic_rows`** (new, pure, unit-tested) keeps every reply. Element ids
  hold a single integer and cannot carry the `(bucket, id)` pair, so the origin's
  `row_anchor_id` moves out of the replies' id space instead of a row being
  dropped.
- **`topic_row_index`** resolves id-keyed row actions — context menu, forward
  group — against `(bucket, id)`, preferring the reply. Landing on the wrong row
  is far cheaper on a reply than on the origin, since deleting the origin takes
  the whole topic with it.

## Testing

- `just lint` (clippy `-D warnings` + fmt gate) — clean
- `just test` — **2235 passed**, including 7 new tests
- `cargo build -p mezon-app` — links
- Ran on a worktree branched off `develop`, not just on my local branch

To confirm on a running build, against a topic whose reply count is one higher
than the rows you can see:

```
mezon mcp call topic_state --args '{}'
# before: loaded_count 8, item_count 8
# after:  loaded_count 8, item_count 9
```

## Known follow-ups (deliberately not in this PR)

Message ids stay non-unique across buckets, so a few UI-only maps in the topic
panel are still keyed on a bare `MessageId` and are ambiguous for that one
colliding row pair. All cosmetic, none of them drop a row:

- `hovered_row` / `context_menu_message` — hovering the reply also lights up the
  origin row. Fixing it means moving hover **and** `context_menu_target` onto
  `row_anchor_id` together, which the channel path shares.
- `sync_selection_order`'s `order_map: HashMap<MessageId, usize>` loses one entry,
  so it rebuilds on every selection interaction.
- Scroll anchoring (`topic_row_ids.position`) can anchor to the origin instead of
  the reply.
