### PR TITLE
fix(chat): resolve a message's sender name in DMs too, not just clans

### DIFF
--- a/crates/mezon-ui/src/chat/message/parts.rs
+++ b/crates/mezon-ui/src/chat/message/parts.rs
@@ -250,17 +250,29 @@ pub fn resolve_message_display_name(msg: &Message, ctx: &RowCtx, cx: &App) -> Sh
         if let Some(cached) = ctx.row_memo.borrow().display_names.get(&key) {
             return cached.clone();
         }
-        let resolved = if let Some(clan_id) = clan_id {
-            ClanMembersStore::global(cx)
+        // A DM used to stop here and take whatever name the message arrived with. That is fine
+        // for an ordinary message, which mezon-api enriches with clan_nick and display_name on
+        // its way out, and wrong for an ephemeral one: mezon-proto-server answers
+        // EphemeralMessageSend by building the ChannelMessage itself and echoing it straight to
+        // the recipient, and the connection only carries `username` — so the row read
+        // `cuson108` where every other message from the same person said `Sony`. Ask the same
+        // ladder the avatar already walks: group member, DM peer, own account.
+        //
+        // The clan branch is left exactly as it was. The member store is the whole answer
+        // there, and routing it through `resolve_user_profile` would buy a presence lookup
+        // whose result this function throws away, on the path most messages take.
+        let resolved = match ctx.profile_context {
+            Some(ProfileContext::Clan(clan_id)) => ClanMembersStore::global(cx)
                 .read(cx)
                 .member(clan_id, user_id)
-                .map(|member| member.name())
-                .filter(|name| !name.is_empty())
-                .map(SharedString::from)
-                .unwrap_or_else(|| msg.sender_name.clone())
-        } else {
-            msg.sender_name.clone()
-        };
+                .map(|member| member.name().to_string()),
+            Some(context) => mezon_store::resolve_user_profile(user_id, context, cx)
+                .map(|profile| profile.display_name),
+            None => None,
+        }
+        .filter(|name| !name.is_empty())
+        .map(SharedString::from)
+        .unwrap_or_else(|| msg.sender_name.clone());
         let mut memo = ctx.row_memo.borrow_mut();
         if memo.display_names.len() >= ROW_MEMO_CAPACITY {
             memo.display_names.clear();


### PR DESCRIPTION
An ephemeral message showed the sender's username where every other message from the same person showed their display name — "cuson108" instead of "Sony".

The name a row renders comes from the store when one has it and from the name baked into the message otherwise, but the store lookup only ever ran the clan branch: `role_scope` yields a clan id in a clan channel and nothing in a DM, so a DM always fell back to the baked name. That is fine for an ordinary message, which mezon-api enriches with clan_nick and display_name on its way out, and wrong for an ephemeral one: mezon-proto-server answers EphemeralMessageSend by building the ChannelMessage itself and echoing it straight to the recipient (`pipeline_channel.c`, `pipeline_ephemeral_message_send`), and the connection only carries `username`, so that is the only name on the wire.

Resolve through `resolve_user_profile` instead, the same ladder the avatar already uses — clan member, group member, DM peer, own account — and keep the baked name as the last resort. The row memo was already invalidated by the DM stores (DirectMessageStore, UsersByUserStore, GroupMembersStore), which only made sense for a resolution that consulted them.

The real fix belongs on the server: the ephemeral echo should carry display_name and clan_nick like every other message. This keeps the client from showing two different names for one person until it does.