### PR TITLE
fix(voice): make call recordings match the live voice view

### DIFF
--- a/crates/mezon-app/src/mcp.rs
+++ b/crates/mezon-app/src/mcp.rs
@@ -235,6 +235,26 @@ impl McpRuntime {
                         let result = cx.update(mezon_ui::app::capture::leave_voice);
                         let _ = reply.send(result);
                     }
+                    #[cfg(debug_assertions)]
+                    McpCommand::SimulateParticipants {
+                        count,
+                        screenshare,
+                        focus,
+                        fullscreen,
+                        member_strip,
+                        reply,
+                    } => {
+                        let options = mezon_store::SimulatedCall {
+                            screenshare,
+                            focus,
+                            fullscreen,
+                            member_strip,
+                        };
+                        let result = cx.update(|cx| {
+                            mezon_ui::app::capture::simulate_participants(count, options, cx)
+                        });
+                        let _ = reply.send(result);
+                    }
                     McpCommand::GetRecordingState { reply } => {
                         let value = cx.update(mezon_ui::app::capture::recording_state);
                         let _ = reply.send(value);

--- a/crates/mezon-mcp/src/catalog.rs
+++ b/crates/mezon-mcp/src/catalog.rs
@@ -901,6 +901,22 @@ Stop the running call recording and finalize the file.
 Parameters: none.",
         write: true,
     },
+    #[cfg(debug_assertions)]
+    ToolSpec {
+        name: "simulate_participants",
+        description: "\
+Debug builds only. Fill the current call with synthetic participants so a crowded
+room can be driven on one machine. They are drawn from the connected clan's member
+list, so names and avatars resolve exactly like real participants; the first one is
+marked speaking and every third is muted. They persist across LiveKit updates until
+cleared.
+
+Parameters: count (integer) - how many to add; 0 clears them.
+Optional: screenshare (bool) - the first one also publishes a screen share;
+focus (bool) - focus that share; fullscreen (bool) - fullscreen it;
+member_strip (bool, default true) - the focus layout's participant strip.",
+        write: true,
+    },
     ToolSpec {
         name: "get_voice_status",
         description: "\

--- a/crates/mezon-mcp/src/command.rs
+++ b/crates/mezon-mcp/src/command.rs
@@ -79,6 +79,15 @@ pub enum McpCommand {
     LeaveVoice {
         reply: oneshot::Sender<anyhow::Result<Value>>,
     },
+    #[cfg(debug_assertions)]
+    SimulateParticipants {
+        count: usize,
+        screenshare: bool,
+        focus: bool,
+        fullscreen: bool,
+        member_strip: bool,
+        reply: oneshot::Sender<anyhow::Result<Value>>,
+    },
     GetRecordingState {
         reply: oneshot::Sender<Value>,
     },

--- a/crates/mezon-mcp/src/tools.rs
+++ b/crates/mezon-mcp/src/tools.rs
@@ -373,6 +373,32 @@ impl McpBackend {
                 self.send_ui_result(|reply| McpCommand::StopRecording { reply })
                     .await
             }
+            #[cfg(debug_assertions)]
+            "simulate_participants" => {
+                self.require_write_mode("simulate_participants")?;
+                let count = parse_i64_field(&arguments, "count")?.clamp(0, 200) as usize;
+                let flag = |name: &str, default: bool| {
+                    arguments
+                        .get(name)
+                        .and_then(Value::as_bool)
+                        .unwrap_or(default)
+                };
+                let (screenshare, focus, fullscreen, member_strip) = (
+                    flag("screenshare", false),
+                    flag("focus", false),
+                    flag("fullscreen", false),
+                    flag("member_strip", true),
+                );
+                self.send_ui_result(|reply| McpCommand::SimulateParticipants {
+                    count,
+                    screenshare,
+                    focus,
+                    fullscreen,
+                    member_strip,
+                    reply,
+                })
+                .await
+            }
             "get_voice_status" => self.get_voice_status().await,
             "list_stickers" => self.list_stickers().await,
             "get_sticker" => self.get_sticker(&arguments).await,

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -240,6 +240,8 @@ pub use user_profile::{
     resolve_user_profile,
 };
 pub use users_by_user::{UsersByUserEvent, UsersByUserStore};
+#[cfg(debug_assertions)]
+pub use voice::SimulatedCall;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub use voice::record_wayland_session;
 pub use voice::{

--- a/crates/mezon-store/src/voice.rs
+++ b/crates/mezon-store/src/voice.rs
@@ -261,7 +261,10 @@ pub struct VoiceStore {
     recording: RecordingState,
     recording_elapsed: Duration,
     recording_stalled: bool,
-    recording_avatars: HashMap<String, Option<Arc<mezon_voice::compose::AvatarImage>>>,
+    member_strip_visible: bool,
+    recording_avatars: HashMap<String, RecordingAvatar>,
+    #[cfg(debug_assertions)]
+    simulated_participants: Vec<VoiceParticipant>,
     _recording_tick: Option<Task<()>>,
     _recording_start: Option<Task<()>>,
     _events_task: Option<Task<()>>,
@@ -360,6 +363,76 @@ impl VoiceStore {
     }
 }
 
+#[cfg(debug_assertions)]
+const SIMULATED_SCREEN_KEY: u64 = u64::MAX - 1;
+
+#[cfg(debug_assertions)]
+#[derive(Debug, Clone, Copy)]
+pub struct SimulatedCall {
+    pub screenshare: bool,
+    pub focus: bool,
+    pub fullscreen: bool,
+    pub member_strip: bool,
+}
+
+#[cfg(debug_assertions)]
+impl Default for SimulatedCall {
+    fn default() -> Self {
+        Self {
+            screenshare: false,
+            focus: false,
+            fullscreen: false,
+            member_strip: true,
+        }
+    }
+}
+
+const RECORDING_AVATAR_PX: u32 = 256;
+
+const RECORDING_AVATAR_MAX_ATTEMPTS: u8 = 3;
+
+const RECORDING_AVATAR_WARMUP: Duration = Duration::from_millis(1_500);
+
+const RECORDING_AVATAR_WARMUP_STEP: Duration = Duration::from_millis(50);
+
+#[derive(Default)]
+struct RecordingAvatar {
+    url: String,
+    image: Option<Arc<mezon_voice::compose::AvatarImage>>,
+    loading: bool,
+    attempts: u8,
+}
+
+impl RecordingAvatar {
+    fn claim(&mut self, url: &str) -> bool {
+        if self.url != url {
+            *self = Self {
+                url: url.to_string(),
+                ..Self::default()
+            };
+        }
+        if self.loading || self.image.is_some() || self.attempts >= RECORDING_AVATAR_MAX_ATTEMPTS {
+            return false;
+        }
+        self.loading = true;
+        true
+    }
+
+    fn settle(&mut self, url: &str, image: Option<Arc<mezon_voice::compose::AvatarImage>>) {
+        if self.url != url {
+            return;
+        }
+        self.loading = false;
+        match image {
+            Some(image) => {
+                self.image = Some(image);
+                self.attempts = 0;
+            }
+            None => self.attempts += 1,
+        }
+    }
+}
+
 async fn load_avatar(url: &str) -> Option<Arc<mezon_voice::compose::AvatarImage>> {
     let (bytes, _) = mezon_client::transport_runtime::fetch_bytes(url)
         .await
@@ -368,7 +441,7 @@ async fn load_avatar(url: &str) -> Option<Arc<mezon_voice::compose::AvatarImage>
     let decoded = image::load_from_memory(&bytes)
         .map_err(|error| tracing::warn!("could not decode a recording avatar: {error}"))
         .ok()?
-        .thumbnail(256, 256)
+        .thumbnail(RECORDING_AVATAR_PX, RECORDING_AVATAR_PX)
         .to_rgba8();
     let (width, height) = decoded.dimensions();
     let mut bgra = decoded.into_raw();
@@ -382,11 +455,30 @@ async fn load_avatar(url: &str) -> Option<Arc<mezon_voice::compose::AvatarImage>
     }))
 }
 
