### PR TITLE
fix(chat): stop sizing inline channel icons from a fallback font

### DIFF
--- a/crates/mezon-ui/src/chat/message/channel_messages.rs
+++ b/crates/mezon-ui/src/chat/message/channel_messages.rs
@@ -452,6 +452,17 @@ mod selection_copy_tests {
     fn clipboard_selection_preserves_real_whitespace() {
         assert_eq!(clipboard_selection_slice(" a "), Some(" a ".to_string()));
     }
+
+    /// The character that reserves room for a channel icon while the message is being
+    /// shaped is not the one selection indexes, precisely so that stripping the marker
+    /// out of copied text cannot eat a per mille someone typed on purpose.
+    #[test]
+    fn clipboard_selection_keeps_a_typed_per_mille() {
+        assert_eq!(
+            clipboard_selection_slice("lãi 5\u{2030} một tháng"),
+            Some("lãi 5\u{2030} một tháng".to_string())
+        );
+    }
 }
 
 const FAB_SIZE: f32 = 32.;

--- a/crates/mezon-ui/src/chat/message/content.rs
+++ b/crates/mezon-ui/src/chat/message/content.rs
@@ -50,7 +50,22 @@ const EMOJI_JUMBO_SIZE: f32 = 48.;
 fn emoji_source_px(size: Pixels) -> u32 {
     (f32::from(size) * 2.0).round().max(1.0) as u32
 }
+/// Stands in for an inline channel icon in the string selection and copy work off.
+/// Braille blank is never typed, so stripping it out of a copied slice cannot eat a
+/// character someone meant to send.
 pub(crate) const INLINE_ICON_PLACEHOLDER: char = '\u{2800}';
+/// Reserves the box the icon is painted into, in the string that actually gets shaped.
+/// It has to be about one em wide, and nothing else about it is observable: the run is
+/// faded out. Braille blank cannot do this job — no bundled font carries it, so its
+/// advance came from whatever the platform fell back to (Apple Symbols, 0.684em on
+/// macOS), which drew the icon at 11px instead of 16 and moved with the OS. Per mille is
+/// the one glyph gg sans defines near an em (1.004em at Normal), and the run pins the
+/// weight because the glyph widens with it.
+///
+/// The two strings are indexed against each other, so this must stay the same number of
+/// UTF-8 bytes as [`INLINE_ICON_PLACEHOLDER`] — `placeholders_agree_on_utf8_length` holds
+/// that line.
+pub(crate) const INLINE_ICON_RESERVE: char = '\u{2030}';
 pub(crate) const ATTACHMENT_PLACEHOLDER: char = '\u{fffc}';
 const RICH_TEXT_PLAN_LIMIT: usize = 512;
 const SELECTABLE_LAYOUT_PLAN_LIMIT: usize = 128;
