### PR TITLE
fix(pdf): open the document externally when no renderer is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,36 @@ jobs:
 #       - name: Check Windows platform crates
 #         run: cargo check -p mezon-app --locked
 #
+  windows-pdf:
+    name: Windows PDF
+    # The one backend no other runner can prove. `Windows.Data.Pdf` exists only on
+    # Windows, so the macOS and Linux jobs compile `windows_pdf.rs` at best and never
+    # run a page through it - which is how the Windows path shipped unverified.
+    # `mezon-pdf` is a leaf crate (anyhow, image, windows), so this costs minutes
+    # rather than the half hour a full `mezon-app` build takes.
+    runs-on: windows-latest
+    env:
+      # Without this the smoke tests skip themselves when the backend is missing, and
+      # the job would go green having rendered nothing.
+      MEZON_PDF_REQUIRE_BACKEND: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.95.0
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
+      # `--nocapture` so a backend that refuses to activate names its HRESULT in the log.
+      - name: Render a page through Windows.Data.Pdf
+        run: cargo test -p mezon-pdf --locked -- --nocapture
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/crates/mezon-pdf/src/windows_pdf.rs
+++ b/crates/mezon-pdf/src/windows_pdf.rs
@@ -1,12 +1,26 @@
+use std::sync::OnceLock;
+
 use windows::Data::Pdf::{PdfDocument as WinPdfDocument, PdfPageRenderOptions};
 use windows::Storage::Streams::{DataReader, DataWriter, InMemoryRandomAccessStream};
 
