### PR TITLE
fix(header): line the topbar divider up with the member list border

### DIFF
--- a/crates/mezon-ui/src/chat/member_list.rs
+++ b/crates/mezon-ui/src/chat/member_list.rs
@@ -45,6 +45,9 @@ enum HeaderKind {
     Members,
 }
 
+/// Width of the member list rail, its 1px left border included. The channel header
+/// derives the collapsed search bar from this so its divider sits on that border.
+pub const MEMBER_LIST_WIDTH: f32 = 245.;
 const MEMBER_SKELETON_DELAY_MS: u64 = 400;
 const MEMBER_SKELETON_ROWS: usize = 10;
 
@@ -1306,7 +1309,7 @@ impl Render for MemberListPanel {
             .children(crate::tour::probe(crate::tour::TourAnchor::MemberList))
             .flex()
             .flex_col()
-            .w(px(245.))
+            .w(px(MEMBER_LIST_WIDTH))
             .h_full()
             .flex_shrink_0()
             .border_l_1()

--- a/crates/mezon-ui/src/chat/message_search.rs
+++ b/crates/mezon-ui/src/chat/message_search.rs
@@ -36,7 +36,12 @@ use crate::router::{Route, Router, navigate};
 use crate::theme::{ActiveTheme, Theme};
 
 pub const MESSAGE_SEARCH_PANEL_WIDTH: f32 = 420.;
-pub const SEARCH_BAR_WIDTH_COLLAPSED: f32 = 160.;
+// Derived, not chosen: the channel header packs `| inbox search` flush to the right edge,
+// so this width is what lands the divider exactly on the member list's left border —
+// MEMBER_LIST_WIDTH (245) less the header's 16px right padding, the 4px gap before the
+// search bar, the 32px inbox button, and the divider's own 8px gap and 1px rule.
+pub const SEARCH_BAR_WIDTH_COLLAPSED: f32 =
+    crate::chat::member_list::MEMBER_LIST_WIDTH - 16. - 4. - 32. - 8. - 1.;
 pub const SEARCH_BAR_WIDTH_EXPANDED: f32 = 320.;
 pub const SEARCH_OPTIONS_WIDTH: f32 = 400.;
 


### PR DESCRIPTION
The divider that separates the channel action icons from the inbox button and the search box sat 24px to the right of where the member list rail starts, so the two vertical lines in the top-right corner were visibly out of step.

Everything right of the divider is laid out flush to the window edge, so the divider's position is whatever those widths add up to: 16px header padding, a 4px gap, the 32px inbox button, an 8px gap and the 1px rule itself, plus the collapsed search bar. With the search bar at 160 that came to 221, against the member list's 245.

Derive the collapsed width from MEMBER_LIST_WIDTH instead of hard-coding it, so the search bar is 184 and the divider lands on the border — and so the two cannot drift apart the next time the rail is resized. The width is only used for this one element; the expanded state is unchanged.