### PR TITLE
fix: fix width of word cause break word in list friend

### DIFF
--- a/crates/mezon-ui/src/chat/friends_page.rs
+++ b/crates/mezon-ui/src/chat/friends_page.rs
@@ -945,7 +945,7 @@ impl FriendsPage {
     }
 
     fn render_list(&self, theme: &Theme, locale: &str, cx: &mut Context<Self>) -> impl IntoElement {
-        let container = div().flex().flex_1().min_h_0().px_8().pb_4();
+        let container = div().flex().flex_1().min_h_0().px_8().pb_4().w_full();
 
         if self.rows.is_empty() {
             let has_text = self.search_has_text(cx);
@@ -966,11 +966,7 @@ impl FriendsPage {
                             .justify_center()
                             .text_center()
                             .mb(px(120.))
-                            .child(
-                                div()
-                                    .max_w_full()
-                                    .child(mezon_i18n::t(locale, key).to_string()),
-                            ),
+                            .child(mezon_i18n::t(locale, key).to_string()),
                     ),
             );
         }


### PR DESCRIPTION
> `Description:`

**env development:** window

<img width="1917" height="1020" alt="image" src="https://github.com/user-attachments/assets/b69a2897-3159-433a-a6c7-6bf96ed0c09e" />
<img width="1917" height="1018" alt="image" src="https://github.com/user-attachments/assets/5621e13e-2d69-487d-b03c-931492acbc5d" />
==================================================================================
<img width="1007" height="982" alt="image" src="https://github.com/user-attachments/assets/a5c14951-ca11-4a98-89e9-9508132aa539" />

