### PR TITLE
feat(desktop): play a YouTube channel app on the public embed route

### DIFF
--- a/crates/mezon-client/src/social.rs
+++ b/crates/mezon-client/src/social.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use futures::AsyncReadExt as _;
 use http_client::{AsyncBody, HttpClient, HttpRequestExt as _, RedirectPolicy, http};
 use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+use url::Url;
 
 use crate::transport_runtime::{http_client, runtime};
 
@@ -50,6 +51,70 @@ pub fn youtube_poster_fallback(poster_url: &str) -> Option<String> {
         .position(|candidate| *candidate == quality)?;
     let next = YOUTUBE_POSTER_QUALITIES.get(current + 1)?;
     Some(format!("{YOUTUBE_POSTER_BASE}{video_id}/{next}"))
+}
+
+/// `?t=90`, `?t=1m30s` and `?start=90` all mean "start 90 seconds in".
+fn youtube_start_seconds(link: &str) -> u64 {
+    let Ok(url) = Url::parse(link) else {
+        return 0;
+    };
+    let Some((_, raw)) = url
+        .query_pairs()
+        .find(|(key, _)| key == "t" || key == "start")
+    else {
+        return 0;
+    };
+    if let Ok(seconds) = raw.parse::<u64>() {
+        return seconds;
+    }
+    let mut total = 0u64;
+    let mut digits = 0u64;
+    let mut seen_digit = false;
+    for c in raw.chars() {
+        match c {
+            '0'..='9' => {
+                digits = digits
+                    .saturating_mul(10)
+                    .saturating_add((c as u64) - ('0' as u64));
+                seen_digit = true;
+            }
+            'h' | 'H' => {
+                total += digits * 3600;
+                digits = 0;
+            }
+            'm' | 'M' => {
+                total += digits * 60;
+                digits = 0;
+            }
+            's' | 'S' => {
+                total += digits;
+                digits = 0;
+            }
+            _ => return 0,
+        }
+    }
+    if seen_digit { total } else { 0 }
+}
+
+/// Public (no-login) web route that iframes a single YouTube video.
+pub const YOUTUBE_EMBED_ROUTE: &str = "/embed/youtube";
+
+/// A YouTube link opens on the web client's own player page instead of on the
+/// whole youtube.com site — what the reader clicked is the video, not the site
+/// around it.
+///
+/// Returns `None` for every other link, so callers fall back to the link itself.
+pub fn build_youtube_embed_route_url(domain_url: &str, link: &str) -> Option<String> {
+    let video_id = youtube_video_id(link)?;
+    let base = domain_url.trim_end_matches('/');
+    let start = youtube_start_seconds(link);
+    if start > 0 {
+        Some(format!(
+            "{base}{YOUTUBE_EMBED_ROUTE}?v={video_id}&t={start}"
+        ))
+    } else {
+        Some(format!("{base}{YOUTUBE_EMBED_ROUTE}?v={video_id}"))
+    }
 }
 
 pub fn is_youtube_shorts(url: &str) -> bool {
@@ -243,5 +308,42 @@ mod tests {
         );
         assert_eq!(tiktok_poster_from_oembed(br#"{"type":"video"}"#), None);
         assert_eq!(tiktok_poster_from_oembed(b"not json"), None);
+    }
+
+    #[test]
+    fn a_youtube_link_points_at_the_public_embed_route() {
+        assert_eq!(
+            build_youtube_embed_route_url(
+                "https://mezon.ai/",
+                "https://www.youtube.com/watch?v=lHW3fsJQ1sg"
+            )
+            .as_deref(),
+            Some("https://mezon.ai/embed/youtube?v=lHW3fsJQ1sg")
+        );
+    }
+
+    #[test]
+    fn carries_the_start_offset_over_to_the_embed_route() {
+        assert_eq!(
+            build_youtube_embed_route_url("https://mezon.ai", "https://youtu.be/lHW3fsJQ1sg?t=90")
+                .as_deref(),
+            Some("https://mezon.ai/embed/youtube?v=lHW3fsJQ1sg&t=90")
+        );
+        assert_eq!(
+            build_youtube_embed_route_url(
+                "https://mezon.ai",
+                "https://youtu.be/lHW3fsJQ1sg?t=1h2m3s"
+            )
+            .as_deref(),
+            Some("https://mezon.ai/embed/youtube?v=lHW3fsJQ1sg&t=3723")
+        );
+    }
+
+    #[test]
+    fn leaves_every_other_link_alone() {
+        assert_eq!(
+            build_youtube_embed_route_url("https://mezon.ai", "https://www.tiktok.com/@u/video/1"),
+            None
+        );
     }
 }

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -9,9 +9,9 @@ use gpui::{
     prelude::*, px, relative, rems, rgb, rgba, size,
 };
 use mezon_store::{
-    ChannelId, ChannelList, ChannelType, ClanId, Embed, LinkKind, Message, MessageCode, MessageId,
-    MessageSpan, PlatformStore, ProfileContext, RichClick, RichLayout, RichRunKind, RichToken,
-    UserId, is_here_user_id,
+    AppConfig, ChannelId, ChannelList, ChannelType, ClanId, Embed, LinkKind, Message, MessageCode,
+    MessageId, MessageSpan, PlatformStore, ProfileContext, RichClick, RichLayout, RichRunKind,
+    RichToken, UserId, is_here_user_id,
 };
 
 use ui::Clickable;
@@ -1927,6 +1927,17 @@ fn render_social_poster(poster: SocialPoster, cache: Entity<LruImageCache>) -> A
         .into_any_element()
 }
 
