### PR TITLE
fix(chat): show the no-permission banner instead of a ban countdown

### DIFF
--- a/crates/mezon-ui/src/chat/area.rs
+++ b/crates/mezon-ui/src/chat/area.rs
@@ -900,8 +900,14 @@ impl ChatArea {
 
         // A ban replaces the composer outright, the way the web client does — the moderator list
         // only says *who* is banned, so the countdown has to come from `IsBanned`.
+        //
+        // A denied send wins over it: the server answers `IsBanned` with `EXISTS ucns:<user>:<channel>`,
+        // and that key is also what revoking send-message on a channel writes — without a TTL — so
+        // every member of a bot-only channel reads back as banned (KOMU #checkin: is_banned=1,
+        // ttl=-1, send-message active=0). Trust the permission over the ban when they disagree.
         let ban_notice = if !is_dm
             && !media_channel_view
+            && !send_denied
             && let Some(channel_id) = channel_id
         {
             let store = BannedUsersStore::global(cx);
@@ -972,9 +978,7 @@ impl ChatArea {
                     },
                 ))
                 .when_some(ban_notice, |col, notice| col.child(notice))
-                .when(!banned && send_denied, |col| {
-                    col.child(no_permission_notice)
-                })
+                .when(send_denied, |col| col.child(no_permission_notice))
                 .when(!banned && !send_denied, |col| {
                     col.children(onboarding_mission)
                         .when_some(input_bar.clone(), |col, input_bar| col.child(input_bar))


### PR DESCRIPTION
A channel that only revoked send-message showed every ordinary member the "you are banned" countdown and no explanation of what was actually wrong.

The server's `IsBanned` is just `EXISTS ucns:<user_id>:<channel_id>` on Valkey, and `ucns` ("user channel no send") is written by three unrelated flows: a real ban, blocking a friend in a DM, and revoking send-message on a channel — the last one with no TTL. So a bot-only channel reads back as is_banned=1 forever. Measured on KOMU #checkin: is_banned=1, ttl=-1, send-message active=0, against #backend/#bangtin where is_banned=0 and the permission is active.

Trust the permission over the ban when they disagree: skip the `IsBanned` lookup entirely once the send is denied, and render the no-permission notice on `send_denied` alone rather than on `!banned && send_denied`. A real ban still shows its countdown, because a banned user keeps send-message active=1 — only the ban key carries a TTL.

The fix is client-side and narrow; the underlying conflation belongs to `IsBanned`, which should read `banned_users` or use its own key namespace.