@@ -2261,13 +2276,18 @@ fn hashtag_display_label(display: &str) -> SharedString {
 }
 
 fn build_inline_content(msg: &Message, ctx: &RowCtx, body_color: gpui::Rgba) -> Option<AnyElement> {
-    let all_supported = msg.spans.iter().all(|span| {
-        matches!(
-            span,
-            MessageSpan::Text(_) | MessageSpan::Mention { .. } | MessageSpan::Hashtag { .. }
-        )
-    });
-    if !all_supported {
+    // This path exists only to paint channel icons over a single shaped string, and it used
+    // to find that out at the end — after copying the whole body into a String and filling
+    // three vectors, which every chipless message then threw away. Ask the spans first.
+    let mut has_icon = false;
+    for span in &msg.spans {
+        match span {
+            MessageSpan::Hashtag { .. } => has_icon = true,
+            MessageSpan::Text(_) | MessageSpan::Mention { .. } => {}
+            _ => return None,
+        }
+    }
+    if !has_icon {
         return None;
     }
 
@@ -2299,6 +2319,8 @@ fn build_inline_content(msg: &Message, ctx: &RowCtx, body_color: gpui::Rgba) -> 
                     range: start..end,
                     color: Some(if is_role { role_color } else { mention_color }),
                     background: Some(if is_role { role_bg } else { mention_bg }),
+                    font_weight: None,
+                    fade_out: None,
                 });
                 if is_role {
                     continue;
@@ -2343,24 +2365,23 @@ fn build_inline_content(msg: &Message, ctx: &RowCtx, body_color: gpui::Rgba) -> 
             } => {
                 let chip = hashtag_chip(display, channel_id.as_deref(), ctx.locale, ctx.app);
                 let icon_index = text.len();
-                text.push(INLINE_ICON_PLACEHOLDER);
+                text.push(INLINE_ICON_RESERVE);
                 let label_index = text.len();
                 text.push_str(&chip.label);
                 let end = text.len();
                 runs.push(StyledRun {
                     range: icon_index..label_index,
-                    color: Some(Hsla {
-                        h: 0.,
-                        s: 0.,
-                        l: 0.,
-                        a: 0.,
-                    }),
+                    color: None,
                     background: Some(mention_bg),
+                    font_weight: Some(gpui::FontWeight::NORMAL),
+                    fade_out: Some(1.),
                 });
                 runs.push(StyledRun {
                     range: label_index..end,
                     color: Some(mention_color),
                     background: Some(mention_bg),
+                    font_weight: None,
+                    fade_out: None,
                 });
                 icons.push(IconOverlay {
                     byte_index: icon_index,
@@ -2846,13 +2867,31 @@ fn split_unbreakable(text: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        RichRunPalette, RichTextRenderPlan, SelectableSectionCursor, parse_channel_id,
-        rich_highlights_with_link_hover, rich_run_highlight,
-        rich_run_highlight_with_link_underline, rich_text_plan_matches,
+        INLINE_ICON_PLACEHOLDER, INLINE_ICON_RESERVE, RichRunPalette, RichTextRenderPlan,
+        SelectableSectionCursor, parse_channel_id, rich_highlights_with_link_hover,
+        rich_run_highlight, rich_run_highlight_with_link_underline, rich_text_plan_matches,
         selectable_message_layout_identity, selectable_text_chunks,
     };
     use gpui::{Hsla, SharedString};
     use mezon_store::{ChannelId, Message, MessageId, MessageSpan, RichRunKind, build_rich_layout};
+
+    /// The shaped string and the string selection indexes into carry different characters
+    /// where a channel icon goes, and every offset is shared between them. Same byte width
+    /// or a selection that crosses a chip lands on the wrong character.
+    #[test]
+    fn placeholders_agree_on_utf8_length() {
+        assert_eq!(
+            INLINE_ICON_PLACEHOLDER.len_utf8(),
+            INLINE_ICON_RESERVE.len_utf8()
+        );
+    }
+
+    /// The reserve is only ever shaped, never read back, so it may be a character someone
+    /// could type. The placeholder is stripped out of copied text wholesale, so it must not.
+    #[test]
+    fn only_the_reserve_may_be_a_typeable_character() {
+        assert!(('\u{2800}'..='\u{28ff}').contains(&INLINE_ICON_PLACEHOLDER));
+    }
 
     #[test]
     fn parse_channel_id_rejects_zero() {

--- a/crates/mezon-ui/src/chat/message/inline_content.rs
+++ b/crates/mezon-ui/src/chat/message/inline_content.rs
@@ -4,21 +4,32 @@ use std::ops::Range;
 use std::rc::Rc;
 
 use gpui::{
-    App, Bounds, CursorStyle, DispatchPhase, Element, ElementId, GlobalElementId, HighlightStyle,
-    Hitbox, HitboxBehavior, Hsla, InspectorElementId, IntoElement, LayoutId, MouseDownEvent,
-    MouseUpEvent, Pixels, SharedString, StyledText, TextLayout, TransformationMatrix, Window,
-    point, px, size,
+    App, Bounds, CursorStyle, DispatchPhase, Element, ElementId, FontWeight, GlobalElementId,
+    HighlightStyle, Hitbox, HitboxBehavior, Hsla, InspectorElementId, IntoElement, LayoutId,
+    MouseDownEvent, MouseUpEvent, Pixels, SharedString, StyledText, TextLayout,
+    TransformationMatrix, Window, point, px, size,
 };
 
 use super::selection::{SharedSelection, merge_selection_background};
 use crate::components::primitives::IconName;
 
 const INLINE_ICON_SIZE: Pixels = px(16.);
+/// Icon height as a fraction of the em box. Matches the 11px the icon has always been
+/// drawn at in a 16px body, which is what the reserve happened to give on macOS before
+/// the placeholder was made deterministic.
+const INLINE_ICON_EM_RATIO: f32 = 0.6875;
 
 pub struct StyledRun {
     pub range: Range<usize>,
     pub color: Option<Hsla>,
     pub background: Option<Hsla>,
+    /// Pins the run to one weight. The icon placeholder needs it: its advance is
+    /// the box the icon is painted into, and gg sans widens `‰` from 1.004em at
+    /// Normal to 1.092em at ExtraBold, which would resize the icon with the text.
+    pub font_weight: Option<FontWeight>,
+    /// Fades the run out, 1.0 being invisible. A transparent `color` cannot do this:
+    /// `HighlightStyle` blends its color over the base one, so alpha 0 is a no-op.
+    pub fade_out: Option<f32>,
 }
 
 pub struct IconOverlay {
@@ -100,6 +111,8 @@ fn build_highlights(
             HighlightStyle {
                 color: run.color.or(Some(body_color)),
                 background_color: run.background,
+                font_weight: run.font_weight,
+                fade_out: run.fade_out,
                 ..Default::default()
             },
         ));
@@ -242,14 +255,35 @@ impl Element for InlineContent {
                         }
                         _ => (start.x, start.y, INLINE_ICON_SIZE),
                     };
-                let icon_size = if reserved < line_height {
-                    reserved
-                } else {
-                    line_height
-                };
-                let vertical_offset = (line_height - icon_size) * 0.5;
+                // The placeholder reserves one em; the icon is drawn smaller inside it and
+                // centred, so the slack reads as padding between the icon and the label.
+                let line = text_layout.line_layout_for_index(overlay.byte_index);
+                let em = line
+                    .as_ref()
+                    .map(|line| line.unwrapped_layout.font_size)
+                    .unwrap_or(reserved);
+                // `reserved` is the placeholder's advance on the common path, but the wrapped
+                // arm above hands back the whole distance from the row's left edge, which must
+                // not be treated as the icon's slot: centring in it would push the icon halfway
+                // across the line.
+                let slot = reserved.min(em);
+                let icon_size = (em * INLINE_ICON_EM_RATIO).min(slot).min(line_height);
+                // Sit the icon on the text baseline rather than centred in the line box: a line
+                // is only as tall as its tallest run, so centring drifts whenever a chip shares
+                // the line with something bigger. This is the baseline gpui itself draws to
+                // (`text_system::line::paint`).
+                let baseline = line
+                    .map(|line| {
+                        let ascent = line.unwrapped_layout.ascent;
+                        let descent = line.unwrapped_layout.descent;
+                        (line_height - ascent - descent) / 2. + ascent
+                    })
+                    .unwrap_or((line_height + icon_size) / 2.);
                 let icon_bounds = Bounds {
-                    origin: point(icon_x, icon_y + vertical_offset),
+                    origin: point(
+                        icon_x + (slot - icon_size) / 2.,
+                        icon_y + baseline - icon_size,
+                    ),
                     size: size(icon_size, icon_size),
                 };
                 let _ = window.paint_svg(

--- a/crates/mezon-ui/src/chat/message/selection.rs
+++ b/crates/mezon-ui/src/chat/message/selection.rs
@@ -561,6 +561,22 @@ mod tests {
         assert_eq!(out[2].1.color, color(0.1).color);
     }
 
+    /// The character reserving space for an inline channel icon is hidden with `fade_out`,
+    /// and selecting a chip must not bring it back.
+    #[test]
+    fn merge_keeps_a_faded_out_run_invisible() {
+        let hidden = HighlightStyle {
+            fade_out: Some(1.),
+            ..color(0.1)
+        };
+        let base = vec![(0..3, hidden), (3..10, color(0.1))];
+        let out = merge_selection_background(&base, 0..10, bg());
+        assert_eq!(out[0].0, 0..3);
+        assert_eq!(out[0].1.fade_out, Some(1.));
+        assert_eq!(out[0].1.background_color, Some(bg()));
+        assert_eq!(out[1].1.fade_out, None);
+    }
+
     #[test]
     fn merge_covers_selection_past_last_highlight() {
         let base = vec![(0..2, color(0.1))];


### PR DESCRIPTION
A `#channel` chip paints its icon over a placeholder character and sizes it to that character's advance. The placeholder was U+2800 BRAILLE PATTERN BLANK, which no bundled font carries, so the advance came from whatever the platform fell back to — Apple Symbols on macOS, 0.684em — and every other OS picks its own. The icon is therefore a different size on every platform and moves if the system fonts change; QA saw it as icons that do not line up with their label.

Reserve the box with U+2030 instead, the one glyph gg sans defines near an em (1.004em at Normal), and pin the run to Normal so the reserve does not grow with the body weight. That also drops the font fallback the old placeholder forced on every chip. The glyph has ink, so it is hidden with `fade_out`, not with a transparent color: HighlightStyle blends its color over the base one, which makes alpha 0 a no-op — the old placeholder only looked hidden because braille blank draws nothing.

The icon keeps the 11px it has always had on macOS (0.6875em), centred in the em box, so the extra room reads as the padding between icon and label that was missing before. It now sits on the text baseline rather than centred in the line box: a line is only as tall as its tallest run, so centring drifted whenever a chip shared a line with something taller.