### PR TITLE
fix(sidebar): sort threads alphabetically under their parent channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6052,6 +6052,7 @@ dependencies = [
  "smallvec",
  "tokio",
  "tracing",
+ "unicode-normalization",
  "url",
 ]
 

--- a/crates/mezon-store/Cargo.toml
+++ b/crates/mezon-store/Cargo.toml
@@ -35,6 +35,7 @@ url.workspace = true
 tokio.workspace = true
 prost.workspace = true
 regex.workspace = true
+unicode-normalization.workspace = true
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/mezon-store/src/channel.rs
+++ b/crates/mezon-store/src/channel.rs
@@ -30,6 +30,7 @@ use crate::permissions::{
     PERMISSION_MANAGE_CLAN, PermissionStore,
 };
 use crate::realtime::{RealtimeDispatch, RealtimeKind};
+use crate::text_utils::normalize_diacritics;
 use crate::threads::CHANNEL_TYPE_THREAD;
 
 pub const FAVOR_CATE_ID: &str = "favorCate";
@@ -4041,6 +4042,12 @@ impl ChannelList {
         );
     }
 
+    fn resort_thread_block_for(&mut self, clan_id: ClanId, channel_id: ChannelId) {
+        if let Some(categories) = self.cache.get_mut(&clan_id) {
+            resort_thread_block(categories, channel_id);
+        }
+    }
+
     pub fn ensure_thread_with_parent_active(
         &mut self,
         thread_id: ChannelId,
@@ -4052,7 +4059,10 @@ impl ChannelList {
         private: Option<bool>,
         cx: &mut Context<Self>,
     ) {
+        let mut already_present = false;
+        let mut renamed = false;
         if let Some(existing) = self.channel_mut(clan_id, thread_id) {
+            already_present = true;
             let mut changed = sync_thread_active_status(existing, active, active_confirmed);
             if let Some(private) = private
                 && existing.private != private
@@ -4061,11 +4071,17 @@ impl ChannelList {
                 changed = true;
             }
             if !label.is_empty() && existing.name != label {
-                existing.name = label;
+                existing.name = label.clone();
+                renamed = true;
                 changed = true;
             }
             if changed {
                 cx.notify();
+            }
+        }
+        if already_present {
+            if renamed {
+                self.resort_thread_block_for(clan_id, thread_id);
             }
             return;
         }
@@ -4239,6 +4255,7 @@ impl ChannelList {
             }
         }
 
+        self.resort_thread_block_for(clan_id, channel_id);
         self.reactivating.remove(&channel_id);
         self.archived_channel_ids.remove(&channel_id);
         self.archived_channel_parents.remove(&channel_id);
@@ -4651,6 +4668,7 @@ impl ChannelList {
                     ch.category_id = Some(e.category_id.to_string());
                 }
             }