+fn solo_tile_for(
+    fullscreen_screen: Option<u64>,
+    member_strip_visible: bool,
+    focused_tile: Option<&str>,
+    participants: &[VoiceParticipant],
+) -> Option<String> {
+    if let Some(key) = fullscreen_screen {
+        return participants
+            .iter()
+            .find(|p| p.screenshare == Some(key))
+            .map(|p| screen_tile_id(&p.identity));
+    }
+    if !member_strip_visible {
+        return focused_tile.map(str::to_string);
+    }
+    None
+}
+
 fn initial_of(name: &str) -> String {
     name.chars()
         .next()
-        .map(|c| c.to_uppercase().to_string())
-        .unwrap_or_default()
+        .and_then(|c| c.to_uppercase().next())
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "?".to_string())
 }
 
 pub fn screen_tile_id(identity: &str) -> String {
@@ -524,7 +616,10 @@ impl VoiceStore {
             recording: RecordingState::Idle,
             recording_elapsed: Duration::ZERO,
             recording_stalled: false,
+            member_strip_visible: true,
             recording_avatars: HashMap::new(),
+            #[cfg(debug_assertions)]
+            simulated_participants: Vec::new(),
             _recording_tick: None,
             _recording_start: None,
             _events_task: None,
@@ -810,6 +905,23 @@ impl VoiceStore {
 
     pub fn focused_tile(&self) -> Option<&str> {
         self.focused_tile.as_deref()
+    }
+
+    pub fn member_strip_visible(&self) -> bool {
+        self.member_strip_visible
+    }
+
+    pub fn set_member_strip_visible(&mut self, visible: bool, cx: &mut Context<Self>) {
+        if self.member_strip_visible == visible {
+            return;
+        }
+        self.member_strip_visible = visible;
+        self.publish_recording_scene(cx);
+        cx.notify();
+    }
+
+    pub fn toggle_member_strip(&mut self, cx: &mut Context<Self>) {
+        self.set_member_strip_visible(!self.member_strip_visible, cx);
     }
 
     pub fn link_copied(&self) -> bool {
@@ -2647,6 +2759,7 @@ impl VoiceStore {
                     });
                     list.retain(|p| !self.pending_removals.contains_key(&p.identity));
                 }
+                self.apply_simulated_participants(&mut list);
                 if self.participants == list {
                     return;
                 }
@@ -2982,6 +3095,33 @@ impl VoiceStore {
         cx.notify();
 
         self._recording_start = Some(cx.spawn(async move |this, cx| {
+            let deadline = Instant::now() + RECORDING_AVATAR_WARMUP;
+            while Instant::now() < deadline {
+                let loading = this
+                    .update(cx, |this, _| this.recording_avatars_loading())
+                    .unwrap_or(false);
+                if !loading {
+                    break;
+                }
+                cx.background_executor()
+                    .timer(RECORDING_AVATAR_WARMUP_STEP)
+                    .await;
+            }
+            let still_starting = this
+                .update(cx, |this, cx| {
+                    if this.session_generation != generation
+                        || this.recording != RecordingState::Starting
+                    {
+                        return false;
+                    }
+                    this.publish_recording_scene(cx);
+                    true
+                })
+                .unwrap_or(false);
+            if !still_starting {
+                return;
+            }
+
             let started = cx
                 .background_executor()
                 .spawn(async move { starter.start(path, scene) })
@@ -3142,6 +3282,117 @@ impl VoiceStore {
         .detach();
     }
 
+    fn recording_avatars_loading(&self) -> bool {
+        self.recording_avatars.values().any(|entry| entry.loading)
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn apply_simulated_participants(&self, _list: &mut Vec<VoiceParticipant>) {}
+
+    #[cfg(debug_assertions)]
+    fn apply_simulated_participants(&self, list: &mut Vec<VoiceParticipant>) {
+        for fake in &self.simulated_participants {
+            if !list.iter().any(|p| p.identity == fake.identity) {
+                list.push(fake.clone());
+            }
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn simulate_participants(&mut self, count: usize, cx: &mut Context<Self>) -> usize {
+        self.simulate_call(count, &SimulatedCall::default(), cx)
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn simulate_call(
+        &mut self,
+        count: usize,
+        options: &SimulatedCall,
+        cx: &mut Context<Self>,
+    ) -> usize {
+        let previous: Vec<String> = self
+            .simulated_participants
+            .iter()
+            .map(|p| p.identity.clone())
+            .collect();
+        self.simulated_participants.clear();
+
+        if count > 0 {
+            let taken: HashSet<String> = self
+                .participants
+                .iter()
+                .filter(|p| !previous.contains(&p.identity))
+                .map(|p| p.identity.clone())
+                .collect();
+            let clan_id = self
+                .connection
+                .connected_channel()
+                .and_then(|(_, clan)| clan.parse::<i64>().ok());
+            let mut pool: Vec<(String, String)> = Vec::new();
+            if let Some(clan_id) = clan_id
+                && let Some(store) = ClanMembersStore::try_global(cx)
+            {
+                for member in store.read(cx).members(ClanId(clan_id)) {
+                    let identity = member.id().0.to_string();
+                    if taken.contains(&identity) {
+                        continue;
+                    }
+                    pool.push((identity, member.name().to_string()));
+                    if pool.len() == count {
+                        break;
+                    }
+                }
+            }
+            for index in pool.len()..count {
+                pool.push((
+                    format!("9000000000000000{index:03}"),
+                    format!("test.user{index}"),
+                ));
+            }
+
+            self.simulated_participants = pool
+                .into_iter()
+                .enumerate()
+                .map(|(index, (identity, name))| VoiceParticipant {
+                    screenshare: (index == 0 && options.screenshare)
+                        .then_some(SIMULATED_SCREEN_KEY),
+                    identity,
+                    name,
+                    is_local: false,
+                    is_agent: false,
+                    speaking: index == 0,
+                    muted: index % 3 == 2,
+                    camera: None,
+                    quality: NetworkQuality::Excellent,
+                })
+                .collect();
+        }
+
+        let mut list = self.participants.clone();
+        list.retain(|p| !previous.contains(&p.identity));
+        self.apply_simulated_participants(&mut list);
+        self.track_visual_ranks(&list);
+        self.participants = list;
+
+        let screen_owner = self
+            .simulated_participants
+            .first()
+            .filter(|_| options.screenshare)
+            .map(|p| p.identity.clone());
+        self.focused_tile = match (&screen_owner, options.focus) {
+            (Some(identity), true) => Some(screen_tile_id(identity)),
+            _ => None,
+        };
+        self.fullscreen_screen =
+            (options.fullscreen && screen_owner.is_some()).then_some(SIMULATED_SCREEN_KEY);
+        self.member_strip_visible = options.member_strip;
+
+        self.fetch_missing_avatars(cx);
+        self.publish_recording_scene(cx);
+        cx.notify();
+        self.simulated_participants.len()
+    }
+
     fn fetch_missing_avatars(&mut self, cx: &mut Context<Self>) {
         let Some((_, clan)) = self.connection.connected_channel() else {
             return;
@@ -3149,35 +3400,72 @@ impl VoiceStore {
         let Ok(clan_id) = clan.parse::<i64>() else {
             return;
         };
-        let wanted: Vec<(String, String)> = self
-            .participants
-            .iter()
-            .filter(|p| !self.recording_avatars.contains_key(&p.identity))
-            .filter_map(|p| {
-                let uid = p.identity.parse::<i64>().ok()?;
-                let url = ClanMembersStore::try_global(cx).and_then(|store| {
-                    store
-                        .read(cx)
-                        .member(ClanId(clan_id), UserId(uid))
-                        .map(|m| m.avatar().to_string())
-                })?;
-                (!url.is_empty()).then_some((p.identity.clone(), url))
-            })
-            .collect();
+        let members = ClanMembersStore::try_global(cx);
+        let mut wanted: Vec<(String, String)> = Vec::new();
+        for participant in &self.participants {
+            let Ok(uid) = participant.identity.parse::<i64>() else {
+                continue;
+            };
+            let Some(source) = members.as_ref().and_then(|store| {
+                store
+                    .read(cx)
+                    .member(ClanId(clan_id), UserId(uid))
+                    .map(|m| m.avatar().to_string())
+            }) else {
+                continue;
+            };
+            if source.is_empty() {
+                continue;
+            }
+            let url = AppConfig::try_global(cx)
+                .map(|cfg| {
+                    cfg.imgproxy_url(&source, RECORDING_AVATAR_PX, RECORDING_AVATAR_PX, "fit")
+                })
+                .unwrap_or(source);
+            if self
+                .recording_avatars
+                .entry(participant.identity.clone())
+                .or_default()
+                .claim(&url)
+            {
+                wanted.push((participant.identity.clone(), url));
+            }
+        }
 
         for (identity, url) in wanted {
-            self.recording_avatars.insert(identity.clone(), None);
             cx.spawn(async move |this, cx| {
+                let fetch_url = url.clone();
                 let decoded = cx
                     .background_executor()
-                    .spawn(async move { load_avatar(&url).await })
+                    .spawn(async move { load_avatar(&fetch_url).await })
                     .await;
-                let _ = this.update(cx, |this, _| {
-                    this.recording_avatars.insert(identity, decoded);
+                let _ = this.update(cx, |this, cx| {
+                    let Some(entry) = this.recording_avatars.get_mut(&identity) else {
+                        return;
+                    };
+                    entry.settle(&url, decoded);
+                    this.publish_recording_scene(cx);
                 });
             })
             .detach();
         }
+    }
+
+    fn solo_recording_tile(&self) -> Option<String> {
+        solo_tile_for(
+            self.fullscreen_screen,
+            self.member_strip_visible,
+            self.focused_tile.as_deref(),
+            &self.participants,
+        )
+    }
+
+    fn fullscreen_recording_tile(&self) -> Option<String> {
+        let key = self.fullscreen_screen?;
+        self.participants
+            .iter()
+            .find(|p| p.screenshare == Some(key))
+            .map(|p| screen_tile_id(&p.identity))
     }
 
     fn publish_recording_scene(&self, cx: &App) {
@@ -3185,37 +3473,55 @@ impl VoiceStore {
             return;
         };
         let focused = self.focused_tile();
+        let solo = self.solo_recording_tile();
+        let fullscreen = self.fullscreen_recording_tile();
         let mut tiles = Vec::new();
         for participant in &self.participants {
             let label = self.display_name_for(participant, cx);
             let avatar = self
                 .recording_avatars
                 .get(&participant.identity)
-                .cloned()
-                .flatten();
+                .and_then(|entry| entry.image.clone());
             if let Some(key) = participant.screenshare {
                 let id = screen_tile_id(&participant.identity);
-                tiles.push(mezon_voice::compose::SceneTile {
-                    focused: focused == Some(id.as_str()),
-                    key: id,
-                    label: label.clone(),
-                    initial: initial_of(&label),
-                    avatar: avatar.clone(),
-                    frame_key: Some(key),
-                    is_screen_share: true,
-                    speaking: false,
-                });
+                let solo_tile = solo.as_deref() == Some(id.as_str());
+                if solo.is_none() || solo_tile {
+                    let is_fullscreen = fullscreen.as_deref() == Some(id.as_str());
+                    let label = if is_fullscreen {
+                        String::new()
+                    } else {
+                        label.clone()
+                    };
+                    tiles.push(mezon_voice::compose::SceneTile {
+                        focused: solo_tile || focused == Some(id.as_str()),
+                        fullscreen: is_fullscreen,
+                        key: id,
+                        initial: initial_of(&label),
+                        label,
+                        avatar: avatar.clone(),
+                        frame_key: Some(key),
+                        is_screen_share: true,
+                        speaking: false,
+                        muted: participant.muted,
+                    });
+                }
             }
             let id = camera_tile_id(&participant.identity);
+            let solo_tile = solo.as_deref() == Some(id.as_str());
+            if solo.is_some() && !solo_tile {
+                continue;
+            }
             tiles.push(mezon_voice::compose::SceneTile {
-                focused: focused == Some(id.as_str()),
+                focused: solo_tile || focused == Some(id.as_str()),
+                fullscreen: false,
                 key: id,
-                label: label.clone(),
                 initial: initial_of(&label),
-                avatar: avatar.clone(),
+                label,
+                avatar,
                 frame_key: participant.camera,
                 is_screen_share: false,
                 speaking: participant.speaking,
+                muted: participant.muted,
             });
         }
         session.record_scene().set(tiles);
@@ -3312,6 +3618,7 @@ impl VoiceStore {
         self.cancel_reconnect_watchdog();
         self.close_pip(cx);
         self.fullscreen_screen = None;
+        self.member_strip_visible = true;
         self.clear_session_handles(window, cx);
         self.connection = VoiceConnection::Idle;
         self.call_status = VoiceCallStatus::Stable;
@@ -3434,12 +3741,132 @@ mod tests {
 
     use super::parse_raise_token;
     use super::{
-        INTERACTIVE_LAUNCH_DEDUP_TTL, MAX_SOUND_BYTES, is_duplicate_interactive_launch,
-        redact_interactive_app_url, validate_sound_file,
+        INTERACTIVE_LAUNCH_DEDUP_TTL, MAX_SOUND_BYTES, RECORDING_AVATAR_MAX_ATTEMPTS,
+        RecordingAvatar, is_duplicate_interactive_launch, redact_interactive_app_url,
+        solo_tile_for, validate_sound_file,
     };
     use crate::{VoiceInteractiveApp, VoiceInteractiveEventType};
     use gpui::RenderImage;
     use parking_lot::Mutex;
+
+    #[test]
+    fn an_open_member_strip_records_everyone() {
+        let people = [
+            voice_participant("1", Some(7)),
+            voice_participant("2", None),
+        ];
+        assert_eq!(
+            solo_tile_for(None, true, Some(&screen_tile_id("1")), &people),
+            None
+        );
+    }
+
+    #[test]
+    fn a_closed_member_strip_records_only_the_focused_tile() {
+        let people = [
+            voice_participant("1", Some(7)),
+            voice_participant("2", None),
+        ];
+        assert_eq!(
+            solo_tile_for(None, false, Some(&screen_tile_id("1")), &people),
+            Some(screen_tile_id("1"))
+        );
+        assert_eq!(
+            solo_tile_for(None, false, Some(&camera_tile_id("2")), &people),
+            Some(camera_tile_id("2"))
+        );
+    }
+
+    #[test]
+    fn a_closed_strip_with_nothing_focused_still_records_the_grid() {
+        let people = [voice_participant("1", None)];
+        assert_eq!(solo_tile_for(None, false, None, &people), None);
+    }
+
+    #[test]
+    fn a_fullscreen_share_records_only_that_share() {
+        let people = [
+            voice_participant("1", Some(7)),
+            voice_participant("2", None),
+        ];
+        assert_eq!(
+            solo_tile_for(Some(7), true, Some(&camera_tile_id("2")), &people),
+            Some(screen_tile_id("1"))
+        );
+    }
+
+    #[test]
+    fn a_fullscreen_key_whose_sharer_left_records_nothing_extra() {
+        let people = [voice_participant("2", None)];
+        assert_eq!(solo_tile_for(Some(7), true, None, &people), None);
+    }
+
+    fn avatar_pixel() -> Arc<mezon_voice::compose::AvatarImage> {
+        Arc::new(mezon_voice::compose::AvatarImage {
+            width: 1,
+            height: 1,
+            bgra: vec![0, 0, 0, 255],
+        })
+    }
+
+    #[test]
+    fn a_loaded_avatar_is_not_fetched_again() {
+        let mut slot = RecordingAvatar::default();
+        assert!(slot.claim("https://cdn/a.png"));
+        slot.settle("https://cdn/a.png", Some(avatar_pixel()));
+        assert!(!slot.claim("https://cdn/a.png"));
+    }
+
+    #[test]
+    fn a_changed_avatar_drops_the_picture_it_replaces() {
+        let mut slot = RecordingAvatar::default();
+        assert!(slot.claim("https://cdn/old.png"));
+        slot.settle("https://cdn/old.png", Some(avatar_pixel()));
+
+        assert!(slot.claim("https://cdn/new.png"));
+        assert!(
+            slot.image.is_none(),
+            "the recording must not keep drawing the old avatar"
+        );
+    }
+
+    #[test]
+    fn a_fetch_that_lands_after_the_avatar_changed_is_ignored() {
+        let mut slot = RecordingAvatar::default();
+        assert!(slot.claim("https://cdn/old.png"));
+        assert!(slot.claim("https://cdn/new.png"));
+
+        slot.settle("https://cdn/old.png", Some(avatar_pixel()));
+        assert!(slot.image.is_none());
+        assert!(slot.loading, "the newer fetch is still in flight");
+    }
+
+    #[test]
+    fn a_failed_fetch_retries_a_bounded_number_of_times() {
+        let mut slot = RecordingAvatar::default();
+        for _ in 0..RECORDING_AVATAR_MAX_ATTEMPTS {
+            assert!(slot.claim("https://cdn/a.png"));
+            slot.settle("https://cdn/a.png", None);
+        }
+        assert!(
+            !slot.claim("https://cdn/a.png"),
+            "a URL that keeps failing must stop hitting the CDN every tick"
+        );
+        assert!(
+            slot.claim("https://cdn/b.png"),
+            "a new URL starts over from a clean slot"
+        );
+    }
+
+    #[test]
+    fn a_recovered_fetch_clears_the_failure_count() {
+        let mut slot = RecordingAvatar::default();
+        assert!(slot.claim("https://cdn/a.png"));
+        slot.settle("https://cdn/a.png", None);
+        assert!(slot.claim("https://cdn/a.png"));
+        slot.settle("https://cdn/a.png", Some(avatar_pixel()));
+        assert_eq!(slot.attempts, 0);
+    }
 
     #[test]
     fn interactive_app_type_maps_only_app_events() {

--- a/crates/mezon-ui/src/app/capture.rs
+++ b/crates/mezon-ui/src/app/capture.rs
@@ -1326,6 +1326,25 @@ pub fn open_message_pdf_viewer(
     Ok(serde_json::json!({ "ok": true, "url": opened }))
 }
 
+#[cfg(debug_assertions)]
+pub fn simulate_participants(
+    count: usize,
+    options: mezon_store::SimulatedCall,
+    cx: &mut App,
+) -> anyhow::Result<serde_json::Value> {
+    let voice = mezon_store::VoiceStore::try_global(cx)
+        .ok_or_else(|| anyhow::anyhow!("the voice store is not available"))?;
+    let added = voice.update(cx, |store, cx| store.simulate_call(count, &options, cx));
+    Ok(serde_json::json!({
+        "ok": true,
+        "simulated": added,
+        "screenshare": options.screenshare,
+        "focus": options.focus,
+        "fullscreen": options.fullscreen,
+        "member_strip": options.member_strip,
+    }))
+}
+
 pub fn join_voice(channel_id: i64, clan_id: i64, cx: &mut App) -> anyhow::Result<Value> {
     let voice = mezon_store::VoiceStore::try_global(cx)
         .ok_or_else(|| anyhow::anyhow!("the voice store is not available"))?;

--- a/crates/mezon-ui/src/chat/layout.rs
+++ b/crates/mezon-ui/src/chat/layout.rs
@@ -63,7 +63,6 @@ pub struct ChatLayout {
     voice_grid_page: usize,
     voice_grid_wheel_accum: f32,
     voice_grid_size: Size<Pixels>,
-    voice_show_members: bool,
     voice_show_chat: bool,
     voice_session_key: Option<String>,
     voice_visual: crate::chat::voice::VoiceVisualState,
@@ -528,7 +527,6 @@ impl ChatLayout {
             voice_grid_page: 0,
             voice_grid_wheel_accum: 0.,
             voice_grid_size: Size::default(),
-            voice_show_members: true,
             voice_show_chat: false,
             voice_session_key: None,
             voice_visual: Default::default(),
@@ -2449,7 +2447,6 @@ impl ChatLayout {
         };
         if self.voice_session_key != key {
             self.voice_session_key = key;
-            self.voice_show_members = true;
             self.voice_show_chat = false;
             self.voice_grid_page = 0;
             self.voice_grid_wheel_accum = 0.;
@@ -2461,7 +2458,9 @@ impl ChatLayout {
     }
 
     pub(crate) fn toggle_voice_member_strip(&mut self, cx: &mut Context<Self>) {
-        self.voice_show_members = !self.voice_show_members;
+        self.voice_store
+            .clone()
+            .update(cx, |store, cx| store.toggle_member_strip(cx));
         cx.notify();
     }
 
@@ -3019,7 +3018,7 @@ impl ChatLayout {
                     self.voice_strip_width,
                     self.voice_grid_page,
                     self.voice_grid_size,
-                    self.voice_show_members,
+                    self.voice_store.read(cx).member_strip_visible(),
                     show_chat,
                     self.inbox_handle.clone(),
                     &mut self.voice_visual,

--- a/crates/mezon-voice/src/compose/layout.rs
+++ b/crates/mezon-voice/src/compose/layout.rs
@@ -1,8 +1,11 @@
-pub const GAP: f32 = 10.0;
-pub const RADIUS: f32 = 12.0;
+pub const GAP: f32 = 8.0;
+pub const PADDING: f32 = 8.0;
+pub const RADIUS: f32 = 8.0;
 
-const FOCUS_STRIP_SCREEN_SHARE: f32 = 0.13;
-const FOCUS_STRIP_CAMERA: f32 = 0.17;
+const STRIP_MAX_HEIGHT: f32 = 93.0;
+const STRIP_MIN_TILE_WIDTH: f32 = 140.0;
+const STRIP_ASPECT_RATIO: f32 = 16.0 / 10.0;
+const FOCUS_MAIN_SHARE: f32 = 5.0 / 6.0;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TileRect {
@@ -12,132 +15,229 @@ pub struct TileRect {
     pub h: f32,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct TileShape {
     pub focused: bool,
     pub contain: bool,
+    pub fullscreen: bool,
 }
 
-pub fn layout_tiles(width: f32, height: f32, tiles: &[TileShape]) -> Vec<Option<TileRect>> {
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Placement {
+    pub tile: usize,
+    pub rect: TileRect,
+    pub thumbnail: bool,
+}
+
+enum GridOrientation {
+    Portrait,
+    Landscape,
+}
+
+struct GridLayoutDef {
+    columns: usize,
+    rows: usize,
+    min_width: f32,
+    orientation: Option<GridOrientation>,
+}
+
+impl GridLayoutDef {
+    const fn new(columns: usize, rows: usize, min_width: f32) -> Self {
+        Self {
+            columns,
+            rows,
+            min_width,
+            orientation: None,
+        }
+    }
+
+    const fn oriented(columns: usize, rows: usize, orientation: GridOrientation) -> Self {
+        Self {
+            columns,
+            rows,
+            min_width: 0.,
+            orientation: Some(orientation),
+        }
+    }
+
+    fn max_tiles(&self) -> usize {
+        self.columns * self.rows
+    }
+
+    fn fits_orientation(&self, landscape: bool) -> bool {
+        match self.orientation {
+            None => true,
+            Some(GridOrientation::Landscape) => landscape,
+            Some(GridOrientation::Portrait) => !landscape,
+        }
+    }
+}
+
+const GRID_LAYOUTS: &[GridLayoutDef] = &[
+    GridLayoutDef::new(1, 1, 0.),
+    GridLayoutDef::oriented(1, 2, GridOrientation::Portrait),
+    GridLayoutDef::oriented(2, 1, GridOrientation::Landscape),
+    GridLayoutDef::new(2, 2, 560.),
+    GridLayoutDef::new(3, 3, 700.),
+    GridLayoutDef::new(4, 4, 960.),
+    GridLayoutDef::new(5, 5, 1100.),
+];
+
+fn select_grid_layout(
+    layouts: &[GridLayoutDef],
+    participant_count: usize,
+    width: f32,
+    height: f32,
+) -> (usize, usize) {
+    if width <= 0. || height <= 0. {
+        return (layouts[0].columns, layouts[0].rows);
+    }
+    let landscape = width / height > 1.;
+    let mut selected = None;
+    for (index, layout) in layouts.iter().enumerate() {
+        let bigger_same_capacity = layouts[index + 1..]
+            .iter()
+            .any(|l| l.max_tiles() == layout.max_tiles() && l.fits_orientation(landscape));
+        if layout.max_tiles() >= participant_count && !bigger_same_capacity {
+            selected = Some(index);
+            break;
+        }
+    }
+    let index = selected.unwrap_or(layouts.len() - 1);
+    let layout = &layouts[index];
+    if width < layout.min_width && index > 0 {
+        let smaller_count = layouts[index - 1].max_tiles();
+        return select_grid_layout(&layouts[..index], smaller_count, width, height);
+    }
+    (layout.columns, layout.rows)
+}
+
+pub fn layout_tiles(width: f32, height: f32, tiles: &[TileShape]) -> Vec<Placement> {
     let count = tiles.len();
-    if count == 0 {
+    if count == 0 || width <= 0.0 || height <= 0.0 {
         return Vec::new();
     }
 
-    let focus_index = tiles.iter().position(|tile| tile.focused);
-    match focus_index {
+    if let Some(tile) = tiles.iter().position(|tile| tile.fullscreen) {
+        return vec![Placement {
+            tile,
+            rect: TileRect {
+                x: 0.0,
+                y: 0.0,
+                w: width,
+                h: height,
+            },
+            thumbnail: false,
+        }];
+    }
+
+    match tiles.iter().position(|tile| tile.focused) {
         Some(focus) => layout_with_focus(width, height, tiles, focus),
         None => layout_grid(width, height, count),
     }
 }
 
-fn layout_with_focus(
-    width: f32,
-    height: f32,
-    tiles: &[TileShape],
-    focus: usize,
-) -> Vec<Option<TileRect>> {
+fn layout_with_focus(width: f32, height: f32, tiles: &[TileShape], focus: usize) -> Vec<Placement> {
     let count = tiles.len();
-    let mut rects: Vec<Option<TileRect>> = vec![None; count];
-    let others: Vec<usize> = (0..count).filter(|index| *index != focus).collect();
-
-    let focus_is_screen_share = tiles[focus].contain;
-    let strip_height = if others.is_empty() {
-        0.0
-    } else {
-        let ratio = if focus_is_screen_share {
-            FOCUS_STRIP_SCREEN_SHARE
-        } else {
-            FOCUS_STRIP_CAMERA
-        };
-        (height * ratio).round()
-    };
-
-    rects[focus] = Some(if focus_is_screen_share {
-        TileRect {
-            x: 0.0,
-            y: 0.0,
-            w: width,
-            h: height,
-        }
-    } else {
-        TileRect {
-            x: GAP,
-            y: GAP,
-            w: width - GAP * 2.0,
-            h: height - strip_height - GAP * 2.0,
-        }
-    });
-
-    if others.is_empty() {
-        return rects;
+    let inner_width = width - PADDING * 2.0;
+    let inner_height = height - PADDING * 2.0;
+    if inner_width <= 0.0 || inner_height <= 0.0 {
+        return Vec::new();
     }
 
-    let cell_height = strip_height - GAP;
-    let cell_width = (cell_height * 16.0 / 9.0).round();
-    let max_visible = (((width - GAP) / (cell_width + GAP)).floor() as isize).max(1) as usize;
-    let visible = others.len().min(max_visible);
-    let strip_width = visible as f32 * cell_width + (visible as f32 - 1.0) * GAP;
-    let strip_x = if focus_is_screen_share {
-        width - strip_width - GAP
+    let strip: Vec<usize> = if tiles[focus].contain {
+        (0..count).collect()
     } else {
-        ((width - strip_width) / 2.0).round()
+        (0..count).filter(|index| *index != focus).collect()
     };
-    let strip_y = height - strip_height;
 
-    for (position, index) in others.iter().enumerate() {
-        rects[*index] = (position < visible).then_some(TileRect {
-            x: strip_x + position as f32 * (cell_width + GAP),
-            y: strip_y,
-            w: cell_width,
-            h: cell_height,
+    let main_full = Placement {
+        tile: focus,
+        rect: TileRect {
+            x: PADDING,
+            y: PADDING,
+            w: inner_width,
+            h: inner_height,
+        },
+        thumbnail: false,
+    };
+    if strip.is_empty() || strip == [focus] {
+        return vec![main_full];
+    }
+
+    let free = inner_height - GAP;
+    if free <= 0.0 {
+        return vec![main_full];
+    }
+    let strip_height = (free * (1.0 - FOCUS_MAIN_SHARE)).min(STRIP_MAX_HEIGHT);
+    let main_height = free - strip_height;
+
+    let mut placements = vec![Placement {
+        tile: focus,
+        rect: TileRect {
+            x: PADDING,
+            y: PADDING,
+            w: inner_width,
+            h: main_height,
+        },
+        thumbnail: false,
+    }];
+
+    let tile_width = (strip_height * STRIP_ASPECT_RATIO).max(STRIP_MIN_TILE_WIDTH);
+    let max_visible = (((inner_width + GAP) / (tile_width + GAP)).floor() as isize).max(1) as usize;
+    let visible = strip.len().min(max_visible);
+    let content_width = visible as f32 * tile_width + (visible as f32 - 1.0) * GAP;
+    let strip_x = PADDING + ((inner_width - content_width) / 2.0).max(0.0);
+    let strip_y = PADDING + main_height + GAP;
+
+    for (position, tile) in strip.into_iter().take(visible).enumerate() {
+        placements.push(Placement {
+            tile,
+            rect: TileRect {
+                x: strip_x + position as f32 * (tile_width + GAP),
+                y: strip_y,
+                w: tile_width,
+                h: strip_height,
+            },
+            thumbnail: true,
         });
     }
 
-    rects
+    placements
 }
 
-fn layout_grid(width: f32, height: f32, count: usize) -> Vec<Option<TileRect>> {
-    let mut best_cols = 1usize;
-    let mut best_width = 0.0f32;
-    let mut best_height = 0.0f32;
-
-    for cols in 1..=count {
-        let rows = count.div_ceil(cols);
-        let avail_width = (width - GAP * (cols as f32 + 1.0)) / cols as f32;
-        let avail_height = (height - GAP * (rows as f32 + 1.0)) / rows as f32;
-        if avail_width <= 0.0 || avail_height <= 0.0 {
-            continue;
-        }
-        let scale = (avail_width / 16.0).min(avail_height / 9.0);
-        let tile_width = scale * 16.0;
-        let tile_height = scale * 9.0;
-        if tile_width * tile_height > best_width * best_height {
-            best_cols = cols;
-            best_width = tile_width;
-            best_height = tile_height;
-        }
+fn layout_grid(width: f32, height: f32, count: usize) -> Vec<Placement> {
+    let (columns, rows) = grid_shape(width, height, count);
+    let cell_width = (width - PADDING * 2.0 - GAP * (columns as f32 - 1.0)) / columns as f32;
+    let cell_height = (height - PADDING * 2.0 - GAP * (rows as f32 - 1.0)) / rows as f32;
+    if cell_width <= 0.0 || cell_height <= 0.0 {
+        return Vec::new();
     }
-
-    let row_count = count.div_ceil(best_cols);
-    let grid_top =
-        (height - (row_count as f32 * best_height + (row_count as f32 - 1.0) * GAP)) / 2.0;
 
     (0..count)
         .map(|index| {
-            let row = index / best_cols;
-            let col = index - row * best_cols;
-            let in_row = best_cols.min(count - row * best_cols);
-            let row_left =
-                (width - (in_row as f32 * best_width + (in_row as f32 - 1.0) * GAP)) / 2.0;
-            Some(TileRect {
-                x: row_left + col as f32 * (best_width + GAP),
-                y: grid_top + row as f32 * (best_height + GAP),
-                w: best_width,
-                h: best_height,
-            })
+            let row = index / columns;
+            let column = index - row * columns;
+            Placement {
+                tile: index,
+                rect: TileRect {
+                    x: PADDING + column as f32 * (cell_width + GAP),
+                    y: PADDING + row as f32 * (cell_height + GAP),
+                    w: cell_width,
+                    h: cell_height,
+                },
+                thumbnail: false,
+            }
         })
         .collect()
+}
+
+fn grid_shape(width: f32, height: f32, count: usize) -> (usize, usize) {
+    let (columns, rows) = select_grid_layout(GRID_LAYOUTS, count, width, height);
+    if columns * rows >= count {
+        return (columns, rows);
+    }
+    (columns, count.div_ceil(columns))
 }
 
 #[cfg(test)]
@@ -145,13 +245,19 @@ mod tests {
     use super::*;
 
     fn plain(count: usize) -> Vec<TileShape> {
-        vec![
-            TileShape {
-                focused: false,
-                contain: false,
-            };
-            count
-        ]
+        vec![TileShape::default(); count]
+    }
+
+    fn rect_of(placements: &[Placement], tile: usize) -> TileRect {
+        placements
+            .iter()
+            .find(|p| p.tile == tile && !p.thumbnail)
+            .expect("a main placement")
+            .rect
+    }
+
+    fn thumbnails(placements: &[Placement]) -> Vec<&Placement> {
+        placements.iter().filter(|p| p.thumbnail).collect()
     }
 
     #[test]
@@ -160,21 +266,43 @@ mod tests {
     }
 
     #[test]
-    fn a_single_tile_keeps_the_sixteen_by_nine_shape() {
-        let rects = layout_tiles(1280.0, 720.0, &plain(1));
-        let rect = rects[0].expect("one rect");
-        assert!((rect.w / rect.h - 16.0 / 9.0).abs() < 0.01);
-        assert!(rect.x >= 0.0 && rect.y >= 0.0);
-        assert!(rect.x + rect.w <= 1280.0 + 0.5);
+    fn a_single_tile_fills_the_frame_inside_the_padding() {
+        let placements = layout_tiles(1280.0, 720.0, &plain(1));
+        assert_eq!(
+            rect_of(&placements, 0),
+            TileRect {
+                x: PADDING,
+                y: PADDING,
+                w: 1280.0 - PADDING * 2.0,
+                h: 720.0 - PADDING * 2.0,
+            }
+        );
+    }
+
+    #[test]
+    fn a_landscape_pair_sits_side_by_side() {
+        let placements = layout_tiles(1280.0, 720.0, &plain(2));
+        let left = rect_of(&placements, 0);
+        let right = rect_of(&placements, 1);
+        assert_eq!(left.y, right.y);
+        assert!((left.w - right.w).abs() < 0.01);
+        assert!((right.x - (left.x + left.w + GAP)).abs() < 0.01);
+    }
+
+    #[test]
+    fn a_short_last_row_stays_left_aligned_like_the_live_grid() {
+        let placements = layout_tiles(1280.0, 720.0, &plain(3));
+        let first = rect_of(&placements, 0);
+        let third = rect_of(&placements, 2);
+        assert_eq!(third.x, first.x);
+        assert!(third.y > first.y);
     }
 
     #[test]
     fn tiles_never_leave_the_frame() {
         for count in 1..=12 {
-            for rect in layout_tiles(1280.0, 720.0, &plain(count))
-                .into_iter()
-                .flatten()
-            {
+            for placement in layout_tiles(1280.0, 720.0, &plain(count)) {
+                let rect = placement.rect;
                 assert!(rect.x >= -0.5, "count {count}");
                 assert!(rect.y >= -0.5, "count {count}");
                 assert!(rect.x + rect.w <= 1280.5, "count {count}");
@@ -185,12 +313,10 @@ mod tests {
 
     #[test]
     fn a_grid_never_overlaps_two_tiles() {
-        let rects: Vec<TileRect> = layout_tiles(1280.0, 720.0, &plain(5))
-            .into_iter()
-            .flatten()
-            .collect();
-        for (i, a) in rects.iter().enumerate() {
-            for b in rects.iter().skip(i + 1) {
+        let placements = layout_tiles(1280.0, 720.0, &plain(5));
+        for (i, a) in placements.iter().enumerate() {
+            for b in placements.iter().skip(i + 1) {
+                let (a, b) = (a.rect, b.rect);
                 let separated = a.x + a.w <= b.x + 0.5
                     || b.x + b.w <= a.x + 0.5
                     || a.y + a.h <= b.y + 0.5
@@ -201,21 +327,23 @@ mod tests {
     }
 
     #[test]
-    fn a_focused_screen_share_takes_the_whole_frame() {
-        let tiles = vec![
-            TileShape {
-                focused: true,
-                contain: true,
-            },
-            TileShape {
-                focused: false,
-                contain: false,
-            },
-        ];
-        let rects = layout_tiles(1280.0, 720.0, &tiles);
-        let focus = rects[0].expect("focus rect");
+    fn a_crowd_past_the_last_layout_grows_rows_instead_of_paging() {
+        let placements = layout_tiles(1280.0, 720.0, &plain(30));
+        assert_eq!(placements.len(), 30);
+        assert!(placements.iter().all(|p| p.rect.y + p.rect.h <= 720.5));
+    }
+
+    #[test]
+    fn a_fullscreen_share_is_the_only_thing_drawn() {
+        let mut tiles = plain(4);
+        tiles[1].contain = true;
+        tiles[1].focused = true;
+        tiles[1].fullscreen = true;
+        let placements = layout_tiles(1280.0, 720.0, &tiles);
+        assert_eq!(placements.len(), 1);
+        assert_eq!(placements[0].tile, 1);
         assert_eq!(
-            focus,
+            placements[0].rect,
             TileRect {
                 x: 0.0,
                 y: 0.0,
@@ -223,49 +351,90 @@ mod tests {
                 h: 720.0
             }
         );
-        let thumb = rects[1].expect("thumb rect");
-        assert!(thumb.y > 720.0 * 0.8, "thumbnail sits in the bottom strip");
-        assert!(thumb.x + thumb.w <= 1280.5);
     }
 
     #[test]
-    fn a_focused_camera_leaves_room_for_the_strip() {
-        let tiles = vec![
-            TileShape {
-                focused: true,
-                contain: false,
-            },
-            TileShape {
-                focused: false,
-                contain: false,
-            },
-        ];
-        let rects = layout_tiles(1280.0, 720.0, &tiles);
-        let focus = rects[0].expect("focus rect");
-        assert!(focus.x >= GAP - 0.01);
-        assert!(focus.y + focus.h < 720.0 - 720.0 * FOCUS_STRIP_CAMERA + GAP);
+    fn a_focused_share_keeps_its_own_thumbnail_in_the_strip() {
+        let mut tiles = plain(3);
+        tiles[0].contain = true;
+        tiles[0].focused = true;
+        let placements = layout_tiles(1280.0, 720.0, &tiles);
+        let strip = thumbnails(&placements);
+        assert_eq!(strip.len(), 3, "the share is in the strip as well");
+        assert!(strip.iter().any(|p| p.tile == 0));
     }
 
     #[test]
-    fn a_focused_tile_alone_uses_no_strip() {
-        let tiles = vec![TileShape {
-            focused: true,
-            contain: false,
-        }];
-        let rects = layout_tiles(1280.0, 720.0, &tiles);
-        let focus = rects[0].expect("focus rect");
-        assert!((focus.h - (720.0 - GAP * 2.0)).abs() < 0.01);
+    fn a_focused_camera_is_left_out_of_the_strip() {
+        let mut tiles = plain(3);
+        tiles[0].focused = true;
+        let placements = layout_tiles(1280.0, 720.0, &tiles);
+        let strip = thumbnails(&placements);
+        assert_eq!(strip.len(), 2);
+        assert!(strip.iter().all(|p| p.tile != 0));
+    }
+
+    #[test]
+    fn the_strip_is_centred_and_capped_in_height() {
+        let mut tiles = plain(3);
+        tiles[0].focused = true;
+        let placements = layout_tiles(1280.0, 720.0, &tiles);
+        let strip = thumbnails(&placements);
+        let first = strip.first().expect("a thumbnail").rect;
+        let last = strip.last().expect("a thumbnail").rect;
+        assert!(first.h <= STRIP_MAX_HEIGHT + 0.01);
+        assert!((first.w / first.h - STRIP_ASPECT_RATIO).abs() < 0.01);
+        let lead = first.x - PADDING;
+        let trail = (1280.0 - PADDING) - (last.x + last.w);
+        assert!((lead - trail).abs() < 1.0, "centred: {lead} vs {trail}");
+    }
+
+    #[test]
+    fn the_main_tile_sits_above_the_strip_with_one_gap() {
+        let mut tiles = plain(2);
+        tiles[0].focused = true;
+        let placements = layout_tiles(1280.0, 720.0, &tiles);
+        let main = rect_of(&placements, 0);
+        let thumb = thumbnails(&placements)[0].rect;
+        assert_eq!(main.x, PADDING);
+        assert_eq!(main.y, PADDING);
+        assert!((thumb.y - (main.y + main.h + GAP)).abs() < 0.01);
+        assert!((thumb.y + thumb.h - (720.0 - PADDING)).abs() < 0.01);
+    }
+
+    #[test]
+    fn a_lone_focused_share_gets_no_strip_of_itself() {
+        let mut tiles = plain(1);
+        tiles[0].focused = true;
+        tiles[0].contain = true;
+        let placements = layout_tiles(1280.0, 720.0, &tiles);
+        assert_eq!(placements.len(), 1);
+        assert!(!placements[0].thumbnail);
+    }
+
+    #[test]
+    fn a_focused_tile_alone_uses_the_whole_frame() {
+        let mut tiles = plain(1);
+        tiles[0].focused = true;
+        let placements = layout_tiles(1280.0, 720.0, &tiles);
+        assert_eq!(placements.len(), 1);
+        assert_eq!(
+            placements[0].rect,
+            TileRect {
+                x: PADDING,
+                y: PADDING,
+                w: 1280.0 - PADDING * 2.0,
+                h: 720.0 - PADDING * 2.0,
+            }
+        );
     }
 
     #[test]
     fn a_strip_that_cannot_fit_everyone_drops_the_overflow() {
-        let mut tiles = vec![TileShape {
-            focused: true,
-            contain: true,
-        }];
-        tiles.extend(plain(40));
-        let rects = layout_tiles(1280.0, 720.0, &tiles);
-        assert!(rects.iter().skip(1).any(Option::is_none));
-        assert!(rects.iter().skip(1).any(Option::is_some));
+        let mut tiles = plain(41);
+        tiles[0].focused = true;
+        tiles[0].contain = true;
+        let strip = thumbnails(&layout_tiles(1280.0, 720.0, &tiles)).len();
+        assert!(strip > 0 && strip < 41);
     }
 }

--- a/crates/mezon-voice/src/compose/mod.rs
+++ b/crates/mezon-voice/src/compose/mod.rs
@@ -2,7 +2,7 @@ mod layout;
 mod render;
 mod text;
 
-pub use layout::{GAP, RADIUS, TileRect, TileShape, layout_tiles};
+pub use layout::{GAP, PADDING, RADIUS, TileRect, TileShape, layout_tiles};
 pub use render::{DrawTile, Renderer, SourceImage, accent_for};
 pub use text::TextPainter;
 
@@ -26,7 +26,9 @@ pub struct SceneTile {
     pub avatar: Option<Arc<AvatarImage>>,
     pub is_screen_share: bool,
     pub focused: bool,
+    pub fullscreen: bool,
     pub speaking: bool,
+    pub muted: bool,
 }
 
 #[derive(Clone, Default)]

--- a/crates/mezon-voice/src/compose/render.rs
+++ b/crates/mezon-voice/src/compose/render.rs
@@ -7,23 +7,36 @@ use super::layout::{RADIUS, TileRect, TileShape, layout_tiles};
 use super::text::TextPainter;
 use cosmic_text::Weight;
 
-const BACKGROUND: u32 = 0x0b0d10;
-const TILE_BACKGROUND: u32 = 0x1e2124;
-const SPEAKING: u32 = 0x3ba55d;
-const SPEAKING_WIDTH: f32 = 3.0;
-const AVATAR_RATIO: f32 = 0.34;
-const AVATAR_MIN: f32 = 32.0;
+const BACKGROUND: u32 = 0x1e1f22;
+const TILE_BACKGROUND: u32 = 0x5c5e66;
+const SPEAKING: u32 = 0x1f8cf9;
+const SPEAKING_WIDTH: f32 = 2.5;
 
-const ACCENTS: [u32; 8] = [
-    0x5865f2, 0x3ba55d, 0xfaa61a, 0xed4245, 0xeb459e, 0x00a8fc, 0x9b59b6, 0x1abc9c,
+const AVATAR_RATIO: f32 = 0.33;
+const AVATAR_MIN: f32 = 44.0;
+const AVATAR_MAX: f32 = 80.0;
+const AVATAR_INITIAL_RATIO: f32 = 0.4;
+const STRIP_AVATAR_RATIO: f32 = 0.6;
+const STRIP_AVATAR_MIN: f32 = 24.0;
+
+const LABEL_INSET: f32 = 8.0;
+const LABEL_PADDING: f32 = 5.0;
+const LABEL_RADIUS: f32 = 6.0;
+const LABEL_TEXT: f32 = 16.0;
+const LABEL_LINE_HEIGHT: f32 = 16.0;
+const LABEL_SCRIM_ALPHA: u8 = 0x80;
+
+const ACCENTS: [u32; 7] = [
+    0xade603, 0x00b2cc, 0xfda63c, 0xe16dcc, 0xe8467b, 0x9c7cfd, 0x22e2b3,
 ];
 
-pub fn accent_for(seed: &str) -> u32 {
-    let mut hash: u32 = 0;
-    for byte in seed.bytes() {
-        hash = hash.wrapping_mul(31).wrapping_add(byte as u32);
-    }
-    ACCENTS[(hash % ACCENTS.len() as u32) as usize]
+pub fn accent_for(name: &str) -> u32 {
+    let code = first_upper_char(name).map(|c| c as u32).unwrap_or(0);
+    ACCENTS[(code % ACCENTS.len() as u32) as usize]
+}
+
+fn first_upper_char(name: &str) -> Option<char> {
+    name.chars().next().and_then(|c| c.to_uppercase().next())
 }
 
 pub struct SourceImage<'a> {
@@ -40,6 +53,7 @@ pub struct DrawTile<'a> {
     pub accent: u32,
     pub shape: TileShape,
     pub speaking: bool,
+    pub muted: bool,
 }
 
 pub struct Renderer {
@@ -75,27 +89,16 @@ impl Renderer {
         let shapes: Vec<TileShape> = tiles.iter().map(|tile| tile.shape).collect();
         let width = self.pixmap.width() as f32;
         let height = self.pixmap.height() as f32;
-        let rects = layout_tiles(width, height, &shapes);
 
-        if let Some(focus) = shapes.iter().position(|shape| shape.focused)
-            && let Some(Some(rect)) = rects.get(focus)
-        {
-            self.draw_tile(&tiles[focus], *rect);
-        }
-        for (index, rect) in rects.iter().enumerate() {
-            if shapes.get(index).is_some_and(|shape| shape.focused) {
-                continue;
-            }
-            if let Some(rect) = rect {
-                self.draw_tile(&tiles[index], *rect);
-            }
+        for placement in layout_tiles(width, height, &shapes) {
+            self.draw_tile(&tiles[placement.tile], placement.rect, placement.thumbnail);
         }
 
         bgra_from_pixmap(self.pixmap.as_ref(), &mut self.output);
         &self.output
     }
 
-    fn draw_tile(&mut self, tile: &DrawTile<'_>, rect: TileRect) {
+    fn draw_tile(&mut self, tile: &DrawTile<'_>, rect: TileRect, thumbnail: bool) {
         let x = rect.x.round();
         let y = rect.y.round();
         let w = rect.w.round();
@@ -125,15 +128,20 @@ impl Renderer {
             Some(image) if image.width > 0 && image.height > 0 && !image.bgra.is_empty() => {
                 self.draw_image(image, x, y, w, h, tile.shape.contain, &path);
             }
-            _ => match &tile.avatar {
-                Some(avatar) => self.draw_avatar(avatar, x, y, w, h),
-                None => self.draw_avatar_placeholder(tile.accent, tile.initial, x, y, w, h),
-            },
+            _ => {
+                let size = avatar_size(h, thumbnail);
+                match &tile.avatar {
+                    Some(avatar) => self.draw_avatar(avatar, size, x, y, w, h),
+                    None => {
+                        self.draw_avatar_placeholder(tile.accent, tile.initial, size, x, y, w, h)
+                    }
+                }
+            }
         }
 
         self.draw_label(tile.label, x, y, w, h);
 
-        if tile.speaking {
+        if tile.speaking && !tile.muted && !tile.shape.contain {
             let Some(border) = rounded_rect(
                 x + SPEAKING_WIDTH / 2.0,
                 y + SPEAKING_WIDTH / 2.0,
@@ -209,8 +217,7 @@ impl Renderer {
             .fill_path(clip, &paint, FillRule::Winding, Transform::identity(), None);
     }
 
-    fn draw_avatar(&mut self, avatar: &SourceImage<'_>, x: f32, y: f32, w: f32, h: f32) {
-        let size = AVATAR_MIN.max(w.min(h) * AVATAR_RATIO);
+    fn draw_avatar(&mut self, avatar: &SourceImage<'_>, size: f32, x: f32, y: f32, w: f32, h: f32) {
         let cx = x + w / 2.0;
         let cy = y + h / 2.0;
         let mut builder = PathBuilder::new();
@@ -233,12 +240,12 @@ impl Renderer {
         &mut self,
         accent: u32,
         initial: &str,
+        size: f32,
         x: f32,
         y: f32,
         w: f32,
         h: f32,
     ) {
-        let size = AVATAR_MIN.max(w.min(h) * AVATAR_RATIO);
         let cx = x + w / 2.0;
         let cy = y + h / 2.0;
         let mut builder = PathBuilder::new();
@@ -262,7 +269,7 @@ impl Renderer {
         if initial.is_empty() {
             return;
         }
-        let font_size = (size * 0.42).round();
+        let font_size = (size * AVATAR_INITIAL_RATIO).round();
         let text_width = self.text.measure(initial, font_size, Weight::SEMIBOLD);
         self.text.draw(
             &mut self.pixmap,
@@ -279,34 +286,32 @@ impl Renderer {
         if label.is_empty() {
             return;
         }
-        let font_size = (h * 0.075).round().clamp(11.0, 20.0);
-        let pad = (font_size * 0.55).round();
-        let max_text_width = w - pad * 4.0;
+        let max_text_width = w - LABEL_INSET * 2.0 - LABEL_PADDING * 2.0;
         if max_text_width <= 0.0 {
             return;
         }
         let text = self
             .text
-            .truncate(label, font_size, Weight::MEDIUM, max_text_width);
-        let text_width = self.text.measure(&text, font_size, Weight::MEDIUM);
-        let pill_height = font_size + pad;
-        let pill_y = y + h - pill_height - (pad * 0.7).round();
-        let pill_x = x + (pad * 0.7).round();
+            .truncate(label, LABEL_TEXT, Weight::NORMAL, max_text_width);
+        let text_width = self.text.measure(&text, LABEL_TEXT, Weight::NORMAL);
+        let chip_height = LABEL_LINE_HEIGHT + LABEL_PADDING * 2.0;
+        let chip_width = text_width + LABEL_PADDING * 2.0;
+        let chip_x = x + LABEL_INSET;
+        let chip_y = y + h - LABEL_INSET - chip_height;
 
-        if let Some(pill) = rounded_rect(
-            pill_x,
-            pill_y,
-            text_width + pad * 2.0,
-            pill_height,
-            pill_height / 2.0,
-        ) {
+        if let Some(chip) = rounded_rect(chip_x, chip_y, chip_width, chip_height, LABEL_RADIUS) {
             let paint = Paint {
                 anti_alias: true,
-                shader: tiny_skia::Shader::SolidColor(Color::from_rgba8(0, 0, 0, 140)),
+                shader: tiny_skia::Shader::SolidColor(Color::from_rgba8(
+                    0,
+                    0,
+                    0,
+                    LABEL_SCRIM_ALPHA,
+                )),
                 ..Paint::default()
             };
             self.pixmap.fill_path(
-                &pill,
+                &chip,
                 &paint,
                 FillRule::Winding,
                 Transform::identity(),
@@ -317,12 +322,20 @@ impl Renderer {
         self.text.draw(
             &mut self.pixmap,
             &text,
-            font_size,
-            Weight::MEDIUM,
-            x + (pad * 1.7).round(),
-            pill_y + pill_height / 2.0,
+            LABEL_TEXT,
+            Weight::NORMAL,
+            chip_x + LABEL_PADDING,
+            chip_y + chip_height / 2.0,
             0xffffff,
         );
+    }
+}
+
+fn avatar_size(tile_height: f32, thumbnail: bool) -> f32 {
+    if thumbnail {
+        (tile_height * STRIP_AVATAR_RATIO).clamp(STRIP_AVATAR_MIN, AVATAR_MAX)
+    } else {
+        (tile_height * AVATAR_RATIO).clamp(AVATAR_MIN, AVATAR_MAX)
     }
 }
 
@@ -405,11 +418,11 @@ mod tests {
     }
 
     #[test]
-    fn an_empty_scene_renders_the_background() {
+    fn an_empty_scene_renders_the_live_grid_background() {
         let mut renderer = Renderer::new(320, 180).expect("renderer");
         let frame = renderer.render(&[]).to_vec();
         assert_eq!(frame.len(), 320 * 180 * 4);
-        assert_eq!(pixel(&frame, 320, 5, 5), [0x10, 0x0d, 0x0b, 255]);
+        assert_eq!(pixel(&frame, 320, 2, 2), [0x22, 0x1f, 0x1e, 255]);
     }
 
     #[test]
@@ -422,11 +435,9 @@ mod tests {
                 label: "",
                 initial: "",
                 accent: 0xff0000,
-                shape: TileShape {
-                    focused: false,
-                    contain: false,
-                },
+                shape: TileShape::default(),
                 speaking: false,
+                muted: false,
             }])
             .to_vec();
         let centre = pixel(&frame, 320, 160, 90);
@@ -451,11 +462,9 @@ mod tests {
                     height: 36,
                 }),
                 accent: 0x000000,
-                shape: TileShape {
-                    focused: false,
-                    contain: false,
-                },
+                shape: TileShape::default(),
                 speaking: false,
+                muted: false,
             }])
             .to_vec();
         let centre = pixel(&frame, 320, 160, 90);
@@ -463,7 +472,7 @@ mod tests {
     }
 
     #[test]
-    fn a_speaking_tile_draws_a_green_border() {
+    fn a_speaking_tile_draws_the_speaking_border() {
         let mut renderer = Renderer::new(320, 180).expect("renderer");
         let quiet = renderer
             .render(&[DrawTile {
@@ -474,9 +483,10 @@ mod tests {
                 accent: 0x000000,
                 shape: TileShape {
                     focused: true,
-                    contain: false,
+                    ..TileShape::default()
                 },
                 speaking: false,
+                muted: false,
             }])
             .to_vec();
         let loud = renderer
@@ -488,18 +498,49 @@ mod tests {
                 accent: 0x000000,
                 shape: TileShape {
                     focused: true,
-                    contain: false,
+                    ..TileShape::default()
                 },
                 speaking: true,
+                muted: false,
             }])
             .to_vec();
         assert_ne!(quiet, loud, "the speaking border changes the frame");
     }
 
     #[test]
-    fn an_accent_is_stable_per_seed() {
+    fn an_accent_matches_the_avatar_primitives_palette() {
         assert_eq!(accent_for("alice"), accent_for("alice"));
         assert!(ACCENTS.contains(&accent_for("bob")));
+        assert_eq!(accent_for("lich.duongthanh"), accent_for("Lam"));
+        assert_ne!(accent_for("lich.duongthanh"), accent_for("ha.lehong"));
+        assert_eq!(accent_for(""), ACCENTS[0]);
+    }
+
+    #[test]
+    fn a_muted_speaker_gets_no_border() {
+        let mut renderer = Renderer::new(320, 180).expect("renderer");
+        let tile = |muted| DrawTile {
+            image: None,
+            avatar: None,
+            label: "",
+            initial: "",
+            accent: 0x000000,
+            shape: TileShape::default(),
+            speaking: true,
+            muted,
+        };
+        let quiet = renderer.render(&[tile(true)]).to_vec();
+        let loud = renderer.render(&[tile(false)]).to_vec();
+        assert_ne!(quiet, loud, "only the unmuted speaker lights up");
+    }
+
+    #[test]
+    fn an_avatar_never_outgrows_the_live_grids_cap() {
+        assert_eq!(avatar_size(704.0, false), AVATAR_MAX);
+        assert_eq!(avatar_size(60.0, false), AVATAR_MIN);
+        assert_eq!(avatar_size(200.0, false), 66.0);
+        assert_eq!(avatar_size(93.0, true), 93.0 * STRIP_AVATAR_RATIO);
+        assert_eq!(avatar_size(20.0, true), STRIP_AVATAR_MIN);
     }
 
     #[test]
@@ -512,11 +553,9 @@ mod tests {
                 label: "",
                 initial: "",
                 accent: accent_for(&index.to_string()),
-                shape: TileShape {
-                    focused: false,
-                    contain: false,
-                },
+                shape: TileShape::default(),
                 speaking: index % 3 == 0,
+                muted: false,
             })
             .collect();
         assert_eq!(renderer.render(&tiles).len(), 1280 * 720 * 4);
@@ -534,8 +573,13 @@ mod tests {
             label: "Nguyen Van Long",
             initial: "N",
             accent: 0x3ba55d,
-            shape: TileShape { focused, contain },
+            shape: TileShape {
+                focused,
+                contain,
+                fullscreen: false,
+            },
             speaking: true,
+            muted: false,
         }
     }
 

--- a/crates/mezon-voice/src/record.rs
+++ b/crates/mezon-voice/src/record.rs
@@ -207,12 +207,14 @@ fn compose_pump(
                 }),
                 label: tile.label.as_str(),
                 initial: tile.initial.as_str(),
-                accent: accent_for(&tile.key),
+                accent: accent_for(&tile.label),
                 shape: TileShape {
                     focused: tile.focused,
                     contain: tile.is_screen_share,
+                    fullscreen: tile.fullscreen,
                 },
                 speaking: tile.speaking,
+                muted: tile.muted,
             })
             .collect();
 


### PR DESCRIPTION
The recording compositor drew its own thing rather than what the call showed, which reported as three separate bugs.

Avatars. The recording resolved `member.avatar()` and fetched it raw, skipping the `read_media_url` rewrite every render path applies through imgproxy, so an avatar stored against the upload origin never loaded and the tile fell back to its initial. A failed fetch was then cached forever, because the `None` written as an in-flight marker also became the failure state and `contains_key` filtered the participant out of every later attempt. The cache was keyed only by identity and never invalidated, so it survived across calls and clans and kept drawing an avatar the call had already replaced. Entries now carry the URL they were fetched from, refetch when it changes, retry a bounded number of times, and republish the scene when one lands. The recorder also waits briefly for the opening fetches so the first frames are not the initial-letter placeholder.

Style. Colours, sizes, radii, the grid ladder and the name chip are now ported from `mezon-ui/src/chat/voice.rs` instead of being invented: `bg_tertiary` behind the grid, `PARTICIPANT_TILE_BG` tiles, `rounded_lg`, `gap_2`/`p_2`, the blue speaking border (off when muted or sharing), the avatar clamp that stops a lone tile blowing the face up to a quarter of the frame, `AVATAR_COLORS` keyed by the first character of the name, and the `GRID_LAYOUTS` ladder with a left-aligned short last row.

Focus and fullscreen. A fullscreen share hides everything else in the app and closing the member strip leaves only the focused tile, but the recording knew neither: `fullscreen_screen` was never read and the strip flag lived in `ChatLayout` where the store could not see it. The flag moves to `VoiceStore` so both read one value, and the scene collapses to the solo tile. The focus layout itself is ported too - a focused share keeps its own strip thumbnail the way the app does, which is why layout now returns placements rather than one rect per tile.

Adds a debug-only `simulate_participants` MCP tool that fills a call with synthetic participants drawn from the clan member list, and drives the share/focus/fullscreen/strip knobs, so these paths can be exercised on one machine. It is gated on `debug_assertions` end to end and absent from release builds.