+/// A YouTube card opens on the web client's own `/embed/youtube` player page — the
+/// point of the card is the video, not the site around it. Every other social link
+/// (and any URL we cannot read an id out of) opens as it always did.
+fn social_card_launch_url(url: &str, cx: &gpui::App) -> String {
+    AppConfig::try_global(cx)
+        .and_then(|config| {
+            mezon_client::social::build_youtube_embed_route_url(&config.domain_url, url)
+        })
+        .unwrap_or_else(|| url.to_string())
+}
+
 fn render_social_link_card(
     kind: LinkKind,
     selection: &SharedSelection,
@@ -1973,7 +1984,7 @@ fn render_social_link_card(
                 .cursor_pointer()
                 .on_click(move |_, _, cx| {
                     if !selection.borrow().has_selection() {
-                        PlatformStore::open_app_window(resolved.to_string(), cx);
+                        PlatformStore::open_app_window(social_card_launch_url(&resolved, cx), cx);
                     }
                 })
                 .child(
@@ -3058,5 +3069,34 @@ mod hashtag_label_tests {
             chip("#g", Some(2), resolved(Some("g"))).channel_id,
             Some(ChannelId(2))
         );
+    }
+}
+
+#[cfg(test)]
+mod social_card_tests {
+    use super::social_card_launch_url;
+
+    /// The card's whole job: a YouTube link goes to our player page, everything else
+    /// keeps opening what the reader actually clicked.
+    #[gpui::test]
+    fn a_youtube_card_opens_the_configured_embed_route(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            mezon_store::AppConfig::init_global(
+                std::sync::Arc::new(mezon_store::AppConfig {
+                    domain_url: "http://127.0.0.1:4207".into(),
+                    ..Default::default()
+                }),
+                cx,
+            );
+
+            assert_eq!(
+                social_card_launch_url("https://www.youtube.com/watch?v=jNQXAC9IVRw&t=1m30s", cx),
+                "http://127.0.0.1:4207/embed/youtube?v=jNQXAC9IVRw&t=90"
+            );
+            assert_eq!(
+                social_card_launch_url("https://www.tiktok.com/@user/video/123", cx),
+                "https://www.tiktok.com/@user/video/123"
+            );
+        });
     }
 }


### PR DESCRIPTION
A channel app whose URL is a YouTube video used to open the whole youtube.com page in the browser app window, carrying a signed `data`/`clanId` hash that YouTube ignores. Send those apps to the web client's public `/embed/youtube?v=<id>[&t=<seconds>]` route instead: a session-less page that renders nothing but the video in an iframe.

`youtube_video_id` only accepts real YouTube hosts and the 11-char id shape, so every other app URL still takes the signed launch — and a YouTube app no longer needs the hash RPC at all.