+            self.resort_thread_block_for(clan_id, channel_id);
         } else if let Some(ch) = self.channel_mut(clan_id, channel_id) {
             ch.active = CHANNEL_ACTIVE_JOINED;
             if !label.is_empty() {
@@ -5091,6 +5109,47 @@ fn assemble_with_favorites(mut categories: Vec<Category>, clan_id: ClanId) -> Ve
     categories
 }
 
+/// Sort key for a thread row in the sidebar: accent-folded, lower-cased label,
+/// tie-broken by id so equal labels keep a stable order.
+fn thread_sort_key(ch: &Channel) -> (String, ChannelId) {
+    (normalize_diacritics(&ch.name), ch.id)
+}
+
+/// Half-open range of the contiguous rows belonging to `parent_id`'s thread block.
+fn thread_block_bounds(channels: &[Channel], parent_id: ChannelId) -> Option<(usize, usize)> {
+    let start = channels
+        .iter()
+        .position(|ch| ch.parent_id == Some(parent_id))?;
+    let mut end = start;
+    while end < channels.len() && channels[end].parent_id == Some(parent_id) {
+        end += 1;
+    }
+    Some((start, end))
+}
+
+/// Re-sorts the thread block `channel_id` belongs to. Labels are mutated in place
+/// on rename, which would otherwise leave the block unsorted until the next clan
+/// refetch and mislead the binary search in `insert_channel`.
+fn resort_thread_block(categories: &mut [Category], channel_id: ChannelId) {
+    let Some(parent_id) = categories
+        .iter()
+        .filter(|c| c.id != FAVOR_CATE_ID)
+        .flat_map(|c| c.channels.iter())
+        .find(|ch| ch.id == channel_id)
+        .and_then(|ch| ch.parent_id)
+    else {
+        return;
+    };
+    for cat in categories.iter_mut() {
+        if cat.id == FAVOR_CATE_ID {
+            continue;
+        }
+        if let Some((start, end)) = thread_block_bounds(&cat.channels, parent_id) {
+            cat.channels[start..end].sort_by_cached_key(thread_sort_key);
+        }
+    }
+}
+
 fn flatten_parents_with_threads(
     mut parents: Vec<Channel>,
     thread_groups: &mut HashMap<ChannelId, Vec<Channel>>,
@@ -5100,7 +5159,8 @@ fn flatten_parents_with_threads(
     for parent in parents {
         let threads = thread_groups.remove(&parent.id);
         ordered.push(parent);
-        if let Some(ts) = threads {
+        if let Some(mut ts) = threads {
+            ts.sort_by_cached_key(thread_sort_key);
             ordered.extend(ts);
         }
     }
@@ -5221,17 +5281,13 @@ fn insert_channel(categories: &mut Vec<Category>, mut channel: Channel) -> bool 
             .iter_mut()
             .find(|c| c.id != FAVOR_CATE_ID && c.id == target_cat_id)
         {
-            let insert_pos = cat
-                .channels
-                .iter()
-                .position(|ch| ch.parent_id == Some(parent_id))
-                .map(|first_thread_pos| {
-                    let mut end = first_thread_pos;
-                    while end < cat.channels.len() && cat.channels[end].parent_id == Some(parent_id)
-                    {
-                        end += 1;
-                    }
-                    end
+            let key = thread_sort_key(&channel);
+            let insert_pos = thread_block_bounds(&cat.channels, parent_id)
+                .map(|(start, end)| {
+                    // The block is kept sorted, so binary-search the slot instead of
+                    // folding every label on the way past.
+                    start
+                        + cat.channels[start..end].partition_point(|ch| thread_sort_key(ch) <= key)
                 })
                 .or_else(|| {
                     cat.channels
@@ -5699,6 +5755,9 @@ fn update_channel(
                 found = true;
             }
         }
+    }
+    if found && label.is_some() {
+        resort_thread_block(categories, channel_id);
     }
     found
 }
@@ -6692,6 +6751,73 @@ mod tests {
     }
 
     #[test]
+    fn update_channel_resorts_the_thread_block_after_a_rename() {
+        let mut alpha = make_thread(15, 10, "cat1");
+        alpha.name = "alpha".into();
+        let mut mike = make_thread(16, 10, "cat1");
+        mike.name = "mike".into();
+        let mut zulu = make_thread(17, 10, "cat1");
+        zulu.name = "zulu".into();
+        let mut cats = vec![Category {
+            id: "cat1".into(),
+            clan_id: ClanId(1),
+            name: "General".into(),
+            order: 0,
+            channels: vec![
+                make_channel(10, "parent", "cat1"),
+                alpha,
+                mike,
+                zulu,
+                make_channel(50, "later", "cat1"),
+            ],
+        }];
+
+        assert!(update_channel(
+            &mut cats,
+            ChannelId(15),
+            Some("zzz".into()),
+            None,
+            None,
+            false,
+        ));
+
+        let names: Vec<&str> = cats[0].channels.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["parent", "mike", "zulu", "zzz", "later"]);
+    }
+
+    #[test]
+    fn insert_channel_still_lands_correctly_after_a_rename() {
+        let mut alpha = make_thread(15, 10, "cat1");
+        alpha.name = "alpha".into();
+        let mut zulu = make_thread(17, 10, "cat1");
+        zulu.name = "zulu".into();
+        let mut cats = vec![Category {
+            id: "cat1".into(),
+            clan_id: ClanId(1),
+            name: "General".into(),
+            order: 0,
+            channels: vec![make_channel(10, "parent", "cat1"), alpha, zulu],
+        }];
+
+        // "alpha" -> "yankee" moves it behind nothing yet, but the block must stay sorted
+        assert!(update_channel(
+            &mut cats,
+            ChannelId(15),
+            Some("yankee".into()),
+            None,
+            None,
+            false,
+        ));
+
+        let mut mike = make_thread(99, 10, "cat1");
+        mike.name = "mike".into();
+        assert!(insert_channel(&mut cats, mike));
+
+        let names: Vec<&str> = cats[0].channels.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["parent", "mike", "yankee", "zulu"]);
+    }
+
+    #[test]
     fn update_channel_patches_topic_and_age_restricted() {
         let mut c = categories();
         assert!(update_channel(
@@ -7048,11 +7174,11 @@ mod tests {
         let cats = build_categories(api_cats, &mut channels);
         assert_eq!(cats.len(), 1);
         let ids: Vec<i64> = cats[0].channels.iter().map(|c| c.id.get()).collect();
-        assert_eq!(ids, vec![10, 15, 12, 20, 25]);
+        assert_eq!(ids, vec![10, 12, 15, 20, 25]);
     }
 
     #[test]
-    fn build_categories_keeps_server_order_within_a_thread_group() {
+    fn build_categories_sorts_threads_alphabetically_within_a_group() {
         let api_cats = vec![ApiCategoryDesc {
             category_id: 1,
             category_name: "General".into(),
@@ -7068,7 +7194,54 @@ mod tests {
         let mut channels = vec![make_channel(10, "parent", "1"), zulu, alpha, mike];
         let cats = build_categories(api_cats, &mut channels);
         let names: Vec<&str> = cats[0].channels.iter().map(|c| c.name.as_str()).collect();
-        assert_eq!(names, vec!["parent", "zulu", "alpha", "mike"]);
+        assert_eq!(names, vec!["parent", "alpha", "mike", "zulu"]);
+    }
+
+    #[test]
+    fn build_categories_thread_sort_is_case_and_accent_insensitive() {
+        let api_cats = vec![ApiCategoryDesc {
+            category_id: 1,
+            category_name: "General".into(),
+            clan_id: 1,
+            category_order: 0,
+        }];
+        let mut da_nang = make_thread(11, 10, "1");
+        da_nang.name = "Đà Nẵng".into();
+        let mut zebra = make_thread(12, 10, "1");
+        zebra.name = "zebra".into();
+        let mut echo = make_thread(13, 10, "1");
+        echo.name = "Echo".into();
+        let mut channels = vec![make_channel(10, "parent", "1"), zebra, echo, da_nang];
+        let cats = build_categories(api_cats, &mut channels);
+        let names: Vec<&str> = cats[0].channels.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["parent", "Đà Nẵng", "Echo", "zebra"]);
+    }
+
+    #[test]
+    fn insert_channel_places_thread_at_alphabetical_position() {
+        let mut alpha = make_thread(15, 10, "cat1");
+        alpha.name = "alpha".into();
+        let mut zulu = make_thread(40, 10, "cat1");
+        zulu.name = "zulu".into();
+        let mut cats = vec![Category {
+            id: "cat1".into(),
+            clan_id: ClanId(1),
+            name: "General".into(),
+            order: 0,
+            channels: vec![
+                make_channel(10, "parent", "cat1"),
+                alpha,
+                zulu,
+                make_channel(50, "later", "cat1"),
+            ],
+        }];
+
+        let mut mike = make_thread(99, 10, "cat1");
+        mike.name = "mike".into();
+        assert!(insert_channel(&mut cats, mike));
+
+        let names: Vec<&str> = cats[0].channels.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["parent", "alpha", "mike", "zulu", "later"]);
     }
 
     #[test]
@@ -11068,6 +11241,97 @@ mod tests {
                 channels.user_channels.insert(ChannelId(42), dm);
                 channels.user_channels_order.push(ChannelId(42));
                 assert!(channels.should_persist_compose_draft(ChannelId(42)));
+            });
+        });
+    }
+
+    fn structure_with_three_named_threads() -> Vec<Category> {
+        let api_cats = vec![ApiCategoryDesc {
+            category_id: 1,
+            category_name: "General".into(),
+            clan_id: 1,
+            category_order: 0,
+        }];
+        let mut channels = vec![{
+            let mut ch = make_channel(1, "parent", "1");
+            ch.clan_id = ClanId(1);
+            ch
+        }];
+        for (id, name) in [(7, "alpha"), (8, "mike"), (9, "zulu")] {
+            let mut ch = make_channel(id, name, "1");
+            ch.clan_id = ClanId(1);
+            ch.parent_id = Some(ChannelId(1));
+            ch.channel_type = ChannelType::Thread;
+            channels.push(ch);
+        }
+        build_categories(api_cats, &mut channels)
+    }
+
+    fn thread_names_in_clan(channels: &ChannelList, clan_id: ClanId) -> Vec<String> {
+        channels
+            .categories_for_clan(clan_id)
+            .iter()
+            .filter(|c| c.id != FAVOR_CATE_ID)
+            .flat_map(|c| c.channels.iter())
+            .map(|ch| ch.name.clone())
+            .collect()
+    }
+
+    #[gpui::test]
+    fn ensure_thread_with_parent_active_resorts_after_a_rename(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list_with_threads(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_three_named_threads(),
+                    None,
+                    cx,
+                );
+                assert_eq!(
+                    thread_names_in_clan(channels, ClanId(1)),
+                    vec!["parent", "alpha", "mike", "zulu"]
+                );
+
+                // "alpha" (id 7) is renamed to a label that belongs at the end
+                channels.ensure_thread_with_parent_active(
+                    ChannelId(7),
+                    ChannelId(1),
+                    ClanId(1),
+                    "zzz".into(),
+                    CHANNEL_ACTIVE_JOINED,
+                    true,
+                    None,
+                    cx,
+                );
+
+                assert_eq!(
+                    thread_names_in_clan(channels, ClanId(1)),
+                    vec!["parent", "mike", "zulu", "zzz"]
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn apply_thread_reactivated_resorts_after_a_rename(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let channels = init_channel_list_with_threads(cx);
+            channels.update(cx, |channels, cx| {
+                channels.apply_clan_structure(
+                    ClanId(1),
+                    structure_with_three_named_threads(),
+                    None,
+                    cx,
+                );
+
+                // "zulu" (id 9) comes back with a label that belongs first
+                channels.apply_thread_reactivated(ClanId(1), ChannelId(9), Some("aaa".into()), cx);
+
+                assert_eq!(
+                    thread_names_in_clan(channels, ClanId(1)),
+                    vec!["parent", "aaa", "alpha", "mike"]
+                );
             });
         });
     }

--- a/crates/mezon-store/src/lib.rs
+++ b/crates/mezon-store/src/lib.rs
@@ -56,6 +56,7 @@ pub mod roles;
 pub mod sprite_atlas;
 pub mod sticker;
 pub mod stream;
+pub mod text_utils;
 pub mod threads;
 pub mod topic_badges;
 pub mod topics;

--- a/crates/mezon-store/src/text_utils.rs
+++ b/crates/mezon-store/src/text_utils.rs
@@ -1,0 +1,25 @@
+use unicode_normalization::UnicodeNormalization;
+
+fn push_compatibility_folded(ch: char, out: &mut String) {
+    match ch {
+        '\u{0111}' | '\u{00f0}' => out.push('d'),
+        '\u{0142}' => out.push('l'),
+        '\u{00f8}' => out.push('o'),
+        '\u{00df}' => out.push_str("ss"),
+        '\u{00e6}' => out.push_str("ae"),
+        '\u{0153}' => out.push_str("oe"),
+        '\u{00fe}' => out.push_str("th"),
+        _ => out.push(ch),
+    }
+}
+
+pub fn normalize_diacritics(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.nfd().flat_map(char::to_lowercase) {
+        if ('\u{0300}'..='\u{036f}').contains(&ch) {
+            continue;
+        }
+        push_compatibility_folded(ch, &mut out);
+    }
+    out
+}

--- a/crates/mezon-ui/src/util/text_utils.rs
+++ b/crates/mezon-ui/src/util/text_utils.rs
@@ -1,28 +1,6 @@
 use unicode_normalization::UnicodeNormalization;
 
-fn push_compatibility_folded(ch: char, out: &mut String) {
-    match ch {
-        '\u{0111}' | '\u{00f0}' => out.push('d'),
-        '\u{0142}' => out.push('l'),
-        '\u{00f8}' => out.push('o'),
-        '\u{00df}' => out.push_str("ss"),
-        '\u{00e6}' => out.push_str("ae"),
-        '\u{0153}' => out.push_str("oe"),
-        '\u{00fe}' => out.push_str("th"),
-        _ => out.push(ch),
-    }
-}
-
-pub(crate) fn normalize_diacritics(value: &str) -> String {
-    let mut out = String::with_capacity(value.len());
-    for ch in value.nfd().flat_map(char::to_lowercase) {
-        if ('\u{0300}'..='\u{036f}').contains(&ch) {
-            continue;
-        }
-        push_compatibility_folded(ch, &mut out);
-    }
-    out
-}
+pub(crate) use mezon_store::text_utils::normalize_diacritics;
 
 pub(crate) fn normalize_string(value: &str) -> String {
     if value.is_empty() {


### PR DESCRIPTION
Threads under a channel were emitted in raw API order and never re-sorted, so the sidebar only looked alphabetical because ListChannelDescs happens to return `ORDER BY cd.channel_label`. Any thread that arrived later — created, joined, or reactivated over the realtime socket — was appended to the bottom of its parent's block and stayed there until the next clan refetch.

Sort each thread group by an accent-folded, lower-cased label, tie-broken by channel id so equal labels keep a stable order, and make insert_channel place a new thread at its alphabetical slot instead of at the end of the block. The sort runs once per clan structure fetch inside the existing async task, and insert_channel keeps its single linear scan, so neither path costs more than before.

normalize_diacritics moves from mezon-ui to mezon-store (mezon-ui already depends on mezon-store) and is re-exported from its old path, so existing call sites in clan_channels_page, clan_members_page and archived_channel_page are unchanged. Folding matters here: plain byte order would sort "Đà Nẵng" after "zebra" and split "Echo" from "echo".