+/// `Windows.Data.Pdf` ships with the desktop SKUs, but Server Core and the trimmed
+/// images leave the class unregistered, and activating it there fails with
+/// `REGDB_E_CLASSNOTREG`. Probe once so a machine that genuinely cannot render says
+/// so with the reason attached, instead of reporting every document as unreadable.
+fn probe() -> &'static Option<String> {
+    static PROBE: OnceLock<Option<String>> = OnceLock::new();
+    PROBE.get_or_init(|| match PdfPageRenderOptions::new() {
+        Ok(_) => None,
+        Err(error) => Some(format!("Windows.Data.Pdf could not be activated: {error}")),
+    })
+}
+
 pub fn is_available() -> bool {
-    true
+    probe().is_none()
 }
 
 pub fn unavailable_reason() -> Option<String> {
-    None
+    probe().clone()
 }
 
 pub struct Document {

--- a/crates/mezon-pdf/tests/smoke.rs
+++ b/crates/mezon-pdf/tests/smoke.rs
@@ -30,10 +30,16 @@ fn backend_ready() -> bool {
     if mezon_pdf::is_supported() {
         return true;
     }
-    eprintln!(
-        "skipping: {}",
-        mezon_pdf::unavailable_reason().unwrap_or_else(|| "pdf backend unavailable".to_string())
+    let reason =
+        mezon_pdf::unavailable_reason().unwrap_or_else(|| "pdf backend unavailable".to_string());
+    // A contributor without poppler should see a skip, not two failures in a crate they
+    // did not touch. CI rents a runner *for* the platform backend, so there the missing
+    // backend is the result being reported - skipping would pass without testing anything.
+    assert!(
+        std::env::var_os("MEZON_PDF_REQUIRE_BACKEND").is_none(),
+        "MEZON_PDF_REQUIRE_BACKEND is set but the backend is unavailable: {reason}"
     );
+    eprintln!("skipping: {reason}");
     false
 }
 

--- a/crates/mezon-ui/src/pdf_viewer/mod.rs
+++ b/crates/mezon-ui/src/pdf_viewer/mod.rs
@@ -54,6 +54,16 @@ pub fn open_pdf_viewer(request: OpenPdfRequest, window: &Window, cx: &mut App) {
     if request.url.is_empty() {
         return;
     }
+    // A machine with no renderer has nothing to show, and a window that opens only to
+    // say so is worse than no window: the click hands the document to whatever the OS
+    // opens pdfs with - the browser, on every platform we ship - and stays out of the way.
+    if !mezon_pdf::is_supported() {
+        if let Some(reason) = mezon_pdf::unavailable_reason() {
+            tracing::warn!("pdf viewer unavailable, opening externally: {reason}");
+        }
+        open_externally(&request.url, cx);
+        return;
+    }
     let placement = overlay_placement_from_window(window, cx);
     let mut pending = Some(request);
     if let Some(handle) = cx.try_global::<GlobalPdfViewer>().map(|g| g.0) {
@@ -223,21 +233,6 @@ impl PdfViewer {
     }
 
     fn start_load(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !mezon_pdf::is_supported() {
-            let detail = mezon_pdf::unavailable_reason();
-            if let Some(detail) = &detail {
-                tracing::warn!("pdf viewer unavailable: {detail}");
-            }
-            self.state = LoadState::Failed {
-                message: SharedString::from(mezon_i18n::t(
-                    &self.locale(cx),
-                    "media.pdf.unsupported",
-                )),
-                detail: detail.map(SharedString::from),
-            };
-            cx.notify();
-            return;
-        }
         self.state = LoadState::Loading;
         let url = self.url.to_string();
         let client = cx.http_client();
@@ -245,8 +240,9 @@ impl PdfViewer {
             let bytes = match fetch_pdf(client, url).await {
                 Ok(bytes) => bytes,
                 Err(error) => {
-                    tracing::warn!("pdf download failed: {error}");
-                    let _ = this.update(cx, |this, cx| this.fail(cx));
+                    let reason = error.to_string();
+                    tracing::warn!("pdf download failed: {reason}");
+                    let _ = this.update(cx, move |this, cx| this.fail(reason, cx));
                     return;
                 }
             };
@@ -257,8 +253,9 @@ impl PdfViewer {
             let document = match opened {
                 Ok(document) => Arc::new(document),
                 Err(error) => {
-                    tracing::warn!("pdf open failed: {error}");
-                    let _ = this.update(cx, |this, cx| this.fail(cx));
+                    let reason = error.to_string();
+                    tracing::warn!("pdf open failed: {reason}");
+                    let _ = this.update(cx, move |this, cx| this.fail(reason, cx));
                     return;
                 }
             };
@@ -273,10 +270,13 @@ impl PdfViewer {
         cx.notify();
     }
 
-    fn fail(&mut self, cx: &mut Context<Self>) {
+    /// The reason rides along under the message. Without it a failed document looks
+    /// the same whether the download 404'd, the bytes were not a pdf, or the platform
+    /// renderer refused the page — and a report from another OS cannot be acted on.
+    fn fail(&mut self, reason: String, cx: &mut Context<Self>) {
         self.state = LoadState::Failed {
             message: SharedString::from(mezon_i18n::t(&self.locale(cx), "media.pdf.loadFailed")),
-            detail: None,
+            detail: Some(SharedString::from(reason)),
         };
         cx.notify();
     }
@@ -310,7 +310,13 @@ impl PdfViewer {
                         let Some(buffer) =
                             image::RgbaImage::from_raw(bitmap.width, bitmap.height, bitmap.bgra)
                         else {
-                            this.fail(cx);
+                            this.fail(
+                                format!(
+                                    "page bitmap does not fill {}x{}",
+                                    bitmap.width, bitmap.height
+                                ),
+                                cx,
+                            );
                             return;
                         };
                         this.clear_page_image(Some(window), cx);
@@ -327,7 +333,7 @@ impl PdfViewer {
                     }
                     Err(error) => {
                         tracing::warn!("pdf page render failed: {error}");
-                        this.fail(cx);
+                        this.fail(error.to_string(), cx);
                     }
                 }
             });
@@ -408,9 +414,7 @@ impl PdfViewer {
     }
 
     fn open_externally(&self, cx: &mut App) {
-        if let Some(store) = PlatformStore::try_global(cx) {
-            let _ = store.read(cx).open_url_external(&self.url);
-        }
+        open_externally(&self.url, cx);
     }
 
     fn on_key_down(&mut self, event: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
@@ -423,6 +427,12 @@ impl PdfViewer {
             "0" => self.set_zoom(1.0, window, cx),
             _ => {}
         }
+    }
+}
+
+fn open_externally(url: &str, cx: &mut App) {
+    if let Some(store) = PlatformStore::try_global(cx) {
+        let _ = store.read(cx).open_url_external(url);
     }
 }
 


### PR DESCRIPTION
A machine with no renderer answered a click on a pdf with a window that existed only to say it could show nothing. Windows reports exactly that, even though its backend hardcoded `is_available() = true` and the branch is unreachable on that target - `touch`ing each file and checking against `x86_64-pc-windows-msvc` shows `windows_pdf.rs` compiled and `unsupported.rs` not - so nobody could explain the message, let alone fix it.

`open_pdf_viewer` now decides before opening anything: with no renderer the url goes straight to whatever the OS opens pdfs with - the browser, on all three platforms - and no window is created. Every entry point goes through that one door, so the file name, the pdf button and the mcp tool all behave the same. The unsupported screen inside the viewer goes away with it, leaving `media.pdf.unsupported` unused in the locale files.

Two changes behind it, so the next report from a platform we cannot run is worth something. The Windows backend stops asserting availability and probes `Windows.Data.Pdf` once, keeping the HRESULT as the reason. And `fail()` carries the underlying error into the detail line instead of dropping it: a failed document used to look identical whether the download 404'd, the bytes were not a pdf, or the renderer refused the page.

The smoke tests skip themselves when no backend is present, which would let a Windows CI job pass having rendered nothing, so `MEZON_PDF_REQUIRE_BACKEND` turns that skip into a failure and the new `windows-pdf` job sets it. That job is the only way to learn whether `Windows.Data.Pdf` works at all - macOS and Linux compile that file and never run it - and `mezon-pdf` is a leaf crate, so it costs minutes rather than a full `mezon-app` build.

Both paths were run, not just compiled. macOS renders the page and, with availability forced off, hands the url to the browser. Linux renders through poppler and, with `libpoppler-glib.so.8` removed, calls xdg-open with the same url and opens no window.


Claude-Session: https://claude.ai/code/session_013z7spEej4oZw1oVePndXGr