### PR TITLE
fix(stream): authenticate to the stream server with the JWT, not session_id

### DIFF
--- a/crates/mezon-store/src/stream.rs
+++ b/crates/mezon-store/src/stream.rs
@@ -71,6 +71,9 @@ pub struct StreamStore {
     session_clan_name: String,
     session_user_id: Option<UserId>,
     join_started: Option<Instant>,
+    /// Bumped on every `join_stream`; the async credential fetch checks it before starting the
+    /// session so a leave-and-rejoin cannot resurrect the previous attempt.
+    join_generation: u64,
     _fetch_task: Option<Task<()>>,
     _session_task: Option<Task<()>>,
     _join_timeout: Option<Task<()>>,
@@ -123,6 +126,7 @@ impl StreamStore {
             session_clan_name: String::new(),
             session_user_id: None,
             join_started: None,
+            join_generation: 0,
             _fetch_task: None,
             _session_task: None,
             _join_timeout: None,
@@ -525,27 +529,59 @@ impl StreamStore {
         let session_config = StreamSessionConfig {
             ws_base_url: config.stream_ws_url.clone(),
             username: session.username.clone(),
-            token: session.ws_credential().to_string(),
+            // Filled in below: the stream server takes the JWT, never `ws_credential()`.
+            token: String::new(),
             clan_id: clan_id.to_string(),
             channel_id: channel_id.to_string(),
             user_id: session.user_id.clone(),
             stream_id: channel_id.to_string(),
         };
-        let frame_store = self.frame_store.clone();
-        let session_user_id = session.user_id.parse::<i64>().ok().map(UserId);
-        self.session_user_id = session_user_id;
-
-        let stream_session = StreamSession::start(
-            session_config,
-            frame_store,
-            output_device_id,
-            self.volume,
-            self.muted,
-        );
-        let events = stream_session.events().clone();
-        self.session = Some(stream_session);
+        self.session_user_id = session.user_id.parse::<i64>().ok().map(UserId);
+        self.join_generation += 1;
+        let generation = self.join_generation;
+        let api = self.api.clone();
+        let held_token = session.token.clone();
+        let held_token_is_live = !session.is_expired();
 
         self._session_task = Some(cx.spawn(async move |this, cx| {
+            // The stream server (`stn`) authenticates the `?token=` query with the JWT only. The
+            // socket's `session_id` is a one-shot handshake credential the gateway keeps for 60s
+            // (`SessionTTL` in mezon-gw) and it is what `ws_credential()` prefers, so handing it
+            // over answers a bare HTTP 200 and the upgrade fails. The JWT is renewed lazily, so
+            // go through the fallback's single-flight refresh: it hands back the current token
+            // when it is still valid and mints a new one otherwise, which the connection store's
+            // token watch then adopts into `AuthState`.
+            let token = match api.renew_fallback_token().await {
+                Ok(renewed) => renewed.token,
+                Err(err) if held_token_is_live => {
+                    tracing::warn!(
+                        "stream: SessionRefresh failed ({err:#}) — joining with the session's current JWT"
+                    );
+                    held_token
+                }
+                Err(err) => {
+                    tracing::warn!("stream: no live JWT for the stream server ({err:#})");
+                    this.update(cx, |this, cx| {
+                        if this.join_generation == generation && this.is_joining() {
+                            this.fail_stream("Stream connection failed".into(), cx);
+                        }
+                    })
+                    .ok();
+                    return;
+                }
+            };
+            let Ok(Some(events)) = this.update(cx, |this, _| {
+                this.start_session(
+                    generation,
+                    StreamSessionConfig {
+                        token,
+                        ..session_config
+                    },
+                    output_device_id,
+                )
+            }) else {
+                return;
+            };
             while let Ok(event) = events.recv_async().await {
                 let stop = this
                     .update(cx, |this, cx| {
@@ -571,6 +607,29 @@ impl StreamStore {
             })
             .ok();
         }));
+    }
+
+    /// Open the stream session once the credential is in hand. Returns `None` when the join it
+    /// belongs to was superseded (left, or re-joined) while the credential was being fetched.
+    fn start_session(
+        &mut self,
+        generation: u64,
+        session_config: StreamSessionConfig,
+        output_device_id: Option<String>,
+    ) -> Option<flume::Receiver<StreamEvent>> {
+        if self.join_generation != generation || !self.is_joining() || self.session.is_some() {
+            return None;
+        }
+        let stream_session = StreamSession::start(
+            session_config,
+            self.frame_store.clone(),
+            output_device_id,
+            self.volume,
+            self.muted,
+        );
+        let events = stream_session.events().clone();
+        self.session = Some(stream_session);
+        Some(events)
     }
 
     pub fn leave_stream(&mut self, cx: &mut Context<Self>) {

--- a/crates/mezon-stream/src/session.rs
+++ b/crates/mezon-stream/src/session.rs
@@ -129,7 +129,7 @@ async fn run_session(
     event_tx: Sender<StreamEvent>,
     runtime_handle: tokio::runtime::Handle,
 ) {
-    if let Err(_err) = run_session_inner(
+    if let Err(err) = run_session_inner(
         config,
         frame_store,
         audio,
@@ -139,7 +139,9 @@ async fn run_session(
     )
     .await
     {
-        tracing::warn!("stream session ended with error");
+        // The chain never carries the URL (and so never the token): tungstenite reports a
+        // refused upgrade as a bare status line.
+        tracing::warn!("stream session ended with error: {err:#}");
         let _ = event_tx.send(StreamEvent::Error("Stream connection failed".to_string()));
     }
     let _ = event_tx.send(StreamEvent::Disconnected);
@@ -157,6 +159,11 @@ async fn run_session_inner(
     let (ws_stream, _) = connect_async(url.as_str())
         .await
         .context("stream websocket connect failed")?;
+    tracing::info!(
+        "stream signaling connected channel_id={} stream_id={}",
+        config.channel_id,
+        config.stream_id
+    );
     let (mut ws_tx, mut ws_rx) = ws_stream.split();
     let (outbound_tx, outbound_rx) = flume::unbounded::<OutboundMessage>();
 
@@ -280,6 +287,10 @@ async fn run_session_inner(
                         let Some(value) = inbound.value.as_ref() else { continue; };
                         let channels = parse_channels(value);
                         let is_live = channels.iter().any(|id| id == &config.stream_id);
+                        tracing::info!(
+                            "stream channels update: live={is_live} broadcasting={}",
+                            channels.len()
+                        );
                         if is_live && !live {
                             live = true;
                             send_ws(


### PR DESCRIPTION
`StreamStore::join_stream` handed `Session::ws_credential()` to the stream
server's `/ws?token=` query. That helper prefers `session_id`, which is a
one-shot socket handshake credential: the gateway keeps it in Redis for 60s
(`SessionTTL`) and the proto-server does not renew it once the socket is up.
The stream server answers an expired session_id with a bare HTTP 200 (no
upgrade), tungstenite fails, and the panel shows "Stream connection failed".

It only surfaced now because prod sessions used to end up JWT-only: a refused
session_id was dropped and the gateway had no healthy-endpoint route to remint
one, so `ws_credential()` happened to return the JWT. With the route deployed
and the client reminting on every reconnect, every session carries a
session_id again and joining more than 60s after the last mint always fails.

Fetch the JWT through `AppApi::renew_fallback_token` before opening the
session. It is single-flight, returns the current token while it is valid and
mints a fresh one otherwise (the connection store's token watch adopts it
into `AuthState`), so a JWT that expired while the socket lived on its
session_id no longer blocks the join. A `join_generation` counter keeps a
leave-and-rejoin from resurrecting the superseded attempt, and the join
timeout now covers the credential fetch as well. The socket credential is
untouched: `apply_refresh` leaves `session_id` alone and the reconnect ladder
still remints it.

Log the error chain from `run_session` (it carries the status line, never the
URL) and the two signaling milestones, so the next failure names itself.
